### PR TITLE
Revert feat/cpu-quota — Docker rejects NanoCpus + CpuPeriod/CpuQuota combo

### DIFF
--- a/src/rolemesh/container/docker_runtime.py
+++ b/src/rolemesh/container/docker_runtime.py
@@ -29,11 +29,6 @@ class IncompatibleDockerVersionError(RuntimeError):
 
 _MIN_DOCKERD_VERSION: tuple[int, int] = (20, 10)
 
-# CFS scheduling period for the CPU hard cap (CpuQuota). 100ms matches the
-# kernel's cgroup default. Operators don't tune this in practice; if they
-# ever need to, promoting it to a ContainerSpec field is cheap.
-_DEFAULT_CPU_PERIOD_US: int = 100_000
-
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
@@ -341,17 +336,7 @@ class DockerRuntime:
             host_config["MemorySwappiness"] = int(spec.memory_swappiness)
 
         if spec.cpu_limit:
-            # NanoCpus sets cgroup CPU shares — a *relative* weight that
-            # only kicks in under contention. On an idle host a single
-            # agent can still burst past its share and saturate the box,
-            # starving the orchestrator and other agents of latency.
-            # CpuQuota + CpuPeriod set the CFS *hard cap*: the container
-            # never gets more than `cpu_limit` cores' worth of runtime
-            # within each period, contended or not. Both are set
-            # together — they are complementary, not duplicate limits.
             host_config["NanoCpus"] = int(spec.cpu_limit * 1e9)
-            host_config["CpuPeriod"] = _DEFAULT_CPU_PERIOD_US
-            host_config["CpuQuota"] = int(spec.cpu_limit * _DEFAULT_CPU_PERIOD_US)
         if spec.extra_hosts:
             host_config["ExtraHosts"] = [f"{h}:{ip}" for h, ip in spec.extra_hosts.items()]
 

--- a/tests/container/test_docker_runtime.py
+++ b/tests/container/test_docker_runtime.py
@@ -239,38 +239,6 @@ def test_spec_to_config_cpu() -> None:
     assert config["HostConfig"]["NanoCpus"] == int(1.5e9)
 
 
-def test_spec_to_config_cpu_limit_sets_hard_cap_alongside_shares() -> None:
-    """When cpu_limit is set, CpuPeriod + CpuQuota must accompany NanoCpus.
-
-    NanoCpus alone is a relative weight; without CpuQuota a single agent
-    can burst past its share on an idle host. The hard cap is the whole
-    point of the cpu-quota work — regression here re-opens the burst
-    path silently.
-
-    CpuQuota = cpu_limit * CpuPeriod is the cgroup-native conversion.
-    """
-    spec = ContainerSpec(name="test", image="img", cpu_limit=2.0)
-    hc = DockerRuntime._spec_to_config(spec)["HostConfig"]
-    assert hc["NanoCpus"] == int(2.0e9)
-    assert hc["CpuPeriod"] == 100_000
-    assert hc["CpuQuota"] == 200_000  # 2.0 cores * 100ms period
-    assert hc["CpuQuota"] == int(2.0 * hc["CpuPeriod"])
-
-
-def test_spec_to_config_cpu_limit_unset_omits_all_cpu_keys() -> None:
-    """Without cpu_limit the container should run under cgroup defaults.
-
-    Emitting CpuPeriod or CpuQuota with zero/None would either error at
-    Docker API level or, worse, silently apply a 0-quota = "no CPU at
-    all". All three fields must be absent in the unset case.
-    """
-    spec = ContainerSpec(name="test", image="img")
-    hc = DockerRuntime._spec_to_config(spec)["HostConfig"]
-    assert "NanoCpus" not in hc
-    assert "CpuPeriod" not in hc
-    assert "CpuQuota" not in hc
-
-
 def test_spec_to_config_extra_hosts() -> None:
     spec = ContainerSpec(name="test", image="img", extra_hosts={"host.docker.internal": "host-gateway"})
     config: dict[str, Any] = DockerRuntime._spec_to_config(spec)


### PR DESCRIPTION
## Summary

Reverts merge 8dfa61e (CpuQuota/CpuPeriod alongside NanoCpus) — Docker
daemon ≥ 26 explicitly rejects that combination. Every agent container
with \`cpu_limit\` set has been fatal-failing at create time since the
merge.

\`\`\`
docker run --cpus=1 --cpu-period=100000 --cpu-quota=100000 alpine echo ok
→ Error response from daemon: Conflicting options: Nano CPUs and CPU
   Period cannot both be set
\`\`\`

Verified on Docker 28.2.2.

## Root cause (in commit message)

The original change misread \`NanoCpus\` as "cgroup CPU shares". It
isn't — it's the CFS hard cap, just sugared. Docker translates
\`NanoCpus\` internally into the same Period/Quota the kernel reads.
The real \`shares\` field is \`CpuShares\` (default 1024), which the
original change never touched.

So the "complementary" framing was wrong from the start: the change
duplicated what daemon already does, and modern daemons reject the
duplication outright.

## Why this slipped through CI

\`tests/container/test_docker_runtime.py\` covers \`_spec_to_config\`
as a pure function — it never asks the daemon whether the produced
HostConfig is acceptable. Project doesn't yet have a docker-level
integration test for container spec validity. Worth a follow-up.

## Restoration

Revert is minimal: 47 lines deleted, \`NanoCpus\` line untouched.
\`cpu_limit\` behaviour is identical to pre-8dfa61e.

If a true "relative priority under contention" knob is wanted later,
that's an additive change on \`HostConfig.CpuShares\` and cannot share
the \`cpu_limit\` input.

## Test plan
- [x] \`tests/container/test_docker_runtime.py\` 76/76 (was 78/78 — the 2 cpu-quota cases revert with the change)
- [x] \`docker run --cpus=1 alpine echo ok\` works (NanoCpus alone)
- [ ] Smoke-test in your dev env: start an agent container with cpu_limit set