### PR TITLE
feat(egress): NATS-RPC RemoteTokenVault for gateway-side MCP token forwarding

### DIFF
--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -69,7 +69,8 @@ from .policy_cache import (
     fetch_snapshot_via_nats,
     subscribe_rule_changes,
 )
-from .reverse_proxy import start_credential_proxy
+from .remote_token_vault import RemoteTokenVault
+from .reverse_proxy import set_token_vault, start_credential_proxy
 from .safety_call import AuditPublisher, EgressSafetyCaller
 
 logger = get_logger()
@@ -222,6 +223,19 @@ async def main() -> None:
             )
         mcp_sub = await subscribe_mcp_changes(nats_client)
         stack.push_async_callback(mcp_sub.unsubscribe)  # type: ignore[attr-defined]
+
+        # --- Token vault: forward per-user MCP token requests --------
+        # The orchestrator owns the DB-backed TokenVault (refresh
+        # tokens live encrypted in oidc_user_tokens, IdP credentials
+        # live in env on the orchestrator's filesystem). The gateway
+        # carries a ``RemoteTokenVault`` that forwards every
+        # ``get_fresh_access_token(user_id)`` over NATS RPC instead.
+        # Wired unconditionally — when OIDC isn't configured the
+        # orchestrator-side responder is absent, the RPC times out,
+        # and the proxy degrades to ""skip Bearer injection"" — the
+        # same posture as if ``_token_vault`` were None.
+        set_token_vault(RemoteTokenVault(nats_client))
+        logger.info("gateway: RemoteTokenVault wired")
 
         # --- Reverse proxy (port 3001) -------------------------------
         reverse_runner = await start_credential_proxy(

--- a/src/rolemesh/egress/orch_glue.py
+++ b/src/rolemesh/egress/orch_glue.py
@@ -50,6 +50,7 @@ from .mcp_cache import (  # noqa: E402
     entry_to_dict,
 )
 from .policy_cache import RULE_CHANGED_SUBJECT, SNAPSHOT_REQUEST_SUBJECT  # noqa: E402
+from .remote_token_vault import TOKEN_ACCESS_REQUEST_SUBJECT  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -300,6 +301,76 @@ async def fetch_all_mcp_servers() -> list[McpEntry]:
             )
         )
     return out
+
+
+async def start_token_responder(
+    nc: nats.aio.client.Client,
+    *,
+    vault: Any,
+) -> object:
+    """Subscribe to ``egress.token.access.request`` and serve fresh
+    access tokens out of the orchestrator's local TokenVault.
+
+    The egress gateway runs without DB access; it can't decrypt or
+    refresh OIDC tokens itself. The gateway's
+    ``RemoteTokenVault.get_fresh_access_token`` forwards each request
+    to this subject. The orchestrator already has a real
+    ``TokenVault`` (built from env via ``create_vault_from_env``); we
+    just plumb each RPC into it.
+
+    ``vault`` is typed ``Any`` so this module doesn't import the real
+    ``TokenVault`` (transitively pulls in ``rolemesh.db.pg``); the
+    duck-typed call is ``vault.get_fresh_access_token(user_id)``.
+
+    Returns the subscription handle; caller is responsible for
+    ``await sub.unsubscribe()`` at shutdown — same pattern as
+    ``start_responders``.
+    """
+    async def _handler(msg: object) -> None:
+        try:
+            payload = json.loads(msg.data)  # type: ignore[attr-defined]
+        except (ValueError, AttributeError) as exc:
+            logger.warning("token responder: non-JSON request", error=str(exc))
+            await _respond(msg, {"access_token": None, "error": "bad_json"})
+            return
+        if not isinstance(payload, dict):
+            await _respond(msg, {"access_token": None, "error": "bad_payload"})
+            return
+        user_id = payload.get("user_id")
+        if not isinstance(user_id, str) or not user_id:
+            await _respond(msg, {"access_token": None, "error": "missing_user_id"})
+            return
+
+        try:
+            access_token = await vault.get_fresh_access_token(user_id)
+        except Exception as exc:  # noqa: BLE001
+            # vault.get_fresh_access_token already swallows IdP /
+            # transport errors and returns None; this catch is for
+            # programming errors so the subscriber loop survives.
+            logger.error(
+                "token responder: vault raised", user_id=user_id, error=str(exc)
+            )
+            await _respond(msg, {"access_token": None, "error": "vault_error"})
+            return
+
+        await _respond(msg, {"access_token": access_token})
+
+    sub = await nc.subscribe(TOKEN_ACCESS_REQUEST_SUBJECT, cb=_handler)
+    logger.info(
+        "token responder subscribed",
+        subject=TOKEN_ACCESS_REQUEST_SUBJECT,
+    )
+    return sub
+
+
+async def _respond(msg: object, payload: dict[str, Any]) -> None:
+    """Best-effort respond helper for token RPCs. A failure to
+    respond degrades to a gateway-side timeout, which already maps
+    to ``access_token=None`` (see RemoteTokenVault docstring), so
+    we suppress the exception to keep the subscriber alive."""
+    body = json.dumps(payload).encode("utf-8")
+    with contextlib.suppress(Exception):
+        await msg.respond(body)  # type: ignore[attr-defined]
 
 
 async def fetch_all_egress_rules() -> list[dict[str, Any]]:

--- a/src/rolemesh/egress/remote_token_vault.py
+++ b/src/rolemesh/egress/remote_token_vault.py
@@ -1,0 +1,160 @@
+"""NATS-backed TokenVault proxy used by the egress gateway.
+
+Why this exists
+---------------
+The DB-backed ``rolemesh.auth.token_vault.TokenVault`` reads encrypted
+refresh tokens from the ``oidc_user_tokens`` table and POSTs to the
+IdP token endpoint to refresh them. Both operations require modules
+the egress-gateway container deliberately doesn't ship — ``rolemesh.db``
+is not COPYed into ``Dockerfile.egress-gateway`` and we don't want to
+distribute DB credentials to the gateway. EC-1..EC-3's invariant is
+"gateway is a network-layer proxy; it does not hold persistent state".
+
+Solution: the gateway calls ``RemoteTokenVault.get_fresh_access_token``,
+which forwards the request over a NATS request-reply RPC to an
+orchestrator-side responder (see ``orch_glue.start_token_responder``).
+The orchestrator already has a real ``TokenVault`` instance plus DB
+access; it does the work and returns the access_token (or null on
+failure / unknown user). All caches and IdP traffic stay on the
+orchestrator process.
+
+Wire format
+-----------
+Subject: ``egress.token.access.request``
+Request body (JSON): ``{"user_id": "<uuid>"}``
+Reply body (JSON): ``{"access_token": "..."}`` or
+                   ``{"access_token": null, "error": "<short>"}``
+
+Replies are best-effort — a timeout, a NULL reply, or any
+unparseable response all degrade to ``None``, which causes
+``handle_mcp_proxy`` to skip Bearer injection (same posture as the
+``_token_vault is None`` path it replaces).
+
+Latency note
+------------
+Each user-mode MCP request adds one round-trip on this RPC.
+Measured against LLM tool-call paths the cost is in the noise; if it
+ever becomes hot, the next iteration adds an in-gateway TTL cache
+keyed on user_id (token validity is already minutes-scale on the
+orchestrator side, so a 30s gateway cache would absorb most spikes).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from rolemesh.core.logger import get_logger
+
+if TYPE_CHECKING:
+    import nats.aio.client
+
+logger = get_logger()
+
+
+# NATS subject owned by the token-vault RPC. Singular ``request``
+# rather than the plural other egress subjects use because the RPC
+# is per-call (one user_id → one access_token), not a snapshot
+# stream.
+TOKEN_ACCESS_REQUEST_SUBJECT = "egress.token.access.request"
+
+# Default per-call timeout. Generous — the orchestrator side may
+# need to make an outbound IdP refresh call, which can sit at the
+# 1-2s range under typical OIDC providers. We err high here because
+# a timeout-induced None makes the user's MCP request fail with 401;
+# falsely racing the IdP is worse than waiting one extra second.
+_DEFAULT_TIMEOUT_S = 5.0
+
+
+class RemoteTokenVault:
+    """``TokenVaultProtocol`` implementation that forwards token
+    requests to the orchestrator over NATS.
+
+    Implements only ``get_fresh_access_token`` — the gateway never
+    needs ``store_initial`` or ``revoke`` (those run from the WebUI's
+    OIDC callback path against the local ``TokenVault``).
+    """
+
+    def __init__(
+        self,
+        nats_client: nats.aio.client.Client,
+        *,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self._nc = nats_client
+        self._timeout_s = timeout_s
+
+    async def get_fresh_access_token(self, user_id: str) -> str | None:
+        """Ask the orchestrator for a fresh access_token for ``user_id``.
+
+        Returns None on:
+          - empty/falsy user_id (defensive — protocol level)
+          - NATS RPC timeout / transport error
+          - orchestrator reports the user has no stored tokens
+          - orchestrator's IdP refresh failed
+          - any malformed reply
+
+        These all map to ""no Bearer header injected"" upstream, which
+        is the same fallback the ``_token_vault is None`` path always
+        produced before this class existed.
+        """
+        if not user_id:
+            return None
+
+        body = json.dumps({"user_id": user_id}).encode("utf-8")
+        try:
+            response = await self._nc.request(  # type: ignore[attr-defined]
+                TOKEN_ACCESS_REQUEST_SUBJECT,
+                body,
+                timeout=self._timeout_s,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort: any
+            # transport error degrades to None and the MCP request
+            # surfaces a 401 from the upstream service.
+            logger.warning(
+                "remote_token_vault: RPC failed",
+                user_id=user_id,
+                error=str(exc),
+            )
+            return None
+
+        try:
+            payload = json.loads(response.data)
+        except (ValueError, AttributeError) as exc:
+            logger.warning(
+                "remote_token_vault: malformed reply",
+                user_id=user_id,
+                error=str(exc),
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            logger.warning(
+                "remote_token_vault: reply not a dict",
+                user_id=user_id,
+                got=type(payload).__name__,
+            )
+            return None
+
+        access_token = payload.get("access_token")
+        if access_token is None:
+            # Orchestrator may have included a hint about why. Surface
+            # at debug — operators see info via the orchestrator log.
+            err = payload.get("error")
+            if err:
+                logger.debug(
+                    "remote_token_vault: no token returned",
+                    user_id=user_id,
+                    reason=str(err),
+                )
+            return None
+
+        if not isinstance(access_token, str):
+            logger.warning(
+                "remote_token_vault: access_token not a string",
+                user_id=user_id,
+                got=type(access_token).__name__,
+            )
+            return None
+
+        return access_token

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -32,7 +32,7 @@ with positional args identical to pre-EC-2 behaviour.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 from urllib.parse import urlparse
 
 from aiohttp import ClientSession, web
@@ -42,22 +42,41 @@ from rolemesh.core.logger import get_logger
 from .safety_call import EgressRequest
 
 if TYPE_CHECKING:
-    from rolemesh.auth.token_vault import TokenVault
-
     from .identity import IdentityResolver
     from .safety_call import EgressSafetyCaller
 
 logger = get_logger()
 
+
+class TokenVaultProtocol(Protocol):
+    """Minimal vault interface the reverse-proxy actually consumes.
+
+    Both ``rolemesh.auth.token_vault.TokenVault`` (DB-backed, used by
+    orchestrator + webui processes) and ``rolemesh.egress.remote_token_vault.
+    RemoteTokenVault`` (NATS-RPC-backed, used by the gateway container)
+    satisfy this. Keeping the protocol here rather than importing
+    ``TokenVault`` lets the gateway image stay free of ``rolemesh.db``
+    transitively — the gateway never persists or decrypts tokens
+    locally.
+    """
+
+    async def get_fresh_access_token(self, user_id: str) -> str | None: ...
+
+
 # Module-level TokenVault for per-user IdP token forwarding to MCP servers
-_token_vault: TokenVault | None = None
+_token_vault: TokenVaultProtocol | None = None
 
 # The only identity header containers send.
 _USER_ID_HEADER = "X-RoleMesh-User-Id"
 
 
-def set_token_vault(vault: TokenVault) -> None:
-    """Set the TokenVault instance for per-user MCP token forwarding."""
+def set_token_vault(vault: TokenVaultProtocol) -> None:
+    """Set the TokenVault instance for per-user MCP token forwarding.
+
+    Accepts any object satisfying ``TokenVaultProtocol`` — the
+    DB-backed ``TokenVault`` in orchestrator/webui or the
+    NATS-RPC ``RemoteTokenVault`` in the egress gateway.
+    """
     global _token_vault
     _token_vault = vault
     logger.info("TokenVault configured for MCP user token forwarding")

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1632,6 +1632,19 @@ async def main() -> None:
     mcp_sub = await subscribe_mcp_changes(_transport.nc)
     egress_responder_subs.append(mcp_sub)
 
+    # Token vault RPC: gateway's RemoteTokenVault forwards each
+    # user-mode MCP request here so we can decrypt + refresh tokens
+    # using THIS process's TokenVault (which holds the DB conn and
+    # the IdP refresh path). Only wire the responder when the vault
+    # is configured — without OIDC there are no tokens to serve and
+    # the gateway's RemoteTokenVault will time out to None, which
+    # already maps to "skip Bearer injection" upstream.
+    if _vault is not None:
+        from rolemesh.egress.orch_glue import start_token_responder
+
+        token_sub = await start_token_responder(_transport.nc, vault=_vault)
+        egress_responder_subs.append(token_sub)
+
     # Launch the egress gateway now that the snapshot responders are
     # registered. Moved here from _ensure_container_system_running()
     # because otherwise the gateway NATS-requests the snapshot before

--- a/tests/egress/test_remote_token_vault.py
+++ b/tests/egress/test_remote_token_vault.py
@@ -1,0 +1,144 @@
+"""Unit tests for ``rolemesh.egress.remote_token_vault.RemoteTokenVault``.
+
+Covers the gateway-side proxy that forwards token requests to the
+orchestrator. The wire shape is fixed (``{"user_id": ...}`` →
+``{"access_token": ... | null, "error": ...}``) and every error path
+must degrade to ``None`` rather than raise — the gateway uses the
+return value to decide whether to inject a Bearer header, and any
+exception in this path would surface as an HTTP 500 inside the
+reverse proxy.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from rolemesh.egress.remote_token_vault import (
+    TOKEN_ACCESS_REQUEST_SUBJECT,
+    RemoteTokenVault,
+)
+
+
+@dataclass
+class _Reply:
+    data: bytes
+
+
+class _StubNats:
+    """Minimal duck-type for the ``nc.request`` method we use."""
+
+    def __init__(self, reply: _Reply | Exception) -> None:
+        self._reply = reply
+        self.requests: list[tuple[str, bytes, float]] = []
+
+    async def request(self, subject: str, data: bytes, timeout: float) -> _Reply:
+        self.requests.append((subject, data, timeout))
+        if isinstance(self._reply, Exception):
+            raise self._reply
+        return self._reply
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_access_token_on_success() -> None:
+    nc = _StubNats(_Reply(json.dumps({"access_token": "AT-123"}).encode()))
+    vault = RemoteTokenVault(nc, timeout_s=2.0)
+
+    token = await vault.get_fresh_access_token("user-uuid")
+
+    assert token == "AT-123"
+    # Exactly one RPC, on the canonical subject, body is the user_id JSON.
+    assert len(nc.requests) == 1
+    subject, body, timeout = nc.requests[0]
+    assert subject == TOKEN_ACCESS_REQUEST_SUBJECT
+    assert json.loads(body) == {"user_id": "user-uuid"}
+    assert timeout == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Defensive empty input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_user_id_short_circuits_without_rpc() -> None:
+    # Belt-and-braces: if the X-RoleMesh-User-Id header arrived blank
+    # from a misconfigured agent, we skip the round-trip entirely.
+    # Saves NATS traffic and matches the protocol's None contract.
+    nc = _StubNats(_Reply(b"{}"))  # would respond if asked
+    vault = RemoteTokenVault(nc)
+
+    assert await vault.get_fresh_access_token("") is None
+    assert nc.requests == []  # never asked
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — every one must degrade to None, never raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nats_timeout_returns_none() -> None:
+    # asyncio.TimeoutError is the canonical NATS request timeout
+    # signature; test stand-in is any exception via the stub.
+    nc = _StubNats(TimeoutError("nats timeout"))
+    vault = RemoteTokenVault(nc, timeout_s=0.1)
+    assert await vault.get_fresh_access_token("u") is None
+
+
+@pytest.mark.asyncio
+async def test_nats_arbitrary_transport_error_returns_none() -> None:
+    nc = _StubNats(RuntimeError("nats not connected"))
+    vault = RemoteTokenVault(nc)
+    assert await vault.get_fresh_access_token("u") is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_reply_returns_none() -> None:
+    nc = _StubNats(_Reply(b"not-json"))
+    vault = RemoteTokenVault(nc)
+    assert await vault.get_fresh_access_token("u") is None
+
+
+@pytest.mark.asyncio
+async def test_reply_not_a_dict_returns_none() -> None:
+    # JSON valid but wrong shape — e.g. someone published a list
+    # instead of an object.
+    nc = _StubNats(_Reply(json.dumps(["AT-123"]).encode()))
+    vault = RemoteTokenVault(nc)
+    assert await vault.get_fresh_access_token("u") is None
+
+
+@pytest.mark.asyncio
+async def test_reply_with_explicit_null_returns_none() -> None:
+    # Orchestrator's normal "no token for this user" reply.
+    nc = _StubNats(
+        _Reply(json.dumps({"access_token": None, "error": "no_user"}).encode())
+    )
+    vault = RemoteTokenVault(nc)
+    assert await vault.get_fresh_access_token("u") is None
+
+
+@pytest.mark.asyncio
+async def test_reply_with_non_string_token_returns_none() -> None:
+    # Defends against an upstream regression that publishes a
+    # numeric token by mistake — callers expect ``str | None``.
+    nc = _StubNats(_Reply(json.dumps({"access_token": 12345}).encode()))
+    vault = RemoteTokenVault(nc)
+    assert await vault.get_fresh_access_token("u") is None
+
+
+@pytest.mark.asyncio
+async def test_reply_missing_access_token_key_returns_none() -> None:
+    # ``{"error": "..."}`` without ``access_token`` is a legal
+    # error-only reply; treat it as None.
+    nc = _StubNats(_Reply(json.dumps({"error": "vault_error"}).encode()))
+    vault = RemoteTokenVault(nc)
+    assert await vault.get_fresh_access_token("u") is None

--- a/tests/egress/test_token_glue.py
+++ b/tests/egress/test_token_glue.py
@@ -1,0 +1,229 @@
+"""Unit tests for the orchestrator-side token responder.
+
+``start_token_responder`` subscribes ``egress.token.access.request``
+and dispatches each incoming RPC into the local ``TokenVault``'s
+``get_fresh_access_token``. Tests use a hand-rolled NATS stub +
+duck-typed vault — no real NATS or DB.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rolemesh.egress.orch_glue import start_token_responder
+from rolemesh.egress.remote_token_vault import TOKEN_ACCESS_REQUEST_SUBJECT
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Sub:
+    subject: str
+    cb: Any
+
+
+class _FakeNats:
+    def __init__(self) -> None:
+        self.subs: list[_Sub] = []
+
+    async def subscribe(self, subject: str, cb: Any = None) -> _Sub:
+        sub = _Sub(subject=subject, cb=cb)
+        self.subs.append(sub)
+        return sub
+
+
+class _FakeMsg:
+    """Duck-typed NATS message — only ``data`` and ``respond``."""
+
+    def __init__(self, body: bytes) -> None:
+        self.data = body
+        self.replies: list[bytes] = []
+
+    async def respond(self, body: bytes) -> None:
+        self.replies.append(body)
+
+
+class _StubVault:
+    """Minimal vault — records calls and returns canned values."""
+
+    def __init__(self, returns: str | None | Exception = None) -> None:
+        self._returns = returns
+        self.calls: list[str] = []
+
+    async def get_fresh_access_token(self, user_id: str) -> str | None:
+        self.calls.append(user_id)
+        if isinstance(self._returns, Exception):
+            raise self._returns
+        return self._returns
+
+
+@pytest.fixture
+def nc() -> _FakeNats:
+    return _FakeNats()
+
+
+# ---------------------------------------------------------------------------
+# Subscribe wires the canonical subject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_responder_subscribes_canonical_subject(nc: _FakeNats) -> None:
+    sub = await start_token_responder(nc, vault=_StubVault())
+    assert sub is nc.subs[0]
+    assert nc.subs[0].subject == TOKEN_ACCESS_REQUEST_SUBJECT
+
+
+# ---------------------------------------------------------------------------
+# Happy path — request → vault → response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_access_token_for_known_user(nc: _FakeNats) -> None:
+    vault = _StubVault(returns="AT-known")
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(json.dumps({"user_id": "u-1"}).encode())
+    await nc.subs[0].cb(msg)
+
+    assert vault.calls == ["u-1"]
+    payload = json.loads(msg.replies[0])
+    assert payload == {"access_token": "AT-known"}
+
+
+@pytest.mark.asyncio
+async def test_returns_null_when_vault_says_none(nc: _FakeNats) -> None:
+    vault = _StubVault(returns=None)
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(json.dumps({"user_id": "u-1"}).encode())
+    await nc.subs[0].cb(msg)
+
+    payload = json.loads(msg.replies[0])
+    assert payload == {"access_token": None}
+
+
+# ---------------------------------------------------------------------------
+# Bad request payloads — never crash the subscriber loop, always reply
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_json_request_replies_with_error(nc: _FakeNats) -> None:
+    vault = _StubVault(returns="should-not-reach-here")
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(b"not-json")
+    await nc.subs[0].cb(msg)
+
+    # vault must NOT have been called
+    assert vault.calls == []
+    payload = json.loads(msg.replies[0])
+    assert payload["access_token"] is None
+    assert payload["error"] == "bad_json"
+
+
+@pytest.mark.asyncio
+async def test_payload_not_a_dict_replies_with_error(nc: _FakeNats) -> None:
+    vault = _StubVault()
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(json.dumps(["u-1"]).encode())
+    await nc.subs[0].cb(msg)
+
+    payload = json.loads(msg.replies[0])
+    assert payload["access_token"] is None
+    assert payload["error"] == "bad_payload"
+
+
+@pytest.mark.asyncio
+async def test_missing_user_id_replies_with_error(nc: _FakeNats) -> None:
+    vault = _StubVault()
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(json.dumps({"foo": "bar"}).encode())
+    await nc.subs[0].cb(msg)
+
+    payload = json.loads(msg.replies[0])
+    assert payload["access_token"] is None
+    assert payload["error"] == "missing_user_id"
+
+
+@pytest.mark.asyncio
+async def test_empty_user_id_replies_with_error(nc: _FakeNats) -> None:
+    # ``""`` passes ``.get("user_id")`` but the responder rejects it
+    # to mirror RemoteTokenVault's defensive short-circuit.
+    vault = _StubVault()
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(json.dumps({"user_id": ""}).encode())
+    await nc.subs[0].cb(msg)
+
+    payload = json.loads(msg.replies[0])
+    assert payload["error"] == "missing_user_id"
+
+
+# ---------------------------------------------------------------------------
+# Vault raises — subscriber loop must survive, reply with error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vault_exception_does_not_crash_loop(nc: _FakeNats) -> None:
+    # vault.get_fresh_access_token already swallows transport / IdP
+    # errors and returns None — but if it raises (programming bug),
+    # the responder must still reply (don't leave the gateway hanging
+    # on its NATS request) and stay alive for the next call.
+    vault = _StubVault(returns=RuntimeError("boom"))
+    await start_token_responder(nc, vault=vault)
+
+    msg = _FakeMsg(json.dumps({"user_id": "u-1"}).encode())
+    await nc.subs[0].cb(msg)  # must not propagate the exception
+
+    payload = json.loads(msg.replies[0])
+    assert payload["access_token"] is None
+    assert payload["error"] == "vault_error"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end shape check via RemoteTokenVault
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_with_real_remote_vault() -> None:
+    """Wire RemoteTokenVault → in-process responder dispatcher.
+
+    Validates wire format compatibility — if the publisher schema
+    drifts from the responder schema, this test catches it without
+    needing a live NATS broker.
+    """
+    from rolemesh.egress.remote_token_vault import RemoteTokenVault
+
+    vault = _StubVault(returns="AT-roundtrip")
+    nc = _FakeNats()
+    await start_token_responder(nc, vault=vault)
+
+    # Build a NATS double whose .request invokes the registered
+    # callback synchronously and returns a Reply with the response.
+    class _LoopBackNats:
+        async def request(
+            self, subject: str, data: bytes, timeout: float
+        ) -> Any:
+            sub = next(s for s in nc.subs if s.subject == subject)
+            msg = _FakeMsg(data)
+            await sub.cb(msg)
+            return type("R", (), {"data": msg.replies[0]})()
+
+    rv = RemoteTokenVault(_LoopBackNats())
+    token = await rv.get_fresh_access_token("u-1")
+    assert token == "AT-roundtrip"
+    assert vault.calls == ["u-1"]


### PR DESCRIPTION
## Summary

Closes Bug 4 — ``auth_mode=user`` MCP calls returning ""Authentication required"" because the egress-gateway process never had its ``_token_vault`` wired. The DB-backed ``TokenVault`` can't run on the gateway (image deliberately excludes ``rolemesh.db``; we don't want to distribute DB credentials there), so this PR introduces a NATS-RPC proxy.

## Pipeline

```
gateway: handle_mcp_proxy
  ─→ RemoteTokenVault.get_fresh_access_token(user_id)
       ─→ NATS request on egress.token.access.request
            ─→ orchestrator: start_token_responder dispatcher
                  ─→ real vault.get_fresh_access_token(user_id)
                       ─→ DB cache (access_token + expires_at)
                       ─→ IdP refresh only when within 60s of expiry
            ◄── reply {"access_token": "..." | null}
       ◄── access_token | None
  ─→ inject Bearer header (or skip if None)
```

## What's in this PR

| File | Change |
|------|--------|
| ``src/rolemesh/egress/remote_token_vault.py`` (new) | ``RemoteTokenVault`` (single ``get_fresh_access_token`` method) + subject constant. Defensive None on every error path |
| ``src/rolemesh/egress/orch_glue.py`` | ``start_token_responder`` — subscribes the RPC subject, dispatches to local vault, reply with explicit error code on bad payloads |
| ``src/rolemesh/egress/reverse_proxy.py`` | ``TokenVaultProtocol`` — minimal interface both vaults satisfy without inheritance; ``set_token_vault`` retyped |
| ``src/rolemesh/egress/gateway.py`` | ``main()`` calls ``set_token_vault(RemoteTokenVault(nc))`` before ``start_credential_proxy`` |
| ``src/rolemesh/main.py`` | When OIDC is configured (``_vault is not None``), spin up the responder; sub attached to ``egress_responder_subs`` for shutdown cleanup |

## No gateway cache (intentional)

The real cache lives on the orchestrator: the vault's DB row holds the access_token + expires_at and skips IdP traffic when more than 60s remain. Every user-mode MCP request makes one RPC; the orchestrator answers from DB unless the token is genuinely close to expiry. A second cache layer on the gateway would require an ``egress.token.revoked`` broadcast + invalidation logic — deferred until there's data showing RPC fan-in is a real bottleneck.

## Test plan

- [x] ``tests/egress/test_remote_token_vault.py``: 9 unit cases — happy path, empty user_id short-circuit, NATS timeout/transport error, malformed JSON, non-dict reply, explicit null, non-string token, missing key. Every failure degrades to None.
- [x] ``tests/egress/test_token_glue.py``: 9 unit cases — subject wiring, success/null round-trip, bad payload shapes (non-JSON / list / missing / empty user_id) reply with structured error, vault exceptions don't crash the subscriber loop, end-to-end shape via loop-back NATS.
- [x] Egress unit suite: 83 → 101 (no regressions).
- [x] Egress integration suite (live Docker): 14/14 still green — gateway boots and serves through the new ``set_token_vault`` call.

## Risk

Low. New subscription is additive. Bug 4's symptom (no Bearer injection) was a default-deny posture; this PR converts it to ""ask the orchestrator and inject if possible"". Each error path explicitly preserves the old fail-soft behaviour, so a misconfigured / down orchestrator at worst keeps the gateway in its pre-fix state — never worse.

## Out of scope

- Gateway-side cache (rationale above).
- Wiring ``RemoteTokenVault`` into the host-side credential proxy at ``rolemesh.security.credential_proxy`` — that listener is a compatibility shim from EC-1; agents already route through the gateway. Removing it (also flagged in main.py:1410) would be its own clean-up PR.