### PR TITLE
fix(egress): rewrite loopback to host.docker.internal on every platform

### DIFF
--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -211,17 +211,33 @@ def _extra_hosts() -> dict[str, str]:
 
 
 def _rewrite_loopback_to_host_gateway(url: str) -> str:
-    """Rewrite ``localhost``/``127.0.0.1`` in a URL to ``host.docker.internal``.
+    """Rewrite ``localhost`` / ``127.0.0.1`` in a URL to ``host.docker.internal``.
 
-    The orchestrator runs on the host and its ``NATS_URL`` typically points
-    at ``localhost:4222``. Inside the gateway container ``localhost`` is the
-    container itself, so a verbatim copy breaks the NATS connection. Rewrite
-    only on Linux (where ``host.docker.internal`` needs the ExtraHosts entry
-    we just added); on Docker Desktop the name already resolves and the
-    rewrite would still work but is unnecessary.
+    Required on every platform — inside the gateway container,
+    ``localhost`` resolves to the container's own loopback, not the
+    host. The orchestrator's ``NATS_URL`` typically points at
+    ``localhost:4222`` (the host's NATS), so a verbatim copy makes
+    the gateway dial itself and the NATS connection fails with
+    ``Name or service not known`` / ``Connection refused``.
+
+    Two ways ``host.docker.internal`` is made resolvable, both
+    converging at this rewrite:
+
+      - Linux: ``create_egress_gateway`` adds an ExtraHosts entry
+        (``host.docker.internal:host-gateway``) via
+        ``get_host_gateway_extra_hosts``. Docker Engine does not
+        provide the alias automatically.
+      - Docker Desktop (macOS / Windows / WSL): the name is built
+        into the platform's embedded DNS resolver. No ExtraHosts
+        entry is needed (and the helper above returns an empty
+        dict).
+
+    The previous implementation gated the rewrite on
+    ``_extra_hosts()`` being non-empty, which conflated "do we
+    need ExtraHosts?" (platform-specific) with "do we need to
+    rewrite?" (universal). On macOS the gate skipped the rewrite
+    and the gateway shipped with a broken ``NATS_URL``.
     """
-    if not _extra_hosts():
-        return url
     return url.replace("://localhost:", "://host.docker.internal:").replace(
         "://127.0.0.1:", "://host.docker.internal:"
     )

--- a/tests/egress/test_launcher.py
+++ b/tests/egress/test_launcher.py
@@ -207,3 +207,80 @@ class TestWaitForGatewayReady:
                 attempts=3,
                 interval_s=0.0,
             )
+
+
+# ---------------------------------------------------------------------------
+# _rewrite_loopback_to_host_gateway — universal loopback rewrite
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteLoopbackToHostGateway:
+    """Originally gated on platform.system()=='Linux' via ``_extra_hosts()``;
+    fixed to rewrite unconditionally because container-internal
+    ``localhost`` is never the host on any platform.
+
+    These cases lock in the contract from both sides — what must
+    rewrite, what must NOT rewrite — so a future revert to the
+    platform-gated logic shows up here rather than in a runtime
+    "Name or service not known" error on macOS only.
+    """
+
+    def test_localhost_in_authority_is_rewritten(self) -> None:
+        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
+
+        assert _rewrite_loopback_to_host_gateway("nats://localhost:4222") == (
+            "nats://host.docker.internal:4222"
+        )
+
+    def test_127_0_0_1_is_rewritten(self) -> None:
+        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
+
+        assert _rewrite_loopback_to_host_gateway("nats://127.0.0.1:4222") == (
+            "nats://host.docker.internal:4222"
+        )
+
+    def test_already_host_docker_internal_is_idempotent(self) -> None:
+        # Belt-and-braces: if a deploy already crafted the right URL
+        # (e.g. via NATS_URL env override), running the rewrite a
+        # second time must not corrupt it.
+        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
+
+        assert _rewrite_loopback_to_host_gateway(
+            "nats://host.docker.internal:4222"
+        ) == "nats://host.docker.internal:4222"
+
+    def test_external_hostname_is_left_alone(self) -> None:
+        # An operator pointing the gateway at a remote NATS cluster
+        # should NOT see their hostname mangled. The rewrite scopes
+        # itself with the ``://`` prefix to avoid eating
+        # ``mylocalhost.example.com`` style bystanders.
+        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
+
+        assert _rewrite_loopback_to_host_gateway(
+            "nats://nats.cluster.internal:4222"
+        ) == "nats://nats.cluster.internal:4222"
+
+    def test_substring_localhost_in_path_is_left_alone(self) -> None:
+        # Hardening against naive ``localhost`` substring replacement.
+        # The colon after the prefix anchors it to the authority
+        # component, so a path-side ``localhost`` (unusual but legal)
+        # stays intact.
+        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
+
+        # Token "localhost" *not* followed by a port colon -> not
+        # touched. ``://localhost:`` is the only rewrite trigger.
+        assert _rewrite_loopback_to_host_gateway(
+            "https://nats.example.com/path/localhost/x"
+        ) == "https://nats.example.com/path/localhost/x"
+
+    def test_rewrites_irrespective_of_platform(self) -> None:
+        # Direct regression for the macOS bug: previously the rewrite
+        # was no-op when ``_extra_hosts()`` returned empty (i.e. on
+        # any non-Linux host). Patch it to empty here and assert the
+        # rewrite still fires.
+        from rolemesh.egress import launcher
+
+        with patch.object(launcher, "_extra_hosts", return_value={}):
+            assert launcher._rewrite_loopback_to_host_gateway(
+                "nats://localhost:4222"
+            ) == "nats://host.docker.internal:4222"


### PR DESCRIPTION
## Summary

The gateway launcher's ``_rewrite_loopback_to_host_gateway`` early-returned the URL unchanged when ``_extra_hosts()`` was empty (every platform except Linux). That made the rewrite a no-op on macOS / Windows / WSL — the gateway shipped with ``NATS_URL=nats://localhost:4222`` and dialed its own loopback.

The fix removes the ``_extra_hosts()`` gate. The rewrite is universal:

- **Linux** — ``create_egress_gateway`` adds an ``ExtraHosts: host.docker.internal:host-gateway`` entry on the same code path, so the rewritten URL resolves.
- **Docker Desktop (macOS / Windows / WSL)** — the alias is built into the platform's embedded DNS resolver. No ExtraHosts needed.

The two earlier-and-still-true uses of ``_extra_hosts()`` (the Linux-only ExtraHosts block in ``host_config``) are untouched.

## Root cause

Two questions got conflated in one helper:

- *Do we need ExtraHosts?* — platform-specific, only Linux.
- *Do we need to rewrite the URL?* — universal, every platform: container-internal ``localhost`` is never the host.

Symptom on macOS: gateway logs ``Name or service not known`` against ``nats://localhost:4222``, never reaches the host's NATS, never serves traffic.

## Test plan

- [x] 6 new unit tests in ``tests/egress/test_launcher.py``:
  - localhost / 127.0.0.1 rewrite
  - idempotent on already-rewritten URL
  - external hostname left alone
  - substring ``localhost`` in path left alone (anchor on ``://...:``)
  - direct macOS regression: patch ``_extra_hosts`` to empty, rewrite still fires
- [x] Full launcher test file: 12/12 passed.
- [ ] Manual verification on macOS Docker Desktop (gateway boots, NATS subscriptions register).

## Risk

Low. Linux behaviour is unchanged (rewrite was already firing there). macOS/Windows/WSL move from broken to working. No code path "depends on ``localhost`` *not* being rewritten" because container-internal localhost has no legitimate use.