### PR TITLE
feat(egress): NATS-backed MCP registry sync (PR-1: snapshot + subscribe)

### DIFF
--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -59,6 +59,11 @@ from .identity import (
     fetch_identity_snapshot_via_nats,
     subscribe_lifecycle,
 )
+from .mcp_cache import (
+    apply_snapshot_to_registry,
+    fetch_mcp_snapshot_via_nats,
+    subscribe_mcp_changes,
+)
 from .policy_cache import (
     PolicyCache,
     fetch_snapshot_via_nats,
@@ -192,6 +197,31 @@ async def main() -> None:
             checks=check_map,
             audit_publisher=audit,
         )
+
+        # --- MCP server registry: snapshot + hot reload --------------
+        # The MCP registry has to be seeded BEFORE start_credential_proxy
+        # binds — otherwise a client request that lands during the boot
+        # window between bind and snapshot-arrival sees the registry as
+        # empty and gets a 404 it shouldn't have. Snapshot failure is
+        # fail-soft (log + continue with empty registry); subsequent
+        # ``egress.mcp.changed`` events still fill it in as the
+        # orchestrator publishes them, and the operator sees the warning
+        # instead of crash-looping the gateway over a transient NATS
+        # blip on the orchestrator side.
+        try:
+            mcp_entries = await fetch_mcp_snapshot_via_nats(
+                nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S
+            )
+            apply_snapshot_to_registry(mcp_entries)
+            logger.info("gateway: MCP registry seeded", count=len(mcp_entries))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "gateway: MCP snapshot fetch failed — continuing with empty "
+                "registry; live change events will refill",
+                error=str(exc),
+            )
+        mcp_sub = await subscribe_mcp_changes(nats_client)
+        stack.push_async_callback(mcp_sub.unsubscribe)  # type: ignore[attr-defined]
 
         # --- Reverse proxy (port 3001) -------------------------------
         reverse_runner = await start_credential_proxy(

--- a/src/rolemesh/egress/mcp_cache.py
+++ b/src/rolemesh/egress/mcp_cache.py
@@ -1,0 +1,233 @@
+"""MCP-server registry sync for the egress gateway (PR-egress-mcp-sync).
+
+Mirrors the safety-rule sync layout (``policy_cache.py`` + the
+publishers/responders in ``orch_glue.py``) but for the MCP server
+registry that ``reverse_proxy.handle_mcp_proxy`` reads.
+
+Why this exists
+---------------
+Before this module, ``register_mcp_server`` was called only on the
+orchestrator process (``rolemesh.main`` walking ``coworker.tools`` at
+startup). The gateway is a separate container with its own copy of
+``reverse_proxy._mcp_registry`` — no IPC fed it, so every
+``/mcp-proxy/<name>/<path>`` request returned ``404 MCP server not
+found``.
+
+This module fills that gap with the same NATS pattern safety rules
+use:
+
+  - ``egress.mcp.snapshot.request`` (request-reply): gateway boots,
+    fetches the orchestrator's current registry, seeds itself.
+  - ``egress.mcp.changed`` (broadcast): orchestrator pushes deltas
+    so the gateway can hot-reload without a restart.
+
+The gateway end is intentionally thin: it just translates each
+event into a ``register_mcp_server`` / ``unregister_mcp_server``
+call against the existing module-level dict in ``reverse_proxy``.
+No new cache layer — the dict that ``handle_mcp_proxy`` already
+reads is the cache.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from rolemesh.core.logger import get_logger
+
+if TYPE_CHECKING:
+    import nats.aio.client
+
+logger = get_logger()
+
+
+# NATS subjects owned by the MCP-registry sync. Naming mirrors
+# ``egress.rules.snapshot.request`` / ``safety.rule.changed`` so an
+# operator skimming subjects can group them.
+MCP_SNAPSHOT_REQUEST_SUBJECT = "egress.mcp.snapshot.request"
+MCP_CHANGED_SUBJECT = "egress.mcp.changed"
+
+
+@dataclass(frozen=True)
+class McpEntry:
+    """Wire-format MCP server entry.
+
+    ``url`` carries the scheme://host:port origin form (no path). The
+    orchestrator computes it as ``urlparse(tool.url).scheme + ://
+    + .netloc`` before publishing — same shape ``register_mcp_server``
+    has stored historically.
+    """
+
+    name: str
+    url: str
+    headers: dict[str, str]
+    auth_mode: str
+
+
+def entry_to_dict(entry: McpEntry) -> dict[str, Any]:
+    """Serialize for the wire / responders."""
+    return {
+        "name": entry.name,
+        "url": entry.url,
+        "headers": dict(entry.headers),
+        "auth_mode": entry.auth_mode,
+    }
+
+
+def entry_from_dict(d: dict[str, Any]) -> McpEntry:
+    """Parse one wire entry. Raises on missing required keys; the
+    snapshot/event handlers catch + log so a single malformed entry
+    can't poison the rest."""
+    return McpEntry(
+        name=str(d["name"]),
+        url=str(d["url"]),
+        headers={str(k): str(v) for k, v in (d.get("headers") or {}).items()},
+        auth_mode=str(d.get("auth_mode") or "user"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gateway-side: snapshot fetch + live subscription
+# ---------------------------------------------------------------------------
+
+
+async def fetch_mcp_snapshot_via_nats(
+    nats_client: nats.aio.client.Client,
+    *,
+    timeout_s: float = 5.0,
+) -> list[McpEntry]:
+    """Request the orchestrator's current MCP registry over NATS.
+
+    Mirrors ``egress.policy_cache.fetch_snapshot_via_nats``. Core NATS
+    request-reply because the snapshot is a one-shot — a missed reply
+    should surface as a timeout, not be persisted and replayed.
+    """
+    response = await nats_client.request(  # type: ignore[attr-defined]
+        MCP_SNAPSHOT_REQUEST_SUBJECT,
+        b"",
+        timeout=timeout_s,
+    )
+    payload = json.loads(response.data)
+    raw = payload.get("entries")
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"Unexpected MCP snapshot shape: expected list under 'entries', "
+            f"got {type(raw).__name__}"
+        )
+    out: list[McpEntry] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            logger.warning("mcp_cache: skipping non-dict snapshot entry")
+            continue
+        try:
+            out.append(entry_from_dict(item))
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning(
+                "mcp_cache: skipping malformed snapshot entry",
+                error=str(exc),
+            )
+    return out
+
+
+def apply_snapshot_to_registry(entries: list[McpEntry]) -> None:
+    """Seed ``reverse_proxy._mcp_registry`` from a snapshot.
+
+    Replaces every entry rather than merging — the snapshot is the
+    authoritative current state on the orchestrator side, and merging
+    would leave stale entries around if the orchestrator removed a
+    coworker while the gateway was offline. Names not in the snapshot
+    are dropped.
+    """
+    # Local import: keeps the cache module importable from contexts
+    # that don't actually want to bring in aiohttp transitively (e.g.
+    # tests of just the wire format).
+    from rolemesh.egress.reverse_proxy import (
+        get_mcp_registry,
+        register_mcp_server,
+        unregister_mcp_server,
+    )
+
+    new_names = {e.name for e in entries}
+    for stale in set(get_mcp_registry()) - new_names:
+        unregister_mcp_server(stale)
+    for entry in entries:
+        register_mcp_server(
+            entry.name, entry.url, entry.headers, entry.auth_mode
+        )
+
+
+def apply_change_event(event: dict[str, Any]) -> None:
+    """Apply one ``egress.mcp.changed`` event to the registry.
+
+    Event shape:
+        {"action": "created" | "updated" | "deleted",
+         "name": "<name>",
+         "url": "<origin>",
+         "headers": {...},
+         "auth_mode": "user" | "service" | "both"}
+
+    For ``deleted``, only ``name`` is required; other fields are
+    ignored if present.
+    """
+    from rolemesh.egress.reverse_proxy import (
+        register_mcp_server,
+        unregister_mcp_server,
+    )
+
+    action = event.get("action")
+    name = event.get("name")
+    if not isinstance(name, str) or not name:
+        # structlog reserves the `event` kwarg for the log message; use
+        # `payload` to surface the offending dict without colliding.
+        logger.warning("mcp_cache: change event missing 'name'", payload=event)
+        return
+
+    if action == "deleted":
+        unregister_mcp_server(name)
+        return
+
+    if action not in ("created", "updated"):
+        logger.warning("mcp_cache: unknown action", action=action, name=name)
+        return
+
+    try:
+        entry = entry_from_dict(event)
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning(
+            "mcp_cache: malformed change event",
+            error=str(exc),
+            name=name,
+        )
+        return
+    register_mcp_server(entry.name, entry.url, entry.headers, entry.auth_mode)
+
+
+async def subscribe_mcp_changes(
+    nats_client: nats.aio.client.Client,
+) -> object:
+    """Subscribe to ``MCP_CHANGED_SUBJECT`` and apply events as they arrive.
+
+    Returns the subscription handle so the caller can ``await
+    sub.unsubscribe()`` at shutdown. Modeled after
+    ``policy_cache.subscribe_rule_changes``.
+    """
+    async def _handler(msg: object) -> None:
+        try:
+            event = json.loads(msg.data)  # type: ignore[attr-defined]
+        except (ValueError, AttributeError) as exc:
+            logger.warning("mcp_cache: non-JSON change event", error=str(exc))
+            return
+        if not isinstance(event, dict):
+            logger.warning(
+                "mcp_cache: change event not a dict",
+                got=type(event).__name__,
+            )
+            return
+        with contextlib.suppress(Exception):
+            apply_change_event(event)
+
+    sub = await nats_client.subscribe(MCP_CHANGED_SUBJECT, cb=_handler)  # type: ignore[attr-defined]
+    logger.info("mcp_cache: subscribed", subject=MCP_CHANGED_SUBJECT)
+    return sub

--- a/src/rolemesh/egress/orch_glue.py
+++ b/src/rolemesh/egress/orch_glue.py
@@ -43,6 +43,12 @@ logger = get_logger()
 # so there's a single authoritative string for each subject. Duplicate
 # definitions would drift.
 from .identity import IDENTITY_SNAPSHOT_SUBJECT, LIFECYCLE_SUBJECT  # noqa: E402
+from .mcp_cache import (  # noqa: E402
+    MCP_CHANGED_SUBJECT,
+    MCP_SNAPSHOT_REQUEST_SUBJECT,
+    McpEntry,
+    entry_to_dict,
+)
 from .policy_cache import RULE_CHANGED_SUBJECT, SNAPSHOT_REQUEST_SUBJECT  # noqa: E402
 
 
@@ -133,6 +139,45 @@ async def publish_lifecycle_stopped(
         logger.warning("lifecycle publish failed (stopped)", error=str(exc))
 
 
+async def publish_mcp_registry_changed(
+    nc: nats.aio.client.Client,
+    *,
+    action: str,
+    entry: McpEntry | None = None,
+    name: str | None = None,
+) -> None:
+    """Push a single MCP registry delta to the gateway.
+
+    For ``created`` / ``updated``: pass ``entry`` with the full payload.
+    For ``deleted``: pass ``name`` (the only field the consumer needs).
+
+    Best-effort publish: a failure here means the gateway misses one
+    delta, but its next snapshot fetch on restart still recovers full
+    state.
+    """
+    if action == "deleted":
+        if not name:
+            logger.warning("mcp_registry publish: deleted without name")
+            return
+        payload: dict[str, Any] = {"action": "deleted", "name": name}
+    else:
+        if entry is None:
+            logger.warning(
+                "mcp_registry publish: missing entry",
+                action=action,
+            )
+            return
+        payload = {"action": action, **entry_to_dict(entry)}
+    try:
+        await nc.publish(MCP_CHANGED_SUBJECT, json.dumps(payload).encode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "mcp_registry publish failed",
+            error=str(exc),
+            action=action,
+        )
+
+
 async def publish_rule_changed(
     nc: nats.aio.client.Client,
     *,
@@ -164,8 +209,9 @@ async def start_responders(
     *,
     state: OrchestratorState,
     rules_fetcher: Callable[[], Awaitable[list[dict[str, Any]]]],
+    mcp_fetcher: Callable[[], Awaitable[list[McpEntry]]] | None = None,
 ) -> list[object]:
-    """Subscribe to both snapshot-request subjects and return sub handles.
+    """Subscribe to all snapshot-request subjects and return sub handles.
 
     Caller is responsible for ``await sub.unsubscribe()`` at shutdown.
     Kept fire-and-forget rather than using JetStream: these are
@@ -174,8 +220,17 @@ async def start_responders(
 
     ``rules_fetcher`` is injected so tests can feed a canned list
     without standing up the DB. Production wires it to
-    ``_fetch_all_egress_rules`` below.
+    ``fetch_all_egress_rules`` below.
+
+    ``mcp_fetcher`` defaults to ``fetch_all_mcp_servers``, which
+    reads the orchestrator's process-local ``_mcp_registry``. Tests
+    can pass a stub. ``None`` (default) wires the production fetcher
+    rather than skipping the responder, because a missing responder
+    would cause every gateway boot to time out.
     """
+    if mcp_fetcher is None:
+        mcp_fetcher = fetch_all_mcp_servers
+
     async def _rules_handler(msg: object) -> None:
         try:
             rules = await rules_fetcher()
@@ -196,13 +251,55 @@ async def start_responders(
         with contextlib.suppress(Exception):
             await msg.respond(body)  # type: ignore[attr-defined]
 
+    async def _mcp_handler(msg: object) -> None:
+        try:
+            entries = await mcp_fetcher()
+            body = json.dumps(
+                {"entries": [entry_to_dict(e) for e in entries]}
+            ).encode("utf-8")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("mcp snapshot fetch failed", error=str(exc))
+            body = json.dumps({"entries": [], "error": str(exc)}).encode("utf-8")
+        with contextlib.suppress(Exception):
+            await msg.respond(body)  # type: ignore[attr-defined]
+
     rules_sub = await nc.subscribe(SNAPSHOT_REQUEST_SUBJECT, cb=_rules_handler)
     identity_sub = await nc.subscribe(IDENTITY_SNAPSHOT_SUBJECT, cb=_identity_handler)
+    mcp_sub = await nc.subscribe(MCP_SNAPSHOT_REQUEST_SUBJECT, cb=_mcp_handler)
     logger.info(
         "egress responders subscribed",
-        subjects=[SNAPSHOT_REQUEST_SUBJECT, IDENTITY_SNAPSHOT_SUBJECT],
+        subjects=[
+            SNAPSHOT_REQUEST_SUBJECT,
+            IDENTITY_SNAPSHOT_SUBJECT,
+            MCP_SNAPSHOT_REQUEST_SUBJECT,
+        ],
     )
-    return [rules_sub, identity_sub]
+    return [rules_sub, identity_sub, mcp_sub]
+
+
+async def fetch_all_mcp_servers() -> list[McpEntry]:
+    """Production MCP fetcher: snapshot the orchestrator's in-process
+    ``_mcp_registry``.
+
+    The orchestrator already populates this dict in ``main`` by walking
+    ``coworker.tools`` at startup. We read the dict directly rather than
+    re-walking the DB because the dict is the authoritative
+    "what has the orchestrator registered" view that future hot-reload
+    publishers will keep in lockstep.
+    """
+    from rolemesh.egress.reverse_proxy import get_mcp_registry
+
+    out: list[McpEntry] = []
+    for name, (url, headers, auth_mode) in get_mcp_registry().items():
+        out.append(
+            McpEntry(
+                name=name,
+                url=url,
+                headers=dict(headers),
+                auth_mode=auth_mode,
+            )
+        )
+    return out
 
 
 async def fetch_all_egress_rules() -> list[dict[str, Any]]:

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -153,6 +153,21 @@ def register_mcp_server(
     logger.info("MCP server registered", name=name, url=url, auth_mode=auth_mode)
 
 
+def unregister_mcp_server(name: str) -> bool:
+    """Remove an MCP server from the registry. Returns True if it was present.
+
+    Used by the gateway-side hot-reload subscriber when the orchestrator
+    publishes ``egress.mcp.changed action=deleted``. Idempotent: a
+    redundant delete (e.g. the same broadcast arriving twice) returns
+    False rather than raising.
+    """
+    removed = _mcp_registry.pop(name, None)
+    if removed is None:
+        return False
+    logger.info("MCP server unregistered", name=name)
+    return True
+
+
 def get_mcp_registry() -> dict[str, tuple[str, dict[str, str], str]]:
     return dict(_mcp_registry)
 
@@ -473,6 +488,7 @@ __all__ = [
     "register_mcp_server",
     "set_token_vault",
     "start_credential_proxy",
+    "unregister_mcp_server",
 ]
 
 

--- a/tests/egress/test_mcp_cache.py
+++ b/tests/egress/test_mcp_cache.py
@@ -1,0 +1,179 @@
+"""Unit tests for ``rolemesh.egress.mcp_cache`` — gateway-side MCP sync.
+
+These pin the wire-format contract and the dispatch logic from
+``apply_snapshot_to_registry`` / ``apply_change_event`` against the
+``reverse_proxy._mcp_registry`` it controls. Each case clears the
+registry first so leftover state from another test can't paper over a
+regression.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.egress import reverse_proxy
+from rolemesh.egress.mcp_cache import (
+    McpEntry,
+    apply_change_event,
+    apply_snapshot_to_registry,
+    entry_from_dict,
+    entry_to_dict,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> None:
+    # The registry is module-global — wipe it between cases so tests
+    # don't observe each other's writes.
+    reverse_proxy._mcp_registry.clear()
+
+
+# ---------------------------------------------------------------------------
+# Wire format round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_entry_roundtrip_preserves_all_fields() -> None:
+    entry = McpEntry(
+        name="github",
+        url="https://api.github.com",
+        headers={"X-Custom": "value"},
+        auth_mode="user",
+    )
+    assert entry_from_dict(entry_to_dict(entry)) == entry
+
+
+def test_entry_from_dict_defaults_auth_mode_to_user() -> None:
+    # Auth mode is the most likely field to be omitted by an operator
+    # crafting a snapshot manually. Explicit default protects the
+    # downstream RBAC check.
+    entry = entry_from_dict(
+        {"name": "x", "url": "https://x", "headers": {}}
+    )
+    assert entry.auth_mode == "user"
+
+
+def test_entry_from_dict_normalises_header_keys_and_values_to_str() -> None:
+    # Wire payload may carry non-string values if a publisher gets
+    # creative. We store as str to avoid surprising the proxy's
+    # header-injection path.
+    entry = entry_from_dict(
+        {
+            "name": "x",
+            "url": "https://x",
+            "headers": {"X-Int": 42, "X-Bool": True},
+            "auth_mode": "service",
+        }
+    )
+    assert entry.headers == {"X-Int": "42", "X-Bool": "True"}
+
+
+# ---------------------------------------------------------------------------
+# apply_snapshot_to_registry
+# ---------------------------------------------------------------------------
+
+
+def test_apply_snapshot_seeds_empty_registry() -> None:
+    apply_snapshot_to_registry(
+        [
+            McpEntry("github", "https://api.github.com", {}, "user"),
+            McpEntry("internal", "http://localhost:9100", {"X-Tenant": "t1"}, "service"),
+        ]
+    )
+    reg = reverse_proxy.get_mcp_registry()
+    assert set(reg) == {"github", "internal"}
+    assert reg["github"][0] == "https://api.github.com"
+    assert reg["internal"][2] == "service"
+
+
+def test_apply_snapshot_drops_stale_names() -> None:
+    """If the orchestrator removed an MCP server while the gateway was
+    offline, the next snapshot must not leave the dropped name behind.
+    Failure mode of the alternative (merge) is "deleted server still
+    routable on the gateway after the orchestrator forgot it" —
+    a privilege-escalation-grade bug."""
+    reverse_proxy.register_mcp_server("stale", "https://stale", {}, "user")
+    reverse_proxy.register_mcp_server("kept", "https://kept", {}, "user")
+
+    apply_snapshot_to_registry(
+        [McpEntry("kept", "https://kept", {}, "user")]
+    )
+    assert set(reverse_proxy.get_mcp_registry()) == {"kept"}
+
+
+def test_apply_snapshot_overwrites_existing_entry() -> None:
+    # Same name, different URL — the snapshot wins. Catches the
+    # regression where a half-merge leaves the original URL.
+    reverse_proxy.register_mcp_server("x", "https://old", {}, "user")
+    apply_snapshot_to_registry([McpEntry("x", "https://new", {}, "user")])
+    assert reverse_proxy.get_mcp_registry()["x"][0] == "https://new"
+
+
+# ---------------------------------------------------------------------------
+# apply_change_event
+# ---------------------------------------------------------------------------
+
+
+def test_change_event_created_inserts() -> None:
+    apply_change_event(
+        {
+            "action": "created",
+            "name": "github",
+            "url": "https://api.github.com",
+            "headers": {},
+            "auth_mode": "user",
+        }
+    )
+    assert "github" in reverse_proxy.get_mcp_registry()
+
+
+def test_change_event_updated_overwrites() -> None:
+    reverse_proxy.register_mcp_server("x", "https://old", {}, "user")
+    apply_change_event(
+        {
+            "action": "updated",
+            "name": "x",
+            "url": "https://new",
+            "headers": {},
+            "auth_mode": "service",
+        }
+    )
+    url, _, mode = reverse_proxy.get_mcp_registry()["x"]
+    assert url == "https://new"
+    assert mode == "service"
+
+
+def test_change_event_deleted_only_needs_name() -> None:
+    reverse_proxy.register_mcp_server("x", "https://x", {}, "user")
+    apply_change_event({"action": "deleted", "name": "x"})
+    assert "x" not in reverse_proxy.get_mcp_registry()
+
+
+def test_change_event_deleted_unknown_name_is_idempotent() -> None:
+    # An at-most-once-loss broadcast may re-deliver the same delete
+    # twice. Apply must not raise on the second arrival.
+    apply_change_event({"action": "deleted", "name": "ghost"})
+    assert reverse_proxy.get_mcp_registry() == {}  # still empty, no exception
+
+
+def test_change_event_unknown_action_is_dropped() -> None:
+    apply_change_event(
+        {"action": "renamed", "name": "x", "url": "https://x", "auth_mode": "user"}
+    )
+    assert reverse_proxy.get_mcp_registry() == {}
+
+
+def test_change_event_missing_name_is_dropped() -> None:
+    # Required field. Missing => skip + log; never raise (handler is
+    # behind a NATS callback and an exception there crashes the
+    # subscriber loop).
+    apply_change_event({"action": "created", "url": "https://x"})
+    assert reverse_proxy.get_mcp_registry() == {}
+
+
+def test_change_event_malformed_url_is_dropped_not_raised() -> None:
+    # Missing required field on a created event. The reverse_proxy is
+    # protected against half-populated entries because we'd try to
+    # forward to ``None``.
+    apply_change_event({"action": "created", "name": "x"})
+    assert reverse_proxy.get_mcp_registry() == {}

--- a/tests/egress/test_mcp_glue.py
+++ b/tests/egress/test_mcp_glue.py
@@ -1,0 +1,243 @@
+"""Unit tests for the orchestrator-side MCP-registry glue.
+
+Covers the publisher / responder layer added to ``orch_glue.py``:
+
+  * ``publish_mcp_registry_changed`` shapes the wire payload correctly
+    for created / updated / deleted actions.
+  * ``start_responders`` wires an ``egress.mcp.snapshot.request``
+    handler that returns the orchestrator's current view.
+  * ``fetch_all_mcp_servers`` reads the in-process registry without
+    touching the DB.
+
+The NATS client is a hand-rolled stub (no real NATS dependency)
+focused on the publish / subscribe surface ``orch_glue`` uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rolemesh.egress import reverse_proxy
+from rolemesh.egress.mcp_cache import (
+    MCP_CHANGED_SUBJECT,
+    MCP_SNAPSHOT_REQUEST_SUBJECT,
+    McpEntry,
+)
+from rolemesh.egress.orch_glue import (
+    fetch_all_mcp_servers,
+    publish_mcp_registry_changed,
+    start_responders,
+)
+
+
+# ---------------------------------------------------------------------------
+# NATS stub
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Sub:
+    subject: str
+    cb: Any  # Callable[[FakeMsg], Awaitable[None]]
+
+
+class _FakeMsg:
+    """Minimal duck-typed NATS message so handlers can ``msg.respond``."""
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.replies: list[bytes] = []
+
+    async def respond(self, body: bytes) -> None:
+        self.replies.append(body)
+
+
+class FakeNats:
+    """Tiny NATS double with the methods orch_glue uses."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+        self.subs: list[_Sub] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append((subject, data))
+
+    async def subscribe(self, subject: str, cb: Any = None) -> _Sub:
+        sub = _Sub(subject=subject, cb=cb)
+        self.subs.append(sub)
+        return sub
+
+
+@pytest.fixture
+def nc() -> FakeNats:
+    return FakeNats()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> None:
+    reverse_proxy._mcp_registry.clear()
+
+
+# ---------------------------------------------------------------------------
+# publish_mcp_registry_changed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_created_carries_full_entry(nc: FakeNats) -> None:
+    entry = McpEntry(
+        name="github",
+        url="https://api.github.com",
+        headers={"X-T": "v"},
+        auth_mode="user",
+    )
+    await publish_mcp_registry_changed(nc, action="created", entry=entry)
+    assert len(nc.published) == 1
+    subj, body = nc.published[0]
+    assert subj == MCP_CHANGED_SUBJECT
+    payload = json.loads(body)
+    assert payload == {
+        "action": "created",
+        "name": "github",
+        "url": "https://api.github.com",
+        "headers": {"X-T": "v"},
+        "auth_mode": "user",
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_deleted_only_carries_name(nc: FakeNats) -> None:
+    # Deleted events are intentionally minimal — the consumer just
+    # needs to know which name to drop, the rest of the row was
+    # already removed.
+    await publish_mcp_registry_changed(nc, action="deleted", name="github")
+    payload = json.loads(nc.published[0][1])
+    assert payload == {"action": "deleted", "name": "github"}
+
+
+@pytest.mark.asyncio
+async def test_publish_created_without_entry_is_no_op(nc: FakeNats) -> None:
+    # Defensive: publishing a created event without payload would be a
+    # caller bug. Don't crash, don't publish a half-formed event.
+    await publish_mcp_registry_changed(nc, action="created", entry=None)
+    assert nc.published == []
+
+
+@pytest.mark.asyncio
+async def test_publish_deleted_without_name_is_no_op(nc: FakeNats) -> None:
+    await publish_mcp_registry_changed(nc, action="deleted", name=None)
+    assert nc.published == []
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_transient_nats_errors() -> None:
+    # ``best-effort`` contract from the docstring — a transient NATS
+    # outage during a delta publish must not break the orchestrator
+    # path that called us.
+    class _Boom:
+        async def publish(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("nats down")
+
+    await publish_mcp_registry_changed(
+        _Boom(),
+        action="created",
+        entry=McpEntry("x", "https://x", {}, "user"),
+    )  # would-raise without the guard
+
+
+# ---------------------------------------------------------------------------
+# fetch_all_mcp_servers — production fetcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_mcp_servers_reads_registry() -> None:
+    reverse_proxy.register_mcp_server(
+        "internal", "http://localhost:9100", {"X-Tenant": "t1"}, "service"
+    )
+    entries = await fetch_all_mcp_servers()
+    assert len(entries) == 1
+    assert entries[0] == McpEntry(
+        name="internal",
+        url="http://localhost:9100",
+        headers={"X-Tenant": "t1"},
+        auth_mode="service",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_mcp_servers_returns_empty_when_unregistered() -> None:
+    assert await fetch_all_mcp_servers() == []
+
+
+# ---------------------------------------------------------------------------
+# start_responders — MCP snapshot handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_responder_returns_current_registry(nc: FakeNats) -> None:
+    reverse_proxy.register_mcp_server("x", "https://x", {}, "user")
+
+    async def _rules_fetcher() -> list[dict[str, Any]]:
+        return []
+
+    await start_responders(nc, state=None, rules_fetcher=_rules_fetcher)  # type: ignore[arg-type]
+
+    mcp_subs = [s for s in nc.subs if s.subject == MCP_SNAPSHOT_REQUEST_SUBJECT]
+    assert len(mcp_subs) == 1, "MCP snapshot subject must be subscribed"
+
+    msg = _FakeMsg(b"")
+    await mcp_subs[0].cb(msg)
+    payload = json.loads(msg.replies[0])
+    assert payload == {
+        "entries": [
+            {"name": "x", "url": "https://x", "headers": {}, "auth_mode": "user"}
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_responder_replies_with_empty_on_fetcher_error(nc: FakeNats) -> None:
+    # Fail-soft: a fetcher exception must not leave the gateway hung
+    # waiting for a reply. We always send a payload, even if it's
+    # ``{"entries": []}``.
+    async def _broken_mcp_fetcher() -> list[McpEntry]:
+        raise RuntimeError("DB down")
+
+    async def _rules_fetcher() -> list[dict[str, Any]]:
+        return []
+
+    await start_responders(
+        nc,
+        state=None,  # type: ignore[arg-type]
+        rules_fetcher=_rules_fetcher,
+        mcp_fetcher=_broken_mcp_fetcher,
+    )
+
+    mcp_subs = [s for s in nc.subs if s.subject == MCP_SNAPSHOT_REQUEST_SUBJECT]
+    msg = _FakeMsg(b"")
+    await mcp_subs[0].cb(msg)
+    payload = json.loads(msg.replies[0])
+    assert payload["entries"] == []
+    assert "error" in payload
+
+
+@pytest.mark.asyncio
+async def test_responder_attaches_three_subjects(nc: FakeNats) -> None:
+    # Regression guard against a future split that forgets to include
+    # the MCP responder. We assert the count + the exact subject set.
+    async def _rules_fetcher() -> list[dict[str, Any]]:
+        return []
+
+    subs = await start_responders(
+        nc, state=None, rules_fetcher=_rules_fetcher  # type: ignore[arg-type]
+    )
+    assert len(subs) == 3
+    subjects = {s.subject for s in nc.subs}
+    assert MCP_SNAPSHOT_REQUEST_SUBJECT in subjects


### PR DESCRIPTION
## Summary

Closes the gap that made every ``/mcp-proxy/<name>/<path>`` request return ``404 MCP server not found``. ``register_mcp_server`` writes to a module-global dict on the orchestrator process; once EC-1..EC-3 moved the reverse proxy into its own ``egress-gateway`` container, that container's dict stayed empty forever — no IPC connected the two.

This PR mirrors the ``safety.rule.changed`` pattern for the MCP registry:

- ``egress.mcp.snapshot.request`` (request-reply) — gateway boots, fetches the orchestrator's current registry, seeds itself.
- ``egress.mcp.changed`` (broadcast) — orchestrator pushes deltas; gateway hot-reloads.

## What's in this PR

| File | Change |
|------|--------|
| ``src/rolemesh/egress/mcp_cache.py`` (new) | ``McpEntry`` dataclass, snapshot fetch, ``apply_snapshot_to_registry`` (replaces, not merges — so a removed coworker can't stay routable), ``apply_change_event``, ``subscribe_mcp_changes`` |
| ``src/rolemesh/egress/orch_glue.py`` | ``publish_mcp_registry_changed`` + extended ``start_responders`` to subscribe ``egress.mcp.snapshot.request`` + ``fetch_all_mcp_servers`` (reads in-process registry, single source of truth) |
| ``src/rolemesh/egress/reverse_proxy.py`` | ``unregister_mcp_server`` (idempotent, used by the deleted-event path) |
| ``src/rolemesh/egress/gateway.py`` | Boot order: NATS connect → policy snapshot → identity snapshot → MCP snapshot → ``start_credential_proxy``. MCP fetch sits BEFORE the proxy bind so a request landing during boot can't see an empty registry. |

## Test plan

- [x] ``tests/egress/test_mcp_cache.py``: 13 unit cases (wire-format roundtrip, auth_mode default, header str coercion, apply_snapshot drops stale names, apply_change_event handles all action variants + malformed without raising)
- [x] ``tests/egress/test_mcp_glue.py``: 10 unit cases (publish shape contract, fetch_all_mcp_servers, start_responders fail-soft on fetcher exception, 3 subjects subscribed)
- [x] Existing egress unit suite: 53 → 76 passed, 0 regressions
- [x] Egress integration suite (live Docker, ``pytest -m integration``): 14/14 passed — gateway boots, fetches snapshot, serves proxy

## Risk

Low. New subjects are additive; existing rule + identity snapshot paths are untouched. Gateway boot is fail-soft on MCP snapshot failure (logs + continues with empty registry; live events refill); follows the same posture identity already uses.

## Out of scope (PR-2)

The orchestrator doesn't yet ``publish_mcp_registry_changed`` from its existing register call sites or from admin REST when an operator edits ``coworker.tools``. PR-1 closes the symptom because the gateway gets a current snapshot at boot — that's the user-visible fix. PR-2 adds the publish wiring so admin edits land without a gateway restart.