### PR TITLE
fix(egress): rewrite localhost on every MCP-registry publish boundary (Bug 5)

### DIFF
--- a/src/rolemesh/container/runtime.py
+++ b/src/rolemesh/container/runtime.py
@@ -197,6 +197,45 @@ def get_host_gateway_extra_hosts() -> dict[str, str]:
     return {}
 
 
+def rewrite_loopback_to_host_gateway(url: str) -> str:
+    """Rewrite ``localhost`` / ``127.0.0.1`` in a URL's authority to
+    ``host.docker.internal``.
+
+    Required at every boundary that hands a URL from the orchestrator
+    (running on the host) to a process running inside a container —
+    inside the container, ``localhost`` resolves to the container's
+    own loopback, not the host. Examples:
+
+      * ``NATS_URL`` injected into the egress-gateway's environment.
+      * MCP server origins serialised into ``egress.mcp.changed``
+        events / ``egress.mcp.snapshot.request`` replies — the
+        gateway stores them verbatim and dials directly.
+
+    The rewrite is universal across platforms because
+    ``host.docker.internal`` is resolvable on every platform we
+    support:
+
+      * Linux: via the ``ExtraHosts: host-gateway`` mapping
+        ``create_host_config`` adds (see ``get_host_gateway_extra_hosts``).
+      * macOS / Windows / WSL (Docker Desktop): built into the
+        platform's embedded DNS resolver.
+
+    Anchors on ``://...:`` so paths or hostnames containing the
+    substring ``localhost`` (e.g. ``mylocalhost.example.com``) are
+    not touched.
+
+    Note: do NOT use this on the orchestrator's own in-process
+    registries. There, ``localhost`` legitimately means "the host"
+    (because the orchestrator IS on the host) and rewriting would
+    redirect intra-host calls through Docker's DNS for no reason.
+    The right place is at every IPC boundary where a URL leaves
+    the orchestrator process.
+    """
+    return url.replace("://localhost:", "://host.docker.internal:").replace(
+        "://127.0.0.1:", "://host.docker.internal:"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------

--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -32,7 +32,10 @@ import aiodocker
 import aiodocker.exceptions
 
 from rolemesh.container.network import verify_egress_gateway_reachable
-from rolemesh.container.runtime import get_host_gateway_extra_hosts
+from rolemesh.container.runtime import (
+    get_host_gateway_extra_hosts,
+    rewrite_loopback_to_host_gateway,
+)
 from rolemesh.core.config import (
     CREDENTIAL_PROXY_PORT,
     EGRESS_GATEWAY_CONTAINER_NAME,
@@ -210,39 +213,6 @@ def _extra_hosts() -> dict[str, str]:
     return get_host_gateway_extra_hosts()
 
 
-def _rewrite_loopback_to_host_gateway(url: str) -> str:
-    """Rewrite ``localhost`` / ``127.0.0.1`` in a URL to ``host.docker.internal``.
-
-    Required on every platform — inside the gateway container,
-    ``localhost`` resolves to the container's own loopback, not the
-    host. The orchestrator's ``NATS_URL`` typically points at
-    ``localhost:4222`` (the host's NATS), so a verbatim copy makes
-    the gateway dial itself and the NATS connection fails with
-    ``Name or service not known`` / ``Connection refused``.
-
-    Two ways ``host.docker.internal`` is made resolvable, both
-    converging at this rewrite:
-
-      - Linux: ``create_egress_gateway`` adds an ExtraHosts entry
-        (``host.docker.internal:host-gateway``) via
-        ``get_host_gateway_extra_hosts``. Docker Engine does not
-        provide the alias automatically.
-      - Docker Desktop (macOS / Windows / WSL): the name is built
-        into the platform's embedded DNS resolver. No ExtraHosts
-        entry is needed (and the helper above returns an empty
-        dict).
-
-    The previous implementation gated the rewrite on
-    ``_extra_hosts()`` being non-empty, which conflated "do we
-    need ExtraHosts?" (platform-specific) with "do we need to
-    rewrite?" (universal). On macOS the gate skipped the rewrite
-    and the gateway shipped with a broken ``NATS_URL``.
-    """
-    return url.replace("://localhost:", "://host.docker.internal:").replace(
-        "://127.0.0.1:", "://host.docker.internal:"
-    )
-
-
 def _gateway_env() -> list[str]:
     """Build the Env block for the gateway container.
 
@@ -263,7 +233,7 @@ def _gateway_env() -> list[str]:
 
     from rolemesh.core.config import NATS_URL as _NATS_URL
 
-    env_pairs: list[str] = [f"NATS_URL={_rewrite_loopback_to_host_gateway(_NATS_URL)}"]
+    env_pairs: list[str] = [f"NATS_URL={rewrite_loopback_to_host_gateway(_NATS_URL)}"]
 
     # Forward-only allowlist of variables the gateway might need.
     # Declared close to the consumer (reverse_proxy's secret list) so

--- a/src/rolemesh/egress/orch_glue.py
+++ b/src/rolemesh/egress/orch_glue.py
@@ -287,7 +287,17 @@ async def fetch_all_mcp_servers() -> list[McpEntry]:
     re-walking the DB because the dict is the authoritative
     "what has the orchestrator registered" view that future hot-reload
     publishers will keep in lockstep.
+
+    Bug 5 (2026-04-26): rewrite ``localhost`` / ``127.0.0.1`` in each
+    URL to ``host.docker.internal`` BEFORE serialising. The
+    orchestrator stores raw origins (``localhost`` legitimately means
+    the host inside this process), but the gateway running in a
+    container will dial its own loopback if it sees the literal
+    string. Rewrite at the publish boundary so the in-process
+    registry stays useful for the rollback / pre-EC-1 path that
+    proxies through the host's credential proxy.
     """
+    from rolemesh.container.runtime import rewrite_loopback_to_host_gateway
     from rolemesh.egress.reverse_proxy import get_mcp_registry
 
     out: list[McpEntry] = []
@@ -295,7 +305,7 @@ async def fetch_all_mcp_servers() -> list[McpEntry]:
         out.append(
             McpEntry(
                 name=name,
-                url=url,
+                url=rewrite_loopback_to_host_gateway(url),
                 headers=dict(headers),
                 auth_mode=auth_mode,
             )

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -132,6 +132,7 @@ async def _publish_mcp_for_coworker(action: str, cw: Coworker) -> None:
         return
     from urllib.parse import urlparse
 
+    from rolemesh.container.runtime import rewrite_loopback_to_host_gateway
     from rolemesh.egress.mcp_cache import McpEntry
     from rolemesh.egress.orch_glue import publish_mcp_registry_changed
 
@@ -140,11 +141,19 @@ async def _publish_mcp_for_coworker(action: str, cw: Coworker) -> None:
         # register_mcp_server walk uses (rolemesh/main.py); keep the
         # two paths aligned so the gateway never sees a tool URL the
         # snapshot would have stored differently.
+        #
+        # Bug 5 (2026-04-26): rewrite localhost → host.docker.internal
+        # at the publish boundary. The gateway dials this URL
+        # verbatim from inside its container; the literal "localhost"
+        # would resolve to the gateway's own loopback. The orchestrator
+        # process keeps the unrewritten URL in its in-process
+        # registry because the rollback / pre-EC-1 path proxies
+        # through it on the host (where ``localhost`` IS the host).
         parsed = urlparse(tool.url)
         origin = f"{parsed.scheme}://{parsed.netloc}"
         entry = McpEntry(
             name=tool.name,
-            url=origin,
+            url=rewrite_loopback_to_host_gateway(origin),
             headers=dict(tool.headers or {}),
             auth_mode=tool.auth_mode,
         )

--- a/tests/container/test_runtime.py
+++ b/tests/container/test_runtime.py
@@ -10,6 +10,7 @@ from rolemesh.container.runtime import (
     VolumeMount,
     get_host_gateway_extra_hosts,
     get_runtime,
+    rewrite_loopback_to_host_gateway,
 )
 
 
@@ -82,3 +83,71 @@ def test_get_runtime_k8s_not_implemented() -> None:
 def test_get_runtime_unknown() -> None:
     with pytest.raises(ValueError, match="Unknown container backend"):
         get_runtime("podman")
+
+
+# ---------------------------------------------------------------------------
+# rewrite_loopback_to_host_gateway — universal loopback rewrite
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteLoopbackToHostGateway:
+    """``rewrite_loopback_to_host_gateway`` is shared by every IPC
+    boundary that hands a URL into a container (NATS_URL on gateway
+    spawn; MCP server origins serialised into NATS events). These
+    cases pin the contract from both sides — what must rewrite, what
+    must NOT — so a future revert to a platform-gated implementation
+    surfaces here rather than as a runtime "Connection refused" only
+    on macOS.
+    """
+
+    def test_localhost_in_authority_is_rewritten(self) -> None:
+        assert rewrite_loopback_to_host_gateway("nats://localhost:4222") == (
+            "nats://host.docker.internal:4222"
+        )
+
+    def test_127_0_0_1_is_rewritten(self) -> None:
+        assert rewrite_loopback_to_host_gateway("nats://127.0.0.1:4222") == (
+            "nats://host.docker.internal:4222"
+        )
+
+    def test_already_host_docker_internal_is_idempotent(self) -> None:
+        # Belt-and-braces: if a deploy already crafted the right URL
+        # (e.g. NATS_URL env override), running the rewrite a second
+        # time must not corrupt it.
+        assert rewrite_loopback_to_host_gateway(
+            "nats://host.docker.internal:4222"
+        ) == "nats://host.docker.internal:4222"
+
+    def test_external_hostname_is_left_alone(self) -> None:
+        # An operator pointing at a remote NATS / MCP cluster should
+        # NOT see their hostname mangled. Anchoring on ``://...:``
+        # guards against ``mylocalhost.example.com`` style bystanders.
+        assert rewrite_loopback_to_host_gateway(
+            "nats://nats.cluster.internal:4222"
+        ) == "nats://nats.cluster.internal:4222"
+
+    def test_substring_localhost_in_path_is_left_alone(self) -> None:
+        # Path-side ``localhost`` must NOT be rewritten — the rewrite
+        # is anchored on ``://localhost:`` (port-colon required).
+        assert rewrite_loopback_to_host_gateway(
+            "https://nats.example.com/path/localhost/x"
+        ) == "https://nats.example.com/path/localhost/x"
+
+    def test_handles_https_scheme(self) -> None:
+        # MCP origins typically arrive as https://localhost:8509.
+        # Bug 5 was specifically that this URL was passed verbatim
+        # through ``egress.mcp.changed`` and the gateway dialed itself.
+        assert rewrite_loopback_to_host_gateway(
+            "https://localhost:8509"
+        ) == "https://host.docker.internal:8509"
+
+    def test_handles_http_scheme(self) -> None:
+        assert rewrite_loopback_to_host_gateway(
+            "http://127.0.0.1:9100/mcp/"
+        ) == "http://host.docker.internal:9100/mcp/"
+
+    def test_no_loopback_no_change(self) -> None:
+        # Sanity: clean URLs passed through unchanged.
+        assert rewrite_loopback_to_host_gateway(
+            "https://api.github.com"
+        ) == "https://api.github.com"

--- a/tests/egress/test_admin_mcp_publish.py
+++ b/tests/egress/test_admin_mcp_publish.py
@@ -207,3 +207,71 @@ async def test_publish_swallows_nats_errors() -> None:
     )
     # Must not raise.
     await admin_mod._publish_mcp_for_coworker("updated", cw)
+
+
+# ---------------------------------------------------------------------------
+# Bug 5 (2026-04-26): publish must rewrite localhost; in-process
+# register must NOT (orchestrator's rollback proxy still needs to
+# dial the host's loopback)
+# ---------------------------------------------------------------------------
+
+
+class TestLoopbackRewriteAtPublishBoundary:
+    @pytest.mark.asyncio
+    async def test_localhost_url_is_rewritten_in_published_event(self) -> None:
+        nc = _FakeNats()
+        admin_mod.set_mcp_publisher(nc)
+
+        cw = _coworker_with_tools(
+            [
+                McpServerConfig(
+                    name="tropos-mcp",
+                    type="http",
+                    url="https://localhost:8509/mcp",
+                )
+            ]
+        )
+        await admin_mod._publish_mcp_for_coworker("updated", cw)
+
+        payload = json.loads(nc.published[0].body)
+        # The exact regression that caused Bug 5: gateway-bound event
+        # must carry host.docker.internal, not the literal localhost.
+        assert payload["url"] == "https://host.docker.internal:8509"
+
+    @pytest.mark.asyncio
+    async def test_127_0_0_1_url_is_rewritten_in_published_event(self) -> None:
+        nc = _FakeNats()
+        admin_mod.set_mcp_publisher(nc)
+
+        cw = _coworker_with_tools(
+            [
+                McpServerConfig(
+                    name="local-mcp",
+                    type="http",
+                    url="http://127.0.0.1:9100/mcp/",
+                )
+            ]
+        )
+        await admin_mod._publish_mcp_for_coworker("updated", cw)
+        payload = json.loads(nc.published[0].body)
+        assert payload["url"] == "http://host.docker.internal:9100"
+
+    @pytest.mark.asyncio
+    async def test_external_host_url_is_not_rewritten(self) -> None:
+        # Negative case: only loopback gets rewritten. An operator
+        # pointing at a remote MCP cluster sees their hostname intact.
+        nc = _FakeNats()
+        admin_mod.set_mcp_publisher(nc)
+
+        cw = _coworker_with_tools(
+            [
+                McpServerConfig(
+                    name="github",
+                    type="http",
+                    url="https://api.github.com/mcp",
+                )
+            ]
+        )
+        await admin_mod._publish_mcp_for_coworker("updated", cw)
+        payload = json.loads(nc.published[0].body)
+        assert payload["url"] == "https://api.github.com"

--- a/tests/egress/test_launcher.py
+++ b/tests/egress/test_launcher.py
@@ -209,78 +209,8 @@ class TestWaitForGatewayReady:
             )
 
 
-# ---------------------------------------------------------------------------
-# _rewrite_loopback_to_host_gateway — universal loopback rewrite
-# ---------------------------------------------------------------------------
-
-
-class TestRewriteLoopbackToHostGateway:
-    """Originally gated on platform.system()=='Linux' via ``_extra_hosts()``;
-    fixed to rewrite unconditionally because container-internal
-    ``localhost`` is never the host on any platform.
-
-    These cases lock in the contract from both sides — what must
-    rewrite, what must NOT rewrite — so a future revert to the
-    platform-gated logic shows up here rather than in a runtime
-    "Name or service not known" error on macOS only.
-    """
-
-    def test_localhost_in_authority_is_rewritten(self) -> None:
-        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
-
-        assert _rewrite_loopback_to_host_gateway("nats://localhost:4222") == (
-            "nats://host.docker.internal:4222"
-        )
-
-    def test_127_0_0_1_is_rewritten(self) -> None:
-        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
-
-        assert _rewrite_loopback_to_host_gateway("nats://127.0.0.1:4222") == (
-            "nats://host.docker.internal:4222"
-        )
-
-    def test_already_host_docker_internal_is_idempotent(self) -> None:
-        # Belt-and-braces: if a deploy already crafted the right URL
-        # (e.g. via NATS_URL env override), running the rewrite a
-        # second time must not corrupt it.
-        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
-
-        assert _rewrite_loopback_to_host_gateway(
-            "nats://host.docker.internal:4222"
-        ) == "nats://host.docker.internal:4222"
-
-    def test_external_hostname_is_left_alone(self) -> None:
-        # An operator pointing the gateway at a remote NATS cluster
-        # should NOT see their hostname mangled. The rewrite scopes
-        # itself with the ``://`` prefix to avoid eating
-        # ``mylocalhost.example.com`` style bystanders.
-        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
-
-        assert _rewrite_loopback_to_host_gateway(
-            "nats://nats.cluster.internal:4222"
-        ) == "nats://nats.cluster.internal:4222"
-
-    def test_substring_localhost_in_path_is_left_alone(self) -> None:
-        # Hardening against naive ``localhost`` substring replacement.
-        # The colon after the prefix anchors it to the authority
-        # component, so a path-side ``localhost`` (unusual but legal)
-        # stays intact.
-        from rolemesh.egress.launcher import _rewrite_loopback_to_host_gateway
-
-        # Token "localhost" *not* followed by a port colon -> not
-        # touched. ``://localhost:`` is the only rewrite trigger.
-        assert _rewrite_loopback_to_host_gateway(
-            "https://nats.example.com/path/localhost/x"
-        ) == "https://nats.example.com/path/localhost/x"
-
-    def test_rewrites_irrespective_of_platform(self) -> None:
-        # Direct regression for the macOS bug: previously the rewrite
-        # was no-op when ``_extra_hosts()`` returned empty (i.e. on
-        # any non-Linux host). Patch it to empty here and assert the
-        # rewrite still fires.
-        from rolemesh.egress import launcher
-
-        with patch.object(launcher, "_extra_hosts", return_value={}):
-            assert launcher._rewrite_loopback_to_host_gateway(
-                "nats://localhost:4222"
-            ) == "nats://host.docker.internal:4222"
+# Note: ``rewrite_loopback_to_host_gateway`` was promoted to
+# rolemesh.container.runtime in the Bug 5 fix; its tests live in
+# tests/container/test_runtime.py. The launcher only references the
+# helper at one site (NATS_URL injection) and the integration is
+# exercised by tests/egress/integration.

--- a/tests/egress/test_mcp_glue.py
+++ b/tests/egress/test_mcp_glue.py
@@ -157,14 +157,17 @@ async def test_publish_swallows_transient_nats_errors() -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_all_mcp_servers_reads_registry() -> None:
+    # Use an external URL here to keep this case focused on
+    # registry-pass-through. The loopback-rewrite contract has its
+    # own dedicated test class below (Bug 5 regression).
     reverse_proxy.register_mcp_server(
-        "internal", "http://localhost:9100", {"X-Tenant": "t1"}, "service"
+        "internal", "https://api.example.com", {"X-Tenant": "t1"}, "service"
     )
     entries = await fetch_all_mcp_servers()
     assert len(entries) == 1
     assert entries[0] == McpEntry(
         name="internal",
-        url="http://localhost:9100",
+        url="https://api.example.com",
         headers={"X-Tenant": "t1"},
         auth_mode="service",
     )
@@ -241,3 +244,55 @@ async def test_responder_attaches_three_subjects(nc: FakeNats) -> None:
     assert len(subs) == 3
     subjects = {s.subject for s in nc.subs}
     assert MCP_SNAPSHOT_REQUEST_SUBJECT in subjects
+
+
+# ---------------------------------------------------------------------------
+# Bug 5 (2026-04-26): snapshot path rewrites localhost; the
+# orchestrator's in-process registry intentionally does NOT
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotLoopbackRewrite:
+    @pytest.mark.asyncio
+    async def test_fetch_all_rewrites_localhost(self) -> None:
+        # Orchestrator stores the URL with literal localhost — that's
+        # correct in-process because the orchestrator runs on the host.
+        # But the snapshot is consumed by the gateway container, which
+        # must see host.docker.internal.
+        reverse_proxy.register_mcp_server(
+            "tropos-mcp", "https://localhost:8509", {}, "user"
+        )
+        entries = await fetch_all_mcp_servers()
+        assert len(entries) == 1
+        assert entries[0].url == "https://host.docker.internal:8509"
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_rewrites_127_0_0_1(self) -> None:
+        reverse_proxy.register_mcp_server(
+            "local-mcp", "http://127.0.0.1:9100", {}, "service"
+        )
+        entries = await fetch_all_mcp_servers()
+        assert entries[0].url == "http://host.docker.internal:9100"
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_leaves_external_host_unchanged(self) -> None:
+        reverse_proxy.register_mcp_server(
+            "github", "https://api.github.com", {}, "user"
+        )
+        entries = await fetch_all_mcp_servers()
+        assert entries[0].url == "https://api.github.com"
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_in_process_registry_is_NOT_rewritten(self) -> None:
+        # Critical asymmetry: the rewrite is at the publish boundary,
+        # not at register time. The orchestrator's own reverse proxy
+        # (rollback / pre-EC-1 path) needs to dial the host's
+        # localhost — rewriting at register would break that.
+        # This pins the contract so a future "let's just rewrite
+        # everywhere" refactor doesn't quietly break the rollback path.
+        reverse_proxy.register_mcp_server(
+            "tropos-mcp", "https://localhost:8509", {}, "user"
+        )
+        # Orchestrator-side dict still carries the original URL.
+        registry = reverse_proxy.get_mcp_registry()
+        assert registry["tropos-mcp"][0] == "https://localhost:8509"


### PR DESCRIPTION
## Summary

Closes Bug 5. Same family as Bug 2 (NATS_URL macOS rewrite) — the rewrite was applied at one IPC boundary (gateway env vars) but missed two more added during EC-2 (MCP snapshot RPC + hot-reload broadcast). Symptom under EC-2: ``MCP proxy upstream error: Cannot connect to host localhost:8509`` for every MCP tool call.

## Root cause

The orchestrator stores raw URLs (``localhost:8509``) in its in-process ``_mcp_registry`` — that's correct for the rollback / pre-EC-1 path where the orchestrator's own reverse proxy runs in-process and ``localhost`` legitimately means the host. EC-2 hands those URLs over NATS to the egress-gateway container, which dials them verbatim and ends up looping back to its own container loopback.

Why we missed it: pre-EC-1 rollback (``CONTAINER_NETWORK_NAME`` empty) bypasses the gateway entirely, so the broken registry was never queried. The bug only activates when EC-2 is genuinely on.

## Fix

Rewrite at every **publish boundary**, not at register time:

- ✅ ``orch_glue.fetch_all_mcp_servers`` (snapshot path — gateway boot)
- ✅ ``webui/admin._publish_mcp_for_coworker`` (hot-reload — admin REST)
- ❌ NOT at ``register_mcp_server`` (orchestrator's in-process rollback proxy still needs to dial host's ``localhost``)

Helper promoted from ``rolemesh.egress.launcher._rewrite_loopback_to_host_gateway`` (private) to ``rolemesh.container.runtime.rewrite_loopback_to_host_gateway`` (public, alongside ``get_host_gateway_extra_hosts``). Single source of truth for the three publish boundaries.

## Test plan

- [x] New ``tests/container/test_runtime.py`` cases (8): localhost/127.0.0.1 rewrite, idempotent, external untouched, https/http schemes (Bug 5's exact trigger), substring guard, no-op pass-through.
- [x] New ``tests/egress/test_mcp_glue.py::TestSnapshotLoopbackRewrite`` (4): snapshot rewrites loopback, leaves external alone, **and pins the asymmetry that orchestrator's in-process registry is NOT rewritten** — guards against a future "rewrite everywhere" refactor breaking the rollback path.
- [x] New ``tests/egress/test_admin_mcp_publish.py::TestLoopbackRewriteAtPublishBoundary`` (3): hot-reload publish path, same shape as snapshot.
- [x] Helper tests moved from ``tests/egress/test_launcher.py`` to live alongside the helper.
- [x] Egress + container unit suite: all green.
- [x] ``pytest -m integration`` egress: 14/14 — gateway boot, snapshot fetch, reverse proxy serving.

## Risk

Low. The rewrite is additive at publish points; no caller relied on receiving the literal ``localhost`` over the wire (gateway runs inside a container so that string was always wrong there). Rollback / pre-EC-1 path is unaffected — the asymmetry test pins it.