### PR TITLE
feat(security): tenant-scope all by-id approval/safety DB lookups

### DIFF
--- a/src/rolemesh/approval/engine.py
+++ b/src/rolemesh/approval/engine.py
@@ -377,15 +377,26 @@ class ApprovalEngine:
                 approvers=[],
             )
             if default_mode == "auto_execute":
-                await pg.set_approval_status(req.id, "approved")
-                await self._publish_decided(req.id, status="approved", note=None)
+                await pg.set_approval_status(
+                    req.id, "approved", tenant_id=req.tenant_id
+                )
+                await self._publish_decided(
+                    req.id, tenant_id=req.tenant_id, status="approved", note=None
+                )
             elif default_mode == "require_approval":
                 # Move pending → skipped (system transition). The
                 # originating conversation is notified; admins must
                 # create a policy or decide manually via a side channel.
-                await pg.set_approval_status(req.id, "skipped")
+                await pg.set_approval_status(
+                    req.id, "skipped", tenant_id=req.tenant_id
+                )
                 await self._send_to_origin(
-                    (await pg.get_approval_request(req.id)) or req,
+                    (
+                        await pg.get_approval_request(
+                            req.id, tenant_id=req.tenant_id
+                        )
+                    )
+                    or req,
                     format_skipped_message(req),
                 )
             else:  # "deny"
@@ -397,10 +408,10 @@ class ApprovalEngine:
                     "configured for deny-by-default."
                 )
                 await pg.set_approval_status(
-                    req.id, "rejected", note=note
+                    req.id, "rejected", tenant_id=req.tenant_id, note=note
                 )
                 await self._publish_decided(
-                    req.id, status="rejected", note=note
+                    req.id, tenant_id=req.tenant_id, status="rejected", note=note
                 )
             return
 
@@ -665,6 +676,7 @@ class ApprovalEngine:
         self,
         *,
         request_id: str,
+        tenant_id: str,
         action: str,
         user_id: str,
         note: str | None = None,
@@ -675,6 +687,10 @@ class ApprovalEngine:
         resolved) vs 200 (success) without a second round-trip. The audit
         row is written atomically inside the same transaction by the DB
         trigger — no "ghost decision" window.
+
+        ``tenant_id`` filters the underlying SELECT/UPDATE so a forged
+        request_id from another tenant returns "missing" rather than
+        leaking decision power.
         """
         if action not in ("approve", "reject"):
             raise ValueError(f"Unknown decision action: {action}")
@@ -682,6 +698,7 @@ class ApprovalEngine:
 
         outcome = await pg.decide_approval_request_full(
             request_id,
+            tenant_id=tenant_id,
             new_status=new_status,
             actor_user_id=user_id,
             note=note,
@@ -699,13 +716,26 @@ class ApprovalEngine:
         # approved rows + executes; for rejected it just delivers the
         # rejection notification. Splitting this way lets the WebUI REST
         # process decide without gateway access.
-        await self._publish_decided(request_id, status=new_status, note=note)
+        await self._publish_decided(
+            request_id, tenant_id=tenant_id, status=new_status, note=note
+        )
         return outcome.request
 
     async def _publish_decided(
-        self, request_id: str, *, status: str, note: str | None
+        self,
+        request_id: str,
+        *,
+        tenant_id: str,
+        status: str,
+        note: str | None,
     ) -> None:
-        body = json.dumps({"status": status, "note": note}).encode()
+        # tenant_id rides in the body so the executor can scope its
+        # subsequent get_approval_request / claim_approval calls. The
+        # subject still contains only request_id for backwards compat
+        # with subscriber filters.
+        body = json.dumps(
+            {"tenant_id": tenant_id, "status": status, "note": note}
+        ).encode()
         await self._publisher.publish(f"approval.decided.{request_id}", body)
 
     # -- Cancellation (Stop cascade) --------------------------------------
@@ -719,12 +749,12 @@ class ApprovalEngine:
         (system transition).
         """
         cancelled = await pg.cancel_pending_approvals_for_job(job_id)
-        for req_id in cancelled:
-            req = await pg.get_approval_request(req_id)
+        for req_id, tenant_id in cancelled:
+            req = await pg.get_approval_request(req_id, tenant_id=tenant_id)
             if req is None:
                 continue
             await self._send_to_origin(req, format_cancelled_message(req))
-        return cancelled
+        return [req_id for req_id, _ in cancelled]
 
     # -- Maintenance loops -----------------------------------------------
 
@@ -737,7 +767,9 @@ class ApprovalEngine:
         expired = await pg.list_expired_pending_approvals()
         count = 0
         for req in expired:
-            updated = await pg.expire_approval_if_pending(req.id)
+            updated = await pg.expire_approval_if_pending(
+                req.id, tenant_id=req.tenant_id
+            )
             if updated is None:
                 # A concurrent decide won the CAS — skip silently.
                 continue
@@ -754,12 +786,16 @@ class ApprovalEngine:
         ):
             # Republish with explicit status so the Worker's default-
             # to-approved behavior is not load-bearing here either.
-            await self._publish_decided(req.id, status="approved", note=None)
+            await self._publish_decided(
+                req.id, tenant_id=req.tenant_id, status="approved", note=None
+            )
             republished += 1
         for req in await pg.list_stuck_executing_approvals(
             older_than_seconds=_RECONCILE_EXECUTING_GRACE_S
         ):
-            transitioned = await pg.set_approval_status(req.id, "execution_stale")
+            transitioned = await pg.set_approval_status(
+                req.id, "execution_stale", tenant_id=req.tenant_id
+            )
             if transitioned is None:
                 continue
             stale += 1

--- a/src/rolemesh/approval/executor.py
+++ b/src/rolemesh/approval/executor.py
@@ -151,11 +151,37 @@ class ApprovalWorker:
         except (UnicodeDecodeError, json.JSONDecodeError):
             body = {}
         status = str(body.get("status") or "approved")
+        # tenant_id is encoded in the publish payload by the engine so
+        # subsequent DB lookups can be tenant-scoped without trusting
+        # the bare request_id from the subject.
+        tenant_id = body.get("tenant_id")
+        if not tenant_id:
+            # Legacy message: published by the OLD orchestrator before
+            # tenant_id was added to the body. Resolve tenant_id from
+            # the row itself — the Worker is trusted code consuming
+            # orchestrator-published ids, so the row's own tenant_id
+            # is authoritative. Without this fallback, in-flight
+            # messages at upgrade time would be silently dropped and
+            # users' approved actions would never execute (eventually
+            # surfaced by the reconcile loop, but with a notification
+            # gap).
+            tenant_id = await pg.resolve_request_tenant(request_id)
+            if tenant_id is None:
+                logger.warning(
+                    "approval worker: legacy decided message references unknown request",
+                    request_id=request_id,
+                )
+                await msg.ack()
+                return
+            logger.info(
+                "approval worker: recovered tenant_id for legacy decided message",
+                request_id=request_id,
+            )
 
         if status == "rejected":
             # The engine has already written the 'rejected' state + audit.
             # We just deliver the notification.
-            req = await pg.get_approval_request(request_id)
+            req = await pg.get_approval_request(request_id, tenant_id=tenant_id)
             if req is not None and req.conversation_id:
                 try:
                     await self._channel.send_to_conversation(
@@ -177,7 +203,9 @@ class ApprovalWorker:
             return
 
         # status == "approved": claim and execute.
-        req = await pg.claim_approval_for_execution(request_id)
+        req = await pg.claim_approval_for_execution(
+            request_id, tenant_id=tenant_id
+        )
         if req is None:
             # Another Worker got it first, or the state moved on. Ack so
             # JetStream does not redeliver indefinitely.
@@ -200,7 +228,10 @@ class ApprovalWorker:
         # Pass metadata through the CRUD call so the trigger attaches it
         # to the terminal audit row in the same transaction.
         await pg.set_approval_status(
-            request_id, terminal, metadata={"results": results}
+            request_id,
+            terminal,
+            tenant_id=tenant_id,
+            metadata={"results": results},
         )
         if req.conversation_id:
             try:

--- a/src/rolemesh/approval/types.py
+++ b/src/rolemesh/approval/types.py
@@ -102,6 +102,7 @@ class ApprovalAuditEntry:
     """
 
     id: str
+    tenant_id: str
     request_id: str
     action: str
     actor_user_id: str | None

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -434,26 +434,67 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "ON approval_requests(status, updated_at) WHERE status = 'executing'"
     )
 
-    await conn.execute("""
-        CREATE TABLE IF NOT EXISTS approval_audit_log (
-            id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            request_id    UUID NOT NULL REFERENCES approval_requests(id) ON DELETE CASCADE,
-            action        TEXT NOT NULL
-                CHECK (action IN (
-                    'created', 'approved', 'rejected', 'expired', 'cancelled',
-                    'skipped', 'executing', 'executed',
-                    'execution_failed', 'execution_stale'
-                )),
-            actor_user_id UUID REFERENCES users(id),
-            note          TEXT,
-            metadata      JSONB,
-            created_at    TIMESTAMPTZ DEFAULT now()
+    # tenant_id is denormalised onto the audit row (the canonical value
+    # lives on approval_requests) so that cross-tenant audit reads can
+    # be rejected at the SQL layer without a JOIN. The trigger below
+    # copies tenant_id from the parent row on every INSERT, which is
+    # cheaper than the alternative of always joining at query time —
+    # audit reads happen on a hot REST path.
+    #
+    # The CREATE TABLE / column-add / backfill / SET NOT NULL block runs
+    # inside a transaction so that an in-place upgrade is atomic. Without
+    # this, a concurrent INSERT through the OLD trigger between
+    # ``ADD COLUMN`` and ``SET NOT NULL`` would leave a NULL-tenant row
+    # that fails the NOT NULL promotion. Single-instance startup makes
+    # the race unlikely, but multi-instance rolling deploys would hit it.
+    async with conn.transaction():
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS approval_audit_log (
+                id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                tenant_id     UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+                request_id    UUID NOT NULL REFERENCES approval_requests(id) ON DELETE CASCADE,
+                action        TEXT NOT NULL
+                    CHECK (action IN (
+                        'created', 'approved', 'rejected', 'expired', 'cancelled',
+                        'skipped', 'executing', 'executed',
+                        'execution_failed', 'execution_stale'
+                    )),
+                actor_user_id UUID REFERENCES users(id),
+                note          TEXT,
+                metadata      JSONB,
+                created_at    TIMESTAMPTZ DEFAULT now()
+            )
+        """)
+        # In-place upgrade for databases created before tenant_id was
+        # introduced. Add nullable → backfill from parent → set NOT NULL.
+        # Idempotent against repeat startups (ADD COLUMN IF NOT EXISTS
+        # short-circuits once the column exists; the UPDATE filters
+        # WHERE tenant_id IS NULL so backfilled rows are skipped).
+        await conn.execute(
+            "ALTER TABLE approval_audit_log "
+            "ADD COLUMN IF NOT EXISTS tenant_id UUID "
+            "REFERENCES tenants(id) ON DELETE CASCADE"
         )
-    """)
-    await conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_audit_log_request "
-        "ON approval_audit_log(request_id)"
-    )
+        await conn.execute(
+            "UPDATE approval_audit_log al "
+            "SET tenant_id = ar.tenant_id "
+            "FROM approval_requests ar "
+            "WHERE al.request_id = ar.id AND al.tenant_id IS NULL"
+        )
+        await conn.execute(
+            "ALTER TABLE approval_audit_log "
+            "ALTER COLUMN tenant_id SET NOT NULL"
+        )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_audit_log_request "
+            "ON approval_audit_log(request_id)"
+        )
+        # Composite index keeps tenant-scoped audit reads fast: index
+        # seek on (tenant_id, request_id) then sorted scan on created_at.
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_audit_log_tenant_request "
+            "ON approval_audit_log(tenant_id, request_id, created_at)"
+        )
 
     # ---------------------------------------------------------------------
     # Audit trigger: every INSERT or status-change UPDATE on
@@ -507,11 +548,13 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
 
             IF TG_OP = 'INSERT' THEN
                 -- Every INSERT is a "created" row, attributed to the
-                -- caller (v_actor_uuid) when provided.
+                -- caller (v_actor_uuid) when provided. tenant_id is
+                -- copied from the parent row so audit reads can filter
+                -- by tenant without a JOIN.
                 INSERT INTO approval_audit_log
-                    (request_id, action, actor_user_id, note, metadata)
+                    (tenant_id, request_id, action, actor_user_id, note, metadata)
                 VALUES
-                    (NEW.id, 'created', v_actor_uuid,
+                    (NEW.tenant_id, NEW.id, 'created', v_actor_uuid,
                      NULLIF(v_note, ''), v_meta_json);
                 -- Rows created already in a terminal-ish state (e.g.
                 -- 'skipped' when resolve_approvers returned empty) need
@@ -522,15 +565,15 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
                 -- chosen "skipped."
                 IF NEW.status <> 'pending' THEN
                     INSERT INTO approval_audit_log
-                        (request_id, action, actor_user_id, note, metadata)
+                        (tenant_id, request_id, action, actor_user_id, note, metadata)
                     VALUES
-                        (NEW.id, NEW.status, NULL, NULL, '{}'::jsonb);
+                        (NEW.tenant_id, NEW.id, NEW.status, NULL, NULL, '{}'::jsonb);
                 END IF;
             ELSIF TG_OP = 'UPDATE' AND NEW.status <> OLD.status THEN
                 INSERT INTO approval_audit_log
-                    (request_id, action, actor_user_id, note, metadata)
+                    (tenant_id, request_id, action, actor_user_id, note, metadata)
                 VALUES
-                    (NEW.id, NEW.status, v_actor_uuid,
+                    (NEW.tenant_id, NEW.id, NEW.status, v_actor_uuid,
                      NULLIF(v_note, ''), v_meta_json);
             END IF;
             RETURN NEW;
@@ -2490,11 +2533,24 @@ async def create_approval_policy(
     return _record_to_approval_policy(row)
 
 
-async def get_approval_policy(policy_id: str) -> ApprovalPolicy | None:
+async def get_approval_policy(
+    policy_id: str, *, tenant_id: str
+) -> ApprovalPolicy | None:
+    """Fetch a policy by id, scoped to ``tenant_id``.
+
+    The tenant filter is enforced at the SQL layer so a forged or
+    guessed UUID from another tenant returns None instead of leaking
+    the policy. Callers that already validated tenant ownership at
+    a higher layer can keep their existing checks; this function is
+    the lower bound, not the only line of defense.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM approval_policies WHERE id = $1::uuid", policy_id
+            "SELECT * FROM approval_policies "
+            "WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            policy_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -2556,6 +2612,7 @@ async def get_enabled_policies_for_coworker(
 async def update_approval_policy(
     policy_id: str,
     *,
+    tenant_id: str,
     mcp_server_name: str | None = None,
     tool_name: str | None = None,
     condition_expr: dict[str, Any] | None = None,
@@ -2566,7 +2623,12 @@ async def update_approval_policy(
     enabled: bool | None = None,
     priority: int | None = None,
 ) -> ApprovalPolicy | None:
-    """Update selected fields on a policy; returns the new row or None."""
+    """Update selected fields on a policy; returns the new row or None.
+
+    Both the SELECT (no-fields path) and the UPDATE filter on
+    ``tenant_id``, so a forged policy_id from another tenant has no
+    effect.
+    """
     fields: list[str] = []
     values: list[Any] = []
     idx = 1
@@ -2597,14 +2659,16 @@ async def update_approval_policy(
         _push("priority = ${i}", priority)
 
     if not fields:
-        return await get_approval_policy(policy_id)
+        return await get_approval_policy(policy_id, tenant_id=tenant_id)
 
     fields.append("updated_at = now()")
     values.append(policy_id)
+    values.append(tenant_id)
     sql = (
         "UPDATE approval_policies SET "
         + ", ".join(fields)
-        + f" WHERE id = ${idx}::uuid RETURNING *"
+        + f" WHERE id = ${idx}::uuid AND tenant_id = ${idx + 1}::uuid "
+        "RETURNING *"
     )
     pool = _get_pool()
     async with pool.acquire() as conn:
@@ -2614,12 +2678,21 @@ async def update_approval_policy(
     return _record_to_approval_policy(row)
 
 
-async def delete_approval_policy(policy_id: str) -> bool:
-    """Hard-delete a policy. Returns True if a row was removed."""
+async def delete_approval_policy(policy_id: str, *, tenant_id: str) -> bool:
+    """Hard-delete a policy scoped to ``tenant_id``. Returns True if
+    a row was removed.
+
+    A delete request for a policy id that belongs to another tenant
+    returns False (no rows affected) without raising — same shape as
+    "policy id does not exist".
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         result = await conn.execute(
-            "DELETE FROM approval_policies WHERE id = $1::uuid", policy_id
+            "DELETE FROM approval_policies "
+            "WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            policy_id,
+            tenant_id,
         )
     return result.endswith(" 1")
 
@@ -2752,11 +2825,48 @@ async def create_approval_request(
     return _record_to_approval_request(row)
 
 
-async def get_approval_request(request_id: str) -> ApprovalRequest | None:
+async def resolve_request_tenant(request_id: str) -> str | None:
+    """Look up a request's tenant_id by request_id alone.
+
+    System-only escape hatch. The single legitimate caller is the
+    approval Worker's NATS message handler, which needs to recover
+    tenant_id when processing legacy messages published before the
+    tenant-id-in-body protocol was introduced. The Worker is a trusted
+    orchestrator-internal process and the request_id is taken from
+    the orchestrator-published NATS subject, so trusting the row's
+    own tenant_id is acceptable here.
+
+    DO NOT use this from REST handlers or any code path that consumes
+    user-controlled ids. The return value carries authority — pair it
+    with a tenant-scoped get_approval_request call once you have it.
+
+    Returns None if the request_id does not exist.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM approval_requests WHERE id = $1::uuid", request_id
+            "SELECT tenant_id FROM approval_requests WHERE id = $1::uuid",
+            request_id,
+        )
+    if row is None:
+        return None
+    return str(row["tenant_id"])
+
+
+async def get_approval_request(
+    request_id: str, *, tenant_id: str
+) -> ApprovalRequest | None:
+    """Fetch a request by id, scoped to ``tenant_id``.
+
+    See ``get_approval_policy`` for the tenant-filter rationale.
+    """
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM approval_requests "
+            "WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            request_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -2846,6 +2956,7 @@ class DecisionOutcome:
 async def decide_approval_request_full(
     request_id: str,
     *,
+    tenant_id: str,
     new_status: str,
     actor_user_id: str,
     note: str | None = None,
@@ -2856,6 +2967,11 @@ async def decide_approval_request_full(
     conditional UPDATE in the same statement, and return both — one
     round trip instead of two, and no race window where the status
     changes between two separate reads.
+
+    Both the pre-UPDATE SELECT and the UPDATE filter on
+    ``tenant_id``, so a forged request_id from another tenant is
+    indistinguishable from "request not found" — DecisionOutcome
+    kind="missing".
 
     Also sets the GUCs inside the same transaction so the audit trigger
     records the approver as the actor_user_id on the 'approved' /
@@ -2871,7 +2987,7 @@ async def decide_approval_request_full(
             WITH before AS (
                 SELECT id, status, resolved_approvers
                 FROM approval_requests
-                WHERE id = $2::uuid
+                WHERE id = $2::uuid AND tenant_id = $4::uuid
                 FOR UPDATE
             ),
             upd AS (
@@ -2891,6 +3007,7 @@ async def decide_approval_request_full(
             new_status,
             request_id,
             actor_user_id,
+            tenant_id,
         )
     if row is None:
         return DecisionOutcome(kind="missing")
@@ -2903,7 +3020,7 @@ async def decide_approval_request_full(
             updated_raw = json.loads(updated_raw)
         # row_to_json strips column types; fetch the real row to get
         # datetime objects decoded correctly.
-        updated = await get_approval_request(request_id)
+        updated = await get_approval_request(request_id, tenant_id=tenant_id)
         return DecisionOutcome(kind="updated", request=updated)
     if before_status != "pending":
         return DecisionOutcome(kind="conflict", current_status=before_status)
@@ -2911,8 +3028,10 @@ async def decide_approval_request_full(
     return DecisionOutcome(kind="forbidden", current_status=before_status)
 
 
-async def claim_approval_for_execution(request_id: str) -> ApprovalRequest | None:
-    """Atomic claim: approved → executing.
+async def claim_approval_for_execution(
+    request_id: str, *, tenant_id: str
+) -> ApprovalRequest | None:
+    """Atomic claim: approved → executing, scoped to ``tenant_id``.
 
     The Worker uses this to take exclusive ownership before hitting the
     MCP server. If two Workers race, only one sees the row returned; the
@@ -2932,10 +3051,13 @@ async def claim_approval_for_execution(request_id: str) -> ApprovalRequest | Non
             """
             UPDATE approval_requests
             SET status = 'executing', updated_at = now()
-            WHERE id = $1::uuid AND status = 'approved'
+            WHERE id = $1::uuid
+              AND tenant_id = $2::uuid
+              AND status = 'approved'
             RETURNING *
             """,
             request_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -2946,13 +3068,14 @@ async def set_approval_status(
     request_id: str,
     status: str,
     *,
+    tenant_id: str,
     actor_user_id: str | None = None,
     note: str | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> ApprovalRequest | None:
-    """Unconditional status update. Used for system transitions that do
-    not race (e.g. executing → executed by the Worker that already
-    holds the claim).
+    """Unconditional status update scoped to ``tenant_id``. Used for
+    system transitions that do not race (e.g. executing → executed
+    by the Worker that already holds the claim).
 
     ``actor_user_id`` / ``note`` / ``metadata`` flow through to the
     audit trigger's 'status-change' row.
@@ -2969,22 +3092,31 @@ async def set_approval_status(
             """
             UPDATE approval_requests
             SET status = $1, updated_at = now()
-            WHERE id = $2::uuid
+            WHERE id = $2::uuid AND tenant_id = $3::uuid
             RETURNING *
             """,
             status,
             request_id,
+            tenant_id,
         )
     if row is None:
         return None
     return _record_to_approval_request(row)
 
 
-async def cancel_pending_approvals_for_job(job_id: str) -> list[str]:
+async def cancel_pending_approvals_for_job(
+    job_id: str,
+) -> list[tuple[str, str]]:
     """Move all pending approvals for a job_id to 'cancelled'.
 
-    Returns the IDs of the rows that transitioned, so the caller can
-    write one audit row per cancellation and notify approvers.
+    Returns ``(id, tenant_id)`` tuples for each row that transitioned,
+    so the caller can re-fetch the row scoped to the right tenant and
+    notify approvers without trusting the bare request id.
+
+    job_id is globally unique (orchestrator-issued, includes coworker
+    folder + epoch), so this UPDATE remains job-scoped without an
+    explicit tenant filter; the tenant_id we return is the
+    authoritative value from the row itself.
     """
     pool = _get_pool()
     async with pool.acquire() as conn:
@@ -2993,11 +3125,11 @@ async def cancel_pending_approvals_for_job(job_id: str) -> list[str]:
             UPDATE approval_requests
             SET status = 'cancelled', updated_at = now()
             WHERE job_id = $1 AND status = 'pending'
-            RETURNING id
+            RETURNING id, tenant_id
             """,
             job_id,
         )
-    return [str(r["id"]) for r in rows]
+    return [(str(r["id"]), str(r["tenant_id"])) for r in rows]
 
 
 async def list_expired_pending_approvals() -> list[ApprovalRequest]:
@@ -3068,6 +3200,7 @@ def _record_to_audit_entry(row: asyncpg.Record) -> ApprovalAuditEntry:
         meta = json.loads(meta) if meta else {}
     return ApprovalAuditEntry(
         id=str(row["id"]),
+        tenant_id=str(row["tenant_id"]),
         request_id=str(row["request_id"]),
         action=row["action"],
         actor_user_id=str(row["actor_user_id"]) if row["actor_user_id"] else None,
@@ -3079,6 +3212,7 @@ def _record_to_audit_entry(row: asyncpg.Record) -> ApprovalAuditEntry:
 
 async def write_approval_audit(
     *,
+    tenant_id: str,
     request_id: str,
     action: str,
     actor_user_id: str | None = None,
@@ -3087,15 +3221,25 @@ async def write_approval_audit(
 ) -> ApprovalAuditEntry:
     """Append a single audit row. There is deliberately no update or
     delete counterpart — the whole point of the audit table is that
-    rows are immutable once written."""
+    rows are immutable once written.
+
+    ``tenant_id`` is required and stored on the audit row so that audit
+    reads can be filtered by tenant without a JOIN. Callers must pass
+    the parent request's tenant_id; mismatches will not be detected
+    here (FK only validates request_id existence) but reads via
+    ``list_approval_audit`` filter on tenant_id, so a mis-attributed
+    row would simply be invisible to its rightful tenant.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            INSERT INTO approval_audit_log (request_id, action, actor_user_id, note, metadata)
-            VALUES ($1::uuid, $2, $3::uuid, $4, $5::jsonb)
+            INSERT INTO approval_audit_log
+                (tenant_id, request_id, action, actor_user_id, note, metadata)
+            VALUES ($1::uuid, $2::uuid, $3, $4::uuid, $5, $6::jsonb)
             RETURNING *
             """,
+            tenant_id,
             request_id,
             action,
             actor_user_id,
@@ -3106,19 +3250,33 @@ async def write_approval_audit(
     return _record_to_audit_entry(row)
 
 
-async def list_approval_audit(request_id: str) -> list[ApprovalAuditEntry]:
+async def list_approval_audit(
+    request_id: str, *, tenant_id: str
+) -> list[ApprovalAuditEntry]:
+    """Return audit rows for a request, scoped to ``tenant_id``.
+
+    Filtering by tenant_id at the SQL layer means a forged or guessed
+    request_id from another tenant returns an empty list rather than
+    leaking audit history. The composite index
+    ``idx_audit_log_tenant_request`` keeps this fast.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT * FROM approval_audit_log WHERE request_id = $1::uuid "
+            "SELECT * FROM approval_audit_log "
+            "WHERE request_id = $1::uuid AND tenant_id = $2::uuid "
             "ORDER BY created_at ASC",
             request_id,
+            tenant_id,
         )
     return [_record_to_audit_entry(r) for r in rows]
 
 
-async def expire_approval_if_pending(request_id: str) -> ApprovalRequest | None:
-    """Atomic pending → expired with the CAS guard kept in one place.
+async def expire_approval_if_pending(
+    request_id: str, *, tenant_id: str
+) -> ApprovalRequest | None:
+    """Atomic pending → expired scoped to ``tenant_id``, with the CAS
+    guard kept in one place.
 
     Separate from set_approval_status because the maintenance loop
     must not trample a concurrent decide_approval_request.
@@ -3129,10 +3287,13 @@ async def expire_approval_if_pending(request_id: str) -> ApprovalRequest | None:
             """
             UPDATE approval_requests
             SET status = 'expired', updated_at = now()
-            WHERE id = $1::uuid AND status = 'pending'
+            WHERE id = $1::uuid
+              AND tenant_id = $2::uuid
+              AND status = 'pending'
             RETURNING *
             """,
             request_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -3229,11 +3390,20 @@ async def create_safety_rule(
     return _record_to_safety_rule(row)
 
 
-async def get_safety_rule(rule_id: str) -> SafetyRule | None:
+async def get_safety_rule(
+    rule_id: str, *, tenant_id: str
+) -> SafetyRule | None:
+    """Fetch a safety rule by id, scoped to ``tenant_id``.
+
+    See ``get_approval_policy`` for the tenant-filter rationale.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM safety_rules WHERE id = $1::uuid", rule_id
+            "SELECT * FROM safety_rules "
+            "WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            rule_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -3298,6 +3468,7 @@ async def list_safety_rules_for_coworker(
 async def update_safety_rule(
     rule_id: str,
     *,
+    tenant_id: str,
     stage: str | None = None,
     check_id: str | None = None,
     config: dict[str, Any] | None = None,
@@ -3346,14 +3517,16 @@ async def update_safety_rule(
         _push("description = ${i}", description)
 
     if not fields:
-        return await get_safety_rule(rule_id)
+        return await get_safety_rule(rule_id, tenant_id=tenant_id)
 
     fields.append("updated_at = now()")
     values.append(rule_id)
+    values.append(tenant_id)
     sql = (
         "UPDATE safety_rules SET "
         + ", ".join(fields)
-        + f" WHERE id = ${idx}::uuid RETURNING *"
+        + f" WHERE id = ${idx}::uuid AND tenant_id = ${idx + 1}::uuid "
+        "RETURNING *"
     )
     pool = _get_pool()
     async with pool.acquire() as conn, conn.transaction():
@@ -3365,9 +3538,10 @@ async def update_safety_rule(
 
 
 async def delete_safety_rule(
-    rule_id: str, *, actor_user_id: str | None = None
+    rule_id: str, *, tenant_id: str, actor_user_id: str | None = None
 ) -> bool:
-    """Hard-delete a rule. Returns True if a row was removed.
+    """Hard-delete a rule scoped to ``tenant_id``. Returns True if a
+    row was removed.
 
     The audit trigger captures the row's pre-delete state in
     before_state so the deleted rule is reconstructable forever.
@@ -3376,7 +3550,10 @@ async def delete_safety_rule(
     async with pool.acquire() as conn, conn.transaction():
         await _set_safety_guc(conn, actor_user_id=actor_user_id)
         result = await conn.execute(
-            "DELETE FROM safety_rules WHERE id = $1::uuid", rule_id
+            "DELETE FROM safety_rules "
+            "WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            rule_id,
+            tenant_id,
         )
     return result.endswith(" 1")
 

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -689,8 +689,8 @@ async def get_approval_policy_ep(
     policy_id: str,
     user: AdminUser,
 ) -> ApprovalPolicyResponse:
-    p = await pg.get_approval_policy(policy_id)
-    if p is None or p.tenant_id != user.tenant_id:
+    p = await pg.get_approval_policy(policy_id, tenant_id=user.tenant_id)
+    if p is None:
         raise HTTPException(status_code=404, detail="Policy not found")
     return _policy_to_response(p)
 
@@ -703,11 +703,12 @@ async def update_approval_policy_ep(
     body: ApprovalPolicyUpdate,
     user: AdminUser,
 ) -> ApprovalPolicyResponse:
-    existing = await pg.get_approval_policy(policy_id)
-    if existing is None or existing.tenant_id != user.tenant_id:
+    existing = await pg.get_approval_policy(policy_id, tenant_id=user.tenant_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Policy not found")
     updated = await pg.update_approval_policy(
         policy_id,
+        tenant_id=user.tenant_id,
         mcp_server_name=body.mcp_server_name,
         tool_name=body.tool_name,
         condition_expr=body.condition_expr,
@@ -728,10 +729,10 @@ async def delete_approval_policy_ep(
     policy_id: str,
     user: AdminUser,
 ) -> None:
-    existing = await pg.get_approval_policy(policy_id)
-    if existing is None or existing.tenant_id != user.tenant_id:
+    existing = await pg.get_approval_policy(policy_id, tenant_id=user.tenant_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Policy not found")
-    await pg.delete_approval_policy(policy_id)
+    await pg.delete_approval_policy(policy_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------
@@ -795,10 +796,10 @@ async def get_approval_ep(
     request_id: str,
     user: AuthedUser,
 ) -> ApprovalRequestDetailResponse:
-    req = await pg.get_approval_request(request_id)
-    if req is None or req.tenant_id != user.tenant_id:
+    req = await pg.get_approval_request(request_id, tenant_id=user.tenant_id)
+    if req is None:
         raise HTTPException(status_code=404, detail="Approval not found")
-    audit = await pg.list_approval_audit(request_id)
+    audit = await pg.list_approval_audit(request_id, tenant_id=user.tenant_id)
     return ApprovalRequestDetailResponse(
         **_request_to_response(req).model_dump(),
         audit_log=[_audit_to_response(e) for e in audit],
@@ -813,10 +814,10 @@ async def get_approval_audit_ep(
     request_id: str,
     user: AuthedUser,
 ) -> list[ApprovalAuditEntryResponse]:
-    req = await pg.get_approval_request(request_id)
-    if req is None or req.tenant_id != user.tenant_id:
+    req = await pg.get_approval_request(request_id, tenant_id=user.tenant_id)
+    if req is None:
         raise HTTPException(status_code=404, detail="Approval not found")
-    rows = await pg.list_approval_audit(request_id)
+    rows = await pg.list_approval_audit(request_id, tenant_id=user.tenant_id)
     return [_audit_to_response(r) for r in rows]
 
 
@@ -847,12 +848,13 @@ async def decide_approval_ep(
     user: AuthedUser,
 ) -> ApprovalRequestResponse:
     engine = _require_engine()
-    req = await pg.get_approval_request(request_id)
-    if req is None or req.tenant_id != user.tenant_id:
+    req = await pg.get_approval_request(request_id, tenant_id=user.tenant_id)
+    if req is None:
         raise HTTPException(status_code=404, detail="Approval not found")
     try:
         updated = await engine.handle_decision(
             request_id=request_id,
+            tenant_id=user.tenant_id,
             action=body.action,
             user_id=user.user_id,
             note=_sanitize_note(body.note),
@@ -1083,8 +1085,8 @@ async def get_safety_rule_ep(
     rule_id: str,
     user: AdminUser,
 ) -> SafetyRuleResponse:
-    r = await pg.get_safety_rule(rule_id)
-    if r is None or r.tenant_id != user.tenant_id:
+    r = await pg.get_safety_rule(rule_id, tenant_id=user.tenant_id)
+    if r is None:
         raise HTTPException(status_code=404, detail="Rule not found")
     return _safety_rule_to_response(r)
 
@@ -1097,8 +1099,8 @@ async def update_safety_rule_ep(
     body: SafetyRuleUpdate,
     user: AdminUser,
 ) -> SafetyRuleResponse:
-    existing = await pg.get_safety_rule(rule_id)
-    if existing is None or existing.tenant_id != user.tenant_id:
+    existing = await pg.get_safety_rule(rule_id, tenant_id=user.tenant_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Rule not found")
 
     # Re-validate when either check_id or stage changes: the stage must
@@ -1119,6 +1121,7 @@ async def update_safety_rule_ep(
 
     updated = await pg.update_safety_rule(
         rule_id,
+        tenant_id=user.tenant_id,
         stage=body.stage,
         check_id=body.check_id,
         config=body.config,
@@ -1138,10 +1141,12 @@ async def delete_safety_rule_ep(
     rule_id: str,
     user: AdminUser,
 ) -> None:
-    existing = await pg.get_safety_rule(rule_id)
-    if existing is None or existing.tenant_id != user.tenant_id:
+    existing = await pg.get_safety_rule(rule_id, tenant_id=user.tenant_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Rule not found")
-    await pg.delete_safety_rule(rule_id, actor_user_id=user.user_id)
+    await pg.delete_safety_rule(
+        rule_id, tenant_id=user.tenant_id, actor_user_id=user.user_id
+    )
     await _publish_rule_changed("deleted", existing)
 
 

--- a/tests/approval/e2e/test_e2e_dedup_lifecycle.py
+++ b/tests/approval/e2e/test_e2e_dedup_lifecycle.py
@@ -77,7 +77,7 @@ async def test_dedup_does_not_suppress_retry_after_rejection(
         assert r.status_code == 200
 
     async def _row1_rejected() -> bool:
-        fresh = await pg.get_approval_request(row1.id)
+        fresh = await pg.get_approval_request(row1.id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status == "rejected"
 
     await harness.wait_for(_row1_rejected, timeout=5.0)

--- a/tests/approval/e2e/test_e2e_expire_race.py
+++ b/tests/approval/e2e/test_e2e_expire_race.py
@@ -109,10 +109,10 @@ async def test_concurrent_expire_and_approve_yield_single_terminal(
     # call sees zero rows to touch. Only the terminal DB state is
     # load-bearing for correctness.
     if decide_status == 200:
-        fresh = await pg.get_approval_request(req.id)
+        fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
         assert fresh is not None and fresh.status == "approved"
     elif decide_status == 409:
-        fresh = await pg.get_approval_request(req.id)
+        fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
         assert fresh is not None and fresh.status == "expired"
     else:
         pytest.fail(
@@ -124,7 +124,7 @@ async def test_concurrent_expire_and_approve_yield_single_terminal(
     # No matter who won, audit must contain exactly one terminal row
     # for this request.
     audit_actions = [
-        e.action for e in await pg.list_approval_audit(req.id)
+        e.action for e in await pg.list_approval_audit(req.id, tenant_id=seed.tenant_id)
     ]
     terminals = [
         a for a in audit_actions if a in ("approved", "expired", "rejected")

--- a/tests/approval/e2e/test_e2e_happy_path.py
+++ b/tests/approval/e2e/test_e2e_happy_path.py
@@ -160,12 +160,12 @@ async def test_happy_path_proposal_approve_execute_report(
 
     # 8. Final DB state + full audit chain.
     async def _executed() -> bool:
-        req = await pg.get_approval_request(pending.id)
+        req = await pg.get_approval_request(pending.id, tenant_id=seed.tenant_id)
         return req is not None and req.status == "executed"
 
     await harness.wait_for(_executed, timeout=5.0)
 
-    audit = await pg.list_approval_audit(pending.id)
+    audit = await pg.list_approval_audit(pending.id, tenant_id=seed.tenant_id)
     actions = [e.action for e in audit]
     assert actions == ["created", "approved", "executing", "executed"], (
         f"audit chain mismatch: {actions!r}"

--- a/tests/approval/e2e/test_e2e_long_batch.py
+++ b/tests/approval/e2e/test_e2e_long_batch.py
@@ -113,7 +113,7 @@ async def test_long_batch_does_not_redeliver_or_double_execute(
 
     # Final status: executed.
     async def _executed() -> bool:
-        fresh = await pg.get_approval_request(req.id)
+        fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status == "executed"
 
     await harness.wait_for(_executed, timeout=5.0)

--- a/tests/approval/e2e/test_e2e_mcp_application_error.py
+++ b/tests/approval/e2e/test_e2e_mcp_application_error.py
@@ -114,14 +114,14 @@ async def test_mcp_jsonrpc_error_is_recorded_as_failure(
     # Wait for the Worker to write the terminal status. Whatever it is,
     # we will now assert the correct one.
     async def _terminal() -> bool:
-        fresh = await pg.get_approval_request(req.id)
+        fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status in (
             "executed",
             "execution_failed",
         )
 
     await harness.wait_for(_terminal, timeout=5.0)
-    fresh = await pg.get_approval_request(req.id)
+    fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
     assert fresh is not None
 
     # THE ASSERTION: a JSON-RPC application error MUST mark the batch
@@ -136,7 +136,7 @@ async def test_mcp_jsonrpc_error_is_recorded_as_failure(
 
     # And the audit metadata should record the JSON-RPC error text so an
     # operator diagnosing the request can see what went wrong.
-    audit = await pg.list_approval_audit(req.id)
+    audit = await pg.list_approval_audit(req.id, tenant_id=seed.tenant_id)
     terminal_entry = [e for e in audit if e.action == "execution_failed"]
     assert terminal_entry, "audit should include an execution_failed row"
     results = terminal_entry[0].metadata.get("results") or []

--- a/tests/approval/e2e/test_e2e_mixed_batch_report.py
+++ b/tests/approval/e2e/test_e2e_mixed_batch_report.py
@@ -101,14 +101,14 @@ async def test_mixed_batch_produces_readable_report(
     await harness.wait_for(_both_called, timeout=10.0)
 
     async def _terminal() -> bool:
-        fresh = await pg.get_approval_request(req.id)
+        fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status in (
             "executed",
             "execution_failed",
         )
 
     await harness.wait_for(_terminal, timeout=5.0)
-    fresh = await pg.get_approval_request(req.id)
+    fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
     assert fresh is not None
     assert fresh.status == "execution_failed", (
         "one HTTP 500 among the actions must flip the batch to "
@@ -117,7 +117,7 @@ async def test_mixed_batch_produces_readable_report(
 
     # The terminal audit row carries per-action results.
     audit = [
-        e for e in await pg.list_approval_audit(req.id)
+        e for e in await pg.list_approval_audit(req.id, tenant_id=seed.tenant_id)
         if e.action == "execution_failed"
     ]
     assert audit, "audit must contain execution_failed row"

--- a/tests/approval/e2e/test_e2e_no_match_default_mode.py
+++ b/tests/approval/e2e/test_e2e_no_match_default_mode.py
@@ -65,7 +65,7 @@ async def test_auto_execute_mode_runs_unsupervised(
     req_id = await _submit_unmatched_proposal(harness, seed)
 
     async def _executed() -> bool:
-        fresh = await pg.get_approval_request(req_id)
+        fresh = await pg.get_approval_request(req_id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status == "executed"
 
     await harness.wait_for(_executed, timeout=10.0)
@@ -82,7 +82,7 @@ async def test_require_approval_mode_blocks_unsupervised_execution(
     req_id = await _submit_unmatched_proposal(harness, seed)
 
     async def _skipped() -> bool:
-        fresh = await pg.get_approval_request(req_id)
+        fresh = await pg.get_approval_request(req_id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status == "skipped"
 
     await harness.wait_for(_skipped, timeout=5.0)
@@ -113,7 +113,7 @@ async def test_deny_mode_rejects_with_system_note(
     req_id = await _submit_unmatched_proposal(harness, seed)
 
     async def _rejected() -> bool:
-        fresh = await pg.get_approval_request(req_id)
+        fresh = await pg.get_approval_request(req_id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status == "rejected"
 
     await harness.wait_for(_rejected, timeout=5.0)
@@ -123,7 +123,7 @@ async def test_deny_mode_rejects_with_system_note(
     )
     # The rejection audit row carries the system note explaining why.
     audit = [
-        e for e in await pg.list_approval_audit(req_id)
+        e for e in await pg.list_approval_audit(req_id, tenant_id=seed.tenant_id)
         if e.action == "rejected"
     ]
     assert audit, "audit must include a rejected row"

--- a/tests/approval/e2e/test_e2e_race_stop_vs_proposal.py
+++ b/tests/approval/e2e/test_e2e_race_stop_vs_proposal.py
@@ -120,14 +120,14 @@ async def test_cancel_then_late_proposal_creates_orphan_that_expires(
         )
     await harness.engine.expire_stale_requests()
 
-    fresh = await pg.get_approval_request(row.id)
+    fresh = await pg.get_approval_request(row.id, tenant_id=seed.tenant_id)
     assert fresh is not None
     assert fresh.status == "expired", (
         f"orphan pending row must be reaped by expiry; got {fresh.status!r}"
     )
     # Audit captures the expire as a system transition.
     expired_audit = [
-        e for e in await pg.list_approval_audit(row.id)
+        e for e in await pg.list_approval_audit(row.id, tenant_id=seed.tenant_id)
         if e.action == "expired"
     ]
     assert len(expired_audit) == 1

--- a/tests/approval/e2e/test_e2e_reconcile.py
+++ b/tests/approval/e2e/test_e2e_reconcile.py
@@ -64,7 +64,7 @@ async def test_reconcile_republishes_stuck_approved_to_executed(
         expires_at=datetime.now(UTC) + timedelta(minutes=60),
     )
     # Flip to approved without publishing.
-    await pg.set_approval_status(req.id, "approved")
+    await pg.set_approval_status(req.id, "approved", tenant_id=seed.tenant_id)
 
     # Push updated_at into the past so the 60s grace window triggers.
     pool = pg._get_pool()  # noqa: SLF001
@@ -84,7 +84,7 @@ async def test_reconcile_republishes_stuck_approved_to_executed(
     await harness.wait_for(_mcp_hit, timeout=10.0)
 
     async def _executed() -> bool:
-        fresh = await pg.get_approval_request(req.id)
+        fresh = await pg.get_approval_request(req.id, tenant_id=seed.tenant_id)
         return fresh is not None and fresh.status == "executed"
 
     await harness.wait_for(_executed, timeout=5.0)
@@ -93,7 +93,7 @@ async def test_reconcile_republishes_stuck_approved_to_executed(
     # happen — reconcile's only job is to get the Worker running,
     # everything after that is the normal flow.
     audit_actions = [
-        e.action for e in await pg.list_approval_audit(req.id)
+        e.action for e in await pg.list_approval_audit(req.id, tenant_id=seed.tenant_id)
     ]
     assert "executing" in audit_actions
     assert "executed" in audit_actions

--- a/tests/approval/e2e/test_e2e_reject.py
+++ b/tests/approval/e2e/test_e2e_reject.py
@@ -103,13 +103,13 @@ async def test_reject_delivers_note_and_never_calls_mcp(
     )
 
     audit_actions = [
-        e.action for e in await pg.list_approval_audit(req.id)
+        e.action for e in await pg.list_approval_audit(req.id, tenant_id=seed.tenant_id)
     ]
     assert audit_actions == ["created", "rejected"], (
         f"audit chain mismatch: {audit_actions!r}"
     )
     rejected_entry = [
-        e for e in await pg.list_approval_audit(req.id) if e.action == "rejected"
+        e for e in await pg.list_approval_audit(req.id, tenant_id=seed.tenant_id) if e.action == "rejected"
     ][0]
     assert rejected_entry.actor_user_id == seed.owner_user_id
     assert rejected_entry.note is not None

--- a/tests/approval/e2e/test_e2e_skipped.py
+++ b/tests/approval/e2e/test_e2e_skipped.py
@@ -84,7 +84,7 @@ async def test_proposal_skipped_when_no_approver_configured(
 
     # Audit chain: created + skipped (trigger writes both on initial
     # non-pending INSERT).
-    audit = [e.action for e in await pg.list_approval_audit(row.id)]
+    audit = [e.action for e in await pg.list_approval_audit(row.id, tenant_id=t.id)]
     assert audit == ["created", "skipped"], audit
 
     # Origin got a "no approver" style notification.

--- a/tests/approval/test_abort_cascade.py
+++ b/tests/approval/test_abort_cascade.py
@@ -144,14 +144,14 @@ async def _seed_two_requests(job_id: str) -> tuple[str, str, str, str, str, str]
         key=lambda r: r.actions[0]["params"]["i"],
     )
     await engine.handle_decision(
-        request_id=reqs[1].id, action="approve", user_id=u.id
+        request_id=reqs[1].id, tenant_id=t.id, action="approve", user_id=u.id
     )
     return t.id, u.id, cw.id, c.id, reqs[0].id, reqs[1].id
 
 
 async def test_stop_cascade_cancels_pending_preserves_approved() -> None:
     job_id = "job-stop-1"
-    _tenant_id, _user_id, _cw, conv_id, pending_id, approved_id = await _seed_two_requests(job_id)
+    tenant_id, _user_id, _cw, conv_id, pending_id, approved_id = await _seed_two_requests(job_id)
 
     pub = _FakePublisher()
     ch = _FakeChannel()
@@ -163,14 +163,14 @@ async def test_stop_cascade_cancels_pending_preserves_approved() -> None:
     assert pending_id in cancelled
     assert approved_id not in cancelled
 
-    pending_after = await get_approval_request(pending_id)
-    approved_after = await get_approval_request(approved_id)
+    pending_after = await get_approval_request(pending_id, tenant_id=tenant_id)
+    approved_after = await get_approval_request(approved_id, tenant_id=tenant_id)
     assert pending_after is not None and pending_after.status == "cancelled"
     assert approved_after is not None and approved_after.status == "approved"
 
     # Audit trail for the cancelled row includes a cancelled entry with
     # a NULL actor (system transition).
-    audit = await list_approval_audit(pending_id)
+    audit = await list_approval_audit(pending_id, tenant_id=tenant_id)
     cancelled_entries = [e for e in audit if e.action == "cancelled"]
     assert len(cancelled_entries) == 1
     assert cancelled_entries[0].actor_user_id is None

--- a/tests/approval/test_db.py
+++ b/tests/approval/test_db.py
@@ -99,7 +99,7 @@ class TestPolicyCrud:
         assert p.priority == 10
         assert p.mcp_server_name == "erp"
 
-        fetched = await get_approval_policy(p.id)
+        fetched = await get_approval_policy(p.id, tenant_id=tenant_id)
         assert fetched is not None
         assert fetched.id == p.id
         assert fetched.condition_expr == {
@@ -153,7 +153,9 @@ class TestPolicyCrud:
             condition_expr={"always": True},
         )
         original_updated = p.updated_at
-        updated = await update_approval_policy(p.id, priority=99, enabled=False)
+        updated = await update_approval_policy(
+            p.id, tenant_id=tenant_id, priority=99, enabled=False
+        )
         assert updated is not None
         assert updated.priority == 99
         assert updated.enabled is False
@@ -170,8 +172,8 @@ class TestPolicyCrud:
             tool_name="refund",
             condition_expr={"always": True},
         )
-        assert await delete_approval_policy(p.id) is True
-        assert await get_approval_policy(p.id) is None
+        assert await delete_approval_policy(p.id, tenant_id=tenant_id) is True
+        assert await get_approval_policy(p.id, tenant_id=tenant_id) is None
 
     async def test_list_filters_by_coworker(self) -> None:
         tenant_id, _u, cw_id, _b, _c = await _chain()
@@ -261,10 +263,16 @@ class TestDecideAtomic:
             resolved_approvers=[user_id, other.id],
         )
         first = await decide_approval_request_full(
-            request_id, new_status="approved", actor_user_id=user_id
+            request_id,
+            tenant_id=tenant_id,
+            new_status="approved",
+            actor_user_id=user_id,
         )
         second = await decide_approval_request_full(
-            request_id, new_status="rejected", actor_user_id=other.id
+            request_id,
+            tenant_id=tenant_id,
+            new_status="rejected",
+            actor_user_id=other.id,
         )
         assert first.kind == "updated"
         assert first.request is not None and first.request.status == "approved"
@@ -289,7 +297,10 @@ class TestDecideAtomic:
             resolved_approvers=[user_id],
         )
         result = await decide_approval_request_full(
-            request_id, new_status="approved", actor_user_id=outsider.id
+            request_id,
+            tenant_id=tenant_id,
+            new_status="approved",
+            actor_user_id=outsider.id,
         )
         assert result.kind == "forbidden"
 
@@ -306,7 +317,10 @@ class TestDecideAtomic:
             status="approved",
         )
         result = await decide_approval_request_full(
-            request_id, new_status="approved", actor_user_id=user_id
+            request_id,
+            tenant_id=tenant_id,
+            new_status="approved",
+            actor_user_id=user_id,
         )
         assert result.kind == "conflict"
         assert result.current_status == "approved"
@@ -325,8 +339,8 @@ class TestClaimForExecution:
             resolved_approvers=[user_id],
             status="approved",
         )
-        first = await claim_approval_for_execution(request_id)
-        second = await claim_approval_for_execution(request_id)
+        first = await claim_approval_for_execution(request_id, tenant_id=tenant_id)
+        second = await claim_approval_for_execution(request_id, tenant_id=tenant_id)
         assert first is not None and first.status == "executing"
         assert second is None
 
@@ -342,7 +356,10 @@ class TestClaimForExecution:
             resolved_approvers=[user_id],
             status="pending",
         )
-        assert await claim_approval_for_execution(request_id) is None
+        assert (
+            await claim_approval_for_execution(request_id, tenant_id=tenant_id)
+            is None
+        )
 
 
 class TestCancelForJob:
@@ -371,8 +388,8 @@ class TestCancelForJob:
             action_hashes=["hash-2"],
         )
         cancelled = await cancel_pending_approvals_for_job("job-A")
-        assert cancelled == [pending_id]
-        after = await get_approval_request(approved_id)
+        assert cancelled == [(pending_id, tenant_id)]
+        after = await get_approval_request(approved_id, tenant_id=tenant_id)
         assert after is not None and after.status == "approved"
 
 
@@ -409,7 +426,7 @@ class TestDedupLookup:
             resolved_approvers=[user_id],
             action_hashes=["dedup-hash-2"],
         )
-        await set_approval_status(request_id, "rejected")
+        await set_approval_status(request_id, "rejected", tenant_id=tenant_id)
         found = await find_pending_request_by_action_hash(tenant_id, "dedup-hash-2")
         assert found is None
 
@@ -497,7 +514,7 @@ class TestAuditLog:
             policy_id,
             resolved_approvers=[user_id],
         )
-        entries = await list_approval_audit(request_id)
+        entries = await list_approval_audit(request_id, tenant_id=tenant_id)
         assert [e.action for e in entries] == ["created"]
 
     async def test_trigger_writes_status_change_on_update(self) -> None:
@@ -514,9 +531,13 @@ class TestAuditLog:
         # Transition pending → approved via set_approval_status; the
         # trigger writes the 'approved' row in the same transaction.
         await set_approval_status(
-            request_id, "approved", actor_user_id=user_id, note="looks good"
+            request_id,
+            "approved",
+            tenant_id=tenant_id,
+            actor_user_id=user_id,
+            note="looks good",
         )
-        entries = await list_approval_audit(request_id)
+        entries = await list_approval_audit(request_id, tenant_id=tenant_id)
         assert [e.action for e in entries] == ["created", "approved"]
         assert entries[1].actor_user_id == user_id
         assert entries[1].note == "looks good"
@@ -536,9 +557,9 @@ class TestAuditLog:
         # Worker path: executing → executed with metadata passed through.
         meta = {"results": [{"ok": True, "amount": 100}]}
         await set_approval_status(
-            request_id, "executed", metadata=meta
+            request_id, "executed", tenant_id=tenant_id, metadata=meta
         )
-        entries = await list_approval_audit(request_id)
+        entries = await list_approval_audit(request_id, tenant_id=tenant_id)
         # INSERT with status='executing' yields 2 rows (created + executing).
         # UPDATE to 'executed' yields 1 row with metadata.
         actions = [e.action for e in entries]

--- a/tests/approval/test_engine.py
+++ b/tests/approval/test_engine.py
@@ -311,7 +311,7 @@ class TestHandleProposal:
         reqs = await list_approval_requests(tenant_id)
         assert len(reqs) == 1
         assert reqs[0].status == "pending"
-        audit = await list_approval_audit(reqs[0].id)
+        audit = await list_approval_audit(reqs[0].id, tenant_id=reqs[0].tenant_id)
         assert [e.action for e in audit] == ["created"]
         assert audit[0].actor_user_id == user_id, (
             "proposal 'created' audit must record the originating user"
@@ -355,7 +355,7 @@ class TestHandleProposal:
         # flow (created, approved, executing, executed). Without this
         # the auto-executed path diverges from the trail shape admins
         # would expect to reconstruct from audit_log alone.
-        audit = await list_approval_audit(reqs[0].id)
+        audit = await list_approval_audit(reqs[0].id, tenant_id=reqs[0].tenant_id)
         assert [e.action for e in audit] == ["created", "approved"]
         assert audit[0].actor_user_id == user_id
         assert audit[1].actor_user_id is None, (
@@ -418,7 +418,7 @@ class TestHandleProposal:
         reqs = await list_approval_requests(t.id)
         assert len(reqs) == 1
         assert reqs[0].status == "skipped"
-        audit = await list_approval_audit(reqs[0].id)
+        audit = await list_approval_audit(reqs[0].id, tenant_id=reqs[0].tenant_id)
         assert [e.action for e in audit] == ["created", "skipped"]
         # Originating conversation was notified of the skip.
         assert any(conv.id == c for c, _t in ch.sent)
@@ -517,7 +517,7 @@ class TestAutoIntercept:
             }
         )
         reqs = await list_approval_requests(tenant_id)
-        audit = await list_approval_audit(reqs[0].id)
+        audit = await list_approval_audit(reqs[0].id, tenant_id=reqs[0].tenant_id)
         assert audit[0].action == "created"
         assert audit[0].actor_user_id is None
 
@@ -551,13 +551,16 @@ class TestDecision:
         req = (await list_approval_requests(tenant_id))[0]
 
         updated = await engine.handle_decision(
-            request_id=req.id, action="approve", user_id=user_id
+            request_id=req.id,
+            tenant_id=req.tenant_id,
+            action="approve",
+            user_id=user_id,
         )
         assert updated.status == "approved"
         assert any(
             s == f"approval.decided.{req.id}" for s, _d in pub.publishes
         )
-        audit = await list_approval_audit(req.id)
+        audit = await list_approval_audit(req.id, tenant_id=req.tenant_id)
         assert [e.action for e in audit] == ["created", "approved"]
         assert audit[1].actor_user_id == user_id
 
@@ -588,6 +591,7 @@ class TestDecision:
 
         await engine.handle_decision(
             request_id=req.id,
+            tenant_id=req.tenant_id,
             action="reject",
             user_id=user_id,
             note="not this quarter",
@@ -622,11 +626,17 @@ class TestDecision:
         )
         req = (await list_approval_requests(tenant_id))[0]
         await engine.handle_decision(
-            request_id=req.id, action="approve", user_id=user_id
+            request_id=req.id,
+            tenant_id=req.tenant_id,
+            action="approve",
+            user_id=user_id,
         )
         with pytest.raises(ConflictError):
             await engine.handle_decision(
-                request_id=req.id, action="reject", user_id=user_id
+                request_id=req.id,
+                tenant_id=req.tenant_id,
+                action="reject",
+                user_id=user_id,
             )
 
     async def test_non_approver_decide_raises_forbidden(self) -> None:
@@ -655,7 +665,10 @@ class TestDecision:
         req = (await list_approval_requests(tenant_id))[0]
         with pytest.raises(ForbiddenError):
             await engine.handle_decision(
-                request_id=req.id, action="approve", user_id=outsider.id
+                request_id=req.id,
+                tenant_id=req.tenant_id,
+                action="approve",
+                user_id=outsider.id,
             )
 
 
@@ -691,7 +704,10 @@ class TestCancelAndMaintenance:
         # Approve one.
         first_id = reqs[0].id
         await engine.handle_decision(
-            request_id=first_id, action="approve", user_id=user_id
+            request_id=first_id,
+            tenant_id=reqs[0].tenant_id,
+            action="approve",
+            user_id=user_id,
         )
         # Cancel the job.
         await engine.cancel_for_job(job_id)
@@ -728,9 +744,9 @@ class TestCancelAndMaintenance:
         engine, _pub, _ch = _engine()
         count = await engine.expire_stale_requests()
         assert count >= 1
-        after = await get_approval_request(req.id)
+        after = await get_approval_request(req.id, tenant_id=req.tenant_id)
         assert after is not None and after.status == "expired"
-        audit = await list_approval_audit(req.id)
+        audit = await list_approval_audit(req.id, tenant_id=req.tenant_id)
         assert any(e.action == "expired" and e.actor_user_id is None for e in audit)
 
     async def test_reconcile_republishes_stuck_approved(self) -> None:
@@ -806,9 +822,9 @@ class TestCancelAndMaintenance:
             )
         engine, _pub, _ch = _engine()
         await engine.reconcile_stuck_requests()
-        after = await get_approval_request(req.id)
+        after = await get_approval_request(req.id, tenant_id=req.tenant_id)
         assert after is not None and after.status == "execution_stale"
-        audit = await list_approval_audit(req.id)
+        audit = await list_approval_audit(req.id, tenant_id=req.tenant_id)
         assert any(e.action == "execution_stale" for e in audit)
 
 

--- a/tests/approval/test_executor.py
+++ b/tests/approval/test_executor.py
@@ -154,18 +154,18 @@ async def proxy_base():
 class TestApprovedExecution:
     async def test_execute_success_transitions_to_executed(self, proxy_base) -> None:
         base, recorder = proxy_base
-        req_id, conv_id, _user_id, _cw, _t = await _seed_request(status="approved")
+        req_id, conv_id, _user_id, _cw, tenant_id = await _seed_request(status="approved")
         ch = _FakeChannel()
         w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
         msg = _FakeMsg(
             subject=f"approval.decided.{req_id}",
-            data=json.dumps({"status": "approved"}).encode(),
+            data=json.dumps({"status": "approved", "tenant_id": tenant_id}).encode(),
         )
         await w._handle_message(msg)
 
-        req = await get_approval_request(req_id)
+        req = await get_approval_request(req_id, tenant_id=tenant_id)
         assert req is not None and req.status == "executed"
-        audit_actions = [e.action for e in await list_approval_audit(req_id)]
+        audit_actions = [e.action for e in await list_approval_audit(req_id, tenant_id=tenant_id)]
         assert audit_actions[-2:] == ["executing", "executed"]
         # Report went to the origin conversation.
         assert any(conv_id == c for c, _t in ch.sent)
@@ -185,7 +185,7 @@ class TestApprovedExecution:
         base, recorder = proxy_base
         # Two actions; force the second server to 500.
         recorder.server_override["erp2"] = {"status": 500, "body": {"err": "boom"}}
-        req_id, _conv, _user, _cw, _t = await _seed_request(
+        req_id, _conv, _user, _cw, tenant_id = await _seed_request(
             status="approved",
             actions=[
                 {"mcp_server": "erp", "tool_name": "a", "params": {}},
@@ -196,29 +196,29 @@ class TestApprovedExecution:
         w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
         msg = _FakeMsg(
             subject=f"approval.decided.{req_id}",
-            data=json.dumps({"status": "approved"}).encode(),
+            data=json.dumps({"status": "approved", "tenant_id": tenant_id}).encode(),
         )
         await w._handle_message(msg)
 
-        req = await get_approval_request(req_id)
+        req = await get_approval_request(req_id, tenant_id=tenant_id)
         assert req is not None and req.status == "execution_failed"
-        audit_actions = [e.action for e in await list_approval_audit(req_id)]
+        audit_actions = [e.action for e in await list_approval_audit(req_id, tenant_id=tenant_id)]
         assert "execution_failed" in audit_actions
         # Both actions were attempted (best-effort batch).
         assert len(recorder.requests) == 2
 
     async def test_duplicate_decided_does_not_double_execute(self, proxy_base) -> None:
         base, recorder = proxy_base
-        req_id, _c, _u, _cw, _t = await _seed_request(status="approved")
+        req_id, _c, _u, _cw, tenant_id = await _seed_request(status="approved")
         ch = _FakeChannel()
         w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
         msg1 = _FakeMsg(
             subject=f"approval.decided.{req_id}",
-            data=json.dumps({"status": "approved"}).encode(),
+            data=json.dumps({"status": "approved", "tenant_id": tenant_id}).encode(),
         )
         msg2 = _FakeMsg(
             subject=f"approval.decided.{req_id}",
-            data=json.dumps({"status": "approved"}).encode(),
+            data=json.dumps({"status": "approved", "tenant_id": tenant_id}).encode(),
         )
         await w._handle_message(msg1)
         await w._handle_message(msg2)
@@ -236,12 +236,12 @@ class TestRejectionNotify:
     async def test_rejected_sends_notification_no_execute(self, proxy_base) -> None:
         base, recorder = proxy_base
         # Seed as already-rejected (engine would have set it before publish)
-        req_id, conv_id, _user, _cw, _t = await _seed_request(status="rejected")
+        req_id, conv_id, _user, _cw, tenant_id = await _seed_request(status="rejected")
         ch = _FakeChannel()
         w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
         msg = _FakeMsg(
             subject=f"approval.decided.{req_id}",
-            data=json.dumps({"status": "rejected", "note": "no"}).encode(),
+            data=json.dumps({"status": "rejected", "note": "no", "tenant_id": tenant_id}).encode(),
         )
         await w._handle_message(msg)
         assert len(recorder.requests) == 0
@@ -285,10 +285,83 @@ class TestRejectionNotify:
         w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
         msg = _FakeMsg(
             subject=f"approval.decided.{req.id}",
-            data=json.dumps({"status": "rejected"}).encode(),
+            data=json.dumps({"status": "rejected", "tenant_id": t.id}).encode(),
         )
         await w._handle_message(msg)  # must not raise
         assert ch.sent == []
+
+
+# ---------------------------------------------------------------------------
+# Legacy message compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyMessageFallback:
+    """Pre-fix publishers omitted ``tenant_id`` from the
+    ``approval.decided.*`` body. The Worker's first contract change
+    was to drop such messages with a warning; this is a behavior
+    regression because in-flight messages at upgrade time would never
+    execute. The Worker now falls back to ``resolve_request_tenant``,
+    which is a single SELECT scoped to a known-good orchestrator-
+    issued request_id. These tests pin the fallback so a future
+    refactor cannot silently re-introduce the data-loss window."""
+
+    async def test_legacy_approved_message_recovers_tenant_and_executes(
+        self, proxy_base
+    ) -> None:
+        base, recorder = proxy_base
+        req_id, _conv, _user, _cw, tenant_id = await _seed_request(status="approved")
+        ch = _FakeChannel()
+        w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
+        # Body lacks tenant_id — simulates a message published by the
+        # OLD orchestrator before tenant_id was added to the protocol.
+        msg = _FakeMsg(
+            subject=f"approval.decided.{req_id}",
+            data=json.dumps({"status": "approved"}).encode(),
+        )
+        await w._handle_message(msg)
+
+        req = await get_approval_request(req_id, tenant_id=tenant_id)
+        assert req is not None and req.status == "executed", (
+            "legacy decided message MUST be processed via tenant fallback, "
+            "otherwise upgrade-window approvals are silently dropped"
+        )
+        assert len(recorder.requests) == 1
+        assert msg.acks == [1]
+
+    async def test_legacy_rejected_message_recovers_tenant_and_notifies(
+        self, proxy_base
+    ) -> None:
+        base, _recorder = proxy_base
+        req_id, conv_id, _user, _cw, tenant_id = await _seed_request(status="rejected")
+        ch = _FakeChannel()
+        w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
+        msg = _FakeMsg(
+            subject=f"approval.decided.{req_id}",
+            data=json.dumps({"status": "rejected", "note": "x"}).encode(),
+        )
+        await w._handle_message(msg)
+        assert any(c == conv_id and "rejected" in t for c, t in ch.sent), (
+            "legacy rejected message MUST surface the rejection notification"
+        )
+        assert msg.acks == [1]
+
+    async def test_legacy_message_with_unknown_request_id_is_dropped(
+        self, proxy_base
+    ) -> None:
+        base, recorder = proxy_base
+        # Don't seed any request — the request_id is bogus.
+        bogus_id = str(uuid.uuid4())
+        ch = _FakeChannel()
+        w = ApprovalWorker(js=None, channel_sender=ch, proxy_base_url=base)  # type: ignore[arg-type]
+        msg = _FakeMsg(
+            subject=f"approval.decided.{bogus_id}",
+            data=json.dumps({"status": "approved"}).encode(),
+        )
+        await w._handle_message(msg)
+        # Nothing executed, message acked so JetStream stops redelivering.
+        assert recorder.requests == []
+        assert msg.acks == [1]
 
 
 # Silence unused-import warnings.

--- a/tests/attack_sim/test_E_tenant_isolation.py
+++ b/tests/attack_sim/test_E_tenant_isolation.py
@@ -221,14 +221,18 @@ async def test_E4_cross_tenant_decide_blocked(fake_publisher, fake_channel) -> N
     )
     req_b = (await pg.list_approval_requests(tenant_b.tenant_id))[0]
 
-    # Simulate the admin endpoint's cross-tenant check:
-    req_fetch = await pg.get_approval_request(req_b.id)
-    assert req_fetch is not None
-    # Admin endpoint code: if req.tenant_id != user.tenant_id → 404.
-    # Here user is tenant A's owner but request lives in B.
-    assert req_fetch.tenant_id != tenant_a.tenant_id, (
-        "REST /decide must 404 when req.tenant_id doesn't match the caller"
+    # DB-layer tenant filter: a forged request_id from tenant B looked
+    # up under tenant A's context returns None — no leak even before the
+    # REST 404 check is reached.
+    leaked = await pg.get_approval_request(req_b.id, tenant_id=tenant_a.tenant_id)
+    assert leaked is None, (
+        "get_approval_request must reject cross-tenant lookup at the SQL "
+        "layer; if this assertion fails the REST 404 check became the "
+        "single line of defense"
     )
+    # And the legitimate read still works.
+    same_tenant = await pg.get_approval_request(req_b.id, tenant_id=tenant_b.tenant_id)
+    assert same_tenant is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/attack_sim/test_F_approval_abuse.py
+++ b/tests/attack_sim/test_F_approval_abuse.py
@@ -119,11 +119,12 @@ async def test_F1_non_approver_cannot_decide(fake_publisher, fake_channel) -> No
     with pytest.raises(ForbiddenError):
         await engine.handle_decision(
             request_id=request_id,
+            tenant_id=victim.tenant_id,
             action="approve",
             user_id=attacker.id,
         )
 
-    fresh = await pg.get_approval_request(request_id)
+    fresh = await pg.get_approval_request(request_id, tenant_id=victim.tenant_id)
     assert fresh is not None and fresh.status == "pending"
 
 
@@ -172,10 +173,10 @@ async def test_F2_concurrent_approve_wins_once(fake_publisher, fake_channel) -> 
 
     results = await asyncio.gather(
         engine.handle_decision(
-            request_id=req.id, action="approve", user_id=victim.owner_user_id
+            request_id=req.id, tenant_id=victim.tenant_id, action="approve", user_id=victim.owner_user_id
         ),
         engine.handle_decision(
-            request_id=req.id, action="reject", user_id=other_approver.id
+            request_id=req.id, tenant_id=victim.tenant_id, action="reject", user_id=other_approver.id
         ),
         return_exceptions=True,
     )
@@ -184,7 +185,7 @@ async def test_F2_concurrent_approve_wins_once(fake_publisher, fake_channel) -> 
     assert len(successes) == 1, f"expected 1 winner; got {results}"
     assert len(conflicts) == 1, f"expected 1 conflict; got {results}"
 
-    audit = await pg.list_approval_audit(req.id)
+    audit = await pg.list_approval_audit(req.id, tenant_id=victim.tenant_id)
     terminals = [e for e in audit if e.action in ("approved", "rejected")]
     assert len(terminals) == 1, (
         "atomic CAS must emit exactly one terminal audit; got "
@@ -242,12 +243,14 @@ async def test_F3_self_promotion_cannot_reach_prior_pending(
 
     # Attacker edits the policy to add themselves.
     await pg.update_approval_policy(
-        policy.id, approver_user_ids=[original_approver, attacker.id]
+        policy.id,
+        tenant_id=victim.tenant_id,
+        approver_user_ids=[original_approver, attacker.id],
     )
 
     with pytest.raises(ForbiddenError):
         await engine.handle_decision(
-            request_id=req.id, action="approve", user_id=attacker.id
+            request_id=req.id, tenant_id=victim.tenant_id, action="approve", user_id=attacker.id
         )
 
 
@@ -269,13 +272,13 @@ async def test_F4_decided_event_replay_does_not_double_execute(
     engine = _engine(fake_publisher, fake_channel)
     request_id, approver_id = await _seed_approver_and_pending(victim, engine)
     await engine.handle_decision(
-        request_id=request_id, action="approve", user_id=approver_id
+        request_id=request_id, tenant_id=victim.tenant_id, action="approve", user_id=approver_id
     )
 
-    first = await pg.claim_approval_for_execution(request_id)
+    first = await pg.claim_approval_for_execution(request_id, tenant_id=victim.tenant_id)
     assert first is not None and first.status == "executing"
 
-    second = await pg.claim_approval_for_execution(request_id)
+    second = await pg.claim_approval_for_execution(request_id, tenant_id=victim.tenant_id)
     assert second is None, (
         "atomic claim must return None on replay — worker drops "
         "replayed messages silently"
@@ -406,7 +409,7 @@ async def test_F6_stop_race_orphan_reaped_by_expiry(
             orphan.id,
         )
     await engine.expire_stale_requests()
-    after = await pg.get_approval_request(orphan.id)
+    after = await pg.get_approval_request(orphan.id, tenant_id=victim.tenant_id)
     assert after is not None and after.status == "expired"
 
 
@@ -438,7 +441,7 @@ async def test_F7_expire_and_approve_race_wins_once(
     async def _approver() -> Exception | None:
         try:
             await engine.handle_decision(
-                request_id=request_id, action="approve", user_id=approver_id
+                request_id=request_id, tenant_id=victim.tenant_id, action="approve", user_id=approver_id
             )
             return None
         except Exception as exc:  # noqa: BLE001
@@ -447,7 +450,7 @@ async def test_F7_expire_and_approve_race_wins_once(
     approver_outcome, _ = await asyncio.gather(
         _approver(), engine.expire_stale_requests()
     )
-    fresh = await pg.get_approval_request(request_id)
+    fresh = await pg.get_approval_request(request_id, tenant_id=victim.tenant_id)
     assert fresh is not None
     assert fresh.status in ("approved", "expired")
 
@@ -456,6 +459,6 @@ async def test_F7_expire_and_approve_race_wins_once(
     else:
         assert isinstance(approver_outcome, ConflictError)
 
-    audit_actions = [e.action for e in await pg.list_approval_audit(request_id)]
+    audit_actions = [e.action for e in await pg.list_approval_audit(request_id, tenant_id=victim.tenant_id)]
     terminals = [a for a in audit_actions if a in ("approved", "expired", "rejected")]
     assert len(terminals) == 1, f"audit must have one terminal; got {audit_actions!r}"

--- a/tests/attack_sim/test_G_dos.py
+++ b/tests/attack_sim/test_G_dos.py
@@ -139,7 +139,7 @@ async def test_G4_approval_flood_does_not_corrupt_state(
     assert len(rows) == N, f"expected {N} distinct requests, got {len(rows)}"
     # Each row has one 'created' audit entry — trigger kept up.
     for r in rows:
-        audit = await pg.list_approval_audit(r.id)
+        audit = await pg.list_approval_audit(r.id, tenant_id=victim.tenant_id)
         assert audit and audit[0].action == "created", (
             f"request {r.id} missing created audit under flood"
         )

--- a/tests/db/test_cross_tenant_isolation.py
+++ b/tests/db/test_cross_tenant_isolation.py
@@ -1,0 +1,225 @@
+"""DB-layer cross-tenant isolation regression tests.
+
+Pre-commit fc4b0... `get_approval_policy(policy_id)`,
+`get_approval_request(request_id)`, `get_safety_rule(rule_id)`, and
+`list_approval_audit(request_id)` looked up rows by id alone, with no
+tenant filter. Tenant isolation was enforced one layer up (REST handlers
+checked `row.tenant_id == user.tenant_id`).
+
+If any caller forgot the upstream check — or a future caller forgot the
+upstream check — the DB would happily hand over another tenant's data.
+These tests pin the boundary at the DB function layer: each lookup MUST
+reject mismatched tenant_id.
+
+`approval_audit_log` previously had no `tenant_id` column at all
+(rows were tied to `approval_requests` only via FK), so cross-tenant
+audit reads relied entirely on the upstream `get_approval_request`
+check. The audit-log test below verifies the DB function now refuses
+mismatched tenants on its own.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from rolemesh.db.pg import (
+    create_approval_policy,
+    create_approval_request,
+    create_channel_binding,
+    create_conversation,
+    create_coworker,
+    create_safety_rule,
+    create_tenant,
+    create_user,
+    get_approval_policy,
+    get_approval_request,
+    get_safety_rule,
+    list_approval_audit,
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+# ---------------------------------------------------------------------------
+# Two-tenant fixture
+# ---------------------------------------------------------------------------
+
+
+async def _two_tenants() -> dict[str, dict[str, str]]:
+    """Build two complete (tenant, user, coworker, conversation) chains."""
+    out: dict[str, dict[str, str]] = {}
+    for tag in ("A", "B"):
+        t = await create_tenant(name=f"Tenant {tag}", slug=f"t-{tag.lower()}-{uuid.uuid4().hex[:6]}")
+        u = await create_user(
+            tenant_id=t.id,
+            name=f"User {tag}",
+            email=f"u-{tag.lower()}-{uuid.uuid4().hex[:6]}@x.com",
+            role="owner",
+        )
+        cw = await create_coworker(
+            tenant_id=t.id, name=f"CW{tag}", folder=f"cw-{tag.lower()}-{uuid.uuid4().hex[:6]}"
+        )
+        b = await create_channel_binding(
+            coworker_id=cw.id,
+            tenant_id=t.id,
+            channel_type="telegram",
+            credentials={"bot_token": "x"},
+        )
+        conv = await create_conversation(
+            tenant_id=t.id,
+            coworker_id=cw.id,
+            channel_binding_id=b.id,
+            channel_chat_id=str(uuid.uuid4()),
+        )
+        out[tag] = {
+            "tenant_id": t.id,
+            "user_id": u.id,
+            "coworker_id": cw.id,
+            "conversation_id": conv.id,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# get_approval_policy
+# ---------------------------------------------------------------------------
+
+
+async def test_get_approval_policy_rejects_mismatched_tenant() -> None:
+    """A policy created for tenant A must NOT be returned when looked
+    up under tenant B. Defense: function signature requires tenant_id
+    and SQL filters on it."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    policy = await create_approval_policy(
+        tenant_id=a["tenant_id"],
+        coworker_id=a["coworker_id"],
+        mcp_server_name="erp",
+        tool_name="refund",
+        condition_expr={"always": True},
+    )
+    # Same-tenant lookup works.
+    same_tenant = await get_approval_policy(policy.id, tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == policy.id
+
+    # Cross-tenant lookup must return None — no leakage even with
+    # a valid policy_id.
+    leaked = await get_approval_policy(policy.id, tenant_id=b["tenant_id"])
+    assert leaked is None, (
+        "get_approval_policy returned tenant A's policy when called "
+        "with tenant B's id — DB-layer isolation broken"
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_approval_request
+# ---------------------------------------------------------------------------
+
+
+async def test_get_approval_request_rejects_mismatched_tenant() -> None:
+    """An approval request created for tenant A must NOT be returned
+    when looked up under tenant B."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    req = await create_approval_request(
+        tenant_id=a["tenant_id"],
+        coworker_id=a["coworker_id"],
+        conversation_id=a["conversation_id"],
+        policy_id=None,
+        user_id=a["user_id"],
+        job_id=f"j-{uuid.uuid4().hex[:8]}",
+        mcp_server_name="erp",
+        actions=[{"tool_name": "refund", "params": {}}],
+        action_hashes=[uuid.uuid4().hex],
+        rationale="test",
+        source="proposal",
+        status="pending",
+        resolved_approvers=[a["user_id"]],
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    same_tenant = await get_approval_request(req.id, tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == req.id
+
+    leaked = await get_approval_request(req.id, tenant_id=b["tenant_id"])
+    assert leaked is None, (
+        "get_approval_request leaked tenant A's request to tenant B"
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_safety_rule
+# ---------------------------------------------------------------------------
+
+
+async def test_get_safety_rule_rejects_mismatched_tenant() -> None:
+    """A safety rule created for tenant A must NOT be returned when
+    looked up under tenant B."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    rule = await create_safety_rule(
+        tenant_id=a["tenant_id"],
+        stage="pre_tool_call",
+        check_id="domain_allowlist",
+        config={"allowed_hosts": ["api.example.com"]},
+    )
+
+    same_tenant = await get_safety_rule(rule.id, tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == rule.id
+
+    leaked = await get_safety_rule(rule.id, tenant_id=b["tenant_id"])
+    assert leaked is None, (
+        "get_safety_rule leaked tenant A's rule to tenant B"
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_approval_audit
+# ---------------------------------------------------------------------------
+
+
+async def test_list_approval_audit_rejects_mismatched_tenant() -> None:
+    """The audit-trigger writes a 'created' row whenever an approval
+    request is INSERTed. Reading those audit rows by request_id alone
+    used to leak across tenants because the audit table had no tenant
+    column. Now the function takes tenant_id and filters on it."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    req = await create_approval_request(
+        tenant_id=a["tenant_id"],
+        coworker_id=a["coworker_id"],
+        conversation_id=a["conversation_id"],
+        policy_id=None,
+        user_id=a["user_id"],
+        job_id=f"j-{uuid.uuid4().hex[:8]}",
+        mcp_server_name="erp",
+        actions=[{"tool_name": "refund", "params": {}}],
+        action_hashes=[uuid.uuid4().hex],
+        rationale="test",
+        source="proposal",
+        status="pending",
+        resolved_approvers=[a["user_id"]],
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+
+    # Same-tenant read works and returns the trigger-written 'created' row.
+    same_tenant = await list_approval_audit(req.id, tenant_id=a["tenant_id"])
+    assert same_tenant, "same-tenant audit read returned nothing"
+    assert any(e.action == "created" for e in same_tenant)
+
+    # Cross-tenant read returns empty even with a valid request_id.
+    leaked = await list_approval_audit(req.id, tenant_id=b["tenant_id"])
+    assert leaked == [], (
+        "list_approval_audit leaked audit rows for tenant A's request "
+        "to tenant B — audit table tenant filter broken"
+    )

--- a/tests/safety/e2e/test_pii_block.py
+++ b/tests/safety/e2e/test_pii_block.py
@@ -211,7 +211,7 @@ class TestV1Acceptance:
         )
 
         # Admin disables the rule.
-        await pg.update_safety_rule(rule.id, enabled=False)
+        await pg.update_safety_rule(rule.id, tenant_id=tenant.id, enabled=False)
 
         # Snapshot B: disabled rule, fresh Handler, SAME tool_input
         # must now be allowed through. This is the property the

--- a/tests/safety/e2e/test_snapshot_immutability.py
+++ b/tests/safety/e2e/test_snapshot_immutability.py
@@ -106,7 +106,7 @@ class TestSnapshotImmutability:
         assert await _run_ssn_against(handler_a), "initial SSN must block"
 
         # Admin disables the rule mid-flight.
-        await pg.update_safety_rule(rule_id, enabled=False)
+        await pg.update_safety_rule(rule_id, tenant_id=tid, enabled=False)
 
         # Handler A is UNCHANGED — still blocks. This is the core
         # contract: the snapshot is immutable until container restart.
@@ -190,7 +190,7 @@ class TestSnapshotImmutability:
         snapshot = [r.to_snapshot_dict() for r in rows]
 
         # Delete the rule in DB.
-        await pg.delete_safety_rule(rule.id)
+        await pg.delete_safety_rule(rule.id, tenant_id=tenant.id)
 
         # Snapshot dicts must still carry the old data.
         assert snapshot[0]["check_id"] == "pii.regex"

--- a/tests/safety/test_db.py
+++ b/tests/safety/test_db.py
@@ -50,7 +50,7 @@ class TestSafetyRules:
         assert rule.enabled is True
         assert rule.description == "block SSN"
 
-        got = await pg.get_safety_rule(rule.id)
+        got = await pg.get_safety_rule(rule.id, tenant_id=tid)
         assert got is not None
         assert got.id == rule.id
 
@@ -131,7 +131,7 @@ class TestSafetyRules:
             enabled=True, priority=50,
         )
         updated = await pg.update_safety_rule(
-            rule.id, enabled=False, priority=75
+            rule.id, tenant_id=tid, enabled=False, priority=75
         )
         assert updated is not None
         assert updated.enabled is False
@@ -143,8 +143,15 @@ class TestSafetyRules:
 
     @pytest.mark.asyncio
     async def test_update_missing_returns_none(self) -> None:
+        # Random tenant_id ensures the WHERE id = ... AND tenant_id = ...
+        # finds nothing — that's the case under test (UPDATE matches no
+        # row), regardless of which axis fails to match.
         assert (
-            await pg.update_safety_rule(str(uuid.uuid4()), enabled=False)
+            await pg.update_safety_rule(
+                str(uuid.uuid4()),
+                tenant_id=str(uuid.uuid4()),
+                enabled=False,
+            )
         ) is None
 
     @pytest.mark.asyncio
@@ -154,9 +161,9 @@ class TestSafetyRules:
             tenant_id=tid, stage="pre_tool_call",
             check_id="pii.regex", config={},
         )
-        assert await pg.delete_safety_rule(rule.id) is True
-        assert await pg.get_safety_rule(rule.id) is None
-        assert await pg.delete_safety_rule(rule.id) is False
+        assert await pg.delete_safety_rule(rule.id, tenant_id=tid) is True
+        assert await pg.get_safety_rule(rule.id, tenant_id=tid) is None
+        assert await pg.delete_safety_rule(rule.id, tenant_id=tid) is False
 
 
 class TestSafetyDecisions:

--- a/tests/safety/test_rest_discovery.py
+++ b/tests/safety/test_rest_discovery.py
@@ -267,7 +267,7 @@ class TestRuleAuditEndpoint:
         )
         # Edit the rule to produce an 'updated' audit row.
         await update_safety_rule(
-            rule.id, enabled=False, actor_user_id=actor.id
+            rule.id, tenant_id=tenant.id, enabled=False, actor_user_id=actor.id
         )
         app = _build_app(user)
         async with _client(app) as client:

--- a/tests/safety/test_rules_audit.py
+++ b/tests/safety/test_rules_audit.py
@@ -84,7 +84,7 @@ class TestAuditTrail:
             actor_user_id=uid,
         )
         await pg.update_safety_rule(
-            rule.id, enabled=False, actor_user_id=uid
+            rule.id, tenant_id=tid, enabled=False, actor_user_id=uid
         )
         rows = await pg.list_safety_rules_audit(
             tenant_id=tid, rule_id=rule.id
@@ -112,7 +112,9 @@ class TestAuditTrail:
         # Touch only with unchanged fields. update_safety_rule returns
         # the current row when nothing was passed — but even explicit
         # same-value assignments should be filtered.
-        await pg.update_safety_rule(rule.id, enabled=True, actor_user_id=uid)
+        await pg.update_safety_rule(
+            rule.id, tenant_id=tid, enabled=True, actor_user_id=uid
+        )
         rows = await pg.list_safety_rules_audit(
             tenant_id=tid, rule_id=rule.id
         )
@@ -130,7 +132,10 @@ class TestAuditTrail:
             description="blocks PII",
             actor_user_id=uid,
         )
-        assert await pg.delete_safety_rule(rule.id, actor_user_id=uid) is True
+        assert (
+            await pg.delete_safety_rule(rule.id, tenant_id=tid, actor_user_id=uid)
+            is True
+        )
         rows = await pg.list_safety_rules_audit(
             tenant_id=tid, rule_id=rule.id
         )
@@ -139,7 +144,7 @@ class TestAuditTrail:
         assert rows[0]["after_state"] is None
         assert rows[0]["actor_user_id"] == uid
         # The rule row is gone, but the audit row remains.
-        assert await pg.get_safety_rule(rule.id) is None
+        assert await pg.get_safety_rule(rule.id, tenant_id=tid) is None
 
     @pytest.mark.asyncio
     async def test_audit_survives_rule_hard_delete(self) -> None:
@@ -155,7 +160,7 @@ class TestAuditTrail:
             config={},
             actor_user_id=uid,
         )
-        await pg.delete_safety_rule(rule.id, actor_user_id=uid)
+        await pg.delete_safety_rule(rule.id, tenant_id=tid, actor_user_id=uid)
         rows = await pg.list_safety_rules_audit(tenant_id=tid)
         rule_ids_in_audit = {r["rule_id"] for r in rows}
         assert rule.id in rule_ids_in_audit


### PR DESCRIPTION
## Summary

Promote 13 by-id `pg.*` functions to require a `tenant_id` keyword so cross-tenant id forging is rejected at the SQL layer (`WHERE id = \$1 AND tenant_id = \$2`) — not just by the REST handler's `row.tenant_id == user.tenant_id` check.

Previously, tenant isolation was a single line of defense: any new endpoint, NATS handler, or admin script that forgot the post-fetch tenant comparison would leak across tenants. This adds SQL-layer enforcement as a second line.

### What changed

**Public DB API** — these now require `tenant_id` keyword:
- \`get_approval_policy\` / \`get_approval_request\` / \`get_safety_rule\` / \`list_approval_audit\`
- \`update_approval_policy\` / \`delete_approval_policy\` / \`update_safety_rule\` / \`delete_safety_rule\`
- \`set_approval_status\` / \`decide_approval_request_full\`
- \`claim_approval_for_execution\` / \`expire_approval_if_pending\`
- \`write_approval_audit\`

**Schema** — \`approval_audit_log\` gains \`NOT NULL tenant_id\` (denormalised from \`approval_requests\` via the audit trigger) so cross-tenant audit reads filter at SQL without a JOIN. Migration runs in a single transaction so multi-instance rolling deploy cannot wedge on NULL rows. Composite index \`idx_audit_log_tenant_request\` keeps the hot REST path fast.

**NATS \`approval.decided.*\` protocol** — body now carries \`tenant_id\`. The Worker falls back to \`pg.resolve_request_tenant\` (a private system-only escape hatch documented for upgrade-window legacy-message recovery) when an in-flight message from an older publisher omits it. Without the fallback, approvals issued seconds before deploy would be silently dropped.

**Return shape** — \`cancel_pending_approvals_for_job\` returns \`list[tuple[id, tenant_id]]\` (was \`list[str]\`) so the cancel cascade can re-fetch each request under its authoritative tenant_id.

### What this is NOT

This is **Phase 0** of the broader RLS work. It does NOT enable PostgreSQL row-level security (no \`ENABLE/FORCE ROW LEVEL SECURITY\`, no \`CREATE POLICY\`, no \`rolemesh_app\` / \`rolemesh_system\` roles, no \`acquire_app\` / \`acquire_system\` helpers, no ContextVar plumbing). PG-engine-level enforcement is deferred to a follow-up branch where the architecture (explicit tenant_id parameter vs. ContextVar vs. JWT-claim-to-session-var) gets its own design discussion.

### Defense layers after this PR

| Layer | Before | After |
|---|---|---|
| REST handler \`if user.tenant_id != row.tenant_id\` | ✓ | ✓ |
| **SQL \`WHERE tenant_id = \$X\` at the pg.* layer** | ❌ | ✓ |
| Postgres RLS engine | ❌ | ❌ (future) |
| Connection role isolation | ❌ | ❌ (future) |

## Test plan

- [x] \`tests/db/test_cross_tenant_isolation.py\` — 4 adversarial tests pinning DB-layer rejection (TDD-style: written failing-first against pre-fix code)
- [x] \`tests/approval/test_executor.py::TestLegacyMessageFallback\` — 3 tests covering legacy NATS message recovery + bogus-id drop
- [x] 25+ existing test files updated to pass \`tenant_id\` to new signatures (no logic changes)
- [x] Manual testing: WebUI chat, Telegram bot, Slack bot all functional (commit 09e898a's changes are independent of recent main updates)

## Companion to

- The "single line of defense" finding from \`safety/attack-simulations\`.
- A follow-up will pick up PG RLS proper (currently being prototyped on \`feat/rls\`, kept as origin reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)