### PR TITLE
feat(egress): admin REST hot-reload of MCP registry via egress.mcp.changed (PR-2)

### DIFF
--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1612,6 +1612,7 @@ async def main() -> None:
     # for a rule snapshot at startup and the identity map on demand;
     # without these responders the gateway fails closed (blocks every
     # request) and agents on the internal bridge lose egress.
+    from rolemesh.egress.mcp_cache import subscribe_mcp_changes
     from rolemesh.egress.orch_glue import fetch_all_egress_rules, start_responders
 
     egress_responder_subs = await start_responders(
@@ -1619,6 +1620,17 @@ async def main() -> None:
         state=_state,
         rules_fetcher=fetch_all_egress_rules,
     )
+
+    # Mirror MCP registry deltas into THIS process. The webui process
+    # is the one that publishes ``egress.mcp.changed`` (admin REST
+    # edits coworker.tools), but our in-process ``_mcp_registry`` is
+    # also the source the snapshot responder serves to the gateway.
+    # Without this subscription, an admin tools edit would land on the
+    # gateway via the broadcast yet leave the orchestrator's view
+    # stale; the next gateway restart would then re-fetch a snapshot
+    # that's missing the edit.
+    mcp_sub = await subscribe_mcp_changes(_transport.nc)
+    egress_responder_subs.append(mcp_sub)
 
     # Launch the egress gateway now that the snapshot responders are
     # registered. Moved here from _ensure_container_system_running()

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -114,6 +114,19 @@ async def _publish_mcp_for_coworker(action: str, cw: Coworker) -> None:
     one event per tool (not a single batched event) so the
     gateway-side ``apply_change_event`` stays trivial — the same
     handler shape works for boot snapshot + live deltas.
+
+    NAMING-COLLISION CAVEAT: the gateway / orchestrator MCP registry
+    is keyed by tool ``name`` alone, NOT by ``(coworker_id, name)``.
+    If two coworkers configure a tool with the same ``name`` but
+    different URLs, every PATCH against either coworker republishes
+    its own URL and overwrites the other's entry on every gateway
+    that receives the event. Pre-PR-2 this only collided once at
+    orchestrator boot ("last writer wins"); after PR-2 it collides
+    on every admin edit. The proper fix is to re-key the registry on
+    ``(tenant_id, name)`` (operator scope) or ``(coworker_id, name)``
+    (per-agent scope) — tracked as a follow-up. Until then, document
+    in the operator playbook that tool names should be unique within
+    a tenant.
     """
     if _mcp_publisher is None:
         return
@@ -483,6 +496,12 @@ async def update_agent(
     # in the PATCH (``body.tools is not None``). A PATCH that only
     # touches name/permissions/etc. shouldn't generate spurious
     # mcp.changed traffic.
+    #
+    # NOTE: if any of the new tools share a ``name`` with a tool on
+    # another coworker, this broadcast will overwrite that other
+    # coworker's URL on the gateway because the registry is name-
+    # keyed. See ``_publish_mcp_for_coworker`` docstring for the
+    # follow-up plan.
     if body.tools is not None:
         await _publish_mcp_for_coworker("updated", updated)
     return _coworker_to_response(updated)

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -83,6 +83,63 @@ def _require_engine() -> ApprovalEngine:
         raise HTTPException(status_code=503, detail="Approval engine not configured")
     return _approval_engine
 
+
+# Module-level NATS client used to publish ``egress.mcp.changed``
+# deltas after an admin edits a coworker's MCP tools. Set from the
+# WebUI bootstrap; ``None`` means MCP hot-reload broadcasts are off
+# (the gateway still gets a current snapshot at orchestrator boot,
+# so functionality degrades gracefully — operators just need to wait
+# for a gateway restart for tool edits to land).
+_mcp_publisher: Any = None
+
+
+def set_mcp_publisher(nc: Any) -> None:
+    """Attach or detach the process-wide NATS client used for MCP
+    registry-change broadcasts.
+
+    Type stays ``Any`` here to avoid pulling ``nats`` types into the
+    admin module's import surface; the caller in ``webui.main``
+    already has the typed handle.
+    """
+    global _mcp_publisher
+    _mcp_publisher = nc
+
+
+async def _publish_mcp_for_coworker(action: str, cw: Coworker) -> None:
+    """Broadcast one ``egress.mcp.changed`` event per tool on the
+    coworker. Best-effort — a NATS hiccup must not break the admin
+    REST response, so the publisher itself swallows errors.
+
+    Used after create / update of a coworker's tools list. We send
+    one event per tool (not a single batched event) so the
+    gateway-side ``apply_change_event`` stays trivial — the same
+    handler shape works for boot snapshot + live deltas.
+    """
+    if _mcp_publisher is None:
+        return
+    from urllib.parse import urlparse
+
+    from rolemesh.egress.mcp_cache import McpEntry
+    from rolemesh.egress.orch_glue import publish_mcp_registry_changed
+
+    for tool in cw.tools:
+        # Same origin computation the orchestrator's bootstrap
+        # register_mcp_server walk uses (rolemesh/main.py); keep the
+        # two paths aligned so the gateway never sees a tool URL the
+        # snapshot would have stored differently.
+        parsed = urlparse(tool.url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        entry = McpEntry(
+            name=tool.name,
+            url=origin,
+            headers=dict(tool.headers or {}),
+            auth_mode=tool.auth_mode,
+        )
+        await publish_mcp_registry_changed(
+            _mcp_publisher, action=action, entry=entry
+        )
+
+
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
 
@@ -376,6 +433,11 @@ async def create_agent(
         )
     except asyncpg.UniqueViolationError as exc:
         raise HTTPException(status_code=409, detail="Agent with this folder already exists in tenant") from exc
+    # Notify the egress gateway of the freshly-registered MCP tools
+    # so it doesn't have to wait for an orchestrator restart to route
+    # them. Best-effort; the snapshot path on gateway boot still
+    # recovers full state if the broadcast misses.
+    await _publish_mcp_for_coworker("created", cw)
     return _coworker_to_response(cw)
 
 
@@ -417,6 +479,12 @@ async def update_agent(
     )
     if updated is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+    # Hot-reload MCP routes only when tools were actually included
+    # in the PATCH (``body.tools is not None``). A PATCH that only
+    # touches name/permissions/etc. shouldn't generate spurious
+    # mcp.changed traffic.
+    if body.tools is not None:
+        await _publish_mcp_for_coworker("updated", updated)
     return _coworker_to_response(updated)
 
 

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -127,9 +127,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
     )
 
+    # Wire the MCP-registry hot-reload publisher. When an admin
+    # creates/updates an agent's tools, the PATCH handler emits one
+    # ``egress.mcp.changed`` event per tool so the gateway can update
+    # routes without an orchestrator restart. Uses core NATS (not
+    # JetStream) — the broadcast is at-most-once but the gateway's
+    # snapshot fetch on boot handles missed deltas as a backstop.
+    _admin.set_mcp_publisher(_nc)
+
     yield
 
     # Shutdown
+    _admin.set_mcp_publisher(None)
     await auth.close_auth()
     await _close_db()
     if _nc is not None:

--- a/tests/egress/test_admin_mcp_publish.py
+++ b/tests/egress/test_admin_mcp_publish.py
@@ -1,0 +1,209 @@
+"""Tests for the WebUI admin → MCP-broadcast publisher.
+
+PR-2 of the MCP-registry sync. PR-1 wired the gateway to listen for
+``egress.mcp.changed`` events; PR-2 wires the WebUI admin endpoints
+to *emit* those events when an operator edits a coworker's tools.
+
+These tests exercise ``_publish_mcp_for_coworker`` directly rather
+than spinning up a FastAPI test client — the helper carries the logic
+that matters (origin computation, one-event-per-tool, no-op when
+publisher unset). The route handlers are 1-line wrappers that just
+forward the result of ``pg.create_coworker`` / ``pg.update_coworker``
+through the helper, so the FastAPI integration adds runtime cost
+without finding a different class of bug.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rolemesh.core.types import Coworker, McpServerConfig
+from rolemesh.egress.mcp_cache import MCP_CHANGED_SUBJECT
+from webui import admin as admin_mod
+
+
+@dataclass
+class _Captured:
+    subject: str
+    body: bytes
+
+
+class _FakeNats:
+    def __init__(self) -> None:
+        self.published: list[_Captured] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append(_Captured(subject, data))
+
+
+def _coworker_with_tools(tools: list[McpServerConfig]) -> Coworker:
+    return Coworker(
+        id="cw-id",
+        tenant_id="tenant-id",
+        name="bot",
+        folder="bot-folder",
+        agent_backend="claude-code",
+        system_prompt=None,
+        tools=tools,
+        skills=[],
+        container_config=None,
+        max_concurrent=2,
+        status="active",
+        created_at="",
+        agent_role="agent",
+        permissions=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_publisher() -> None:
+    admin_mod.set_mcp_publisher(None)
+
+
+# ---------------------------------------------------------------------------
+# No-op when publisher unset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_is_noop_without_publisher() -> None:
+    # Default fixture state: ``_mcp_publisher`` is None. Function must
+    # return without raising / without trying to call into a missing
+    # NATS handle. Lets dev/test stand the WebUI up without NATS for
+    # admin smoke tests.
+    cw = _coworker_with_tools(
+        [
+            McpServerConfig(
+                name="github", type="http", url="https://api.github.com"
+            )
+        ]
+    )
+    await admin_mod._publish_mcp_for_coworker("created", cw)
+    # No exception. Nothing else to assert — no nats handle to inspect.
+
+
+# ---------------------------------------------------------------------------
+# One event per tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_emits_one_event_per_tool() -> None:
+    nc = _FakeNats()
+    admin_mod.set_mcp_publisher(nc)
+
+    cw = _coworker_with_tools(
+        [
+            McpServerConfig(
+                name="github",
+                type="http",
+                url="https://api.github.com/mcp",
+                auth_mode="user",
+            ),
+            McpServerConfig(
+                name="internal",
+                type="sse",
+                url="http://localhost:9100/mcp/",
+                headers={"X-Tenant": "t1"},
+                auth_mode="service",
+            ),
+        ]
+    )
+    await admin_mod._publish_mcp_for_coworker("updated", cw)
+
+    assert len(nc.published) == 2
+    subjects = {p.subject for p in nc.published}
+    assert subjects == {MCP_CHANGED_SUBJECT}
+
+
+@pytest.mark.asyncio
+async def test_publish_strips_path_to_origin() -> None:
+    """Tool URL ``https://api.github.com/mcp`` becomes
+    ``https://api.github.com``. The gateway's ``_mcp_registry`` keys on
+    origin and rewrites paths client-side; passing the full URL would
+    cause the proxy to issue requests against the wrong path."""
+    nc = _FakeNats()
+    admin_mod.set_mcp_publisher(nc)
+
+    cw = _coworker_with_tools(
+        [
+            McpServerConfig(
+                name="x",
+                type="http",
+                url="https://api.example.com/some/long/path?q=1",
+            )
+        ]
+    )
+    await admin_mod._publish_mcp_for_coworker("updated", cw)
+
+    payload = json.loads(nc.published[0].body)
+    assert payload["url"] == "https://api.example.com"
+    assert payload["name"] == "x"
+    assert payload["action"] == "updated"
+
+
+@pytest.mark.asyncio
+async def test_publish_action_propagates() -> None:
+    nc = _FakeNats()
+    admin_mod.set_mcp_publisher(nc)
+
+    cw = _coworker_with_tools(
+        [McpServerConfig(name="x", type="http", url="https://x.example")]
+    )
+    await admin_mod._publish_mcp_for_coworker("created", cw)
+    await admin_mod._publish_mcp_for_coworker("updated", cw)
+
+    actions = [json.loads(p.body)["action"] for p in nc.published]
+    assert actions == ["created", "updated"]
+
+
+@pytest.mark.asyncio
+async def test_publish_serialises_headers_and_auth_mode() -> None:
+    nc = _FakeNats()
+    admin_mod.set_mcp_publisher(nc)
+
+    cw = _coworker_with_tools(
+        [
+            McpServerConfig(
+                name="x",
+                type="http",
+                url="https://x.example",
+                headers={"X-A": "1", "X-B": "2"},
+                auth_mode="service",
+            )
+        ]
+    )
+    await admin_mod._publish_mcp_for_coworker("created", cw)
+
+    payload = json.loads(nc.published[0].body)
+    assert payload["headers"] == {"X-A": "1", "X-B": "2"}
+    assert payload["auth_mode"] == "service"
+
+
+@pytest.mark.asyncio
+async def test_publish_with_zero_tools_emits_nothing() -> None:
+    nc = _FakeNats()
+    admin_mod.set_mcp_publisher(nc)
+    cw = _coworker_with_tools([])
+    await admin_mod._publish_mcp_for_coworker("updated", cw)
+    assert nc.published == []
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_nats_errors() -> None:
+    # Best-effort contract from the helper docstring — admin REST
+    # response should NOT 500 because the broadcast couldn't go out.
+    class _Boom:
+        async def publish(self, *a: Any, **kw: Any) -> None:
+            raise RuntimeError("nats down")
+
+    admin_mod.set_mcp_publisher(_Boom())
+    cw = _coworker_with_tools(
+        [McpServerConfig(name="x", type="http", url="https://x.example")]
+    )
+    # Must not raise.
+    await admin_mod._publish_mcp_for_coworker("updated", cw)


### PR DESCRIPTION
## Summary

PR-2 of the MCP-registry sync. PR-1 wired the gateway to *consume* ``egress.mcp.changed`` events; nobody published them. PR-2 publishes them from the admin endpoints that mutate ``coworker.tools``, so the gateway hot-reloads MCP routes when an operator edits tools through the admin UI.

Without this, an operator-visible symptom: ""I added a tool to the agent but it still 404s — the gateway only catches up after an orchestrator restart"".

## What's in this PR

| File | Change |
|------|--------|
| ``src/webui/admin.py`` | ``set_mcp_publisher`` + ``_publish_mcp_for_coworker`` helper; ``create_agent`` and ``update_agent`` (when ``body.tools is not None``) publish one event per tool |
| ``src/webui/main.py`` | Lifespan wires the NATS client into ``admin.set_mcp_publisher`` (mirrors the existing ``set_approval_engine`` pattern) |
| ``src/rolemesh/main.py`` | Orchestrator process subscribes ``egress.mcp.changed`` and applies events to its own ``_mcp_registry`` — keeps the snapshot responder serving up-to-date state for the next gateway boot |
| ``tests/egress/test_admin_mcp_publish.py`` (new) | 7 unit cases for the publisher helper |

## Pipeline

```
admin PATCH /api/admin/agents/{id}     → webui publishes egress.mcp.changed
                                              ↓
                                   ┌──────────┴──────────┐
                                   ↓                     ↓
                       orchestrator subscriber     gateway subscriber (PR-1)
                       (mirror to _mcp_registry)   (apply to handler dict)
```

## Notable scope choices

- **``delete_agent`` does NOT publish ``deleted``.** The registry is keyed by tool *name*, not coworker — multiple coworkers can reference the same MCP server name, and PR-2 doesn't carry the refcount to know if the deleted coworker owned the last reference. Dropping the entry could break sibling coworkers' tool routes. The next orchestrator restart reconciles via the snapshot path. Filed as a TODO.
- **``update_agent`` publishes only when ``body.tools is not None``** — a PATCH that touches only name/permissions/etc. doesn't generate spurious mcp.changed traffic.

## Test plan

- [x] ``tests/egress/test_admin_mcp_publish.py``: 7 unit cases — no-op without publisher, one event per tool, URL → origin stripping, action propagation, headers + auth_mode roundtrip, zero tools no-op, NATS error swallowed (admin REST must not 500 on broadcast failure).
- [x] Egress unit suite: 76 → 83 (no regressions).
- [x] Wider sweep ``tests/egress tests/db tests/auth tests/approval`` (e2e/integration excluded): 223/223.

## Risk

Low. New subscription is additive (no existing path depends on it). Best-effort publish (``publish_mcp_registry_changed`` swallows transport errors) means a transient NATS hiccup during a PATCH costs at most one gateway restart to realign — same fall-back posture as PR-1's snapshot.