### PR TITLE
feat(rls): multi-tenant Row Level Security rollout (PR-A..E + post-merge fixes)

### DIFF
--- a/src/rolemesh/approval/engine.py
+++ b/src/rolemesh/approval/engine.py
@@ -816,7 +816,7 @@ class ApprovalEngine:
         """Fallback chain: policy → assigned users → tenant owners."""
         if policy.approver_user_ids:
             return list(policy.approver_user_ids)
-        assigned = await pg.get_users_for_agent(coworker_id)
+        assigned = await pg.get_users_for_agent(coworker_id, tenant_id=tenant_id)
         if assigned:
             return [u.id for u in assigned]
         return await _tenant_owner_ids(tenant_id)

--- a/src/rolemesh/auth/oidc/provider.py
+++ b/src/rolemesh/auth/oidc/provider.py
@@ -178,9 +178,15 @@ class OIDCAuthProvider:
 
         existing = await get_user_by_external_sub(external_sub)
         if existing is not None:
-            # Sync changeable fields
+            # Sync changeable fields. ``existing.tenant_id`` is the
+            # authoritative tenant binding from the OIDC mapping —
+            # passing it (rather than the function-arg ``tenant_id``)
+            # protects against an IdP that mutates its tenant claim
+            # mid-session: we keep updating the user under their
+            # original tenant rather than silently moving them.
             updated = await update_user(
                 existing.id,
+                tenant_id=existing.tenant_id,
                 name=str(name) if name != existing.name else None,
                 email=str(email) if email and email != existing.email else None,
                 role=role if role != existing.role else None,

--- a/src/rolemesh/auth/oidc/provider.py
+++ b/src/rolemesh/auth/oidc/provider.py
@@ -111,14 +111,18 @@ class OIDCAuthProvider:
         Returns None if the user does not exist. external_token is not
         available because no token is presented for this lookup path.
 
-        SECURITY: This lookup is NOT tenant-scoped — the AuthProvider Protocol
-        does not pass tenant context. Callers MUST enforce tenant authorization
-        themselves before exposing the result, otherwise a holder of any user_id
-        can probe users across tenants.
+        Two-step bootstrap: ``resolve_user_for_auth`` recovers the user's
+        tenant_id from a signature-verified user_id (admin escape hatch,
+        no tenant context yet); then ``get_user`` runs the tenant-scoped
+        query that downstream RLS will enforce.
         """
-        from rolemesh.db.pg import get_user
+        from rolemesh.db.pg import get_user, resolve_user_for_auth
 
-        user = await get_user(user_id)
+        resolved = await resolve_user_for_auth(user_id)
+        if resolved is None:
+            return None
+        tenant_id, _ = resolved
+        user = await get_user(user_id, tenant_id=tenant_id)
         if user is None:
             return None
         return AuthenticatedUser(

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -29,6 +29,12 @@ GROUPS_DIR: Path = PROJECT_ROOT / "groups"
 DATA_DIR: Path = PROJECT_ROOT / "data"
 
 DATABASE_URL: str = os.environ.get("DATABASE_URL", "postgresql://rolemesh:rolemesh@localhost:5432/rolemesh")
+# RLS rollout (PR-B): a separate pool for cross-tenant maintenance,
+# resolvers, and DDL connects under a BYPASSRLS role. In production
+# this is its own DSN so the business pool can drop privileges. If
+# unset, falls back to ``DATABASE_URL`` (acceptable for dev/test where
+# the bootstrap user is also used for admin work).
+ADMIN_DATABASE_URL: str = os.environ.get("ADMIN_DATABASE_URL", "")
 NATS_URL: str = os.environ.get("NATS_URL", "nats://localhost:4222")
 
 CONTAINER_IMAGE: str = os.environ.get("CONTAINER_IMAGE", "rolemesh-agent:latest")

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -278,6 +278,57 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         )
     """)
 
+    # PR-D D10: backfill tenant_id on oidc_user_tokens so RLS can
+    # bind it. Same pattern PR #11 used on approval_audit_log:
+    # ADD COLUMN nullable + UPDATE from parent + SET NOT NULL + FK
+    # CASCADE + composite index + BEFORE-INSERT trigger to keep new
+    # rows in sync with users.tenant_id without making every caller
+    # remember to pass it.
+    await conn.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'oidc_user_tokens'
+                  AND column_name = 'tenant_id'
+            ) THEN
+                ALTER TABLE oidc_user_tokens ADD COLUMN tenant_id UUID;
+                UPDATE oidc_user_tokens t
+                   SET tenant_id = u.tenant_id
+                  FROM users u
+                 WHERE u.id = t.user_id AND t.tenant_id IS NULL;
+                ALTER TABLE oidc_user_tokens
+                    ALTER COLUMN tenant_id SET NOT NULL;
+                ALTER TABLE oidc_user_tokens
+                    ADD CONSTRAINT oidc_user_tokens_tenant_fk
+                    FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+                    ON DELETE CASCADE;
+                CREATE INDEX idx_oidc_user_tokens_tenant
+                    ON oidc_user_tokens (tenant_id, user_id);
+            END IF;
+        END $$;
+    """)
+    await conn.execute("""
+        CREATE OR REPLACE FUNCTION oidc_user_tokens_set_tenant()
+        RETURNS TRIGGER AS $trigger$
+        BEGIN
+            IF NEW.tenant_id IS NULL THEN
+                SELECT tenant_id INTO NEW.tenant_id
+                  FROM users WHERE id = NEW.user_id;
+            END IF;
+            RETURN NEW;
+        END $trigger$ LANGUAGE plpgsql;
+    """)
+    await conn.execute(
+        "DROP TRIGGER IF EXISTS trg_oidc_user_tokens_set_tenant "
+        "ON oidc_user_tokens"
+    )
+    await conn.execute("""
+        CREATE TRIGGER trg_oidc_user_tokens_set_tenant
+            BEFORE INSERT ON oidc_user_tokens
+            FOR EACH ROW EXECUTE FUNCTION oidc_user_tokens_set_tenant();
+    """)
+
     await conn.execute("""
         CREATE TABLE IF NOT EXISTS channel_bindings (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -933,6 +984,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "channel_bindings")
     await _enable_rls_on(conn, "user_agent_assignments")
     await _enable_rls_on(conn, "users")                # D9
+    await _enable_rls_on(conn, "oidc_user_tokens")     # D10 (tenant_id backfilled above)
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -927,6 +927,8 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "scheduled_tasks")      # D5
     await _enable_rls_on(conn, "task_run_logs")
     await _enable_rls_on(conn, "messages")             # D6
+    await _enable_rls_on(conn, "conversations")        # D7
+    await _enable_rls_on(conn, "sessions")
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -926,6 +926,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "safety_rules_audit")
     await _enable_rls_on(conn, "scheduled_tasks")      # D5
     await _enable_rls_on(conn, "task_run_logs")
+    await _enable_rls_on(conn, "messages")             # D6
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
 import asyncpg
 
 from rolemesh.auth.permissions import AgentPermissions
-from rolemesh.core.config import DATABASE_URL
+from rolemesh.core.config import ADMIN_DATABASE_URL, DATABASE_URL
 from rolemesh.core.group_folder import is_valid_group_folder
 from rolemesh.core.logger import get_logger
 from rolemesh.core.types import (
@@ -48,6 +49,7 @@ def _to_dt(ts: str | None) -> datetime | None:
 
 
 _pool: asyncpg.Pool[asyncpg.Record] | None = None
+_admin_pool: asyncpg.Pool[asyncpg.Record] | None = None
 DEFAULT_TENANT: str = "default"
 
 
@@ -55,6 +57,52 @@ def _get_pool() -> asyncpg.Pool[asyncpg.Record]:
     """Return the module-level connection pool, asserting it is initialized."""
     assert _pool is not None, "Database not initialized. Call await init_database() first."
     return _pool
+
+
+def _get_admin_pool() -> asyncpg.Pool[asyncpg.Record]:
+    """Return the BYPASSRLS admin pool used by cross-tenant maintenance,
+    resolvers, and DDL. Falls back to the business pool if no separate
+    admin DSN was configured (dev/test convenience)."""
+    if _admin_pool is not None:
+        return _admin_pool
+    return _get_pool()
+
+
+@asynccontextmanager
+async def tenant_conn(
+    tenant_id: str,
+) -> AsyncIterator[asyncpg.pool.PoolConnectionProxy[asyncpg.Record]]:
+    """Acquire a business connection bound to ``tenant_id``.
+
+    Sets ``app.current_tenant_id`` GUC inside an explicit transaction so
+    the value is wiped when the transaction commits/rolls back. RLS
+    policies (added in PR-D) read it via ``current_tenant_id()``.
+
+    Use ``set_config(name, value, is_local=true)`` rather than
+    ``SET LOCAL`` so the value can be parameterised — string-concat'd
+    SET LOCAL would be a SQL injection foothold.
+    """
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                str(tenant_id),
+            )
+            yield conn
+
+
+@asynccontextmanager
+async def admin_conn() -> AsyncIterator[asyncpg.pool.PoolConnectionProxy[asyncpg.Record]]:
+    """Acquire a BYPASSRLS connection for cross-tenant maintenance.
+
+    Callers must justify cross-tenant scope in their docstring (see the
+    classification in the RLS design: B = list_*/cleanup_*, C =
+    resolve_*, D = init_*/_create_*). Never use this from REST handlers.
+    """
+    pool = _get_admin_pool()
+    async with pool.acquire() as conn:
+        yield conn
 
 
 # ---------------------------------------------------------------------------
@@ -800,21 +848,115 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         """
     )
 
+    # ----- RLS infrastructure (PR-B) ---------------------------------------
+    # current_tenant_id() reads the per-connection GUC set by
+    # tenant_conn(). Returns NULL when unset → policies of the form
+    # ``USING (tenant_id = current_tenant_id())`` evaluate to NULL,
+    # which the planner treats as "row excluded" (fail-closed). STABLE
+    # lets PG cache the result within a single statement.
+    await conn.execute("""
+        CREATE OR REPLACE FUNCTION current_tenant_id() RETURNS UUID
+        LANGUAGE sql STABLE AS $$
+            SELECT NULLIF(current_setting('app.current_tenant_id', true), '')::uuid
+        $$
+    """)
 
-async def init_database(database_url: str | None = None) -> None:
-    """Initialize PostgreSQL connection pool and create schema."""
-    global _pool
+    # rolemesh_app: business connections; NOBYPASSRLS so policies bind.
+    # rolemesh_system: maintenance/resolver/DDL connections; BYPASSRLS
+    # because cross-tenant work is intentional (named via admin_conn()
+    # in code so it's grep-able). LOGIN on both — operators set passwords
+    # out-of-band via ALTER ROLE.
+    await conn.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'rolemesh_app'
+            ) THEN
+                CREATE ROLE rolemesh_app LOGIN NOBYPASSRLS;
+            END IF;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_roles WHERE rolname = 'rolemesh_system'
+            ) THEN
+                CREATE ROLE rolemesh_system LOGIN BYPASSRLS;
+            END IF;
+        END $$;
+    """)
+
+    await conn.execute(
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public "
+        "TO rolemesh_app, rolemesh_system"
+    )
+    await conn.execute(
+        "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public "
+        "TO rolemesh_app, rolemesh_system"
+    )
+    await conn.execute(
+        "GRANT EXECUTE ON FUNCTION current_tenant_id() "
+        "TO rolemesh_app, rolemesh_system"
+    )
+    # external_tenant_map and tenants are owner-administered. Even
+    # under PR-D the business role must not touch them — RLS is the
+    # second layer; the GRANT is the first.
+    await conn.execute("REVOKE ALL ON external_tenant_map FROM rolemesh_app")
+    await conn.execute("REVOKE ALL ON tenants FROM rolemesh_app")
+
+    # Future tables created by migrations should inherit the same privs
+    # automatically so we don't have to remember to GRANT after each DDL.
+    await conn.execute(
+        "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES "
+        "TO rolemesh_app, rolemesh_system"
+    )
+
+
+async def init_database(
+    database_url: str | None = None,
+    admin_database_url: str | None = None,
+) -> None:
+    """Initialize PostgreSQL pools and create schema.
+
+    ``database_url`` connects the business pool (drops to ``rolemesh_app``
+    in production after PR-D). ``admin_database_url`` connects the
+    BYPASSRLS pool used by maintenance/resolvers; if omitted, falls
+    back to ``ADMIN_DATABASE_URL`` env, then to ``database_url``.
+    """
+    global _pool, _admin_pool
     url = database_url or DATABASE_URL
+    admin_url = admin_database_url or ADMIN_DATABASE_URL or url
     _pool = await asyncpg.create_pool(url, min_size=2, max_size=10)
-    async with _pool.acquire() as conn:
+    _admin_pool = await asyncpg.create_pool(admin_url, min_size=1, max_size=3)
+    async with _admin_pool.acquire() as conn:
         await _create_schema(conn)
+    await _log_pool_identities()
 
 
-async def _init_test_database(database_url: str) -> None:
+async def _log_pool_identities() -> None:
+    """Emit one structured log line per pool with its current_user.
+
+    Lets operators verify at boot that the business pool is connected
+    as the NOBYPASSRLS role and the admin pool as the BYPASSRLS role
+    (or that they share an identity in dev/test, which is also useful
+    to see explicitly).
+    """
+    if _pool is not None:
+        async with _pool.acquire() as conn:
+            who = await conn.fetchval("SELECT current_user")
+        logger.info("DB business pool ready", current_user=who)
+    if _admin_pool is not None:
+        async with _admin_pool.acquire() as conn:
+            who = await conn.fetchval("SELECT current_user")
+        logger.info("DB admin pool ready", current_user=who)
+
+
+async def _init_test_database(
+    database_url: str, admin_database_url: str | None = None
+) -> None:
     """Initialize a test database with a fresh schema."""
-    global _pool
+    global _pool, _admin_pool
+    admin_url = admin_database_url or database_url
     _pool = await asyncpg.create_pool(database_url, min_size=2, max_size=10)
-    async with _pool.acquire() as conn:
+    _admin_pool = await asyncpg.create_pool(admin_url, min_size=1, max_size=3)
+    async with _admin_pool.acquire() as conn:
         # Drop all tables for a clean slate
         await conn.execute("DROP TABLE IF EXISTS safety_decisions CASCADE")
         await conn.execute("DROP TABLE IF EXISTS safety_rules_audit CASCADE")
@@ -843,11 +985,14 @@ async def _init_test_database(database_url: str) -> None:
 
 
 async def close_database() -> None:
-    """Close the connection pool. Call on shutdown."""
-    global _pool
+    """Close both connection pools. Call on shutdown."""
+    global _pool, _admin_pool
     if _pool:
         await _pool.close()
         _pool = None
+    if _admin_pool:
+        await _admin_pool.close()
+        _admin_pool = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -920,6 +920,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     # ``ALTER TABLE <t> DISABLE ROW LEVEL SECURITY``.
     await _enable_rls_on(conn, "approval_audit_log")  # D1 canary
     await _enable_rls_on(conn, "approval_requests")    # D2
+    await _enable_rls_on(conn, "approval_policies")    # D3
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -1007,8 +1007,7 @@ async def create_tenant(
     max_concurrent_containers: int = 5,
 ) -> Tenant:
     """Create a new tenant and return it."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO tenants (slug, name, plan, max_concurrent_containers)
@@ -1048,8 +1047,7 @@ def _record_to_tenant(row: asyncpg.Record) -> Tenant:
 
 async def get_tenant(tenant_id: str) -> Tenant | None:
     """Get a tenant by ID."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow("SELECT * FROM tenants WHERE id = $1::uuid", tenant_id)
     if row is None:
         return None
@@ -1091,8 +1089,7 @@ async def update_tenant(
         return await get_tenant(tenant_id)
 
     values.append(tenant_id)
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             f"UPDATE tenants SET {', '.join(fields)} WHERE id = ${param_idx}::uuid RETURNING *",
             *values,
@@ -1104,8 +1101,7 @@ async def update_tenant(
 
 async def get_tenant_by_slug(slug: str) -> Tenant | None:
     """Get a tenant by slug."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow("SELECT * FROM tenants WHERE slug = $1", slug)
     if row is None:
         return None
@@ -1114,8 +1110,7 @@ async def get_tenant_by_slug(slug: str) -> Tenant | None:
 
 async def get_all_tenants() -> list[Tenant]:
     """Get all tenants."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch("SELECT * FROM tenants ORDER BY created_at")
     return [_record_to_tenant(row) for row in rows]
 
@@ -1145,8 +1140,7 @@ async def create_user(
     channel_ids: dict[str, str] | None = None,
 ) -> User:
     """Create a new user."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO users (tenant_id, name, email, role, channel_ids)
@@ -1179,8 +1173,7 @@ def _record_to_user(row: asyncpg.Record) -> User:
 
 async def get_user_by_external_sub(external_sub: str) -> User | None:
     """Look up a user by their external OIDC subject identifier."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow("SELECT * FROM users WHERE external_sub = $1", external_sub)
     if row is None:
         return None
@@ -1195,8 +1188,7 @@ async def create_user_with_external_sub(
     external_sub: str,
 ) -> User:
     """Create a user linked to an external OIDC subject."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO users (tenant_id, name, email, role, channel_ids, external_sub)
@@ -1215,8 +1207,7 @@ async def create_user_with_external_sub(
 
 async def get_local_tenant_id(provider: str, external_tenant_id: str) -> str | None:
     """Look up the local tenant ID for an external IdP tenant."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             "SELECT local_tenant_id FROM external_tenant_map WHERE provider = $1 AND external_tenant_id = $2",
             provider,
@@ -1233,8 +1224,7 @@ async def create_external_tenant_mapping(
     local_tenant_id: str,
 ) -> None:
     """Create a mapping between an external IdP tenant and a local tenant."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             """
             INSERT INTO external_tenant_map (provider, external_tenant_id, local_tenant_id)
@@ -1259,8 +1249,7 @@ async def upsert_user_oidc_tokens(
     access_token_expires_at: datetime | None,
 ) -> None:
     """Insert or replace the encrypted token row for a user."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             """
             INSERT INTO oidc_user_tokens (
@@ -1285,8 +1274,7 @@ async def get_user_oidc_tokens(
     user_id: str,
 ) -> tuple[bytes, bytes | None, datetime | None] | None:
     """Return (refresh_token_enc, access_token_enc, expires_at) or None."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             "SELECT refresh_token_encrypted, access_token_encrypted, access_token_expires_at "
             "FROM oidc_user_tokens WHERE user_id = $1::uuid",
@@ -1307,8 +1295,7 @@ async def update_user_access_token(
     access_token_expires_at: datetime,
 ) -> None:
     """Update only the cached access_token (after refresh)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             """
             UPDATE oidc_user_tokens
@@ -1328,8 +1315,7 @@ async def update_user_refresh_token(
     refresh_token_encrypted: bytes,
 ) -> None:
     """Update only the refresh_token (after IdP rotation)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             "UPDATE oidc_user_tokens SET refresh_token_encrypted = $1, updated_at = now() "
             "WHERE user_id = $2::uuid",
@@ -1340,8 +1326,7 @@ async def update_user_refresh_token(
 
 async def delete_user_oidc_tokens(user_id: str) -> None:
     """Remove a user's stored OIDC tokens (logout / refresh failure)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             "DELETE FROM oidc_user_tokens WHERE user_id = $1::uuid",
             user_id,
@@ -1356,8 +1341,7 @@ async def get_user(user_id: str, *, tenant_id: str) -> User | None:
     REST layer maps None to 404 — indistinguishable from "doesn't
     exist" so we don't leak UUID existence across tenants.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM users WHERE id = $1::uuid AND tenant_id = $2::uuid",
             user_id,
@@ -1383,8 +1367,7 @@ async def resolve_user_for_auth(user_id: str) -> tuple[str, str] | None:
 
     Returns None if the user_id does not exist.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             "SELECT tenant_id, role FROM users WHERE id = $1::uuid",
             user_id,
@@ -1396,8 +1379,7 @@ async def resolve_user_for_auth(user_id: str) -> tuple[str, str] | None:
 
 async def get_users_for_tenant(tenant_id: str) -> list[User]:
     """Get all users for a tenant."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             "SELECT * FROM users WHERE tenant_id = $1::uuid ORDER BY name",
             tenant_id,
@@ -1436,8 +1418,7 @@ async def update_user(
 
     values.append(user_id)
     values.append(tenant_id)
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             f"UPDATE users SET {', '.join(fields)} "
             f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
@@ -1511,8 +1492,7 @@ async def create_coworker(
             }
         )
     effective_perms = permissions or AgentPermissions.for_role(agent_role)
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO coworkers (tenant_id, name, folder, agent_backend, system_prompt,
@@ -1611,8 +1591,7 @@ async def get_coworker(coworker_id: str, *, tenant_id: str) -> Coworker | None:
 
     See ``get_user`` for the tenant-filter rationale.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM coworkers WHERE id = $1::uuid AND tenant_id = $2::uuid",
             coworker_id,
@@ -1625,8 +1604,7 @@ async def get_coworker(coworker_id: str, *, tenant_id: str) -> Coworker | None:
 
 async def get_coworker_by_folder(tenant_id: str, folder: str) -> Coworker | None:
     """Get a coworker by tenant and folder."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM coworkers WHERE tenant_id = $1::uuid AND folder = $2",
             tenant_id,
@@ -1639,8 +1617,7 @@ async def get_coworker_by_folder(tenant_id: str, folder: str) -> Coworker | None
 
 async def get_coworkers_for_tenant(tenant_id: str) -> list[Coworker]:
     """Get all coworkers for a tenant."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             "SELECT * FROM coworkers WHERE tenant_id = $1::uuid ORDER BY name",
             tenant_id,
@@ -1650,8 +1627,7 @@ async def get_coworkers_for_tenant(tenant_id: str) -> list[Coworker]:
 
 async def get_all_coworkers() -> list[Coworker]:
     """Get all coworkers."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch("SELECT * FROM coworkers ORDER BY tenant_id, name")
     return [_record_to_coworker(row) for row in rows]
 
@@ -1726,8 +1702,7 @@ async def update_coworker(
 
     values.append(coworker_id)
     values.append(tenant_id)
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             f"UPDATE coworkers SET {', '.join(fields)} "
             f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
@@ -1760,8 +1735,7 @@ async def create_channel_binding(
     bot_display_name: str | None = None,
 ) -> ChannelBinding:
     """Create a channel binding."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO channel_bindings (coworker_id, tenant_id, channel_type, credentials, bot_display_name)
@@ -1797,8 +1771,7 @@ async def get_channel_binding(binding_id: str, *, tenant_id: str) -> ChannelBind
 
     See ``get_user`` for the tenant-filter rationale.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM channel_bindings WHERE id = $1::uuid AND tenant_id = $2::uuid",
             binding_id,
@@ -1825,8 +1798,7 @@ async def get_channel_binding_for_coworker(coworker_id: str, channel_type: str) 
 
 async def get_all_channel_bindings() -> list[ChannelBinding]:
     """Get all channel bindings."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch("SELECT * FROM channel_bindings ORDER BY tenant_id, coworker_id")
     return [_record_to_channel_binding(row) for row in rows]
 
@@ -1873,8 +1845,7 @@ async def update_channel_binding(
 
     values.append(binding_id)
     values.append(tenant_id)
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             f"UPDATE channel_bindings SET {', '.join(fields)} "
             f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
@@ -1909,8 +1880,7 @@ async def create_conversation(
     user_id: str | None = None,
 ) -> Conversation:
     """Create a conversation."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO conversations (tenant_id, coworker_id, channel_binding_id, channel_chat_id, name, requires_trigger, user_id)
@@ -1951,8 +1921,7 @@ async def get_conversation(conversation_id: str, *, tenant_id: str) -> Conversat
 
     See ``get_user`` for the tenant-filter rationale.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM conversations WHERE id = $1::uuid AND tenant_id = $2::uuid",
             conversation_id,
@@ -1978,8 +1947,7 @@ async def get_conversation_for_notification(conversation_id: str) -> Conversatio
     ``get_conversation`` for any path where the conversation_id can
     come from user input.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             "SELECT * FROM conversations WHERE id = $1::uuid",
             conversation_id,
@@ -2002,8 +1970,7 @@ async def get_conversations_for_coworker(coworker_id: str) -> list[Conversation]
 
 async def get_all_conversations() -> list[Conversation]:
     """Get all conversations."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch("SELECT * FROM conversations ORDER BY tenant_id, coworker_id")
     return [_record_to_conversation(row) for row in rows]
 
@@ -2073,8 +2040,7 @@ async def get_session(conversation_id: str) -> str | None:
 
 async def set_session(conversation_id: str, tenant_id: str, coworker_id: str, session_id: str) -> None:
     """Set the session ID for a conversation."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
             """
             INSERT INTO sessions (conversation_id, tenant_id, coworker_id, session_id)
@@ -2090,8 +2056,7 @@ async def set_session(conversation_id: str, tenant_id: str, coworker_id: str, se
 
 async def get_all_sessions() -> dict[str, str]:
     """Get all session mappings (conversation_id -> session_id)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch("SELECT conversation_id, session_id FROM sessions")
     return {str(row["conversation_id"]): row["session_id"] for row in rows}
 
@@ -2113,8 +2078,7 @@ async def store_message(
     is_bot_message: bool = False,
 ) -> None:
     """Store a message."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
             """
             INSERT INTO messages (tenant_id, conversation_id, id, sender, sender_name, content, timestamp, is_from_me, is_bot_message)
@@ -2294,8 +2258,7 @@ async def get_task_by_id(task_id: str, *, tenant_id: str) -> ScheduledTask | Non
 
     See ``get_user`` for the tenant-filter rationale.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM scheduled_tasks WHERE id = $1::uuid AND tenant_id = $2::uuid",
             task_id,
@@ -2319,8 +2282,7 @@ async def get_tasks_for_coworker(coworker_id: str) -> list[ScheduledTask]:
 
 async def get_all_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
     """Get all scheduled tasks, optionally filtered by tenant."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with (tenant_conn(tenant_id) if tenant_id is not None else admin_conn()) as conn:
         if tenant_id:
             rows = await conn.fetch(
                 "SELECT * FROM scheduled_tasks WHERE tenant_id = $1::uuid ORDER BY created_at DESC",
@@ -2505,8 +2467,7 @@ async def set_registered_group(jid: str, group: RegisteredGroup) -> None:
             }
         )
 
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             """
             INSERT INTO registered_groups (tenant_id, jid, name, folder, trigger_pattern, added_at, container_config, requires_trigger, is_main)
@@ -2534,8 +2495,7 @@ async def set_registered_group(jid: str, group: RegisteredGroup) -> None:
 
 async def get_all_registered_groups() -> dict[str, RegisteredGroup]:
     """Get all registered groups as a dict keyed by JID."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch(
             "SELECT * FROM registered_groups WHERE tenant_id = $1",
             DEFAULT_TENANT,
@@ -2555,8 +2515,7 @@ async def get_all_registered_groups() -> dict[str, RegisteredGroup]:
 
 async def get_session_legacy(group_folder: str) -> str | None:
     """Get session from legacy sessions table (old 'sessions' or 'sessions_legacy')."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         # Try the old sessions table first (pre-migration)
         has_old = await conn.fetchval(
             "SELECT EXISTS(SELECT 1 FROM information_schema.columns "
@@ -2575,8 +2534,7 @@ async def get_session_legacy(group_folder: str) -> str | None:
 
 async def set_session_legacy(group_folder: str, session_id: str) -> None:
     """Set session in legacy sessions table."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         has_old = await conn.fetchval(
             "SELECT EXISTS(SELECT 1 FROM information_schema.columns "
             "WHERE table_name='sessions' AND column_name='group_folder')"
@@ -2595,8 +2553,7 @@ async def set_session_legacy(group_folder: str, session_id: str) -> None:
 
 async def get_all_sessions_legacy() -> dict[str, str]:
     """Get all legacy session mappings (group_folder -> session_id)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         has_old = await conn.fetchval(
             "SELECT EXISTS(SELECT 1 FROM information_schema.columns "
             "WHERE table_name='sessions' AND column_name='group_folder')"
@@ -2616,8 +2573,7 @@ async def get_all_sessions_legacy() -> dict[str, str]:
 
 async def drop_legacy_tables() -> None:
     """Drop legacy tables and recreate shared tables in new format."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         # Drop legacy-only tables
         await conn.execute("DROP TABLE IF EXISTS router_state CASCADE")
         await conn.execute("DROP TABLE IF EXISTS registered_groups CASCADE")
@@ -2640,8 +2596,7 @@ async def drop_legacy_tables() -> None:
 
 async def assign_agent_to_user(user_id: str, coworker_id: str, tenant_id: str) -> None:
     """Assign a coworker (agent) to a user."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
             """
             INSERT INTO user_agent_assignments (user_id, coworker_id, tenant_id)
@@ -2788,8 +2743,7 @@ async def get_approval_policy(
     a higher layer can keep their existing checks; this function is
     the lower bound, not the only line of defense.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM approval_policies "
             "WHERE id = $1::uuid AND tenant_id = $2::uuid",
@@ -2837,8 +2791,7 @@ async def get_enabled_policies_for_coworker(
     rows — container snapshots never carry disabled policies, and
     neither does the engine's dedup/match path.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT * FROM approval_policies
@@ -2914,8 +2867,7 @@ async def update_approval_policy(
         + f" WHERE id = ${idx}::uuid AND tenant_id = ${idx + 1}::uuid "
         "RETURNING *"
     )
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(sql, *values)
     if row is None:
         return None
@@ -2930,8 +2882,7 @@ async def delete_approval_policy(policy_id: str, *, tenant_id: str) -> bool:
     returns False (no rows affected) without raising — same shape as
     "policy id does not exist".
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         result = await conn.execute(
             "DELETE FROM approval_policies "
             "WHERE id = $1::uuid AND tenant_id = $2::uuid",
@@ -3028,8 +2979,7 @@ async def create_approval_request(
     ``actor_user_id`` is recorded by the audit trigger on the 'created'
     row. None ⇒ audit 'created' row has NULL actor (system-initiated).
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         await _set_approval_guc(
             conn, actor_user_id=actor_user_id, note=None, metadata=None
         )
@@ -3086,8 +3036,7 @@ async def resolve_request_tenant(request_id: str) -> str | None:
 
     Returns None if the request_id does not exist.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchrow(
             "SELECT tenant_id FROM approval_requests WHERE id = $1::uuid",
             request_id,
@@ -3104,8 +3053,7 @@ async def get_approval_request(
 
     See ``get_approval_policy`` for the tenant-filter rationale.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM approval_requests "
             "WHERE id = $1::uuid AND tenant_id = $2::uuid",
@@ -3154,8 +3102,7 @@ async def find_pending_request_by_action_hash(
     This prevents the hook chain from creating two pending requests
     when an agent retries the same blocked tool call seconds apart.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             SELECT * FROM approval_requests
@@ -3221,8 +3168,7 @@ async def decide_approval_request_full(
     records the approver as the actor_user_id on the 'approved' /
     'rejected' row.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         await _set_approval_guc(
             conn, actor_user_id=actor_user_id, note=note, metadata=None
         )
@@ -3284,8 +3230,7 @@ async def claim_approval_for_execution(
     The audit trigger writes the 'executing' audit row with NULL actor
     (system transition).
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         # No actor: the Worker is a system process, so the trigger writes
         # executing with NULL actor.
         await _set_approval_guc(
@@ -3324,8 +3269,7 @@ async def set_approval_status(
     ``actor_user_id`` / ``note`` / ``metadata`` flow through to the
     audit trigger's 'status-change' row.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         await _set_approval_guc(
             conn,
             actor_user_id=actor_user_id,
@@ -3362,8 +3306,7 @@ async def cancel_pending_approvals_for_job(
     explicit tenant filter; the tenant_id we return is the
     authoritative value from the row itself.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch(
             """
             UPDATE approval_requests
@@ -3377,8 +3320,7 @@ async def cancel_pending_approvals_for_job(
 
 
 async def list_expired_pending_approvals() -> list[ApprovalRequest]:
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch(
             """
             SELECT * FROM approval_requests
@@ -3396,8 +3338,7 @@ async def list_stuck_approved_approvals(
     claimed by a Worker — either the Worker missed the NATS publish or
     the orchestrator restarted mid-flight. The reconciler republishes
     these."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch(
             """
             SELECT * FROM approval_requests
@@ -3417,8 +3358,7 @@ async def list_stuck_executing_approvals(
     after claiming but before writing the terminal status. The reconciler
     marks them execution_stale rather than retrying, because we cannot
     tell whether the MCP-side work partially completed."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         rows = await conn.fetch(
             """
             SELECT * FROM approval_requests
@@ -3474,8 +3414,7 @@ async def write_approval_audit(
     ``list_approval_audit`` filter on tenant_id, so a mis-attributed
     row would simply be invisible to its rightful tenant.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO approval_audit_log
@@ -3504,8 +3443,7 @@ async def list_approval_audit(
     leaking audit history. The composite index
     ``idx_audit_log_tenant_request`` keeps this fast.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             "SELECT * FROM approval_audit_log "
             "WHERE request_id = $1::uuid AND tenant_id = $2::uuid "
@@ -3525,8 +3463,7 @@ async def expire_approval_if_pending(
     Separate from set_approval_status because the maintenance loop
     must not trample a concurrent decide_approval_request.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             UPDATE approval_requests
@@ -3606,8 +3543,7 @@ async def create_safety_rule(
     trigger. ``None`` is a legitimate value for bulk imports / migration
     scripts where no user is the actor — the audit row carries NULL.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         await _set_safety_guc(conn, actor_user_id=actor_user_id)
         row = await conn.fetchrow(
             """
@@ -3641,8 +3577,7 @@ async def get_safety_rule(
 
     See ``get_approval_policy`` for the tenant-filter rationale.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM safety_rules "
             "WHERE id = $1::uuid AND tenant_id = $2::uuid",
@@ -3693,8 +3628,7 @@ async def list_safety_rules_for_coworker(
     only enabled rows are returned, and a NULL ``coworker_id`` means the
     rule applies to every coworker in the tenant.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT * FROM safety_rules
@@ -3772,8 +3706,7 @@ async def update_safety_rule(
         + f" WHERE id = ${idx}::uuid AND tenant_id = ${idx + 1}::uuid "
         "RETURNING *"
     )
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         await _set_safety_guc(conn, actor_user_id=actor_user_id)
         row = await conn.fetchrow(sql, *values)
     if row is None:
@@ -3790,8 +3723,7 @@ async def delete_safety_rule(
     The audit trigger captures the row's pre-delete state in
     before_state so the deleted rule is reconstructable forever.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         await _set_safety_guc(conn, actor_user_id=actor_user_id)
         result = await conn.execute(
             "DELETE FROM safety_rules "
@@ -3881,8 +3813,7 @@ async def insert_safety_decision(
     caller passes None and the column stays NULL. See the 24-hour
     cleanup task note in the ``safety_decisions`` schema block.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO safety_decisions (
@@ -4024,8 +3955,7 @@ async def cleanup_old_safety_approval_contexts(
     own history via ``approval_audit_log``, so nothing is lost by
     clearing the safety-side copy.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         row = await conn.fetchval(
             """
             WITH cleared AS (
@@ -4054,8 +3984,7 @@ async def get_safety_decision(
     None to 404 — indistinguishable from "doesn't exist" so we don't
     leak UUID existence across tenants.
     """
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT * FROM safety_decisions WHERE id = $1::uuid "
             "AND tenant_id = $2::uuid",
@@ -4147,8 +4076,7 @@ async def count_safety_decisions(
         from_ts=from_ts,
         to_ts=to_ts,
     )
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchval(
             f"SELECT COUNT(*) FROM safety_decisions WHERE {where}",
             *params,
@@ -4189,8 +4117,7 @@ async def list_safety_decisions(
         f"ORDER BY created_at DESC LIMIT ${len(params) - 1} "
         f"OFFSET ${len(params)}"
     )
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)
     result: list[dict[str, Any]] = []
     for r in rows:

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -908,6 +908,50 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "TO rolemesh_app, rolemesh_system"
     )
 
+    # ----- RLS policies (PR-D) ---------------------------------------------
+    # Each table that holds tenant data gets ENABLE + FORCE + four
+    # policies. FORCE keeps the table owner (which superuser DDL flags
+    # as a bypass path) under the policy too — only roles with
+    # BYPASSRLS see across rows.
+    #
+    # Order is canary-first (small audit table) then increasing
+    # blast-radius. Per design, each table arrives in its own commit
+    # so a single-table regression is trivially revertable via
+    # ``ALTER TABLE <t> DISABLE ROW LEVEL SECURITY``.
+    await _enable_rls_on(conn, "approval_audit_log")  # D1 canary
+
+
+async def _enable_rls_on(
+    conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record], table: str
+) -> None:
+    """Enable RLS on one table with the four standard policies.
+
+    The policy names ``rls_select`` / ``rls_insert`` / ``rls_update`` /
+    ``rls_delete`` are reused across every table — they live in a
+    per-table namespace, so collisions are impossible. ``DROP POLICY
+    IF EXISTS`` keeps schema bootstrap idempotent.
+
+    Used per-table at the end of ``_create_schema``. Each row's
+    ``tenant_id`` column is matched against ``current_tenant_id()``,
+    which reads ``app.current_tenant_id`` GUC. Connections that
+    forgot to set the GUC see zero rows (fail closed).
+    """
+    await conn.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+    await conn.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
+    for op, body in (
+        ("SELECT", "USING (tenant_id = current_tenant_id())"),
+        ("INSERT", "WITH CHECK (tenant_id = current_tenant_id())"),
+        (
+            "UPDATE",
+            "USING (tenant_id = current_tenant_id()) "
+            "WITH CHECK (tenant_id = current_tenant_id())",
+        ),
+        ("DELETE", "USING (tenant_id = current_tenant_id())"),
+    ):
+        policy = f"rls_{op.lower()}"
+        await conn.execute(f"DROP POLICY IF EXISTS {policy} ON {table}")
+        await conn.execute(f"CREATE POLICY {policy} ON {table} FOR {op} {body}")
+
 
 async def init_database(
     database_url: str | None = None,

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -61,11 +61,23 @@ def _get_pool() -> asyncpg.Pool[asyncpg.Record]:
 
 def _get_admin_pool() -> asyncpg.Pool[asyncpg.Record]:
     """Return the BYPASSRLS admin pool used by cross-tenant maintenance,
-    resolvers, and DDL. Falls back to the business pool if no separate
-    admin DSN was configured (dev/test convenience)."""
-    if _admin_pool is not None:
-        return _admin_pool
-    return _get_pool()
+    resolvers, and DDL.
+
+    Asserts the pool was initialised. The previous version silently
+    fell back to the business pool when ``_admin_pool`` was None so
+    dev/test wouldn't have to set ``ADMIN_DATABASE_URL`` — but that
+    fallback also masks a real misconfiguration in prod (admin path
+    suddenly running under ``rolemesh_app`` NOBYPASSRLS, every
+    cross-tenant query returns zero rows). Both ``init_database``
+    and ``_init_test_database`` already create ``_admin_pool``
+    unconditionally (with a DSN fallback to ``DATABASE_URL`` when
+    ``ADMIN_DATABASE_URL`` is unset), so dev convenience is
+    preserved without the silent-fallback hazard.
+    """
+    assert _admin_pool is not None, (
+        "Admin pool not initialised. Call await init_database() first."
+    )
+    return _admin_pool
 
 
 @asynccontextmanager
@@ -2457,8 +2469,15 @@ async def update_task(
     schedule_value: str | None = None,
     next_run: str | None = None,
     status: str | None = None,
-) -> None:
-    """Update selected fields on a scheduled task, scoped to ``tenant_id``."""
+) -> ScheduledTask | None:
+    """Update selected fields on a scheduled task, scoped to ``tenant_id``.
+
+    Mirrors ``update_user`` / ``update_coworker``: when no fields are
+    supplied, returns the current row instead of silently doing
+    nothing — keeps PATCH-style callers consistent across resources.
+    Returns ``None`` if the row doesn't exist or belongs to another
+    tenant.
+    """
     fields: list[str] = []
     values: list[Any] = []
     param_idx = 1
@@ -2485,16 +2504,20 @@ async def update_task(
         param_idx += 1
 
     if not fields:
-        return
+        return await get_task_by_id(task_id, tenant_id=tenant_id)
 
     values.append(task_id)
     values.append(tenant_id)
     async with tenant_conn(tenant_id) as conn:
-        await conn.execute(
+        row = await conn.fetchrow(
             f"UPDATE scheduled_tasks SET {', '.join(fields)} "
-            f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid",
+            f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
+            f"RETURNING *",
             *values,
         )
+    if row is None:
+        return None
+    return _record_to_scheduled_task(row)
 
 
 async def delete_task(task_id: str, *, tenant_id: str) -> None:

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -1203,14 +1203,50 @@ async def delete_user_oidc_tokens(user_id: str) -> None:
         )
 
 
-async def get_user(user_id: str) -> User | None:
-    """Get a user by ID."""
+async def get_user(user_id: str, *, tenant_id: str) -> User | None:
+    """Fetch a user by id, scoped to ``tenant_id``.
+
+    Tenant scoping is on the query (not a post-fetch check) so a guess
+    at another tenant's user_id returns None from the DB itself. The
+    REST layer maps None to 404 — indistinguishable from "doesn't
+    exist" so we don't leak UUID existence across tenants.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow("SELECT * FROM users WHERE id = $1::uuid", user_id)
+        row = await conn.fetchrow(
+            "SELECT * FROM users WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            user_id,
+            tenant_id,
+        )
     if row is None:
         return None
     return _record_to_user(row)
+
+
+async def resolve_user_for_auth(user_id: str) -> tuple[str, str] | None:
+    """Look up ``(tenant_id, role)`` for a user by id alone.
+
+    System-only escape hatch. The single legitimate caller is the
+    AuthProvider's ``get_user_by_id`` (JWT resume path), which needs
+    to recover the user's tenant_id before any tenant-scoped query
+    can run. The user_id input must be from a signature-verified JWT
+    claim — never from an unauthenticated request body.
+
+    DO NOT use this from REST handlers. The return value carries
+    authority — pair it with a tenant-scoped ``get_user`` once you
+    have it.
+
+    Returns None if the user_id does not exist.
+    """
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT tenant_id, role FROM users WHERE id = $1::uuid",
+            user_id,
+        )
+    if row is None:
+        return None
+    return (str(row["tenant_id"]), str(row["role"]))
 
 
 async def get_users_for_tenant(tenant_id: str) -> list[User]:
@@ -1227,11 +1263,12 @@ async def get_users_for_tenant(tenant_id: str) -> list[User]:
 async def update_user(
     user_id: str,
     *,
+    tenant_id: str,
     name: str | None = None,
     email: str | None = None,
     role: str | None = None,
 ) -> User | None:
-    """Update selected fields on a user."""
+    """Update selected fields on a user, scoped to ``tenant_id``."""
     fields: list[str] = []
     values: list[Any] = []
     param_idx = 1
@@ -1250,13 +1287,16 @@ async def update_user(
         param_idx += 1
 
     if not fields:
-        return await get_user(user_id)
+        return await get_user(user_id, tenant_id=tenant_id)
 
     values.append(user_id)
+    values.append(tenant_id)
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            f"UPDATE users SET {', '.join(fields)} WHERE id = ${param_idx}::uuid RETURNING *",
+            f"UPDATE users SET {', '.join(fields)} "
+            f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
+            f"RETURNING *",
             *values,
         )
     if row is None:
@@ -1421,11 +1461,18 @@ def _record_to_coworker(row: asyncpg.Record) -> Coworker:
     )
 
 
-async def get_coworker(coworker_id: str) -> Coworker | None:
-    """Get a coworker by ID."""
+async def get_coworker(coworker_id: str, *, tenant_id: str) -> Coworker | None:
+    """Fetch a coworker by id, scoped to ``tenant_id``.
+
+    See ``get_user`` for the tenant-filter rationale.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow("SELECT * FROM coworkers WHERE id = $1::uuid", coworker_id)
+        row = await conn.fetchrow(
+            "SELECT * FROM coworkers WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            coworker_id,
+            tenant_id,
+        )
     if row is None:
         return None
     return _record_to_coworker(row)
@@ -1467,6 +1514,7 @@ async def get_all_coworkers() -> list[Coworker]:
 async def update_coworker(
     coworker_id: str,
     *,
+    tenant_id: str,
     name: str | None = None,
     system_prompt: str | None = None,
     tools: list[McpServerConfig] | None = None,
@@ -1476,7 +1524,7 @@ async def update_coworker(
     agent_role: str | None = None,
     permissions: AgentPermissions | None = None,
 ) -> Coworker | None:
-    """Update selected fields on a coworker."""
+    """Update selected fields on a coworker, scoped to ``tenant_id``."""
     fields: list[str] = []
     values: list[Any] = []
     param_idx = 1
@@ -1529,13 +1577,16 @@ async def update_coworker(
         param_idx += 1
 
     if not fields:
-        return await get_coworker(coworker_id)
+        return await get_coworker(coworker_id, tenant_id=tenant_id)
 
     values.append(coworker_id)
+    values.append(tenant_id)
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            f"UPDATE coworkers SET {', '.join(fields)} WHERE id = ${param_idx}::uuid RETURNING *",
+            f"UPDATE coworkers SET {', '.join(fields)} "
+            f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
+            f"RETURNING *",
             *values,
         )
     if row is None:
@@ -1596,11 +1647,18 @@ def _record_to_channel_binding(row: asyncpg.Record) -> ChannelBinding:
     )
 
 
-async def get_channel_binding(binding_id: str) -> ChannelBinding | None:
-    """Get a channel binding by ID."""
+async def get_channel_binding(binding_id: str, *, tenant_id: str) -> ChannelBinding | None:
+    """Fetch a channel binding by id, scoped to ``tenant_id``.
+
+    See ``get_user`` for the tenant-filter rationale.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow("SELECT * FROM channel_bindings WHERE id = $1::uuid", binding_id)
+        row = await conn.fetchrow(
+            "SELECT * FROM channel_bindings WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            binding_id,
+            tenant_id,
+        )
     if row is None:
         return None
     return _record_to_channel_binding(row)
@@ -1642,11 +1700,12 @@ async def get_channel_bindings_for_coworker(coworker_id: str) -> list[ChannelBin
 async def update_channel_binding(
     binding_id: str,
     *,
+    tenant_id: str,
     credentials: dict[str, str] | None = None,
     bot_display_name: str | None = None,
     status: str | None = None,
 ) -> ChannelBinding | None:
-    """Update selected fields on a channel binding."""
+    """Update selected fields on a channel binding, scoped to ``tenant_id``."""
     fields: list[str] = []
     values: list[Any] = []
     param_idx = 1
@@ -1665,13 +1724,16 @@ async def update_channel_binding(
         param_idx += 1
 
     if not fields:
-        return await get_channel_binding(binding_id)
+        return await get_channel_binding(binding_id, tenant_id=tenant_id)
 
     values.append(binding_id)
+    values.append(tenant_id)
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            f"UPDATE channel_bindings SET {', '.join(fields)} WHERE id = ${param_idx}::uuid RETURNING *",
+            f"UPDATE channel_bindings SET {', '.join(fields)} "
+            f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid "
+            f"RETURNING *",
             *values,
         )
     if row is None:
@@ -1739,11 +1801,44 @@ def _record_to_conversation(row: asyncpg.Record) -> Conversation:
     )
 
 
-async def get_conversation(conversation_id: str) -> Conversation | None:
-    """Get a conversation by ID."""
+async def get_conversation(conversation_id: str, *, tenant_id: str) -> Conversation | None:
+    """Fetch a conversation by id, scoped to ``tenant_id``.
+
+    See ``get_user`` for the tenant-filter rationale.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow("SELECT * FROM conversations WHERE id = $1::uuid", conversation_id)
+        row = await conn.fetchrow(
+            "SELECT * FROM conversations WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            conversation_id,
+            tenant_id,
+        )
+    if row is None:
+        return None
+    return _record_to_conversation(row)
+
+
+async def get_conversation_for_notification(conversation_id: str) -> Conversation | None:
+    """Look up a conversation by id alone, intentionally cross-tenant.
+
+    System path. Called from the approval notification fan-out
+    (``_OrchestratorChannelSender`` and ``NotificationTargetResolver``)
+    where the only inputs are a ``conversation_id`` resolved by the
+    engine from an ``ApprovalRequest`` it already trusts. The
+    ``ChannelSender`` protocol carries no tenant context, so this
+    function exists as the explicit, named admin escape rather than
+    silently bypassing tenant scoping.
+
+    DO NOT use this from REST handlers — use the tenant-scoped
+    ``get_conversation`` for any path where the conversation_id can
+    come from user input.
+    """
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM conversations WHERE id = $1::uuid",
+            conversation_id,
+        )
     if row is None:
         return None
     return _record_to_conversation(row)
@@ -2049,13 +2144,17 @@ def _record_to_scheduled_task(row: asyncpg.Record) -> ScheduledTask:
     )
 
 
-async def get_task_by_id(task_id: str) -> ScheduledTask | None:
-    """Get a task by its ID, or None if not found."""
+async def get_task_by_id(task_id: str, *, tenant_id: str) -> ScheduledTask | None:
+    """Fetch a task by id, scoped to ``tenant_id``.
+
+    See ``get_user`` for the tenant-filter rationale.
+    """
     pool = _get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM scheduled_tasks WHERE id = $1::uuid",
+            "SELECT * FROM scheduled_tasks WHERE id = $1::uuid AND tenant_id = $2::uuid",
             task_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -3800,7 +3899,7 @@ async def cleanup_old_safety_approval_contexts(
 
 
 async def get_safety_decision(
-    decision_id: str, tenant_id: str
+    decision_id: str, *, tenant_id: str
 ) -> dict[str, Any] | None:
     """Fetch a single safety_decisions row, scoped to ``tenant_id``.
 

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -924,6 +924,8 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "safety_rules")         # D4 (safety triplet)
     await _enable_rls_on(conn, "safety_decisions")
     await _enable_rls_on(conn, "safety_rules_audit")
+    await _enable_rls_on(conn, "scheduled_tasks")      # D5
+    await _enable_rls_on(conn, "task_run_logs")
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -921,6 +921,9 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "approval_audit_log")  # D1 canary
     await _enable_rls_on(conn, "approval_requests")    # D2
     await _enable_rls_on(conn, "approval_policies")    # D3
+    await _enable_rls_on(conn, "safety_rules")         # D4 (safety triplet)
+    await _enable_rls_on(conn, "safety_decisions")
+    await _enable_rls_on(conn, "safety_rules_audit")
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -932,6 +932,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "coworkers")            # D8
     await _enable_rls_on(conn, "channel_bindings")
     await _enable_rls_on(conn, "user_agent_assignments")
+    await _enable_rls_on(conn, "users")                # D9
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -2155,9 +2155,11 @@ async def update_conversation_user_id(
     """Set the user_id on a conversation (binds a user to a web conversation)."""
     async with tenant_conn(tenant_id) as conn:
         await conn.execute(
-            "UPDATE conversations SET user_id = $1::uuid WHERE id = $2::uuid",
+            "UPDATE conversations SET user_id = $1::uuid "
+            "WHERE id = $2::uuid AND tenant_id = $3::uuid",
             user_id,
             conversation_id,
+            tenant_id,
         )
 
 
@@ -2424,15 +2426,25 @@ async def get_tasks_for_coworker(
 
 
 async def get_all_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
-    """Get all scheduled tasks, optionally filtered by tenant."""
-    async with (tenant_conn(tenant_id) if tenant_id is not None else admin_conn()) as conn:
-        if tenant_id:
+    """Get all scheduled tasks, optionally filtered by tenant.
+
+    Treats both ``None`` and ``""`` as "no tenant scope" so callers
+    that build the parameter from an admin REST query string don't
+    accidentally pass an empty value into ``tenant_conn`` and trigger
+    fail-closed (current_tenant_id = NULL → RLS drops every row).
+    """
+    if tenant_id:
+        async with tenant_conn(tenant_id) as conn:
             rows = await conn.fetch(
-                "SELECT * FROM scheduled_tasks WHERE tenant_id = $1::uuid ORDER BY created_at DESC",
+                "SELECT * FROM scheduled_tasks "
+                "WHERE tenant_id = $1::uuid ORDER BY created_at DESC",
                 tenant_id,
             )
-        else:
-            rows = await conn.fetch("SELECT * FROM scheduled_tasks ORDER BY created_at DESC")
+    else:
+        async with admin_conn() as conn:
+            rows = await conn.fetch(
+                "SELECT * FROM scheduled_tasks ORDER BY created_at DESC"
+            )
     return [_record_to_scheduled_task(row) for row in rows]
 
 
@@ -2496,26 +2508,32 @@ async def delete_task(task_id: str, *, tenant_id: str) -> None:
 
 
 async def get_due_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
-    """Get all active tasks whose next_run is in the past."""
+    """Get all active tasks whose next_run is in the past.
+
+    Treats both ``None`` and ``""`` as "global scheduler scan" so an
+    empty string from a misconfigured caller doesn't enter
+    ``tenant_conn`` and silently filter every row to zero.
+    """
     now = datetime.now(UTC)
-    async with (
-        tenant_conn(tenant_id) if tenant_id is not None else admin_conn()
-    ) as conn:
-        if tenant_id:
+    if tenant_id:
+        async with tenant_conn(tenant_id) as conn:
             rows = await conn.fetch(
                 """
                 SELECT * FROM scheduled_tasks
-                WHERE tenant_id = $1::uuid AND status = 'active' AND next_run IS NOT NULL AND next_run <= $2
+                WHERE tenant_id = $1::uuid AND status = 'active'
+                  AND next_run IS NOT NULL AND next_run <= $2
                 ORDER BY next_run
                 """,
                 tenant_id,
                 now,
             )
-        else:
+    else:
+        async with admin_conn() as conn:
             rows = await conn.fetch(
                 """
                 SELECT * FROM scheduled_tasks
-                WHERE status = 'active' AND next_run IS NOT NULL AND next_run <= $1
+                WHERE status = 'active' AND next_run IS NOT NULL
+                  AND next_run <= $1
                 ORDER BY next_run
                 """,
                 now,

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -929,6 +929,9 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "messages")             # D6
     await _enable_rls_on(conn, "conversations")        # D7
     await _enable_rls_on(conn, "sessions")
+    await _enable_rls_on(conn, "coworkers")            # D8
+    await _enable_rls_on(conn, "channel_bindings")
+    await _enable_rls_on(conn, "user_agent_assignments")
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -1117,9 +1117,8 @@ async def get_all_tenants() -> list[Tenant]:
 
 async def update_tenant_message_cursor(tenant_id: str, cursor: str) -> None:
     """Update the last_message_cursor for a tenant."""
-    pool = _get_pool()
     ts = datetime.fromisoformat(cursor) if cursor else None
-    async with pool.acquire() as conn:
+    async with admin_conn() as conn:
         await conn.execute(
             "UPDATE tenants SET last_message_cursor = $1 WHERE id = $2::uuid",
             ts,
@@ -1430,11 +1429,14 @@ async def update_user(
     return _record_to_user(row)
 
 
-async def delete_user(user_id: str) -> bool:
-    """Delete a user by ID."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
-        result = await conn.execute("DELETE FROM users WHERE id = $1::uuid", user_id)
+async def delete_user(user_id: str, *, tenant_id: str) -> bool:
+    """Delete a user by ID, scoped to ``tenant_id``."""
+    async with tenant_conn(tenant_id) as conn:
+        result = await conn.execute(
+            "DELETE FROM users WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            user_id,
+            tenant_id,
+        )
     return result == "DELETE 1"
 
 
@@ -1714,11 +1716,15 @@ async def update_coworker(
     return _record_to_coworker(row)
 
 
-async def delete_coworker(coworker_id: str) -> bool:
-    """Delete a coworker by ID. CASCADE handles dependent tables."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
-        result = await conn.execute("DELETE FROM coworkers WHERE id = $1::uuid", coworker_id)
+async def delete_coworker(coworker_id: str, *, tenant_id: str) -> bool:
+    """Delete a coworker by ID, scoped to ``tenant_id``. CASCADE handles
+    dependent tables."""
+    async with tenant_conn(tenant_id) as conn:
+        result = await conn.execute(
+            "DELETE FROM coworkers WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            coworker_id,
+            tenant_id,
+        )
     return result == "DELETE 1"
 
 
@@ -1782,14 +1788,18 @@ async def get_channel_binding(binding_id: str, *, tenant_id: str) -> ChannelBind
     return _record_to_channel_binding(row)
 
 
-async def get_channel_binding_for_coworker(coworker_id: str, channel_type: str) -> ChannelBinding | None:
+async def get_channel_binding_for_coworker(
+    coworker_id: str, channel_type: str, *, tenant_id: str
+) -> ChannelBinding | None:
     """Get the channel binding for a coworker and channel type."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM channel_bindings WHERE coworker_id = $1::uuid AND channel_type = $2",
+            "SELECT * FROM channel_bindings "
+            "WHERE coworker_id = $1::uuid AND channel_type = $2 "
+            "AND tenant_id = $3::uuid",
             coworker_id,
             channel_type,
+            tenant_id,
         )
     if row is None:
         return None
@@ -1803,13 +1813,16 @@ async def get_all_channel_bindings() -> list[ChannelBinding]:
     return [_record_to_channel_binding(row) for row in rows]
 
 
-async def get_channel_bindings_for_coworker(coworker_id: str) -> list[ChannelBinding]:
+async def get_channel_bindings_for_coworker(
+    coworker_id: str, *, tenant_id: str
+) -> list[ChannelBinding]:
     """Get all channel bindings for a coworker."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
-            "SELECT * FROM channel_bindings WHERE coworker_id = $1::uuid",
+            "SELECT * FROM channel_bindings "
+            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid",
             coworker_id,
+            tenant_id,
         )
     return [_record_to_channel_binding(row) for row in rows]
 
@@ -1857,11 +1870,14 @@ async def update_channel_binding(
     return _record_to_channel_binding(row)
 
 
-async def delete_channel_binding(binding_id: str) -> bool:
-    """Delete a channel binding by ID."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
-        result = await conn.execute("DELETE FROM channel_bindings WHERE id = $1::uuid", binding_id)
+async def delete_channel_binding(binding_id: str, *, tenant_id: str) -> bool:
+    """Delete a channel binding by ID, scoped to ``tenant_id``."""
+    async with tenant_conn(tenant_id) as conn:
+        result = await conn.execute(
+            "DELETE FROM channel_bindings WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            binding_id,
+            tenant_id,
+        )
     return result == "DELETE 1"
 
 
@@ -1957,13 +1973,17 @@ async def get_conversation_for_notification(conversation_id: str) -> Conversatio
     return _record_to_conversation(row)
 
 
-async def get_conversations_for_coworker(coworker_id: str) -> list[Conversation]:
+async def get_conversations_for_coworker(
+    coworker_id: str, *, tenant_id: str
+) -> list[Conversation]:
     """Get all conversations for a coworker."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
-            "SELECT * FROM conversations WHERE coworker_id = $1::uuid ORDER BY created_at",
+            "SELECT * FROM conversations "
+            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid "
+            "ORDER BY created_at",
             coworker_id,
+            tenant_id,
         )
     return [_record_to_conversation(row) for row in rows]
 
@@ -1975,44 +1995,55 @@ async def get_all_conversations() -> list[Conversation]:
     return [_record_to_conversation(row) for row in rows]
 
 
-async def get_conversation_by_binding_and_chat(channel_binding_id: str, channel_chat_id: str) -> Conversation | None:
+async def get_conversation_by_binding_and_chat(
+    channel_binding_id: str, channel_chat_id: str, *, tenant_id: str
+) -> Conversation | None:
     """Get a conversation by binding and chat ID."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
-            "SELECT * FROM conversations WHERE channel_binding_id = $1::uuid AND channel_chat_id = $2",
+            "SELECT * FROM conversations "
+            "WHERE channel_binding_id = $1::uuid AND channel_chat_id = $2 "
+            "AND tenant_id = $3::uuid",
             channel_binding_id,
             channel_chat_id,
+            tenant_id,
         )
     if row is None:
         return None
     return _record_to_conversation(row)
 
 
-async def delete_conversation(conversation_id: str) -> bool:
-    """Delete a conversation by ID."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
-        result = await conn.execute("DELETE FROM conversations WHERE id = $1::uuid", conversation_id)
+async def delete_conversation(conversation_id: str, *, tenant_id: str) -> bool:
+    """Delete a conversation by ID, scoped to ``tenant_id``."""
+    async with tenant_conn(tenant_id) as conn:
+        result = await conn.execute(
+            "DELETE FROM conversations WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            conversation_id,
+            tenant_id,
+        )
     return result == "DELETE 1"
 
 
-async def update_conversation_last_invocation(conversation_id: str, timestamp: str) -> None:
+async def update_conversation_last_invocation(
+    conversation_id: str, timestamp: str, *, tenant_id: str
+) -> None:
     """Update the last_agent_invocation timestamp for a conversation."""
-    pool = _get_pool()
     ts = datetime.fromisoformat(timestamp) if timestamp else None
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
-            "UPDATE conversations SET last_agent_invocation = $1 WHERE id = $2::uuid",
+            "UPDATE conversations SET last_agent_invocation = $1 "
+            "WHERE id = $2::uuid AND tenant_id = $3::uuid",
             ts,
             conversation_id,
+            tenant_id,
         )
 
 
-async def update_conversation_user_id(conversation_id: str, user_id: str) -> None:
+async def update_conversation_user_id(
+    conversation_id: str, user_id: str, *, tenant_id: str
+) -> None:
     """Set the user_id on a conversation (binds a user to a web conversation)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
             "UPDATE conversations SET user_id = $1::uuid WHERE id = $2::uuid",
             user_id,
@@ -2025,13 +2056,14 @@ async def update_conversation_user_id(conversation_id: str, user_id: str) -> Non
 # ---------------------------------------------------------------------------
 
 
-async def get_session(conversation_id: str) -> str | None:
-    """Get the session ID for a conversation."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+async def get_session(conversation_id: str, *, tenant_id: str) -> str | None:
+    """Get the session ID for a conversation, scoped to ``tenant_id``."""
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
-            "SELECT session_id FROM sessions WHERE conversation_id = $1::uuid",
+            "SELECT session_id FROM sessions "
+            "WHERE conversation_id = $1::uuid AND tenant_id = $2::uuid",
             conversation_id,
+            tenant_id,
         )
     if row is None:
         return None
@@ -2123,10 +2155,9 @@ async def get_messages_since(
     chat_jid: str = "",
 ) -> list[NewMessage]:
     """Get messages since a timestamp for a specific conversation."""
-    pool = _get_pool()
     # Handle empty timestamp by using epoch
     ts = since_timestamp if since_timestamp else "1970-01-01T00:00:00+00:00"
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT * FROM (
@@ -2161,9 +2192,8 @@ async def get_new_messages_for_conversations(
     """
     if not conversation_ids:
         return []
-    pool = _get_pool()
     ts = since_timestamp if since_timestamp else "1970-01-01T00:00:00+00:00"
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         placeholders = ", ".join(f"${i + 3}::uuid" for i in range(len(conversation_ids)))
         sql = f"""
             SELECT * FROM (
@@ -2210,8 +2240,7 @@ async def get_new_messages_for_conversations(
 
 async def create_task(task: ScheduledTask) -> None:
     """Create a new scheduled task."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(task.tenant_id) as conn:
         await conn.execute(
             """
             INSERT INTO scheduled_tasks (id, tenant_id, coworker_id, conversation_id, prompt, schedule_type, schedule_value, context_mode, next_run, status, created_at)
@@ -2269,13 +2298,17 @@ async def get_task_by_id(task_id: str, *, tenant_id: str) -> ScheduledTask | Non
     return _record_to_scheduled_task(row)
 
 
-async def get_tasks_for_coworker(coworker_id: str) -> list[ScheduledTask]:
+async def get_tasks_for_coworker(
+    coworker_id: str, *, tenant_id: str
+) -> list[ScheduledTask]:
     """Get all tasks for a specific coworker."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
-            "SELECT * FROM scheduled_tasks WHERE coworker_id = $1::uuid ORDER BY created_at DESC",
+            "SELECT * FROM scheduled_tasks "
+            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid "
+            "ORDER BY created_at DESC",
             coworker_id,
+            tenant_id,
         )
     return [_record_to_scheduled_task(row) for row in rows]
 
@@ -2296,13 +2329,14 @@ async def get_all_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
 async def update_task(
     task_id: str,
     *,
+    tenant_id: str,
     prompt: str | None = None,
     schedule_type: str | None = None,
     schedule_value: str | None = None,
     next_run: str | None = None,
     status: str | None = None,
 ) -> None:
-    """Update selected fields on a scheduled task."""
+    """Update selected fields on a scheduled task, scoped to ``tenant_id``."""
     fields: list[str] = []
     values: list[Any] = []
     param_idx = 1
@@ -2332,26 +2366,31 @@ async def update_task(
         return
 
     values.append(task_id)
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    values.append(tenant_id)
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
-            f"UPDATE scheduled_tasks SET {', '.join(fields)} WHERE id = ${param_idx}::uuid",
+            f"UPDATE scheduled_tasks SET {', '.join(fields)} "
+            f"WHERE id = ${param_idx}::uuid AND tenant_id = ${param_idx + 1}::uuid",
             *values,
         )
 
 
-async def delete_task(task_id: str) -> None:
+async def delete_task(task_id: str, *, tenant_id: str) -> None:
     """Delete a task and its run logs (CASCADE handles task_run_logs)."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
-        await conn.execute("DELETE FROM scheduled_tasks WHERE id = $1::uuid", task_id)
+    async with tenant_conn(tenant_id) as conn:
+        await conn.execute(
+            "DELETE FROM scheduled_tasks WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            task_id,
+            tenant_id,
+        )
 
 
 async def get_due_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
     """Get all active tasks whose next_run is in the past."""
-    pool = _get_pool()
     now = datetime.now(UTC)
-    async with pool.acquire() as conn:
+    async with (
+        tenant_conn(tenant_id) if tenant_id is not None else admin_conn()
+    ) as conn:
         if tenant_id:
             rows = await conn.fetch(
                 """
@@ -2378,31 +2417,32 @@ async def update_task_after_run(
     task_id: str,
     next_run: str | None,
     last_result: str,
+    *,
+    tenant_id: str,
 ) -> None:
     """Update task state after execution."""
-    pool = _get_pool()
     now = datetime.now(UTC)
     new_status = "completed" if next_run is None else None
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
             """
             UPDATE scheduled_tasks
             SET next_run = $1, last_run = $2, last_result = $3,
                 status = COALESCE($4::text, status)
-            WHERE id = $5::uuid
+            WHERE id = $5::uuid AND tenant_id = $6::uuid
             """,
             _to_dt(next_run),
             now,
             last_result[:500] if last_result else last_result,
             new_status,
             task_id,
+            tenant_id,
         )
 
 
 async def log_task_run(log: TaskRunLog) -> None:
     """Insert a task run log entry."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(log.tenant_id) as conn:
         await conn.execute(
             """
             INSERT INTO task_run_logs (tenant_id, task_id, run_at, duration_ms, status, result, error)
@@ -2609,45 +2649,49 @@ async def assign_agent_to_user(user_id: str, coworker_id: str, tenant_id: str) -
         )
 
 
-async def unassign_agent_from_user(user_id: str, coworker_id: str) -> None:
+async def unassign_agent_from_user(
+    user_id: str, coworker_id: str, *, tenant_id: str
+) -> None:
     """Remove a coworker assignment from a user."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         await conn.execute(
-            "DELETE FROM user_agent_assignments WHERE user_id = $1::uuid AND coworker_id = $2::uuid",
+            "DELETE FROM user_agent_assignments "
+            "WHERE user_id = $1::uuid AND coworker_id = $2::uuid "
+            "AND tenant_id = $3::uuid",
             user_id,
             coworker_id,
+            tenant_id,
         )
 
 
-async def get_agents_for_user(user_id: str) -> list[Coworker]:
-    """Get all coworkers assigned to a user."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+async def get_agents_for_user(user_id: str, *, tenant_id: str) -> list[Coworker]:
+    """Get all coworkers assigned to a user, scoped to ``tenant_id``."""
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT c.* FROM coworkers c
             JOIN user_agent_assignments uaa ON c.id = uaa.coworker_id
-            WHERE uaa.user_id = $1::uuid
+            WHERE uaa.user_id = $1::uuid AND uaa.tenant_id = $2::uuid
             ORDER BY c.name
             """,
             user_id,
+            tenant_id,
         )
     return [_record_to_coworker(row) for row in rows]
 
 
-async def get_users_for_agent(coworker_id: str) -> list[User]:
-    """Get all users assigned to a coworker."""
-    pool = _get_pool()
-    async with pool.acquire() as conn:
+async def get_users_for_agent(coworker_id: str, *, tenant_id: str) -> list[User]:
+    """Get all users assigned to a coworker, scoped to ``tenant_id``."""
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT u.* FROM users u
             JOIN user_agent_assignments uaa ON u.id = uaa.user_id
-            WHERE uaa.coworker_id = $1::uuid
+            WHERE uaa.coworker_id = $1::uuid AND uaa.tenant_id = $2::uuid
             ORDER BY u.name
             """,
             coworker_id,
+            tenant_id,
         )
     return [_record_to_user(row) for row in rows]
 
@@ -2699,9 +2743,8 @@ async def create_approval_policy(
     priority: int = 0,
 ) -> ApprovalPolicy:
     """Insert a new approval policy and return the stored row."""
-    pool = _get_pool()
     approvers = approver_user_ids or []
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             """
             INSERT INTO approval_policies (
@@ -2762,7 +2805,6 @@ async def list_approval_policies(
     enabled: bool | None = None,
 ) -> list[ApprovalPolicy]:
     """List policies for a tenant, optionally filtered by coworker and state."""
-    pool = _get_pool()
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if coworker_id is not None:
@@ -2776,7 +2818,7 @@ async def list_approval_policies(
         + " AND ".join(clauses)
         + " ORDER BY priority DESC, updated_at DESC"
     )
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)
     return [_record_to_approval_policy(r) for r in rows]
 
@@ -3072,7 +3114,6 @@ async def list_approval_requests(
     coworker_id: str | None = None,
     limit: int = 100,
 ) -> list[ApprovalRequest]:
-    pool = _get_pool()
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if status is not None:
@@ -3087,7 +3128,7 @@ async def list_approval_requests(
         + " AND ".join(clauses)
         + f" ORDER BY created_at DESC LIMIT ${len(params)}"
     )
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)
     return [_record_to_approval_request(r) for r in rows]
 
@@ -3597,7 +3638,6 @@ async def list_safety_rules(
     enabled: bool | None = None,
 ) -> list[SafetyRule]:
     """List rules for a tenant, optionally filtered."""
-    pool = _get_pool()
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if coworker_id is not None:
@@ -3614,7 +3654,7 @@ async def list_safety_rules(
         + " AND ".join(clauses)
         + " ORDER BY priority DESC, updated_at DESC"
     )
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)
     return [_record_to_safety_rule(r) for r in rows]
 
@@ -3747,7 +3787,6 @@ async def list_safety_rules_audit(
     V2 admin UI will surface this as a timeline. Test fixture uses it
     to pin actor/action correctness.
     """
-    pool = _get_pool()
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if rule_id is not None:
@@ -3759,7 +3798,7 @@ async def list_safety_rules_audit(
         + " AND ".join(clauses)
         + f" ORDER BY created_at DESC LIMIT ${len(params)}"
     )
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)
     result: list[dict[str, Any]] = []
     for r in rows:
@@ -3868,7 +3907,6 @@ async def stream_safety_decisions(
     Malformed timestamps raise at query time (psycopg surface) which
     the REST layer turns into 422.
     """
-    pool = _get_pool()
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if from_ts is not None:
@@ -3894,7 +3932,7 @@ async def stream_safety_decisions(
         + " AND ".join(clauses)
         + " ORDER BY created_at DESC"
     )
-    async with pool.acquire() as conn, conn.transaction():
+    async with tenant_conn(tenant_id) as conn:
         cur = await conn.cursor(sql, *params)
         while True:
             rows = await cur.fetch(chunk_size)

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -919,6 +919,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     # so a single-table regression is trivially revertable via
     # ``ALTER TABLE <t> DISABLE ROW LEVEL SECURITY``.
     await _enable_rls_on(conn, "approval_audit_log")  # D1 canary
+    await _enable_rls_on(conn, "approval_requests")    # D2
 
 
 async def _enable_rls_on(

--- a/src/rolemesh/ipc/task_handler.py
+++ b/src/rolemesh/ipc/task_handler.py
@@ -168,7 +168,7 @@ async def process_task_ipc(
             assert isinstance(task_id_val, str)
             task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
             if task and can_manage_task(permissions, task.coworker_id, coworker_id):
-                await update_task(task_id_val, status="paused")
+                await update_task(task_id_val, tenant_id=tenant_id, status="paused")
                 logger.info("Task paused via IPC", task_id=task_id_val, source_group=source_group)
                 await deps.on_tasks_changed()
             else:
@@ -180,7 +180,7 @@ async def process_task_ipc(
             assert isinstance(task_id_val, str)
             task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
             if task and can_manage_task(permissions, task.coworker_id, coworker_id):
-                await update_task(task_id_val, status="active")
+                await update_task(task_id_val, tenant_id=tenant_id, status="active")
                 logger.info("Task resumed via IPC", task_id=task_id_val, source_group=source_group)
                 await deps.on_tasks_changed()
             else:
@@ -192,7 +192,7 @@ async def process_task_ipc(
             assert isinstance(task_id_val, str)
             task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
             if task and can_manage_task(permissions, task.coworker_id, coworker_id):
-                await delete_task(task_id_val)
+                await delete_task(task_id_val, tenant_id=tenant_id)
                 logger.info("Task cancelled via IPC", task_id=task_id_val, source_group=source_group)
                 await deps.on_tasks_changed()
             else:
@@ -246,7 +246,7 @@ async def process_task_ipc(
                 except (ValueError, TypeError):
                     pass
 
-        await update_task(task_id_val, **updates)
+        await update_task(task_id_val, tenant_id=tenant_id, **updates)
         logger.info("Task updated via IPC", task_id=task_id_val, source_group=source_group, updates=updates)
         await deps.on_tasks_changed()
 

--- a/src/rolemesh/ipc/task_handler.py
+++ b/src/rolemesh/ipc/task_handler.py
@@ -166,7 +166,7 @@ async def process_task_ipc(
         task_id_val = data.get("taskId")
         if task_id_val:
             assert isinstance(task_id_val, str)
-            task = await get_task_by_id(task_id_val)
+            task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
             if task and can_manage_task(permissions, task.coworker_id, coworker_id):
                 await update_task(task_id_val, status="paused")
                 logger.info("Task paused via IPC", task_id=task_id_val, source_group=source_group)
@@ -178,7 +178,7 @@ async def process_task_ipc(
         task_id_val = data.get("taskId")
         if task_id_val:
             assert isinstance(task_id_val, str)
-            task = await get_task_by_id(task_id_val)
+            task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
             if task and can_manage_task(permissions, task.coworker_id, coworker_id):
                 await update_task(task_id_val, status="active")
                 logger.info("Task resumed via IPC", task_id=task_id_val, source_group=source_group)
@@ -190,7 +190,7 @@ async def process_task_ipc(
         task_id_val = data.get("taskId")
         if task_id_val:
             assert isinstance(task_id_val, str)
-            task = await get_task_by_id(task_id_val)
+            task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
             if task and can_manage_task(permissions, task.coworker_id, coworker_id):
                 await delete_task(task_id_val)
                 logger.info("Task cancelled via IPC", task_id=task_id_val, source_group=source_group)
@@ -204,7 +204,7 @@ async def process_task_ipc(
             return
         assert isinstance(task_id_val, str)
 
-        task = await get_task_by_id(task_id_val)
+        task = await get_task_by_id(task_id_val, tenant_id=tenant_id)
         if not task:
             logger.warning("Task not found for update", task_id=task_id_val, source_group=source_group)
             return

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1393,7 +1393,7 @@ async def main() -> None:
     # fan-out.
     from rolemesh.approval.engine import ApprovalEngine
     from rolemesh.approval.notification import NotificationTargetResolver
-    from rolemesh.db.pg import get_conversation as _pg_get_conv
+    from rolemesh.db.pg import get_conversation_for_notification as _pg_get_conv
 
     async def _convs_for_user_and_cw(user_id: str, coworker_id: str) -> list[str]:
         # Find conversations this user can talk to this coworker in.

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1420,6 +1420,28 @@ async def main() -> None:
         return ranked
 
     class _OrchestratorChannelSender:
+        """ChannelSender adapter for the approval notification path.
+
+        SECURITY CONTRACT — ``conversation_id`` MUST come from a
+        tenant-scoped DB lookup that the caller has already trusted
+        (in practice: ``ApprovalRequest.conversation_id`` from a row
+        the engine fetched via ``get_approval_request(tenant_id=...)``,
+        OR a conversation_id rotated through
+        ``NotificationTargetResolver`` which the engine bound to the
+        request's tenant). The ``get_conversation_for_notification``
+        lookup below is intentionally cross-tenant (no GUC), so a
+        forged or mis-routed conversation_id would happily resolve
+        to *another* tenant's chat and we would publish the approval
+        prompt there.
+
+        Adding a defence-in-depth ``conv.tenant_id == request.tenant_id``
+        check here would require threading the request's tenant
+        through ChannelSender — left as a follow-up rather than
+        widened in this PR. Until then: callers must not pass an
+        unvalidated conversation_id (e.g. from user input) to this
+        sender.
+        """
+
         async def send_to_conversation(
             self, conversation_id: str, text: str
         ) -> None:

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -412,7 +412,9 @@ async def _auto_create_web_conversation(
                 # ws.py may have already created the conversation before the
                 # NATS message reaches the orchestrator. Check DB first to
                 # avoid a UniqueViolationError on (binding_id, chat_id).
-                conv = await get_conversation_by_binding_and_chat(binding_id, chat_id)
+                conv = await get_conversation_by_binding_and_chat(
+                    binding_id, chat_id, tenant_id=cw.config.tenant_id
+                )
                 if conv is None:
                     conv = await create_conversation(
                         tenant_id=cw.config.tenant_id,
@@ -575,7 +577,9 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
 
     previous_cursor = conv_state.last_agent_timestamp
     conv_state.last_agent_timestamp = missed_messages[-1].timestamp
-    await update_conversation_last_invocation(conv.id, missed_messages[-1].timestamp)
+    await update_conversation_last_invocation(
+        conv.id, missed_messages[-1].timestamp, tenant_id=conv.tenant_id
+    )
 
     logger.info("Processing messages", coworker=config.name, message_count=len(missed_messages))
 
@@ -759,7 +763,9 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             )
             return True
         conv_state.last_agent_timestamp = previous_cursor
-        await update_conversation_last_invocation(conv.id, previous_cursor)
+        await update_conversation_last_invocation(
+            conv.id, previous_cursor, tenant_id=conv.tenant_id
+        )
         logger.warning("Agent error, rolled back message cursor for retry", coworker=config.name)
         return False
 
@@ -1122,7 +1128,9 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                         if _queue.send_message(conv_id, formatted):
                             logger.debug("Piped messages to active container", conv_id=conv_id)
                             conv_state.last_agent_timestamp = all_pending[-1].timestamp
-                            await update_conversation_last_invocation(conv.id, all_pending[-1].timestamp)
+                            await update_conversation_last_invocation(
+                                conv.id, all_pending[-1].timestamp, tenant_id=conv.tenant_id
+                            )
 
                             ch_type = _get_channel_type_for_conv(cw_state, conv)
                             binding = cw_state.channel_bindings.get(ch_type)

--- a/src/rolemesh/orchestration/task_scheduler.py
+++ b/src/rolemesh/orchestration/task_scheduler.py
@@ -268,7 +268,7 @@ async def _run_task(
         result_summary = result[:200]
     else:
         result_summary = "Completed"
-    await update_task_after_run(task.id, next_run, result_summary)
+    await update_task_after_run(task.id, next_run, result_summary, tenant_id=task.tenant_id)
 
 
 _scheduler_running: bool = False

--- a/src/rolemesh/orchestration/task_scheduler.py
+++ b/src/rolemesh/orchestration/task_scheduler.py
@@ -294,7 +294,7 @@ def start_scheduler_loop(deps: SchedulerDependencies) -> asyncio.Task[None]:
                     logger.info("Found due tasks", count=len(due_tasks))
 
                 for task in due_tasks:
-                    current_task = await get_task_by_id(task.id)
+                    current_task = await get_task_by_id(task.id, tenant_id=task.tenant_id)
                     if not current_task or current_task.status != "active":
                         continue
 

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -297,7 +297,7 @@ async def get_user_detail(
     target = await pg.get_user(user_id, tenant_id=user.tenant_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    agents = await pg.get_agents_for_user(user_id)
+    agents = await pg.get_agents_for_user(user_id, tenant_id=user.tenant_id)
     resp = UserDetailResponse(
         **_user_to_response(target).model_dump(),
         assigned_agents=[_coworker_to_summary(a) for a in agents],
@@ -338,7 +338,7 @@ async def delete_user(
     target = await pg.get_user(user_id, tenant_id=user.tenant_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    await pg.delete_user(user_id)
+    await pg.delete_user(user_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------
@@ -385,8 +385,8 @@ async def get_agent_detail(
     user: AdminUser,
 ) -> AgentDetailResponse:
     cw = await _get_agent_or_404(agent_id, user.tenant_id)
-    bindings = await pg.get_channel_bindings_for_coworker(agent_id)
-    conversations = await pg.get_conversations_for_coworker(agent_id)
+    bindings = await pg.get_channel_bindings_for_coworker(agent_id, tenant_id=user.tenant_id)
+    conversations = await pg.get_conversations_for_coworker(agent_id, tenant_id=user.tenant_id)
     return AgentDetailResponse(
         **_coworker_to_response(cw).model_dump(),
         bindings=[_binding_to_response(b) for b in bindings],
@@ -426,7 +426,7 @@ async def delete_agent(
     user: AdminUser,
 ) -> None:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    await pg.delete_coworker(agent_id)
+    await pg.delete_coworker(agent_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------
@@ -440,7 +440,7 @@ async def list_assigned_users(
     user: AdminUser,
 ) -> list[UserResponse]:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    users = await pg.get_users_for_agent(agent_id)
+    users = await pg.get_users_for_agent(agent_id, tenant_id=user.tenant_id)
     return [_user_to_response(u) for u in users]
 
 
@@ -467,7 +467,7 @@ async def unassign_agent(
     target = await pg.get_user(user_id, tenant_id=user.tenant_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    await pg.unassign_agent_from_user(user_id, agent_id)
+    await pg.unassign_agent_from_user(user_id, agent_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------
@@ -481,7 +481,7 @@ async def list_bindings(
     user: AdminUser,
 ) -> list[BindingResponse]:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    bindings = await pg.get_channel_bindings_for_coworker(agent_id)
+    bindings = await pg.get_channel_bindings_for_coworker(agent_id, tenant_id=user.tenant_id)
     return [_binding_to_response(b) for b in bindings]
 
 
@@ -538,7 +538,7 @@ async def delete_binding(
     binding = await pg.get_channel_binding(binding_id, tenant_id=user.tenant_id)
     if binding is None or binding.coworker_id != agent_id:
         raise HTTPException(status_code=404, detail="Binding not found")
-    await pg.delete_channel_binding(binding_id)
+    await pg.delete_channel_binding(binding_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +552,7 @@ async def list_conversations(
     user: AdminUser,
 ) -> list[ConversationResponse]:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    conversations = await pg.get_conversations_for_coworker(agent_id)
+    conversations = await pg.get_conversations_for_coworker(agent_id, tenant_id=user.tenant_id)
     return [_conversation_to_response(c) for c in conversations]
 
 
@@ -588,7 +588,7 @@ async def delete_conversation(
     conv = await pg.get_conversation(conversation_id, tenant_id=user.tenant_id)
     if conv is None or conv.coworker_id != agent_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
-    await pg.delete_conversation(conversation_id)
+    await pg.delete_conversation(conversation_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------
@@ -608,7 +608,7 @@ async def list_agent_tasks(
     user: AdminUser,
 ) -> list[TaskResponse]:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    tasks = await pg.get_tasks_for_coworker(agent_id)
+    tasks = await pg.get_tasks_for_coworker(agent_id, tenant_id=user.tenant_id)
     return [_task_to_response(t) for t in tasks]
 
 
@@ -620,7 +620,7 @@ async def delete_task(
     task = await pg.get_task_by_id(task_id, tenant_id=user.tenant_id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
-    await pg.delete_task(task_id)
+    await pg.delete_task(task_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -201,8 +201,8 @@ def _task_to_response(t: ScheduledTask) -> TaskResponse:
 
 async def _get_agent_or_404(agent_id: str, tenant_id: str) -> Coworker:
     """Fetch a coworker, raising 404 if not found or cross-tenant."""
-    cw = await pg.get_coworker(agent_id)
-    if cw is None or cw.tenant_id != tenant_id:
+    cw = await pg.get_coworker(agent_id, tenant_id=tenant_id)
+    if cw is None:
         raise HTTPException(status_code=404, detail="Agent not found")
     return cw
 
@@ -294,8 +294,8 @@ async def get_user_detail(
     user_id: str,
     user: UserManager,
 ) -> UserDetailResponse:
-    target = await pg.get_user(user_id)
-    if target is None or target.tenant_id != user.tenant_id:
+    target = await pg.get_user(user_id, tenant_id=user.tenant_id)
+    if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     agents = await pg.get_agents_for_user(user_id)
     resp = UserDetailResponse(
@@ -311,12 +311,18 @@ async def update_user(
     body: UserUpdate,
     user: UserManager,
 ) -> UserResponse:
-    target = await pg.get_user(user_id)
-    if target is None or target.tenant_id != user.tenant_id:
+    target = await pg.get_user(user_id, tenant_id=user.tenant_id)
+    if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     if body.role == "owner" and user.role != "owner":
         raise HTTPException(status_code=403, detail="Only owners can assign owner role")
-    updated = await pg.update_user(user_id, name=body.name, email=body.email, role=body.role)
+    updated = await pg.update_user(
+        user_id,
+        tenant_id=user.tenant_id,
+        name=body.name,
+        email=body.email,
+        role=body.role,
+    )
     if updated is None:
         raise HTTPException(status_code=404, detail="User not found")
     return _user_to_response(updated)
@@ -329,8 +335,8 @@ async def delete_user(
 ) -> None:
     if user_id == user.user_id:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
-    target = await pg.get_user(user_id)
-    if target is None or target.tenant_id != user.tenant_id:
+    target = await pg.get_user(user_id, tenant_id=user.tenant_id)
+    if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await pg.delete_user(user_id)
 
@@ -399,6 +405,7 @@ async def update_agent(
     permissions = _parse_permissions(body.permissions)
     updated = await pg.update_coworker(
         agent_id,
+        tenant_id=user.tenant_id,
         name=body.name,
         system_prompt=body.system_prompt,
         tools=tools,
@@ -444,8 +451,8 @@ async def assign_agent(
     user: AdminUser,
 ) -> None:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    target = await pg.get_user(body.user_id)
-    if target is None or target.tenant_id != user.tenant_id:
+    target = await pg.get_user(body.user_id, tenant_id=user.tenant_id)
+    if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await pg.assign_agent_to_user(body.user_id, agent_id, user.tenant_id)
 
@@ -457,8 +464,8 @@ async def unassign_agent(
     user: AdminUser,
 ) -> None:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    target = await pg.get_user(user_id)
-    if target is None or target.tenant_id != user.tenant_id:
+    target = await pg.get_user(user_id, tenant_id=user.tenant_id)
+    if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await pg.unassign_agent_from_user(user_id, agent_id)
 
@@ -506,11 +513,12 @@ async def update_binding(
     user: AdminUser,
 ) -> BindingResponse:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    binding = await pg.get_channel_binding(binding_id)
+    binding = await pg.get_channel_binding(binding_id, tenant_id=user.tenant_id)
     if binding is None or binding.coworker_id != agent_id:
         raise HTTPException(status_code=404, detail="Binding not found")
     updated = await pg.update_channel_binding(
         binding_id,
+        tenant_id=user.tenant_id,
         credentials=body.credentials,
         bot_display_name=body.bot_display_name,
         status=body.status,
@@ -527,7 +535,7 @@ async def delete_binding(
     user: AdminUser,
 ) -> None:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    binding = await pg.get_channel_binding(binding_id)
+    binding = await pg.get_channel_binding(binding_id, tenant_id=user.tenant_id)
     if binding is None or binding.coworker_id != agent_id:
         raise HTTPException(status_code=404, detail="Binding not found")
     await pg.delete_channel_binding(binding_id)
@@ -556,7 +564,7 @@ async def create_conversation(
 ) -> ConversationResponse:
     await _get_agent_or_404(agent_id, user.tenant_id)
     # Verify the binding belongs to this agent
-    binding = await pg.get_channel_binding(body.channel_binding_id)
+    binding = await pg.get_channel_binding(body.channel_binding_id, tenant_id=user.tenant_id)
     if binding is None or binding.coworker_id != agent_id:
         raise HTTPException(status_code=400, detail="Binding does not belong to this agent")
     conv = await pg.create_conversation(
@@ -577,7 +585,7 @@ async def delete_conversation(
     user: AdminUser,
 ) -> None:
     await _get_agent_or_404(agent_id, user.tenant_id)
-    conv = await pg.get_conversation(conversation_id)
+    conv = await pg.get_conversation(conversation_id, tenant_id=user.tenant_id)
     if conv is None or conv.coworker_id != agent_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
     await pg.delete_conversation(conversation_id)
@@ -609,12 +617,8 @@ async def delete_task(
     task_id: str,
     user: AdminUser,
 ) -> None:
-    task = await pg.get_task_by_id(task_id)
+    task = await pg.get_task_by_id(task_id, tenant_id=user.tenant_id)
     if task is None:
-        raise HTTPException(status_code=404, detail="Task not found")
-    # Verify the task's agent belongs to user's tenant
-    cw = await pg.get_coworker(task.coworker_id)
-    if cw is None or cw.tenant_id != user.tenant_id:
         raise HTTPException(status_code=404, detail="Task not found")
     await pg.delete_task(task_id)
 
@@ -993,8 +997,8 @@ async def _validate_safety_rule_body(
     ):
         coworkers: list[object] = []
         if coworker_id is not None:
-            cw = await pg.get_coworker(coworker_id)
-            if cw is not None and cw.tenant_id == tenant_id:
+            cw = await pg.get_coworker(coworker_id, tenant_id=tenant_id)
+            if cw is not None:
                 coworkers.append(cw)
         else:
             coworkers.extend(await pg.get_coworkers_for_tenant(tenant_id))
@@ -1279,7 +1283,7 @@ async def get_safety_decision_ep(
     """
     if tid != user.tenant_id:
         raise HTTPException(status_code=404, detail="decision not found")
-    row = await pg.get_safety_decision(decision_id, tid)
+    row = await pg.get_safety_decision(decision_id, tenant_id=tid)
     if row is None:
         raise HTTPException(status_code=404, detail="decision not found")
     return row

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -27,7 +27,7 @@ from fastapi.staticfiles import StaticFiles
 from nats.js.api import StreamConfig
 
 from rolemesh.db import pg
-from rolemesh.db.pg import _get_pool, close_database, init_database
+from rolemesh.db.pg import _get_pool, close_database, init_database, tenant_conn
 from webui import auth, ws
 from webui.admin import router as admin_router
 from webui.config import (
@@ -187,13 +187,9 @@ async def list_conversations(
     result_or_error = await _resolve_web_agent(agent_id, token)
     if isinstance(result_or_error, JSONResponse):
         return result_or_error
-    binding_id, _ = result_or_error
+    binding_id, tenant_id = result_or_error
 
-    pool = auth.get_pool()
-    if pool is None:
-        return JSONResponse({"error": "Database unavailable"}, status_code=503)
-
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT c.channel_chat_id as chat_id,
@@ -230,13 +226,9 @@ async def get_messages(
     result_or_error = await _resolve_web_agent(agent_id, token)
     if isinstance(result_or_error, JSONResponse):
         return result_or_error
-    binding_id, _ = result_or_error
+    binding_id, tenant_id = result_or_error
 
-    pool = auth.get_pool()
-    if pool is None:
-        return JSONResponse({"error": "Database unavailable"}, status_code=503)
-
-    async with pool.acquire() as conn:
+    async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(
             """
             SELECT m.content, m.timestamp, m.is_from_me, m.is_bot_message

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -167,10 +167,10 @@ async def _resolve_web_agent(agent_id: str, token: str) -> tuple[str, str] | JSO
     if user is None:
         return JSONResponse({"error": "Unauthorized"}, status_code=401)
     try:
-        coworker = await pg.get_coworker(agent_id)
+        coworker = await pg.get_coworker(agent_id, tenant_id=user.tenant_id)
     except asyncpg.DataError:
         coworker = None
-    if coworker is None or coworker.tenant_id != user.tenant_id:
+    if coworker is None:
         return JSONResponse({"error": "Agent not found"}, status_code=404)
     binding = await pg.get_channel_binding_for_coworker(agent_id, "web")
     if binding is None:

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -172,7 +172,7 @@ async def _resolve_web_agent(agent_id: str, token: str) -> tuple[str, str] | JSO
         coworker = None
     if coworker is None:
         return JSONResponse({"error": "Agent not found"}, status_code=404)
-    binding = await pg.get_channel_binding_for_coworker(agent_id, "web")
+    binding = await pg.get_channel_binding_for_coworker(agent_id, "web", tenant_id=user.tenant_id)
     if binding is None:
         return JSONResponse({"error": "Web binding not found"}, status_code=404)
     return binding.id, user.tenant_id

--- a/src/webui/ws.py
+++ b/src/webui/ws.py
@@ -59,10 +59,10 @@ async def handle_ws(ws: WebSocket, agent_id: str, token: str, chat_id: str = "")
 
     # 2. Look up the coworker (agent)
     try:
-        coworker = await pg.get_coworker(agent_id)
+        coworker = await pg.get_coworker(agent_id, tenant_id=user.tenant_id)
     except Exception:  # asyncpg.DataError for invalid UUID  # noqa: BLE001
         coworker = None
-    if coworker is None or coworker.tenant_id != user.tenant_id:
+    if coworker is None:
         await ws.close(code=4004, reason="Agent not found")
         return
 

--- a/src/webui/ws.py
+++ b/src/webui/ws.py
@@ -68,14 +68,14 @@ async def handle_ws(ws: WebSocket, agent_id: str, token: str, chat_id: str = "")
 
     # 3. Check assignment — owners/admins can access any agent
     if user.role not in ("owner", "admin"):
-        assigned = await pg.get_agents_for_user(user.user_id)
+        assigned = await pg.get_agents_for_user(user.user_id, tenant_id=user.tenant_id)
         assigned_ids = {c.id for c in assigned}
         if coworker.id not in assigned_ids:
             await ws.close(code=4003, reason="Not assigned to this agent")
             return
 
     # 4. Look up web binding for this coworker
-    binding = await pg.get_channel_binding_for_coworker(agent_id, "web")
+    binding = await pg.get_channel_binding_for_coworker(agent_id, "web", tenant_id=user.tenant_id)
     if binding is None:
         await ws.close(code=4004, reason="Web binding not found")
         return
@@ -92,7 +92,7 @@ async def handle_ws(ws: WebSocket, agent_id: str, token: str, chat_id: str = "")
     sender_id = user.user_id if user.user_id != BOOTSTRAP_USER_ID else f"web-user-{chat_id[:8]}"
 
     # 5. Find or create conversation
-    conv = await pg.get_conversation_by_binding_and_chat(binding_id, chat_id)
+    conv = await pg.get_conversation_by_binding_and_chat(binding_id, chat_id, tenant_id=user.tenant_id)
     if conv is None:
         conv = await pg.create_conversation(
             tenant_id=user.tenant_id,
@@ -106,7 +106,7 @@ async def handle_ws(ws: WebSocket, agent_id: str, token: str, chat_id: str = "")
             requires_trigger=False,
         )
     elif conv.user_id is None and user.user_id != BOOTSTRAP_USER_ID:
-        await pg.update_conversation_user_id(conv.id, user.user_id)
+        await pg.update_conversation_user_id(conv.id, user.user_id, tenant_id=user.tenant_id)
 
     # Send session info (include binding_id for NATS subscription subjects)
     await ws.send_json({"type": "session", "chatId": chat_id, "bindingId": binding_id})

--- a/tests/approval/e2e/harness.py
+++ b/tests/approval/e2e/harness.py
@@ -378,7 +378,9 @@ async def orchestrator_harness(
         return []
 
     async def _get_conv(conv_id: str) -> object | None:
-        return await pg.get_conversation(conv_id)
+        # Mirror main.py: notification path needs an unscoped lookup
+        # because the ChannelSender protocol carries no tenant context.
+        return await pg.get_conversation_for_notification(conv_id)
 
     resolver = NotificationTargetResolver(
         get_conversations_for_user_and_coworker=_no_convs,
@@ -419,14 +421,27 @@ async def orchestrator_harness(
             try:
                 data = json.loads(msg.data)
                 # Mirror main._handle_tasks: look up coworker, override
-                # tenant_id with the trusted value.
+                # tenant_id with the trusted value. Production resolves
+                # via in-memory _state.coworkers; the e2e harness has no
+                # such state, so we hit the DB directly using the raw
+                # pool (this is a system-level dispatch lookup, not a
+                # tenant-scoped business call).
                 claimed_cw = data.get("coworkerId", "")
-                source_cw = None
+                source_tenant: str | None = None
+                source_id: str | None = None
                 if claimed_cw:
-                    source_cw = await pg.get_coworker(claimed_cw)
-                if source_cw is not None:
-                    tenant_id = source_cw.tenant_id
-                    coworker_id = source_cw.id
+                    pool = pg._get_pool()
+                    async with pool.acquire() as conn:
+                        row = await conn.fetchrow(
+                            "SELECT id, tenant_id FROM coworkers WHERE id = $1::uuid",
+                            claimed_cw,
+                        )
+                    if row is not None:
+                        source_tenant = str(row["tenant_id"])
+                        source_id = str(row["id"])
+                if source_tenant is not None and source_id is not None:
+                    tenant_id = source_tenant
+                    coworker_id = source_id
                 else:
                     tenant_id = data.get("tenantId", "")
                     coworker_id = claimed_cw

--- a/tests/attack_sim/test_E_tenant_isolation.py
+++ b/tests/attack_sim/test_E_tenant_isolation.py
@@ -40,7 +40,7 @@ def _resolver() -> NotificationTargetResolver:
         return []
 
     async def _conv(cid: str) -> object | None:
-        return await pg.get_conversation(cid)
+        return await pg.get_conversation_for_notification(cid)
 
     return NotificationTargetResolver(
         get_conversations_for_user_and_coworker=_convs,

--- a/tests/attack_sim/test_F_approval_abuse.py
+++ b/tests/attack_sim/test_F_approval_abuse.py
@@ -47,7 +47,7 @@ def _resolver() -> NotificationTargetResolver:
         return []
 
     async def _conv(cid: str) -> object | None:
-        return await pg.get_conversation(cid)
+        return await pg.get_conversation_for_notification(cid)
 
     return NotificationTargetResolver(
         get_conversations_for_user_and_coworker=_convs,

--- a/tests/attack_sim/test_G_dos.py
+++ b/tests/attack_sim/test_G_dos.py
@@ -97,7 +97,7 @@ async def test_G4_approval_flood_does_not_corrupt_state(
         return []
 
     async def _resolver_get_conv(cid: str) -> object | None:
-        return await pg.get_conversation(cid)
+        return await pg.get_conversation_for_notification(cid)
 
     engine = ApprovalEngine(
         publisher=fake_publisher,

--- a/tests/db/test_admin_path_isolation.py
+++ b/tests/db/test_admin_path_isolation.py
@@ -1,0 +1,100 @@
+"""PR-E: ``list_*`` admin paths return cross-tenant rows; downstream
+must dispatch each row back into the per-tenant context.
+
+The reconcile loops (approval expiry, stuck-approved republish,
+stuck-executing salvage) all share this shape:
+
+  1. Maintenance loop calls a ``list_*`` admin function — that
+     function uses ``admin_conn()`` (BYPASSRLS) so it sees every
+     tenant's pending rows in one scan.
+  2. For each row, the handler dispatches back into a
+     ``tenant_conn(row.tenant_id)`` block to actually mutate state.
+
+That dispatch is what keeps RLS in play during the mutation step.
+A regression like "loop reuses the admin connection for the UPDATE
+too" would silently bypass RLS on the write path. This test pins
+the contract by:
+
+  - Inserting rows from two tenants.
+  - Calling ``list_expired_pending_approvals`` (the canonical admin
+    list) and asserting it returns rows from BOTH tenants.
+  - Verifying each returned row carries its own ``tenant_id`` so
+    the caller has the value it needs to switch contexts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from rolemesh.db.pg import (
+    create_approval_request,
+    create_channel_binding,
+    create_conversation,
+    create_coworker,
+    create_tenant,
+    create_user,
+    list_expired_pending_approvals,
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+async def _seed_expired_request(tag: str) -> tuple[str, str]:
+    t = await create_tenant(name=f"T{tag}", slug=f"al-{tag.lower()}-{uuid.uuid4().hex[:6]}")
+    u = await create_user(
+        tenant_id=t.id, name=f"U{tag}",
+        email=f"u-{tag.lower()}-{uuid.uuid4().hex[:6]}@x.com",
+        role="owner",
+    )
+    cw = await create_coworker(
+        tenant_id=t.id, name=f"CW{tag}",
+        folder=f"cw-{tag.lower()}-{uuid.uuid4().hex[:6]}"
+    )
+    b = await create_channel_binding(
+        coworker_id=cw.id, tenant_id=t.id,
+        channel_type="telegram", credentials={"bot_token": "x"},
+    )
+    conv = await create_conversation(
+        tenant_id=t.id, coworker_id=cw.id, channel_binding_id=b.id,
+        channel_chat_id=str(uuid.uuid4()),
+    )
+    # Backdate expires_at so the maintenance loop will see it as expired.
+    expired_at = datetime.now(UTC) - timedelta(minutes=5)
+    req = await create_approval_request(
+        tenant_id=t.id, coworker_id=cw.id, conversation_id=conv.id,
+        policy_id=None, user_id=u.id, job_id=f"j-{uuid.uuid4().hex[:8]}",
+        mcp_server_name="erp",
+        actions=[{"tool_name": "refund", "params": {}}],
+        action_hashes=[uuid.uuid4().hex],
+        rationale="t", source="proposal", status="pending",
+        resolved_approvers=[u.id],
+        expires_at=expired_at,
+    )
+    return t.id, req.id
+
+
+async def test_list_expired_returns_all_tenants_with_their_tenant_ids() -> None:
+    """A reconcile-style admin list must:
+
+    1. See rows from every tenant (admin_conn bypass works).
+    2. Carry tenant_id on each row so the dispatch step can hand
+       it back to tenant_conn.
+    """
+    a_tenant, a_req = await _seed_expired_request("A")
+    b_tenant, b_req = await _seed_expired_request("B")
+
+    expired = await list_expired_pending_approvals()
+    by_id = {r.id: r for r in expired}
+
+    assert a_req in by_id, "tenant A's expired request missing from admin list"
+    assert b_req in by_id, "tenant B's expired request missing from admin list"
+
+    assert by_id[a_req].tenant_id == a_tenant
+    assert by_id[b_req].tenant_id == b_tenant
+    assert by_id[a_req].tenant_id != by_id[b_req].tenant_id, (
+        "both rows came back with the same tenant_id — the admin list "
+        "lost the per-row tenant attribution that downstream dispatch needs"
+    )

--- a/tests/db/test_connection_wrappers.py
+++ b/tests/db/test_connection_wrappers.py
@@ -1,0 +1,99 @@
+"""PR-B: tenant_conn / admin_conn behaviour.
+
+These tests pin the connection-wrapper contract:
+
+  - tenant_conn(tenant_id) sets app.current_tenant_id only inside
+    the wrapper's transaction; the GUC must clear when the wrapper
+    exits.
+  - Reusing the same physical connection across acquires (which
+    asyncpg's pool does) must not leak the previous tenant's GUC.
+  - admin_conn() never sets the GUC.
+  - The roles ``rolemesh_app`` and ``rolemesh_system`` exist after
+    schema bootstrap. (We can't easily flip the test container's
+    DSN to log in *as* those roles, so this is a sanity check that
+    PR-B's CREATE ROLE block ran.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.db.pg import (
+    _get_admin_pool,
+    _get_pool,
+    admin_conn,
+    tenant_conn,
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+async def test_tenant_conn_sets_current_tenant_id() -> None:
+    """Inside the wrapper, current_tenant_id() returns the value we set."""
+    tid = "11111111-1111-1111-1111-111111111111"
+    async with tenant_conn(tid) as conn:
+        observed = await conn.fetchval("SELECT current_tenant_id()::text")
+    assert observed == tid
+
+
+async def test_tenant_conn_clears_guc_on_exit() -> None:
+    """After the wrapper exits, the next acquire on the same pool must
+    NOT see the previous tenant's GUC. This is the regression that
+    happens if someone forgets to wrap set_config inside a transaction
+    (with is_local=true)."""
+    tid = "22222222-2222-2222-2222-222222222222"
+    async with tenant_conn(tid) as conn:
+        assert await conn.fetchval("SELECT current_tenant_id()::text") == tid
+    # Bypass the wrapper and read the GUC directly. asyncpg's pool may
+    # or may not hand us the same physical connection back, but either
+    # way the answer must be NULL — both because the connection was
+    # transactionally scoped (is_local=true) AND because RESET ALL is
+    # called between holders by asyncpg.
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        observed = await conn.fetchval("SELECT current_tenant_id()::text")
+    assert observed is None
+
+
+async def test_tenant_conn_back_to_back_no_residue() -> None:
+    """Two tenant_conn calls in sequence must each see only their own
+    tenant — A's GUC must not bleed into B's wrapper."""
+    a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    async with tenant_conn(a) as conn:
+        assert await conn.fetchval("SELECT current_tenant_id()::text") == a
+    async with tenant_conn(b) as conn:
+        assert await conn.fetchval("SELECT current_tenant_id()::text") == b
+
+
+async def test_admin_conn_has_null_current_tenant_id() -> None:
+    """admin_conn never sets the GUC; current_tenant_id() returns NULL.
+    Once RLS lands in PR-D, this is what makes the role's BYPASSRLS
+    bit (or absence of policies) the *only* gate on cross-tenant
+    reads — there's no way to set the GUC accidentally."""
+    async with admin_conn() as conn:
+        observed = await conn.fetchval("SELECT current_tenant_id()::text")
+    assert observed is None
+
+
+async def test_rls_roles_were_created() -> None:
+    """PR-B's _create_schema must have provisioned both roles. If this
+    fails after a clean DB init, the DO $$ ... CREATE ROLE block
+    silently failed (e.g. bootstrap user lacks CREATEROLE)."""
+    pool = _get_admin_pool()
+    async with pool.acquire() as conn:
+        names = await conn.fetch(
+            "SELECT rolname FROM pg_roles WHERE rolname IN "
+            "('rolemesh_app', 'rolemesh_system') ORDER BY rolname"
+        )
+    assert [r["rolname"] for r in names] == ["rolemesh_app", "rolemesh_system"]
+
+
+async def test_rls_function_returns_null_when_unset() -> None:
+    """current_tenant_id() must fail closed (return NULL, not error)
+    when the GUC isn't set — required so RLS policies treat the row
+    as excluded rather than crashing the query."""
+    pool = _get_admin_pool()
+    async with pool.acquire() as conn:
+        observed = await conn.fetchval("SELECT current_tenant_id()")
+    assert observed is None

--- a/tests/db/test_cross_tenant_isolation.py
+++ b/tests/db/test_cross_tenant_isolation.py
@@ -25,6 +25,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from rolemesh.core.types import ScheduledTask
 from rolemesh.db.pg import (
     create_approval_policy,
     create_approval_request,
@@ -32,12 +33,22 @@ from rolemesh.db.pg import (
     create_conversation,
     create_coworker,
     create_safety_rule,
+    create_task,
     create_tenant,
     create_user,
     get_approval_policy,
     get_approval_request,
+    get_channel_binding,
+    get_conversation,
+    get_coworker,
+    get_safety_decision,
     get_safety_rule,
+    get_task_by_id,
+    get_user,
+    insert_safety_decision,
     list_approval_audit,
+    resolve_user_for_auth,
+    update_user,
 )
 
 pytestmark = pytest.mark.usefixtures("test_db")
@@ -223,3 +234,188 @@ async def test_list_approval_audit_rejects_mismatched_tenant() -> None:
         "list_approval_audit leaked audit rows for tenant A's request "
         "to tenant B — audit table tenant filter broken"
     )
+
+
+# ---------------------------------------------------------------------------
+# PR-A: by-id business functions
+# ---------------------------------------------------------------------------
+
+
+async def test_get_user_rejects_mismatched_tenant() -> None:
+    """get_user(user_id, tenant_id=B) for a tenant-A user_id must
+    return None — even when the user_id is a real, valid UUID."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    same_tenant = await get_user(a["user_id"], tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == a["user_id"]
+
+    leaked = await get_user(a["user_id"], tenant_id=b["tenant_id"])
+    assert leaked is None, "get_user leaked tenant A's user to tenant B"
+
+
+async def test_get_coworker_rejects_mismatched_tenant() -> None:
+    """get_coworker is the most-frequented by-id call. Cross-tenant
+    leakage here would cascade into every endpoint going through
+    ``_get_agent_or_404``."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    same_tenant = await get_coworker(a["coworker_id"], tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == a["coworker_id"]
+
+    leaked = await get_coworker(a["coworker_id"], tenant_id=b["tenant_id"])
+    assert leaked is None, "get_coworker leaked tenant A's coworker to tenant B"
+
+
+async def test_get_channel_binding_rejects_mismatched_tenant() -> None:
+    """A binding's id must not be resolvable from another tenant."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+    # _two_tenants doesn't return binding_id; recreate one by lookup.
+    # The tenant chain already created a binding — fish it back via a
+    # fresh insert on tenant A so the test is self-contained.
+    binding = await create_channel_binding(
+        coworker_id=a["coworker_id"],
+        tenant_id=a["tenant_id"],
+        channel_type="slack",
+        credentials={"bot_token": "x"},
+    )
+
+    same_tenant = await get_channel_binding(binding.id, tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == binding.id
+
+    leaked = await get_channel_binding(binding.id, tenant_id=b["tenant_id"])
+    assert leaked is None, (
+        "get_channel_binding leaked tenant A's binding to tenant B"
+    )
+
+
+async def test_get_conversation_rejects_mismatched_tenant() -> None:
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    same_tenant = await get_conversation(
+        a["conversation_id"], tenant_id=a["tenant_id"]
+    )
+    assert same_tenant is not None
+    assert same_tenant.id == a["conversation_id"]
+
+    leaked = await get_conversation(
+        a["conversation_id"], tenant_id=b["tenant_id"]
+    )
+    assert leaked is None, (
+        "get_conversation leaked tenant A's conversation to tenant B"
+    )
+
+
+async def test_get_task_by_id_rejects_mismatched_tenant() -> None:
+    """ScheduledTask.id is globally unique. Cross-tenant fetches must
+    still return None — covers task IPC path that takes task_id from
+    a NATS payload."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    task_id = str(uuid.uuid4())
+    await create_task(
+        ScheduledTask(
+            id=task_id,
+            tenant_id=a["tenant_id"],
+            coworker_id=a["coworker_id"],
+            prompt="ping",
+            schedule_type="cron",
+            schedule_value="0 9 * * *",
+            context_mode="isolated",
+            next_run="2030-01-01T00:00:00+00:00",
+            status="active",
+        )
+    )
+
+    same_tenant = await get_task_by_id(task_id, tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert same_tenant.id == task_id
+
+    leaked = await get_task_by_id(task_id, tenant_id=b["tenant_id"])
+    assert leaked is None, "get_task_by_id leaked tenant A's task to tenant B"
+
+
+async def test_get_safety_decision_rejects_mismatched_tenant() -> None:
+    """Already enforced pre-PR-A but now via kwarg-only signature.
+    A regression that flips it back to positional ``(decision_id,
+    tenant_id)`` would compile against the old call sites that pass
+    only ``decision_id`` and silently bypass the filter."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    decision_id = await insert_safety_decision(
+        tenant_id=a["tenant_id"],
+        stage="pre_tool_call",
+        verdict_action="block",
+        triggered_rule_ids=[],
+        findings=[],
+        context_digest="d",
+        context_summary="s",
+    )
+
+    same_tenant = await get_safety_decision(decision_id, tenant_id=a["tenant_id"])
+    assert same_tenant is not None
+    assert str(same_tenant["id"]) == decision_id
+
+    leaked = await get_safety_decision(decision_id, tenant_id=b["tenant_id"])
+    assert leaked is None, (
+        "get_safety_decision leaked tenant A's decision to tenant B"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR-A: by-id write paths must also enforce tenant scope
+# ---------------------------------------------------------------------------
+
+
+async def test_update_user_does_not_modify_other_tenant() -> None:
+    """update_user with tenant_id=B for a tenant-A user_id must NOT
+    update the row. Without the SQL ``AND tenant_id`` filter, the
+    UPDATE would happily mutate another tenant's user record."""
+    tenants = await _two_tenants()
+    a, b = tenants["A"], tenants["B"]
+
+    result = await update_user(
+        a["user_id"], tenant_id=b["tenant_id"], name="HIJACKED"
+    )
+    assert result is None, "update_user returned a row for cross-tenant id"
+
+    # Verify the actual row in tenant A is untouched.
+    a_user = await get_user(a["user_id"], tenant_id=a["tenant_id"])
+    assert a_user is not None
+    assert a_user.name != "HIJACKED", (
+        "update_user mutated tenant A's user when called with tenant B's id"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR-A: resolve_user_for_auth (admin escape hatch)
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_user_for_auth_returns_tenant_and_role() -> None:
+    """The auth bootstrap path needs (tenant_id, role) from a JWT
+    user_id alone. Verifies shape and content."""
+    tenants = await _two_tenants()
+    a = tenants["A"]
+
+    resolved = await resolve_user_for_auth(a["user_id"])
+    assert resolved is not None
+    tenant_id, role = resolved
+    assert tenant_id == a["tenant_id"]
+    assert role == "owner"  # set by _two_tenants
+
+
+async def test_resolve_user_for_auth_returns_none_for_missing_id() -> None:
+    """A nonexistent user_id must return None — JWT replay against a
+    deleted user must not crash or leak."""
+    bogus = str(uuid.uuid4())
+    resolved = await resolve_user_for_auth(bogus)
+    assert resolved is None

--- a/tests/db/test_function_classification.py
+++ b/tests/db/test_function_classification.py
@@ -1,0 +1,79 @@
+"""PR-E: static check that webui never imports admin escapes.
+
+The classification (in pg.py docstrings + the RLS design doc) is
+that ``admin_conn`` and ``resolve_*`` are system-only paths.
+REST handlers must never reach for them — every webui caller goes
+through tenant-scoped reads/writes that have a user.tenant_id in
+scope.
+
+This test parses every .py under src/webui/ and fails the moment
+someone imports an admin path. It's intentionally a static check
+(not a runtime one) so the violation is caught at PR review,
+not after the offending build ships.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ADMIN_NAMES = frozenset({
+    "admin_conn",
+    "_get_admin_pool",
+    "resolve_user_for_auth",
+    "resolve_request_tenant",
+    "get_conversation_for_notification",
+})
+
+
+def _admin_imports(tree: ast.Module) -> list[str]:
+    """Return any names from ADMIN_NAMES imported by this module."""
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if "rolemesh.db" in node.module or node.module == "pg":
+                for alias in node.names:
+                    if alias.name in ADMIN_NAMES:
+                        found.append(alias.name)
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                # Catch `from rolemesh.db import pg` — that's fine,
+                # but `pg.admin_conn(...)` calls are a separate
+                # check (Attribute access).
+                pass
+    return found
+
+
+def _admin_attribute_calls(tree: ast.Module, src_text: str) -> list[str]:
+    """Return any ``pg.admin_conn(...)`` / ``pg.resolve_*(...)`` calls."""
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in ADMIN_NAMES:
+            # Most callers do ``pg.admin_conn`` — check the value is
+            # an attribute on something named pg, but be lenient since
+            # the rule is "no use", not "no specific syntax".
+            line = src_text.splitlines()[node.lineno - 1] if node.lineno else ""
+            found.append(f"{node.attr} (line {node.lineno}: {line.strip()[:80]})")
+    return found
+
+
+def test_webui_never_imports_admin_paths() -> None:
+    webui_root = Path(__file__).resolve().parents[2] / "src" / "webui"
+    assert webui_root.is_dir(), f"webui dir not found at {webui_root}"
+    violations: dict[str, list[str]] = {}
+    for py in webui_root.rglob("*.py"):
+        text = py.read_text()
+        try:
+            tree = ast.parse(text)
+        except SyntaxError as exc:
+            raise AssertionError(f"failed to parse {py}: {exc}") from exc
+        bad = _admin_imports(tree) + _admin_attribute_calls(tree, text)
+        if bad:
+            violations[str(py.relative_to(webui_root.parents[1]))] = bad
+    assert not violations, (
+        "webui code imports or calls admin paths (must use tenant-scoped "
+        "wrappers instead):\n"
+        + "\n".join(
+            f"  {path}: {', '.join(items)}" for path, items in violations.items()
+        )
+    )

--- a/tests/db/test_pg.py
+++ b/tests/db/test_pg.py
@@ -177,11 +177,11 @@ async def test_conversation_crud() -> None:
     assert conv.channel_chat_id == "12345"
     assert conv.requires_trigger is True
 
-    by_bc = await get_conversation_by_binding_and_chat(bid, "12345")
+    by_bc = await get_conversation_by_binding_and_chat(bid, "12345", tenant_id=_tid)
     assert by_bc is not None
     assert by_bc.id == convid
 
-    await update_conversation_last_invocation(convid, "2024-06-01T12:00:00+00:00")
+    await update_conversation_last_invocation(convid, "2024-06-01T12:00:00+00:00", tenant_id=_tid)
     updated = await get_conversation(convid, tenant_id=_tid)
     assert updated is not None
     assert updated.last_agent_invocation is not None
@@ -194,9 +194,9 @@ async def test_conversation_crud() -> None:
 
 async def test_sessions_per_conversation() -> None:
     tid, cwid, _, convid = await _create_chain()
-    assert await get_session(convid) is None
+    assert await get_session(convid, tenant_id=tid) is None
     await set_session(convid, tid, cwid, "sess-abc")
-    assert await get_session(convid) == "sess-abc"
+    assert await get_session(convid, tenant_id=tid) == "sess-abc"
 
     sessions = await get_all_sessions()
     assert convid in sessions
@@ -274,18 +274,18 @@ async def test_task_crud() -> None:
     assert retrieved is not None
     assert retrieved.prompt == "Do something"
 
-    tasks = await get_tasks_for_coworker(cwid)
+    tasks = await get_tasks_for_coworker(cwid, tenant_id=tid)
     assert len(tasks) == 1
 
     all_tasks = await get_all_tasks(tid)
     assert len(all_tasks) == 1
 
-    await update_task(task_id, prompt="Updated prompt")
+    await update_task(task_id, tenant_id=tid, prompt="Updated prompt")
     updated = await get_task_by_id(task_id, tenant_id=tid)
     assert updated is not None
     assert updated.prompt == "Updated prompt"
 
-    await delete_task(task_id)
+    await delete_task(task_id, tenant_id=tid)
     assert await get_task_by_id(task_id, tenant_id=tid) is None
 
 
@@ -325,7 +325,7 @@ async def test_update_task_after_run() -> None:
             status="active",
         )
     )
-    await update_task_after_run(task_id, "2024-01-03T09:00:00+00:00", "Done")
+    await update_task_after_run(task_id, "2024-01-03T09:00:00+00:00", "Done", tenant_id=tid)
     updated = await get_task_by_id(task_id, tenant_id=tid)
     assert updated is not None
     assert "Done" in (updated.last_result or "")

--- a/tests/db/test_pg.py
+++ b/tests/db/test_pg.py
@@ -137,7 +137,7 @@ async def test_create_and_get_coworker() -> None:
     assert cw.tools == [McpServerConfig(name="my-mcp-server", type="sse", url="http://localhost:9100/mcp/")]
     assert cw.agent_backend == "claude-code"
 
-    fetched = await get_coworker(cw.id)
+    fetched = await get_coworker(cw.id, tenant_id=t.id)
     assert fetched is not None
     assert fetched.name == "Ops Bot"
 
@@ -160,7 +160,7 @@ async def test_channel_binding() -> None:
     assert b.id
     assert b.credentials["bot_token"] == "abc"
 
-    fetched = await get_channel_binding(b.id)
+    fetched = await get_channel_binding(b.id, tenant_id=t.id)
     assert fetched is not None
     assert fetched.channel_type == "telegram"
 
@@ -172,7 +172,7 @@ async def test_channel_binding() -> None:
 
 async def test_conversation_crud() -> None:
     _tid, _cwid, bid, convid = await _create_chain()
-    conv = await get_conversation(convid)
+    conv = await get_conversation(convid, tenant_id=_tid)
     assert conv is not None
     assert conv.channel_chat_id == "12345"
     assert conv.requires_trigger is True
@@ -182,7 +182,7 @@ async def test_conversation_crud() -> None:
     assert by_bc.id == convid
 
     await update_conversation_last_invocation(convid, "2024-06-01T12:00:00+00:00")
-    updated = await get_conversation(convid)
+    updated = await get_conversation(convid, tenant_id=_tid)
     assert updated is not None
     assert updated.last_agent_invocation is not None
 
@@ -270,7 +270,7 @@ async def test_task_crud() -> None:
         )
     )
 
-    retrieved = await get_task_by_id(task_id)
+    retrieved = await get_task_by_id(task_id, tenant_id=tid)
     assert retrieved is not None
     assert retrieved.prompt == "Do something"
 
@@ -281,12 +281,12 @@ async def test_task_crud() -> None:
     assert len(all_tasks) == 1
 
     await update_task(task_id, prompt="Updated prompt")
-    updated = await get_task_by_id(task_id)
+    updated = await get_task_by_id(task_id, tenant_id=tid)
     assert updated is not None
     assert updated.prompt == "Updated prompt"
 
     await delete_task(task_id)
-    assert await get_task_by_id(task_id) is None
+    assert await get_task_by_id(task_id, tenant_id=tid) is None
 
 
 async def test_get_due_tasks() -> None:
@@ -326,7 +326,7 @@ async def test_update_task_after_run() -> None:
         )
     )
     await update_task_after_run(task_id, "2024-01-03T09:00:00+00:00", "Done")
-    updated = await get_task_by_id(task_id)
+    updated = await get_task_by_id(task_id, tenant_id=tid)
     assert updated is not None
     assert "Done" in (updated.last_result or "")
 

--- a/tests/db/test_rls_enforcement.py
+++ b/tests/db/test_rls_enforcement.py
@@ -1,0 +1,267 @@
+"""PR-E: end-to-end RLS enforcement tests.
+
+These run AFTER PR-D enabled policies on every tenant table. The
+goal is to verify that the policies actually block cross-tenant
+access at the DB layer — not just at the application WHERE clause.
+
+Tests use a dedicated asyncpg pool that connects as
+``rolemesh_app`` (NOBYPASSRLS). The default test pool connects
+as the testcontainer's superuser, which bypasses RLS regardless of
+ENABLE/FORCE — useful for fixture setup but useless for verifying
+the policy itself.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import asyncpg
+import pytest
+
+from rolemesh.db import pg
+from rolemesh.db.pg import (
+    _get_pool,
+    admin_conn,
+    create_approval_request,
+    create_channel_binding,
+    create_conversation,
+    create_coworker,
+    create_tenant,
+    create_user,
+    tenant_conn,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+# ---------------------------------------------------------------------------
+# rolemesh_app pool — NOBYPASSRLS, the only role that actually feels RLS
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def app_pool(pg_url: str) -> AsyncGenerator[asyncpg.Pool[asyncpg.Record], None]:
+    """Spin up a separate pool that logs in as ``rolemesh_app``.
+
+    The role was provisioned by PR-B's _create_schema; we set its
+    password here (in-memory testcontainer, throwaway value) so we
+    can connect with a normal DSN.
+    """
+    superuser_pool = _get_pool()
+    async with superuser_pool.acquire() as conn:
+        await conn.execute("ALTER USER rolemesh_app PASSWORD 'test'")
+
+    # Rewrite the DSN to log in as rolemesh_app — testcontainer DSN
+    # has the form postgresql://test:test@host:port/db; swap creds.
+    rewritten = pg_url.replace("test:test@", "rolemesh_app:test@", 1)
+    pool = await asyncpg.create_pool(rewritten, min_size=1, max_size=2)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _two_tenants_full() -> dict[str, dict[str, str]]:
+    """Build two complete chains so we have approval_requests to query."""
+    out: dict[str, dict[str, str]] = {}
+    for tag in ("A", "B"):
+        t = await create_tenant(name=f"T{tag}", slug=f"rls-{tag.lower()}-{uuid.uuid4().hex[:6]}")
+        u = await create_user(
+            tenant_id=t.id, name=f"U{tag}",
+            email=f"u-{tag.lower()}-{uuid.uuid4().hex[:6]}@x.com",
+            role="owner",
+        )
+        cw = await create_coworker(
+            tenant_id=t.id, name=f"CW{tag}",
+            folder=f"cw-{tag.lower()}-{uuid.uuid4().hex[:6]}"
+        )
+        b = await create_channel_binding(
+            coworker_id=cw.id, tenant_id=t.id,
+            channel_type="telegram", credentials={"bot_token": "x"},
+        )
+        conv = await create_conversation(
+            tenant_id=t.id, coworker_id=cw.id, channel_binding_id=b.id,
+            channel_chat_id=str(uuid.uuid4()),
+        )
+        req = await create_approval_request(
+            tenant_id=t.id, coworker_id=cw.id, conversation_id=conv.id,
+            policy_id=None, user_id=u.id, job_id=f"j-{uuid.uuid4().hex[:8]}",
+            mcp_server_name="erp",
+            actions=[{"tool_name": "refund", "params": {}}],
+            action_hashes=[uuid.uuid4().hex],
+            rationale="t", source="proposal", status="pending",
+            resolved_approvers=[u.id],
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        out[tag] = {
+            "tenant_id": t.id,
+            "user_id": u.id,
+            "coworker_id": cw.id,
+            "request_id": req.id,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant blocking (the main reason RLS exists)
+# ---------------------------------------------------------------------------
+
+
+async def test_app_role_select_blocked_across_tenant(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """Set the GUC to tenant A, then issue a SELECT that explicitly
+    asks for tenant B's rows. RLS must drop them — even though the
+    tenant_id literal in the WHERE clause matches a real row, the
+    policy's ``USING (tenant_id = current_tenant_id())`` adds an
+    AND that filters it back out."""
+    tenants = await _two_tenants_full()
+    a, b = tenants["A"], tenants["B"]
+
+    async with app_pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                a["tenant_id"],
+            )
+            rows = await conn.fetch(
+                "SELECT * FROM approval_requests WHERE tenant_id = $1::uuid",
+                b["tenant_id"],
+            )
+    assert rows == [], (
+        "RLS failed: rolemesh_app saw tenant B rows while bound to tenant A"
+    )
+
+
+async def test_app_role_insert_blocked_across_tenant(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """Try to INSERT a row whose tenant_id != current_tenant_id().
+    The policy's ``WITH CHECK`` clause must reject it. asyncpg
+    surfaces this as InsufficientPrivilegeError (PG SQLSTATE 42501)
+    or CheckViolation depending on PG's classification."""
+    tenants = await _two_tenants_full()
+    a, b = tenants["A"], tenants["B"]
+    async with app_pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                a["tenant_id"],
+            )
+            with pytest.raises(
+                (asyncpg.InsufficientPrivilegeError, asyncpg.CheckViolationError)
+            ):
+                await conn.execute(
+                    "INSERT INTO approval_audit_log "
+                    "(request_id, tenant_id, action) "
+                    "VALUES ($1::uuid, $2::uuid, $3)",
+                    a["request_id"],  # valid request id, but...
+                    b["tenant_id"],   # ...wrong tenant_id
+                    "noop",
+                )
+
+
+async def test_unset_guc_returns_empty(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """Forgot to call set_config? Every tenant table must look empty
+    rather than returning all-rows-because-NULL-is-falsy. This is
+    the fail-closed contract that current_tenant_id()'s NULLIF
+    enforces."""
+    await _two_tenants_full()
+    async with app_pool.acquire() as conn:
+        rows = await conn.fetch("SELECT * FROM approval_requests")
+    assert rows == [], (
+        "RLS fail-closed broken: unset GUC returned rows from approval_requests"
+    )
+
+
+async def test_admin_pool_bypasses_rls() -> None:
+    """admin_conn() runs as the superuser (in test) or rolemesh_system
+    (in prod). Either way it has BYPASSRLS, so cross-tenant queries
+    work — that's the whole point of this pool. Without this carve-out
+    the maintenance loops can't reconcile across tenants."""
+    await _two_tenants_full()
+    async with admin_conn() as conn:
+        rows = await conn.fetch(
+            "SELECT DISTINCT tenant_id FROM approval_requests"
+        )
+    assert len({str(r["tenant_id"]) for r in rows}) >= 2, (
+        "admin_conn should see rows from both tenants"
+    )
+
+
+async def test_guc_does_not_leak_across_acquires(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """``set_config(..., true)`` is transaction-local. After the
+    wrapper closes the transaction, the GUC must be cleared even if
+    the same physical connection is handed to the next acquire.
+    Regression target: a careless rewrite that drops the surrounding
+    transaction would persist the GUC across acquires and quietly
+    leak tenant data."""
+    tenants = await _two_tenants_full()
+    a = tenants["A"]
+    async with app_pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                a["tenant_id"],
+            )
+            assert (
+                await conn.fetchval("SELECT current_tenant_id()::text")
+            ) == a["tenant_id"]
+    # Subsequent acquire on the same pool: GUC must be NULL.
+    async with app_pool.acquire() as conn:
+        assert await conn.fetchval("SELECT current_tenant_id()") is None
+        rows = await conn.fetch(
+            "SELECT * FROM approval_requests WHERE tenant_id = $1::uuid",
+            a["tenant_id"],
+        )
+        assert rows == [], (
+            "GUC leaked across acquire — would have shown rows from previous tenant"
+        )
+
+
+async def test_force_rls_keeps_owner_under_policy(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """Without FORCE ROW LEVEL SECURITY, the table owner (which on
+    a fresh testcontainer is the superuser that ran CREATE TABLE) is
+    exempt from policies. PR-D adds FORCE precisely so this exemption
+    is removed for non-superusers. ``rolemesh_app`` is not the owner
+    in this test, but the regression we're guarding against is "we
+    forgot FORCE on table X". Verify pg_class.relrowsecurity AND
+    pg_class.relforcerowsecurity are both true on every tenant table."""
+    expected = [
+        "approval_audit_log", "approval_requests", "approval_policies",
+        "safety_rules", "safety_decisions", "safety_rules_audit",
+        "scheduled_tasks", "task_run_logs",
+        "messages", "conversations", "sessions",
+        "coworkers", "channel_bindings", "user_agent_assignments",
+        "users", "oidc_user_tokens",
+    ]
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT relname, relrowsecurity, relforcerowsecurity "
+            "FROM pg_class WHERE relname = ANY($1::text[])",
+            expected,
+        )
+    seen = {r["relname"]: (r["relrowsecurity"], r["relforcerowsecurity"]) for r in rows}
+    missing = [t for t in expected if t not in seen]
+    assert not missing, f"tables missing from pg_class: {missing}"
+    not_enabled = [t for t, (e, _) in seen.items() if not e]
+    not_forced = [t for t, (_, f) in seen.items() if not f]
+    assert not not_enabled, f"RLS not enabled on: {not_enabled}"
+    assert not not_forced, f"FORCE not set on (would let owner bypass): {not_forced}"
+
+
+# Silence unused-import noise on tenant_conn (kept for future tests).
+assert tenant_conn is pg.tenant_conn

--- a/tests/safety/e2e/test_reversibility_roundtrip.py
+++ b/tests/safety/e2e/test_reversibility_roundtrip.py
@@ -109,7 +109,7 @@ class TestPersistenceRoundTrip:
         )
 
         # Layer 2 → 3 → 4: read coworker back, build spec, serialize.
-        fetched = await pg.get_coworker(cw.id)
+        fetched = await pg.get_coworker(cw.id, tenant_id=tenant.id)
         assert fetched is not None
         assert len(fetched.tools) == 1
         persisted_mcp = fetched.tools[0]
@@ -205,6 +205,7 @@ class TestPersistenceRoundTrip:
         # Update with a modified reversibility map.
         await pg.update_coworker(
             cw.id,
+            tenant_id=tenant.id,
             tools=[
                 McpServerConfig(
                     name="api",
@@ -218,7 +219,7 @@ class TestPersistenceRoundTrip:
                 )
             ],
         )
-        fetched = await pg.get_coworker(cw.id)
+        fetched = await pg.get_coworker(cw.id, tenant_id=tenant.id)
         assert fetched is not None
         assert fetched.tools[0].tool_reversibility == {
             "read": True,

--- a/tests/safety/test_maintenance.py
+++ b/tests/safety/test_maintenance.py
@@ -86,7 +86,7 @@ class TestCleanupOldApprovalContexts:
             retention_hours=24
         )
         assert cleared == 1
-        row = await pg.get_safety_decision(old_id, tid)
+        row = await pg.get_safety_decision(old_id, tenant_id=tid)
         assert row is not None
         assert row["approval_context"] is None
 
@@ -106,7 +106,7 @@ class TestCleanupOldApprovalContexts:
             retention_hours=24
         )
         assert cleared == 0
-        row = await pg.get_safety_decision(recent_id, tid)
+        row = await pg.get_safety_decision(recent_id, tenant_id=tid)
         assert row is not None
         assert row["approval_context"] is not None
 
@@ -150,8 +150,8 @@ class TestCleanupOldApprovalContexts:
             retention_hours=24
         )
         assert cleared == 1
-        young_row = await pg.get_safety_decision(a_young, tid)
-        old_row = await pg.get_safety_decision(a_old, tid)
+        young_row = await pg.get_safety_decision(a_young, tenant_id=tid)
+        old_row = await pg.get_safety_decision(a_old, tenant_id=tid)
         assert young_row is not None
         assert old_row is not None
         assert young_row["approval_context"] is not None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -124,9 +124,9 @@ async def test_session_per_conversation(e2e_env: Path) -> None:
         channel_chat_id="999",
     )
 
-    assert await get_session(conv.id) is None
+    assert await get_session(conv.id, tenant_id=tenant.id) is None
     await set_session(conv.id, tenant.id, cw.id, "sess-123")
-    assert await get_session(conv.id) == "sess-123"
+    assert await get_session(conv.id, tenant_id=tenant.id) == "sess-123"
 
 
 async def test_messages_per_conversation(e2e_env: Path) -> None:
@@ -200,7 +200,7 @@ async def test_tasks_per_coworker(e2e_env: Path) -> None:
     assert task is not None
     assert task.prompt == "Test task"
 
-    tasks = await get_tasks_for_coworker(cw.id)
+    tasks = await get_tasks_for_coworker(cw.id, tenant_id=tenant.id)
     assert len(tasks) == 1
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -196,7 +196,7 @@ async def test_tasks_per_coworker(e2e_env: Path) -> None:
         )
     )
 
-    task = await get_task_by_id(task_id)
+    task = await get_task_by_id(task_id, tenant_id=tenant.id)
     assert task is not None
     assert task.prompt == "Test task"
 

--- a/tests/test_multi_tenant_e2e.py
+++ b/tests/test_multi_tenant_e2e.py
@@ -490,8 +490,8 @@ class TestSessionIsolation:
         # Sessions should be different
         from rolemesh.db.pg import get_session
 
-        sess_a = await get_session(convs[0].id)
-        sess_b = await get_session(convs[1].id)
+        sess_a = await get_session(convs[0].id, tenant_id=tenant.id)
+        sess_b = await get_session(convs[1].id, tenant_id=tenant.id)
         assert sess_a is not None
         assert sess_b is not None
         assert sess_a != sess_b
@@ -828,7 +828,7 @@ class TestMigration:
         assert main_conv.requires_trigger is False
 
         # Session migrated
-        sess = await get_session(main_conv.id)
+        sess = await get_session(main_conv.id, tenant_id=tenant.id)
         assert sess == "sess-legacy-001"
 
         # Filesystem migrated (tenant already in scope from above)

--- a/tests/test_multi_tenant_e2e.py
+++ b/tests/test_multi_tenant_e2e.py
@@ -1026,7 +1026,7 @@ class TestTaskSchedulingPerCoworker:
             coworker_id=cw.id,
         )
 
-        task = await get_task_by_id(task_id)
+        task = await get_task_by_id(task_id, tenant_id=tenant.id)
         assert task is not None
         assert task.coworker_id == cw.id
         assert task.tenant_id == tenant.id

--- a/tests/test_user_flow.py
+++ b/tests/test_user_flow.py
@@ -201,7 +201,7 @@ class TestScenarioIPCFromContainer:
             coworker_id=cw.id,
         )
 
-        task = await get_task_by_id(task_id)
+        task = await get_task_by_id(task_id, tenant_id=t.id)
         assert task is not None
         assert task.prompt == "Daily standup summary"
         assert task.schedule_type == "cron"
@@ -440,14 +440,14 @@ class TestScenarioDatabaseOperations:
             )
         )
 
-        fetched = await get_task_by_id(task_id)
+        fetched = await get_task_by_id(task_id, tenant_id=t.id)
         assert fetched is not None
         assert fetched.prompt == "Check status"
 
         await update_task(task_id, status="paused")
-        fetched = await get_task_by_id(task_id)
+        fetched = await get_task_by_id(task_id, tenant_id=t.id)
         assert fetched is not None
         assert fetched.status == "paused"
 
         await delete_task(task_id)
-        assert await get_task_by_id(task_id) is None
+        assert await get_task_by_id(task_id, tenant_id=t.id) is None

--- a/tests/test_user_flow.py
+++ b/tests/test_user_flow.py
@@ -103,7 +103,7 @@ class TestScenarioFirstTimeUser:
 
         # Set and get session
         await set_session(conv.id, t.id, cw.id, "sess-001")
-        assert await get_session(conv.id) == "sess-001"
+        assert await get_session(conv.id, tenant_id=t.id) == "sess-001"
 
         # Verify all fields
         assert cw.agent_role == "super_agent"
@@ -444,10 +444,10 @@ class TestScenarioDatabaseOperations:
         assert fetched is not None
         assert fetched.prompt == "Check status"
 
-        await update_task(task_id, status="paused")
+        await update_task(task_id, tenant_id=t.id, status="paused")
         fetched = await get_task_by_id(task_id, tenant_id=t.id)
         assert fetched is not None
         assert fetched.status == "paused"
 
-        await delete_task(task_id)
+        await delete_task(task_id, tenant_id=t.id)
         assert await get_task_by_id(task_id, tenant_id=t.id) is None


### PR DESCRIPTION
## Summary

Five-phase rollout of PostgreSQL Row Level Security as a third defence layer behind application WHERE clauses and connection-level GUC, plus post-merge review fixes.

- **PR-A** — require ``tenant_id`` kwarg on by-id business functions (6 reads + 3 writes), new ``resolve_user_for_auth`` and ``get_conversation_for_notification`` admin escapes
- **PR-B** — dual pool (``rolemesh_app`` NOBYPASSRLS + ``rolemesh_system`` BYPASSRLS), ``current_tenant_id()`` SQL function, ``tenant_conn`` / ``admin_conn`` async-context managers
- **PR-C** (2 commits) — route 105 ``pool.acquire()`` sites through the wrappers; 21 SKIP functions gain ``*, tenant_id`` parameter + SQL filter
- **PR-D** (10 commits) — enable ``ENABLE`` + ``FORCE ROW LEVEL SECURITY`` + 4 standard policies on 16 tenant tables; D10 backfills ``tenant_id`` column on ``oidc_user_tokens`` with parent-table sync trigger
- **PR-E** — 8 RLS-enforcement tests (NOBYPASSRLS pool fixture), static classification check on ``src/webui``, admin-path dispatch contract
- **Post-merge fixes**:
  - ``fix(rls)`` 4ba7363 — ``/api/conversations`` and ``/api/conversations/{id}/messages`` were calling ``auth.get_pool()`` directly without setting the GUC; surfaced when manual-testing under the production NOBYPASSRLS posture (sidebar empty)
  - ``fix(rls)`` 06e65c5 — close P1 review findings (``update_conversation_user_id`` SQL filter, DUAL-pattern empty-string traps in ``get_due_tasks``/``get_all_tasks``)
  - ``fix(rls)`` d6b84b2 — close P2 review findings (``_get_admin_pool`` fail-loud, ``_OrchestratorChannelSender`` security contract docstring, ``update_task`` fallback parity)
  - ``fix(rls)`` 8155ef6 — OIDC returning-user path was calling ``update_user`` without ``tenant_id`` — every existing OIDC user would have hit ``TypeError`` on login

Total: 20 commits, +1530 / −414 across 25 files.

## Test plan

- [x] PR-E full sweep: 583 passed across ``tests/db tests/auth tests/safety tests/approval tests/attack_sim`` + root e2e/multi-tenant (17 pre-existing approval-e2e flakes deselected — they reproduce identically on origin/main, NATS-harness consumer issue, unrelated to this PR)
- [x] PR-E RLS enforcement (NOBYPASSRLS pool): 6/6 cross-tenant SELECT/INSERT blocked, fail-closed on unset GUC, GUC doesn't leak across acquires, FORCE bit verified on all 16 tables via pg_class
- [x] Docker integration: 20/20 (container hardening + egress gateway P0 isolation/CONNECT/DNS/hot-reload/reverse-proxy-regression/gateway-down)
- [x] Post-merge regression after each fix: all green
- [x] Manual smoke under production NOBYPASSRLS posture (DATABASE_URL=rolemesh_app, ADMIN_DATABASE_URL=rolemesh): WebUI chat + sidebar + history work; surfaced and fixed two real RLS regressions

## Schema migration notes

- Schema bootstrap is idempotent (DO blocks gated by ``IF NOT EXISTS``). Existing databases pick up:
  - ``current_tenant_id()`` SQL function
  - ``rolemesh_app`` (NOBYPASSRLS) + ``rolemesh_system`` (BYPASSRLS) roles
  - ``oidc_user_tokens.tenant_id`` column backfilled from ``users``
  - 16 tables ENABLE+FORCE RLS with rls_select / rls_insert / rls_update / rls_delete policies
- Existing ``feat/rls`` (pre-cleanup) databases may have a leftover ``tenant_isolation`` policy on each table. Cleanup snippet:
  ``DROP POLICY tenant_isolation ON <table>`` for each table with ``policyname='tenant_isolation'``.
- ``rolemesh_app`` has no password by default. To activate the production posture: ``ALTER ROLE rolemesh_app PASSWORD '<pwd>'`` then set ``DATABASE_URL=postgresql://rolemesh_app:<pwd>@host/db`` and ``ADMIN_DATABASE_URL=postgresql://<superuser>:<pwd>@host/db``. dev/test posture (single DSN) keeps working unchanged.

## Follow-up issues left out of scope

- P3 #6 ``_enable_rls_on`` use ``quote_ident``-style table-name validation (cosmetic; table names are hardcoded)
- P3 #7 ``tenant_conn`` UUID validation at entry (early-fail ergonomics)
- P3 #8 ``test_function_classification`` extend scope to ``src/rolemesh`` business modules
- P3 #9 ``oidc_user_tokens_set_tenant`` trigger ``SECURITY DEFINER``
- Egress gateway MCP/TokenVault sync (separate work, unrelated to RLS)