### PR TITLE
feat(bedrock): route Pi backend Bedrock calls through credential proxy

### DIFF
--- a/src/pi/ai/providers/amazon_bedrock.py
+++ b/src/pi/ai/providers/amazon_bedrock.py
@@ -627,30 +627,46 @@ def _convert_messages(
     return result
 
 
+# Bedrock Converse tool-name contract:
+#   - max 64 chars
+#   - first char a letter, then letters/digits/underscore/hyphen only
+# Source: AWS Bedrock Runtime API ToolSpecification.name documentation.
+# We validate both shape AND length client-side so the failure surfaces
+# in rolemesh's stack with our error message, not as an opaque
+# Bedrock 400 with AWS-flavoured wording. Anthropic / OpenAI / Google
+# providers do their own thing — this is a Bedrock-only contract.
+_BEDROCK_TOOL_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$")
+
+
 def _convert_tool_config(
     tools: list[Tool] | None,
     tool_choice: Literal["auto", "any", "none"] | dict[str, str] | None,
 ) -> dict[str, Any] | None:
     """Convert tools and tool_choice to Bedrock ToolConfiguration format.
 
-    Bedrock Converse caps tool names at 64 characters, while Anthropic
-    native and OpenAI accept up to 128. We do NOT silently truncate
-    here — a hidden mapping layer would just defer the failure to a
-    confusing point downstream (the agent would call a name that no
-    longer matches its tool registry). Fail loudly with the offending
-    name so operators know to apply the short-prefix MCP naming
-    scheme upstream.
+    Bedrock Converse imposes both a 64-char cap and a restricted
+    character set (``^[a-zA-Z][a-zA-Z0-9_-]*$``). Anthropic native
+    and OpenAI accept names up to 128 chars and a wider charset.
+
+    We do NOT silently truncate / sanitise here — a hidden mapping
+    layer would just defer the failure to a confusing point
+    downstream (the agent would call a name that no longer matches
+    its tool registry). Fail loudly with the offending name so
+    operators know to apply the short-prefix MCP naming scheme (and
+    avoid disallowed characters) upstream.
     """
     if not tools or tool_choice == "none":
         return None
 
     for tool in tools:
-        if len(tool.name) > 64:
+        if not _BEDROCK_TOOL_NAME_RE.match(tool.name):
             raise ValueError(
-                f"Bedrock Converse: tool name {tool.name!r} is "
-                f"{len(tool.name)} chars; max 64. Apply the upstream "
-                f"short-prefix MCP naming scheme before sending to "
-                f"this provider."
+                f"Bedrock Converse: tool name {tool.name!r} is invalid "
+                f"(len={len(tool.name)}). Must match "
+                f"^[a-zA-Z][a-zA-Z0-9_-]{{0,63}}$ — at most 64 chars, "
+                f"start with an ASCII letter, then letters/digits/"
+                f"underscore/hyphen only. Apply the upstream short-prefix "
+                f"MCP naming scheme before sending to this provider."
             )
 
     bedrock_tools: list[dict[str, Any]] = [

--- a/src/pi/ai/providers/amazon_bedrock.py
+++ b/src/pi/ai/providers/amazon_bedrock.py
@@ -113,13 +113,32 @@ def stream_bedrock(
             )
 
             client_kwargs: dict[str, Any] = {"region_name": region}
+
+            # ``BEDROCK_BASE_URL`` redirects boto3 to the host-side
+            # credential proxy when set (rolemesh agent containers
+            # have it injected by ``rolemesh.agent.executor._pi_extra_env``).
+            # The proxy holds the real ``AWS_BEARER_TOKEN_BEDROCK``
+            # and overwrites the Authorization header on every
+            # request, so whatever boto3 signs locally is moot — the
+            # placeholder env (see below) just keeps boto3 from
+            # raising ``NoCredentialsError`` before it even sends.
+            base_url = os.environ.get("BEDROCK_BASE_URL", "")
+            if base_url:
+                client_kwargs["endpoint_url"] = base_url
+
             if options.profile:
                 session = botocore.session.Session(profile=options.profile)
                 boto3_session = boto3.session.Session(botocore_session=session)
                 client = boto3_session.client("bedrock-runtime", **client_kwargs)
             else:
-                # Support proxies that don't need authentication
-                if os.environ.get("AWS_BEDROCK_SKIP_AUTH") == "1":
+                # When routed through the rolemesh credential proxy,
+                # boto3 still wants *some* credentials before it will
+                # construct a request — even though the proxy will
+                # replace the Authorization header. Ship dummy SigV4
+                # creds so boto3 1.x (no Bearer support) sails through;
+                # boto3 1.42+ that honours ``AWS_BEARER_TOKEN_BEDROCK``
+                # also continues to work because the proxy still wins.
+                if base_url:
                     client_kwargs["aws_access_key_id"] = "dummy-access-key"
                     client_kwargs["aws_secret_access_key"] = "dummy-secret-key"
                 client = boto3.client("bedrock-runtime", **client_kwargs)
@@ -612,9 +631,27 @@ def _convert_tool_config(
     tools: list[Tool] | None,
     tool_choice: Literal["auto", "any", "none"] | dict[str, str] | None,
 ) -> dict[str, Any] | None:
-    """Convert tools and tool_choice to Bedrock ToolConfiguration format."""
+    """Convert tools and tool_choice to Bedrock ToolConfiguration format.
+
+    Bedrock Converse caps tool names at 64 characters, while Anthropic
+    native and OpenAI accept up to 128. We do NOT silently truncate
+    here — a hidden mapping layer would just defer the failure to a
+    confusing point downstream (the agent would call a name that no
+    longer matches its tool registry). Fail loudly with the offending
+    name so operators know to apply the short-prefix MCP naming
+    scheme upstream.
+    """
     if not tools or tool_choice == "none":
         return None
+
+    for tool in tools:
+        if len(tool.name) > 64:
+            raise ValueError(
+                f"Bedrock Converse: tool name {tool.name!r} is "
+                f"{len(tool.name)} chars; max 64. Apply the upstream "
+                f"short-prefix MCP naming scheme before sending to "
+                f"this provider."
+            )
 
     bedrock_tools: list[dict[str, Any]] = [
         {

--- a/src/pi/ai/providers/amazon_bedrock.py
+++ b/src/pi/ai/providers/amazon_bedrock.py
@@ -126,7 +126,12 @@ def stream_bedrock(
             if base_url:
                 client_kwargs["endpoint_url"] = base_url
 
-            if options.profile:
+            # Profile path is bypassed when going through the rolemesh
+            # proxy: the proxy is the authoritative authn injector, so
+            # SigV4-signing with real long-term creds from a profile
+            # would (a) leak them across the local network as a
+            # signature and (b) be discarded anyway.
+            if options.profile and not base_url:
                 session = botocore.session.Session(profile=options.profile)
                 boto3_session = boto3.session.Session(botocore_session=session)
                 client = boto3_session.client("bedrock-runtime", **client_kwargs)

--- a/src/rolemesh/agent/executor.py
+++ b/src/rolemesh/agent/executor.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from rolemesh.core.logger import get_logger
+
+logger = get_logger()
+
 
 @dataclass(frozen=True)
 class AgentInput:
@@ -118,7 +122,7 @@ def _pi_extra_env() -> dict[str, str]:
     import os
 
     from rolemesh.container.runtime import rewrite_loopback_to_host_gateway
-    from rolemesh.core.config import CREDENTIAL_PROXY_PORT
+    from rolemesh.core.config import BEDROCK_DEFAULT_REGION, CREDENTIAL_PROXY_PORT
 
     # .env loading is handled at process entry by
     # ``rolemesh.bootstrap``; reading from os.environ here works
@@ -135,11 +139,31 @@ def _pi_extra_env() -> dict[str, str]:
     # boto3 client init doesn't raise; the proxy is the real
     # credential gate.
     if model_id.startswith("amazon-bedrock/"):
+        # Diagnostic guard: if the host doesn't actually have the
+        # bearer token set, the credential proxy will not register a
+        # ``bedrock`` provider entry and every container request will
+        # surface as a 404 from the proxy, with no obvious link back
+        # to "you forgot to set AWS_BEARER_TOKEN_BEDROCK in .env".
+        # Warn at container-spec build time so the misconfiguration
+        # is visible in the orchestrator log instead of as an
+        # opaque mid-turn error.
+        if not os.environ.get("AWS_BEARER_TOKEN_BEDROCK"):
+            logger.warning(
+                "Pi backend uses a Bedrock model id but host has no "
+                "AWS_BEARER_TOKEN_BEDROCK set; the credential proxy "
+                "will not register a bedrock provider, and every "
+                "tool call will return 404 from the proxy. Set "
+                "AWS_BEARER_TOKEN_BEDROCK in .env to fix.",
+                model_id=model_id,
+            )
+
         env["AWS_BEARER_TOKEN_BEDROCK"] = "placeholder-proxy-replaces-this"
         # Region picks the model's region context inside boto3 (model
-        # ARNs are region-scoped). Default matches the upstream URL
-        # default in ``_build_provider_registry``.
-        env["AWS_REGION"] = os.environ.get("AWS_REGION", "") or "us-east-1"
+        # ARNs are region-scoped). Single source of truth in
+        # ``rolemesh.core.config.BEDROCK_DEFAULT_REGION``; the
+        # credential proxy uses the same fallback so endpoint URL
+        # and model ARN resolution stay in the same region.
+        env["AWS_REGION"] = os.environ.get("AWS_REGION", "") or BEDROCK_DEFAULT_REGION
         # Synthesize the proxy URL with localhost rewriting so the
         # container always sees host.docker.internal regardless of
         # what the operator wrote in ``.env``.

--- a/src/rolemesh/agent/executor.py
+++ b/src/rolemesh/agent/executor.py
@@ -105,9 +105,20 @@ def _pi_extra_env() -> dict[str, str]:
     """Build extra env for Pi backend — model selection only.
 
     API keys are NOT injected here; all LLM requests go through the
-    credential proxy which injects real keys at the HTTP level.
+    credential proxy which injects real keys at the HTTP level. For
+    Bedrock specifically, we additionally inject a placeholder
+    ``AWS_BEARER_TOKEN_BEDROCK`` (so boto3 doesn't refuse to send) and
+    a synthesized ``BEDROCK_BASE_URL`` pointing at the host's
+    credential proxy. ``BEDROCK_BASE_URL`` is ALWAYS computed here
+    rather than read from ``os.environ`` so an operator setting
+    ``BEDROCK_BASE_URL=http://localhost:...`` in ``.env`` can't
+    accidentally bake the orchestrator-process loopback into the
+    container (that's the Bug 5 family).
     """
     import os
+
+    from rolemesh.container.runtime import rewrite_loopback_to_host_gateway
+    from rolemesh.core.config import CREDENTIAL_PROXY_PORT
 
     # .env loading is handled at process entry by
     # ``rolemesh.bootstrap``; reading from os.environ here works
@@ -117,6 +128,25 @@ def _pi_extra_env() -> dict[str, str]:
     model_id = os.environ.get("PI_MODEL_ID", "")
     if model_id:
         env["PI_MODEL_ID"] = model_id
+
+    # Bedrock wiring — only meaningful when the host has the bearer
+    # token configured AND the model id targets Bedrock. We still
+    # inject the placeholder unconditionally on the Bedrock path so
+    # boto3 client init doesn't raise; the proxy is the real
+    # credential gate.
+    if model_id.startswith("amazon-bedrock/"):
+        env["AWS_BEARER_TOKEN_BEDROCK"] = "placeholder-proxy-replaces-this"
+        # Region picks the model's region context inside boto3 (model
+        # ARNs are region-scoped). Default matches the upstream URL
+        # default in ``_build_provider_registry``.
+        env["AWS_REGION"] = os.environ.get("AWS_REGION", "") or "us-east-1"
+        # Synthesize the proxy URL with localhost rewriting so the
+        # container always sees host.docker.internal regardless of
+        # what the operator wrote in ``.env``.
+        env["BEDROCK_BASE_URL"] = rewrite_loopback_to_host_gateway(
+            f"http://localhost:{CREDENTIAL_PROXY_PORT}/proxy/bedrock"
+        )
+
     return env
 
 

--- a/src/rolemesh/agent/executor.py
+++ b/src/rolemesh/agent/executor.py
@@ -106,23 +106,28 @@ CLAUDE_CODE_BACKEND = AgentBackendConfig(
 )
 
 def _pi_extra_env() -> dict[str, str]:
-    """Build extra env for Pi backend — model selection only.
+    """Build extra env for Pi backend — model selection + boto3
+    placeholders.
 
     API keys are NOT injected here; all LLM requests go through the
     credential proxy which injects real keys at the HTTP level. For
-    Bedrock specifically, we additionally inject a placeholder
-    ``AWS_BEARER_TOKEN_BEDROCK`` (so boto3 doesn't refuse to send) and
-    a synthesized ``BEDROCK_BASE_URL`` pointing at the host's
-    credential proxy. ``BEDROCK_BASE_URL`` is ALWAYS computed here
-    rather than read from ``os.environ`` so an operator setting
-    ``BEDROCK_BASE_URL=http://localhost:...`` in ``.env`` can't
-    accidentally bake the orchestrator-process loopback into the
-    container (that's the Bug 5 family).
+    Bedrock specifically, we inject a placeholder
+    ``AWS_BEARER_TOKEN_BEDROCK`` (so boto3 doesn't raise
+    ``NoCredentialsError`` before it even sends) and an
+    ``AWS_REGION`` so boto3's model-ARN resolution lines up with
+    the upstream URL the credential proxy bound (single-source via
+    ``BEDROCK_DEFAULT_REGION``).
+
+    ``BEDROCK_BASE_URL`` is intentionally NOT set here — it lives
+    in ``rolemesh.container.runner.build_container_spec`` alongside
+    ``ANTHROPIC_BASE_URL`` / ``OPENAI_BASE_URL`` because it depends
+    on per-spawn ``proxy_base`` (egress-gateway under EC-2,
+    host.docker.internal under rollback). Computing it here would
+    bake module-load-time hosting into a per-spawn decision.
     """
     import os
 
-    from rolemesh.container.runtime import rewrite_loopback_to_host_gateway
-    from rolemesh.core.config import BEDROCK_DEFAULT_REGION, CREDENTIAL_PROXY_PORT
+    from rolemesh.core.config import BEDROCK_DEFAULT_REGION
 
     # .env loading is handled at process entry by
     # ``rolemesh.bootstrap``; reading from os.environ here works
@@ -164,12 +169,6 @@ def _pi_extra_env() -> dict[str, str]:
         # credential proxy uses the same fallback so endpoint URL
         # and model ARN resolution stay in the same region.
         env["AWS_REGION"] = os.environ.get("AWS_REGION", "") or BEDROCK_DEFAULT_REGION
-        # Synthesize the proxy URL with localhost rewriting so the
-        # container always sees host.docker.internal regardless of
-        # what the operator wrote in ``.env``.
-        env["BEDROCK_BASE_URL"] = rewrite_loopback_to_host_gateway(
-            f"http://localhost:{CREDENTIAL_PROXY_PORT}/proxy/bedrock"
-        )
 
     return env
 

--- a/src/rolemesh/container/runner.py
+++ b/src/rolemesh/container/runner.py
@@ -486,6 +486,15 @@ def build_container_spec(
         "ANTHROPIC_BASE_URL": proxy_base,
         # Multi-provider proxy URLs for Pi backend (each SDK reads its own env var)
         "OPENAI_BASE_URL": f"{proxy_base}/proxy/openai",
+        # Bedrock — boto3 honours ``BEDROCK_BASE_URL`` as ``endpoint_url``.
+        # Same per-spawn ``proxy_base`` as Anthropic/OpenAI so EC-2
+        # (agent on Internal=true bridge) and rollback (agent on host
+        # bridge) both resolve a reachable address. Setting this here
+        # rather than in ``_pi_extra_env`` is deliberate — that helper
+        # runs at module load time, before CONTAINER_NETWORK_NAME is
+        # decided per spawn, and would have to reimplement the EC-2
+        # branching that already lives above (proxy_base).
+        "BEDROCK_BASE_URL": f"{proxy_base}/proxy/bedrock",
         # Redirect Claude Code CLI's .claude.json writes into the per-coworker
         # writable bind mount at /home/agent/.claude. Without this, the CLI
         # tries to write /home/agent/.claude.json on the readonly rootfs and

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -164,6 +164,14 @@ CONTAINER_ENV_ALLOWLIST: frozenset[str] = frozenset({
     "CLAUDE_CONFIG_DIR",
     "HOME",
     "PI_MODEL_ID",
+    # Bedrock — only the placeholder bearer + synthesized proxy URL
+    # ever reach the container. The real ``ABSK...`` token lives on
+    # the host and is overwritten on every request by the credential
+    # proxy (see ``rolemesh.egress.reverse_proxy._build_provider_registry``).
+    # ``AWS_REGION`` is needed by boto3 to construct model ARNs.
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_REGION",
+    "BEDROCK_BASE_URL",
 })
 
 # Agent backend: "claude" or "pi"

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -174,6 +174,15 @@ CONTAINER_ENV_ALLOWLIST: frozenset[str] = frozenset({
     "BEDROCK_BASE_URL",
 })
 
+# Default AWS region for Bedrock when ``AWS_REGION`` is unset on the
+# host. Single source of truth: the credential proxy uses it to build
+# the upstream URL (``bedrock-runtime.{region}.amazonaws.com``) and
+# ``_pi_extra_env`` uses the same fallback when synthesising the
+# container's ``AWS_REGION`` env so boto3 model-ARN resolution lines
+# up with the proxy's endpoint. Drift between the two would resolve
+# model ARNs in one region while routing requests to another.
+BEDROCK_DEFAULT_REGION: str = "us-east-1"
+
 # Agent backend: "claude" or "pi"
 AGENT_BACKEND_DEFAULT: str = os.environ.get("ROLEMESH_AGENT_BACKEND", "claude")
 

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -169,6 +169,10 @@ CONTAINER_ENV_ALLOWLIST: frozenset[str] = frozenset({
     # the host and is overwritten on every request by the credential
     # proxy (see ``rolemesh.egress.reverse_proxy._build_provider_registry``).
     # ``AWS_REGION`` is needed by boto3 to construct model ARNs.
+    # ``BEDROCK_BASE_URL`` is written directly in
+    # ``runner.build_container_spec`` and bypasses the filter today;
+    # listed here as a guard if a future refactor moves URL synthesis
+    # back into ``backend_config.extra_env``.
     "AWS_BEARER_TOKEN_BEDROCK",
     "AWS_REGION",
     "BEDROCK_BASE_URL",

--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -230,6 +230,12 @@ class _ForwardSpec:
     boundary (Bug 5 family — container-internal ``localhost`` is
     the container's loopback, not the host).
 
+    ``requires`` makes the forward conditional on another host env
+    var being set — used to avoid leaking generic AWS context (e.g.
+    ``AWS_REGION`` set for ``aws cli`` use) into the gateway when
+    Bedrock is not actually configured. Defaults to ``None``
+    (unconditional).
+
     Token-shaped specs leave ``is_url=False`` and are forwarded
     verbatim. We deliberately do NOT run ``string.replace`` on
     every value: a secret that happens to contain ``://localhost:``
@@ -238,6 +244,7 @@ class _ForwardSpec:
 
     key: str
     is_url: bool = False
+    requires: str | None = None
 
 
 # Forward-only allowlist. MUST mirror the keys
@@ -264,8 +271,13 @@ _FORWARDABLE: tuple[_ForwardSpec, ...] = (
     # these two forwards, the gateway container's reverse proxy
     # would never register a ``bedrock`` provider entry — every
     # ``/proxy/bedrock/...`` request from agents would 404.
+    #
+    # ``AWS_REGION`` is gated on ``AWS_BEARER_TOKEN_BEDROCK`` so an
+    # operator who has ``AWS_REGION`` set for ``aws cli`` (or any
+    # other non-Bedrock AWS use) does NOT leak it into the gateway
+    # container's env unless they're actually running Bedrock.
     _ForwardSpec("AWS_BEARER_TOKEN_BEDROCK"),
-    _ForwardSpec("AWS_REGION"),
+    _ForwardSpec("AWS_REGION", requires="AWS_BEARER_TOKEN_BEDROCK"),
 )
 
 
@@ -295,6 +307,8 @@ def _gateway_env() -> list[str]:
     for spec in _FORWARDABLE:
         value = _os.environ.get(spec.key)
         if not value:
+            continue
+        if spec.requires and not _os.environ.get(spec.requires):
             continue
         if spec.is_url:
             value = rewrite_loopback_to_host_gateway(value)

--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -255,6 +255,17 @@ _FORWARDABLE: tuple[_ForwardSpec, ...] = (
     _ForwardSpec("OPENAI_BASE_URL", is_url=True),
     _ForwardSpec("PI_GOOGLE_API_KEY"),
     _ForwardSpec("GOOGLE_BASE_URL", is_url=True),
+    # Bedrock — both forward verbatim. The bearer token is a secret
+    # string (NEVER a URL — keep is_url=False so loopback rewrite
+    # cannot corrupt it). The region is also plain text
+    # ("us-east-1" etc.); the gateway reads it back in
+    # ``_build_provider_registry`` to pick the regional
+    # ``bedrock-runtime.{region}.amazonaws.com`` upstream. Without
+    # these two forwards, the gateway container's reverse proxy
+    # would never register a ``bedrock`` provider entry — every
+    # ``/proxy/bedrock/...`` request from agents would 404.
+    _ForwardSpec("AWS_BEARER_TOKEN_BEDROCK"),
+    _ForwardSpec("AWS_REGION"),
 )
 
 

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -167,7 +167,9 @@ def _build_provider_registry(
     # initial Sonnet/Opus 4.6 use case.
     bedrock_token = secrets.get("AWS_BEARER_TOKEN_BEDROCK", "")
     if bedrock_token:
-        bedrock_region = secrets.get("AWS_REGION", "") or "us-east-1"
+        from rolemesh.core.config import BEDROCK_DEFAULT_REGION
+
+        bedrock_region = secrets.get("AWS_REGION", "") or BEDROCK_DEFAULT_REGION
         registry["bedrock"] = _ProviderConfig(
             upstream=f"https://bedrock-runtime.{bedrock_region}.amazonaws.com",
             secret_key=bedrock_token,

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -153,6 +153,28 @@ def _build_provider_registry(
             header_format="{key}",
         )
 
+    # AWS Bedrock — long-term API key (Bearer ABSK...). The token is
+    # held on the host; agent containers see only a placeholder env
+    # var and route their boto3 client at this proxy via
+    # ``BEDROCK_BASE_URL``. Whatever Authorization header boto3
+    # synthesises (SigV4 signature in older releases, Bearer in
+    # boto3 1.42+) gets overwritten by ``handle_provider_proxy`` —
+    # the proxy is the authoritative authn injector.
+    #
+    # Region is locked at registry-build time. Multi-region deploys
+    # would need to encode region in the proxy path
+    # (``/proxy/bedrock/{region}/...``); not in scope for the
+    # initial Sonnet/Opus 4.6 use case.
+    bedrock_token = secrets.get("AWS_BEARER_TOKEN_BEDROCK", "")
+    if bedrock_token:
+        bedrock_region = secrets.get("AWS_REGION", "") or "us-east-1"
+        registry["bedrock"] = _ProviderConfig(
+            upstream=f"https://bedrock-runtime.{bedrock_region}.amazonaws.com",
+            secret_key=bedrock_token,
+            header_name="authorization",
+            header_format="Bearer {key}",
+        )
+
     return registry
 
 
@@ -274,6 +296,12 @@ async def start_credential_proxy(
                 "OPENAI_BASE_URL",
                 "PI_GOOGLE_API_KEY",
                 "GOOGLE_BASE_URL",
+                # Bedrock — long-term API key (Bearer ABSK...). Held
+                # only on the host; agents see a placeholder
+                # (see ``rolemesh.agent.executor._pi_extra_env``).
+                # Region picks the regional endpoint upstream URL.
+                "AWS_BEARER_TOKEN_BEDROCK",
+                "AWS_REGION",
             )
         )
         if v

--- a/tests/agent/test_executor.py
+++ b/tests/agent/test_executor.py
@@ -298,3 +298,62 @@ class TestPiExtraEnvBedrock:
         monkeypatch.setenv("AWS_REGION", "us-west-2")
         env = _pi_extra_env()
         assert env["AWS_REGION"] == "us-west-2"
+
+    def test_warns_when_host_lacks_bedrock_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # P1 ergonomics: an operator who set
+        # ``PI_MODEL_ID=amazon-bedrock/...`` but forgot
+        # ``AWS_BEARER_TOKEN_BEDROCK`` would otherwise hit a runtime
+        # 404 from the credential proxy with no obvious cause.
+        # Validate the warning fires at container-spec-build time
+        # so the misconfiguration is visible up front.
+        #
+        # rolemesh uses structlog (not stdlib logging), so caplog can't
+        # observe it; spy on the logger directly instead.
+        from rolemesh.agent import executor as executor_mod
+
+        captured: list[tuple[str, dict[str, object]]] = []
+
+        def _spy(msg: str, **kwargs: object) -> None:
+            captured.append((msg, kwargs))
+
+        monkeypatch.setattr(executor_mod.logger, "warning", _spy)
+        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/foo")
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+        env = executor_mod._pi_extra_env()
+
+        # Container env still gets the placeholder — we degrade
+        # gracefully rather than refuse to spawn.
+        assert env["AWS_BEARER_TOKEN_BEDROCK"] == "placeholder-proxy-replaces-this"
+        # And we logged a warning naming the symptom + fix, with the
+        # offending model_id attached for log-search ergonomics.
+        assert len(captured) == 1
+        msg, kwargs = captured[0]
+        assert "AWS_BEARER_TOKEN_BEDROCK" in msg
+        assert kwargs.get("model_id") == "amazon-bedrock/foo"
+
+    def test_no_warning_when_host_has_bedrock_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from rolemesh.agent import executor as executor_mod
+
+        captured: list[tuple[str, dict[str, object]]] = []
+
+        def _spy(msg: str, **kwargs: object) -> None:
+            captured.append((msg, kwargs))
+
+        monkeypatch.setattr(executor_mod.logger, "warning", _spy)
+        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/foo")
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKtoken")
+
+        executor_mod._pi_extra_env()
+
+        # Quiet path — host configured correctly, no nag.
+        bedrock_warnings = [
+            (m, k) for m, k in captured if "AWS_BEARER_TOKEN_BEDROCK" in m
+        ]
+        assert bedrock_warnings == []

--- a/tests/agent/test_executor.py
+++ b/tests/agent/test_executor.py
@@ -251,37 +251,25 @@ class TestPiExtraEnvBedrock:
         assert token_in_env  # but placeholder MUST be set
         assert "placeholder" in token_in_env.lower()
 
-    def test_bedrock_model_id_synthesises_proxy_url_with_host_docker_internal(
+    def test_bedrock_url_NOT_set_in_pi_extra_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Bug 5 family: even if the operator stashed
-        # BEDROCK_BASE_URL=http://localhost:... in .env, the
-        # container must always see host.docker.internal because
-        # localhost inside a container is the container itself.
+        # Architectural pin: ``BEDROCK_BASE_URL`` belongs in
+        # ``container.runner.build_container_spec`` alongside the
+        # other base URLs (Anthropic / OpenAI / Google) because it
+        # depends on the per-spawn ``proxy_base`` decision (EC-2 →
+        # ``egress-gateway``; rollback → ``host.docker.internal``).
+        # Setting it from ``_pi_extra_env`` (module-load time) baked
+        # the rollback-path host into a per-spawn value and made the
+        # Bedrock path silently broken under EC-2. This test pins the
+        # invariant so a future refactor doesn't put it back.
         monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/anything")
         monkeypatch.setenv("BEDROCK_BASE_URL", "http://localhost:9999/wrong")
         env = _pi_extra_env()
-        url = env["BEDROCK_BASE_URL"]
-        assert url.startswith("http://host.docker.internal:")
-        assert url.endswith("/proxy/bedrock")
-        # The wrong .env value must not have leaked through.
-        assert "localhost" not in url
-        assert "9999" not in url  # operator's wrong port not pasted in
-
-    def test_bedrock_url_is_synthesised_even_without_env_override(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Regular case: operator did NOT set BEDROCK_BASE_URL. Helper
-        # must still inject the synthesized one — this is the
-        # "operators don't have to remember a third env var" property
-        # that the design depends on.
-        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/foo")
-        monkeypatch.delenv("BEDROCK_BASE_URL", raising=False)
-        env = _pi_extra_env()
-        assert env["BEDROCK_BASE_URL"].startswith(
-            "http://host.docker.internal:"
+        assert "BEDROCK_BASE_URL" not in env, (
+            "BEDROCK_BASE_URL must be set in build_container_spec, "
+            "not _pi_extra_env"
         )
-        assert env["BEDROCK_BASE_URL"].endswith("/proxy/bedrock")
 
     def test_bedrock_default_region_is_us_east_1(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/agent/test_executor.py
+++ b/tests/agent/test_executor.py
@@ -189,3 +189,112 @@ def test_agent_backend_config_frozen() -> None:
         raise AssertionError("Should have raised")
     except AttributeError:
         pass
+
+
+# ---------------------------------------------------------------------------
+# _pi_extra_env — Bedrock injection (placeholder + synthesized URL)
+# ---------------------------------------------------------------------------
+
+
+import pytest
+
+from rolemesh.agent.executor import _pi_extra_env
+
+
+class TestPiExtraEnvBedrock:
+    """The Bedrock branch in ``_pi_extra_env`` is the security boundary
+    for "the real ABSK token never enters an agent container".
+    These cases verify the contract from both sides — what MUST land
+    in the container env (placeholders + the proxy URL) and what MUST
+    NOT (the literal host token, raw ``localhost`` URL the operator
+    might have stashed in ``.env``).
+    """
+
+    def test_no_pi_model_id_only_returns_backend_marker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("PI_MODEL_ID", raising=False)
+        env = _pi_extra_env()
+        assert env == {"AGENT_BACKEND": "pi"}
+
+    def test_non_bedrock_model_id_does_not_inject_aws_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Anthropic-direct or OpenAI Pi model ids must NOT spuriously
+        # inject AWS_BEARER_TOKEN_BEDROCK / BEDROCK_BASE_URL — those
+        # only make sense on the Bedrock route.
+        monkeypatch.setenv("PI_MODEL_ID", "anthropic/claude-3-5-sonnet")
+        # Even with a real-looking host token set, a non-bedrock
+        # model must not pull it / a placeholder into the container.
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKsecret")
+        env = _pi_extra_env()
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in env
+        assert "BEDROCK_BASE_URL" not in env
+
+    def test_bedrock_model_id_injects_placeholder_not_host_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Critical: the host's real token must NEVER appear in the
+        # container env. Set a recognizable host token, then assert
+        # the container sees only the placeholder.
+        monkeypatch.setenv(
+            "PI_MODEL_ID", "amazon-bedrock/us.anthropic.claude-sonnet-4-6"
+        )
+        monkeypatch.setenv(
+            "AWS_BEARER_TOKEN_BEDROCK", "ABSKreal-host-secret-do-not-leak"
+        )
+        env = _pi_extra_env()
+        token_in_env = env.get("AWS_BEARER_TOKEN_BEDROCK", "")
+        assert "ABSKreal-host-secret" not in token_in_env, (
+            "host's real Bedrock token leaked into agent container env"
+        )
+        assert token_in_env  # but placeholder MUST be set
+        assert "placeholder" in token_in_env.lower()
+
+    def test_bedrock_model_id_synthesises_proxy_url_with_host_docker_internal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Bug 5 family: even if the operator stashed
+        # BEDROCK_BASE_URL=http://localhost:... in .env, the
+        # container must always see host.docker.internal because
+        # localhost inside a container is the container itself.
+        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/anything")
+        monkeypatch.setenv("BEDROCK_BASE_URL", "http://localhost:9999/wrong")
+        env = _pi_extra_env()
+        url = env["BEDROCK_BASE_URL"]
+        assert url.startswith("http://host.docker.internal:")
+        assert url.endswith("/proxy/bedrock")
+        # The wrong .env value must not have leaked through.
+        assert "localhost" not in url
+        assert "9999" not in url  # operator's wrong port not pasted in
+
+    def test_bedrock_url_is_synthesised_even_without_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regular case: operator did NOT set BEDROCK_BASE_URL. Helper
+        # must still inject the synthesized one — this is the
+        # "operators don't have to remember a third env var" property
+        # that the design depends on.
+        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/foo")
+        monkeypatch.delenv("BEDROCK_BASE_URL", raising=False)
+        env = _pi_extra_env()
+        assert env["BEDROCK_BASE_URL"].startswith(
+            "http://host.docker.internal:"
+        )
+        assert env["BEDROCK_BASE_URL"].endswith("/proxy/bedrock")
+
+    def test_bedrock_default_region_is_us_east_1(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/foo")
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        env = _pi_extra_env()
+        assert env["AWS_REGION"] == "us-east-1"
+
+    def test_bedrock_region_propagates_when_host_sets_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PI_MODEL_ID", "amazon-bedrock/foo")
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+        env = _pi_extra_env()
+        assert env["AWS_REGION"] == "us-west-2"

--- a/tests/container/test_runner.py
+++ b/tests/container/test_runner.py
@@ -164,14 +164,24 @@ class TestBuildContainerSpec:
         assert "NATS_URL" in spec.env
 
     def test_spec_env_routes_llm_through_egress_gateway(self) -> None:
-        """EC-1: ANTHROPIC_BASE_URL / OPENAI_BASE_URL point at the gateway
-        by service name, never at host.docker.internal."""
+        """EC-1: ANTHROPIC_BASE_URL / OPENAI_BASE_URL / BEDROCK_BASE_URL
+        point at the gateway by service name, never at
+        host.docker.internal."""
         with patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"):
             spec = build_container_spec([], "c", "j")
         assert "egress-gateway" in spec.env["ANTHROPIC_BASE_URL"]
         assert "egress-gateway" in spec.env["OPENAI_BASE_URL"]
+        # Bedrock — same proxy_base; agents on Internal=true bridge
+        # cannot resolve host.docker.internal, so this MUST be the
+        # gateway service name. Pre-fix it was synthesised in
+        # ``_pi_extra_env`` and hard-coded to host.docker.internal,
+        # which 100%-broke Bedrock under EC-2.
+        assert spec.env["BEDROCK_BASE_URL"] == (
+            "http://egress-gateway:3001/proxy/bedrock"
+        )
         # Regression: the old host.docker.internal escape hatch is gone.
         assert "host.docker.internal" not in spec.env["ANTHROPIC_BASE_URL"]
+        assert "host.docker.internal" not in spec.env["BEDROCK_BASE_URL"]
 
     def test_spec_env_injects_http_proxy(self) -> None:
         """EC-1: standard proxy env is set on every agent container so
@@ -248,6 +258,13 @@ class TestBuildContainerSpec:
         assert "host.docker.internal" in spec.env["ANTHROPIC_BASE_URL"]
         assert "egress-gateway" not in spec.env["ANTHROPIC_BASE_URL"]
         assert "host.docker.internal" in spec.env["OPENAI_BASE_URL"]
+        # Bedrock follows the same per-spawn ``proxy_base`` decision —
+        # under rollback it routes through host.docker.internal. Pin
+        # the value to lock the rollback path's behaviour separately
+        # from the EC-2 path.
+        assert spec.env["BEDROCK_BASE_URL"] == (
+            "http://host.docker.internal:3001/proxy/bedrock"
+        )
 
         # Forward-proxy env must NOT be injected — no gateway exists.
         assert "HTTP_PROXY" not in spec.env

--- a/tests/egress/test_launcher.py
+++ b/tests/egress/test_launcher.py
@@ -445,9 +445,30 @@ class TestAwsBedrockForwarders:
     ) -> None:
         from rolemesh.egress.launcher import _gateway_env
 
+        # AWS_REGION is gated on AWS_BEARER_TOKEN_BEDROCK (see
+        # ``_FORWARDABLE`` ``requires=`` clause), so set both — that
+        # is the operator-Bedrock-on configuration this test
+        # represents.
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKtokenXYZ")
         monkeypatch.setenv("AWS_REGION", "eu-west-1")
         env = self._env_dict(_gateway_env())
         assert env["AWS_REGION"] == "eu-west-1"
+
+    def test_aws_region_skipped_without_bedrock_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Operators set ``AWS_REGION`` for plenty of non-Bedrock
+        # reasons (``aws cli``, the awscli docker image,
+        # ``terraform``). When Bedrock is NOT configured for
+        # rolemesh, that region must NOT leak into the gateway
+        # container's Env — keeping the gateway's AWS context
+        # surface scoped to the only AWS service we actually proxy.
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        env = self._env_dict(_gateway_env())
+        assert "AWS_REGION" not in env
 
     def test_aws_keys_are_not_marked_url(self) -> None:
         # Belt-and-braces: token + region are plain strings, NOT
@@ -461,6 +482,22 @@ class TestAwsBedrockForwarders:
         by_key = {spec.key: spec for spec in _FORWARDABLE}
         assert by_key["AWS_BEARER_TOKEN_BEDROCK"].is_url is False
         assert by_key["AWS_REGION"].is_url is False
+
+    def test_aws_region_requires_bedrock_token_in_spec(self) -> None:
+        # Pin the gating: AWS_REGION's ``requires`` MUST point at
+        # AWS_BEARER_TOKEN_BEDROCK. A future refactor that drops
+        # the gate would silently re-leak AWS_REGION into the
+        # gateway env on every host that has it set.
+        from rolemesh.egress.launcher import _FORWARDABLE
+
+        by_key = {spec.key: spec for spec in _FORWARDABLE}
+        assert by_key["AWS_REGION"].requires == "AWS_BEARER_TOKEN_BEDROCK"
+        # And the token itself must NOT be gated on anything —
+        # accidentally adding a self-cycle (``requires="AWS_REGION"``)
+        # would 100%-break Bedrock for operators who don't set
+        # AWS_REGION explicitly and rely on the BEDROCK_DEFAULT_REGION
+        # fallback.
+        assert by_key["AWS_BEARER_TOKEN_BEDROCK"].requires is None
 
     def test_unset_aws_env_does_not_emit_keys(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/egress/test_launcher.py
+++ b/tests/egress/test_launcher.py
@@ -405,3 +405,74 @@ class TestForwardableSpec:
             "OPENAI_BASE_URL",
             "GOOGLE_BASE_URL",
         }.issubset(url_keys)
+
+
+# ---------------------------------------------------------------------------
+# AWS forwarders (Bedrock) — host → gateway secrets propagation
+# ---------------------------------------------------------------------------
+
+
+class TestAwsBedrockForwarders:
+    """``_build_provider_registry`` reads ``AWS_BEARER_TOKEN_BEDROCK``
+    and ``AWS_REGION`` from the gateway-process os.environ. Without
+    forwarding these from the orchestrator host, the gateway-side
+    registry would never include a bedrock entry → every
+    ``/proxy/bedrock/...`` request from agents 404s. These tests
+    pin the forwarding contract."""
+
+    def _env_dict(self, env_pairs: list[str]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for pair in env_pairs:
+            k, _, v = pair.partition("=")
+            out[k] = v
+        return out
+
+    def test_aws_bearer_token_forwarded_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rolemesh.egress.launcher import _gateway_env
+
+        # The token shape AWS uses for long-term Bedrock API keys.
+        # Forwarded verbatim — must NOT go through loopback rewrite,
+        # because string.replace on a secret could corrupt it on the
+        # rare chance the bytes contain ``://localhost:``.
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKtokenXYZ")
+        env = self._env_dict(_gateway_env())
+        assert env["AWS_BEARER_TOKEN_BEDROCK"] == "ABSKtokenXYZ"
+
+    def test_aws_region_forwarded_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        env = self._env_dict(_gateway_env())
+        assert env["AWS_REGION"] == "eu-west-1"
+
+    def test_aws_keys_are_not_marked_url(self) -> None:
+        # Belt-and-braces: token + region are plain strings, NOT
+        # URLs. The ``test_no_token_key_is_marked_url`` heuristic
+        # only catches names ending in ``_API_KEY`` / ``_OAUTH_TOKEN``
+        # / ``_AUTH_TOKEN`` — explicitly assert AWS_BEARER_TOKEN_BEDROCK
+        # and AWS_REGION too so a future "let's just rewrite every
+        # value" refactor can't quietly mangle them.
+        from rolemesh.egress.launcher import _FORWARDABLE
+
+        by_key = {spec.key: spec for spec in _FORWARDABLE}
+        assert by_key["AWS_BEARER_TOKEN_BEDROCK"].is_url is False
+        assert by_key["AWS_REGION"].is_url is False
+
+    def test_unset_aws_env_does_not_emit_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Operator without Bedrock setup → no AWS keys leak into the
+        # gateway container's Env block (cleaner gateway env, smaller
+        # blast radius if someone later adds an exfil path that
+        # iterates env vars).
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        env = self._env_dict(_gateway_env())
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in env
+        assert "AWS_REGION" not in env

--- a/tests/security/test_credential_proxy.py
+++ b/tests/security/test_credential_proxy.py
@@ -9,3 +9,91 @@ def test_detect_auth_mode_default() -> None:
     mode = detect_auth_mode()
     # Without ANTHROPIC_API_KEY in .env, should default to oauth
     assert mode in ("api-key", "oauth")
+
+
+# ---------------------------------------------------------------------------
+# Bedrock provider registration
+# ---------------------------------------------------------------------------
+
+
+from rolemesh.egress.reverse_proxy import _build_provider_registry
+
+
+class TestBedrockProviderRegistration:
+    """``_build_provider_registry`` should produce a ``bedrock`` entry
+    whenever the host has ``AWS_BEARER_TOKEN_BEDROCK`` set, with a
+    Bearer-style Authorization header (matching the long-term API
+    key format AWS introduced for Bedrock — boto3 SigV4 signing is
+    moot because the proxy overwrites the header anyway).
+    """
+
+    def test_bedrock_entry_added_when_token_present(self) -> None:
+        secrets = {
+            "AWS_BEARER_TOKEN_BEDROCK": "ABSKtokenXYZ",
+            "AWS_REGION": "us-east-1",
+        }
+        registry = _build_provider_registry(secrets, "api-key")
+        assert "bedrock" in registry
+        cfg = registry["bedrock"]
+        assert cfg.upstream == "https://bedrock-runtime.us-east-1.amazonaws.com"
+        assert cfg.secret_key == "ABSKtokenXYZ"
+        # Wire format: ``Authorization: Bearer <key>`` — the same
+        # shape Anthropic OAuth and OpenAI use, so handle_provider_proxy
+        # needs zero per-provider branching.
+        assert cfg.header_name == "authorization"
+        assert cfg.header_format == "Bearer {key}"
+
+    def test_bedrock_entry_uses_region_from_secrets(self) -> None:
+        secrets = {
+            "AWS_BEARER_TOKEN_BEDROCK": "ABSKtokenXYZ",
+            "AWS_REGION": "eu-west-1",
+        }
+        registry = _build_provider_registry(secrets, "api-key")
+        assert (
+            registry["bedrock"].upstream
+            == "https://bedrock-runtime.eu-west-1.amazonaws.com"
+        )
+
+    def test_bedrock_entry_defaults_region_to_us_east_1(self) -> None:
+        secrets = {"AWS_BEARER_TOKEN_BEDROCK": "ABSKtokenXYZ"}
+        registry = _build_provider_registry(secrets, "api-key")
+        assert (
+            registry["bedrock"].upstream
+            == "https://bedrock-runtime.us-east-1.amazonaws.com"
+        )
+
+    def test_bedrock_entry_skipped_when_token_missing(self) -> None:
+        # No token => no entry. An operator who doesn't run Bedrock
+        # shouldn't see ``LLM provider proxy registered provider=bedrock``
+        # in their startup logs (the log line happens in the caller of
+        # ``_build_provider_registry`` based on the keys we returned).
+        secrets = {"AWS_REGION": "us-east-1"}
+        registry = _build_provider_registry(secrets, "api-key")
+        assert "bedrock" not in registry
+
+    def test_bedrock_entry_skipped_when_token_empty_string(self) -> None:
+        # Defends against ``AWS_BEARER_TOKEN_BEDROCK=`` in .env (empty
+        # value, common when an operator deletes a secret without
+        # also deleting the line).
+        secrets = {"AWS_BEARER_TOKEN_BEDROCK": "", "AWS_REGION": "us-east-1"}
+        registry = _build_provider_registry(secrets, "api-key")
+        assert "bedrock" not in registry
+
+    def test_bedrock_entry_independent_of_anthropic_auth_mode(self) -> None:
+        # Bedrock and Anthropic-direct can coexist (some operators
+        # use Anthropic for one model and Bedrock for another).
+        # ``_build_provider_registry`` must register Bedrock on either
+        # auth_mode value.
+        secrets_apikey = {
+            "ANTHROPIC_API_KEY": "sk-ant-...",
+            "AWS_BEARER_TOKEN_BEDROCK": "ABSKtokenXYZ",
+        }
+        registry_apikey = _build_provider_registry(secrets_apikey, "api-key")
+        assert "bedrock" in registry_apikey
+
+        secrets_oauth = {
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-oat-...",
+            "AWS_BEARER_TOKEN_BEDROCK": "ABSKtokenXYZ",
+        }
+        registry_oauth = _build_provider_registry(secrets_oauth, "oauth")
+        assert "bedrock" in registry_oauth

--- a/tests/test_agent_runner/test_amazon_bedrock_tool_limit.py
+++ b/tests/test_agent_runner/test_amazon_bedrock_tool_limit.py
@@ -59,6 +59,60 @@ def test_realistic_long_mcp_name_raises() -> None:
         _convert_tool_config([_tool(bad)], "auto")
 
 
+# ---------------------------------------------------------------------------
+# Character set (added P2-#3): Bedrock requires
+# ^[a-zA-Z][a-zA-Z0-9_-]{0,63}$ — a starting letter, then letters /
+# digits / underscore / hyphen only. Other LLM providers accept a
+# wider charset; we validate ONLY for Bedrock to keep the rolemesh
+# error story specific to "this is a Bedrock constraint".
+# ---------------------------------------------------------------------------
+
+
+def test_dot_in_name_raises() -> None:
+    # ``.`` is common in MCP server names (``github.search``) but
+    # Bedrock rejects it. Surface the error in our layer rather
+    # than as a 400 ValidationException from AWS.
+    with pytest.raises(ValueError, match="Bedrock Converse"):
+        _convert_tool_config([_tool("github.search")], "auto")
+
+
+def test_slash_in_name_raises() -> None:
+    with pytest.raises(ValueError, match="Bedrock Converse"):
+        _convert_tool_config([_tool("scope/tool")], "auto")
+
+
+def test_at_sign_in_name_raises() -> None:
+    with pytest.raises(ValueError, match="Bedrock Converse"):
+        _convert_tool_config([_tool("scope@v1")], "auto")
+
+
+def test_starting_digit_raises() -> None:
+    # First char must be a letter — ``[a-zA-Z]``. Names like
+    # ``2fa_setup`` would slip past a length-only check.
+    with pytest.raises(ValueError, match="Bedrock Converse"):
+        _convert_tool_config([_tool("2fa_setup")], "auto")
+
+
+def test_starting_underscore_raises() -> None:
+    with pytest.raises(ValueError, match="Bedrock Converse"):
+        _convert_tool_config([_tool("_private_tool")], "auto")
+
+
+def test_double_underscore_mcp_style_is_accepted() -> None:
+    # Real-world: rolemesh's MCP tools use ``mcp__server__tool``.
+    # Double underscore must NOT trip the validator — that pattern
+    # is what makes operator-side short-prefix scheme practical.
+    cfg = _convert_tool_config([_tool("mcp__github__search")], "auto")
+    assert cfg is not None
+    assert cfg["tools"][0]["toolSpec"]["name"] == "mcp__github__search"
+
+
+def test_hyphenated_name_is_accepted() -> None:
+    # Common in OpenAPI-derived MCP servers.
+    cfg = _convert_tool_config([_tool("get-user-by-id")], "auto")
+    assert cfg is not None
+
+
 def test_no_tools_short_circuits_without_check() -> None:
     # Empty tools list => no validation runs; mirrors the upstream
     # ``if not tools or tool_choice == "none"`` early return.

--- a/tests/test_agent_runner/test_amazon_bedrock_tool_limit.py
+++ b/tests/test_agent_runner/test_amazon_bedrock_tool_limit.py
@@ -1,0 +1,67 @@
+"""Bedrock Converse tool-name length contract.
+
+Bedrock's Converse API caps tool names at 64 characters; Anthropic
+native and OpenAI accept up to 128. The provider raises rather than
+silently truncating because a hidden mapping layer would defer the
+failure to a confusing point downstream — the agent would call a
+tool name that no longer matches the registry it built locally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# pi.ai providers depend on extras (boto3 etc.). If the dev env
+# doesn't have them installed, skip cleanly rather than blowing up
+# at import time. The container that actually runs Pi backend has
+# boto3 baked in.
+boto3 = pytest.importorskip("boto3")  # noqa: F841
+
+from pi.ai.providers.amazon_bedrock import _convert_tool_config
+from pi.ai.tool import Tool
+
+
+def _tool(name: str) -> Tool:
+    return Tool(name=name, description="x", parameters={"type": "object"})
+
+
+def test_short_name_is_accepted() -> None:
+    cfg = _convert_tool_config([_tool("ok_short_name")], "auto")
+    assert cfg is not None
+    assert cfg["tools"][0]["toolSpec"]["name"] == "ok_short_name"
+
+
+def test_exactly_64_chars_is_accepted() -> None:
+    name = "a" * 64
+    cfg = _convert_tool_config([_tool(name)], "auto")
+    assert cfg is not None
+    assert cfg["tools"][0]["toolSpec"]["name"] == name
+
+
+def test_65_chars_raises_with_specific_name() -> None:
+    bad = "a" * 65
+    with pytest.raises(ValueError) as excinfo:
+        _convert_tool_config([_tool(bad)], "auto")
+    msg = str(excinfo.value)
+    # Error must name the offender so a CI log surfaces actionable
+    # context — the operator needs to know WHICH tool to rename.
+    assert bad in msg
+    assert "64" in msg
+
+
+def test_realistic_long_mcp_name_raises() -> None:
+    # The exact failure mode this guard exists for: an MCP tool name
+    # with a long server prefix that's fine on Anthropic-direct but
+    # exceeds Bedrock's limit. Should fail loud, not truncate.
+    bad = "mcp__internal_dev_tools_v2__github_search_issues_advanced_filter"
+    assert len(bad) > 64
+    with pytest.raises(ValueError, match="Bedrock Converse"):
+        _convert_tool_config([_tool(bad)], "auto")
+
+
+def test_no_tools_short_circuits_without_check() -> None:
+    # Empty tools list => no validation runs; mirrors the upstream
+    # ``if not tools or tool_choice == "none"`` early return.
+    assert _convert_tool_config([], "auto") is None
+    assert _convert_tool_config(None, "auto") is None
+    assert _convert_tool_config([_tool("x")], "none") is None


### PR DESCRIPTION
## Summary

Adds AWS Bedrock as a Pi backend LLM provider on the same security model as Anthropic / OpenAI / Google: the real ``AWS_BEARER_TOKEN_BEDROCK`` lives only on the host, agent containers see a placeholder, and the credential proxy overwrites the ``Authorization`` header at the HTTP layer.

A previous Bedrock attempt forwarded the real token into the agent container env (where ``cat /proc/self/environ`` could leak it). This rewrite reuses the existing reverse-proxy machinery instead of standing up a Bedrock-specific code path.

## Changes

| File | What |
|------|------|
| ``src/rolemesh/egress/reverse_proxy.py`` | ``_build_provider_registry`` registers ``bedrock`` when host has ``AWS_BEARER_TOKEN_BEDROCK``; reads it + ``AWS_REGION`` into the secrets dict at startup |
| ``src/pi/ai/providers/amazon_bedrock.py`` | boto3 client honours ``BEDROCK_BASE_URL`` (proxy endpoint); injects dummy SigV4 creds when proxied (boto3 <1.42 refuses to send otherwise; proxy still wins on header replace); ``_convert_tool_config`` raises with the offending tool name when length > 64 |
| ``src/rolemesh/agent/executor.py`` | ``_pi_extra_env``: bedrock model id triggers placeholder bearer + ``AWS_REGION`` + SYNTHESIZED ``BEDROCK_BASE_URL`` (operators can't override; ``rewrite_loopback_to_host_gateway`` prevents Bug 5 family) |
| ``src/rolemesh/core/config.py`` | ``CONTAINER_ENV_ALLOWLIST`` adds ``AWS_BEARER_TOKEN_BEDROCK``, ``AWS_REGION``, ``BEDROCK_BASE_URL`` (token always carries the placeholder value) |
| **No new** credential proxy | Same port 3001, same ``/proxy/{provider_name}/{path_info:.*}`` routing |

## Why the placeholder works

boto3 may locally generate a SigV4 ``Authorization`` header. The credential proxy's ``handle_provider_proxy`` always **overwrites** the ``Authorization`` header before forwarding upstream — so whatever boto3 signs locally is discarded; the placeholder just keeps boto3 from raising ``NoCredentialsError`` before it gets to that point. boto3 1.42+ that supports ``AWS_BEARER_TOKEN_BEDROCK`` directly also continues to work because the proxy still wins.

## Test plan

- [x] ``tests/security/test_credential_proxy.py::TestBedrockProviderRegistration`` (6): entry shape, region propagation/default, skip when token missing/empty, coexists with both Anthropic auth modes.
- [x] ``tests/agent/test_executor.py::TestPiExtraEnvBedrock`` (7): defaults; non-bedrock model doesn't inject AWS env even when host has a real token; **placeholder injected, host's literal token NOT leaked into env**; Bug-5-family — ``BEDROCK_BASE_URL`` always rewritten to ``host.docker.internal`` even when .env has localhost; URL synthesised without env override; region defaults to us-east-1 / propagates.
- [x] ``tests/test_agent_runner/test_amazon_bedrock_tool_limit.py`` (5): short / exactly 64 / 65 raises with name / realistic long mcp__ name raises / empty list short-circuits. Skips cleanly when boto3 missing in dev (importorskip).
- [x] Regression sweep: 22,542 passed across agent + egress + container + security + core.

## Operator-facing knowns

- New Bedrock models require cross-region inference profile IDs (``us.anthropic.claude-sonnet-4-6`` etc.).
- Tool names must already fit 64 chars upstream — Bedrock provider raises ValueError instead of truncating, so the failure is visible at the right layer (rolemesh's MCP naming, not buried in a Bedrock 400).

## Out of scope

- Multi-region simultaneous Bedrock targets (would need region-encoded path in proxy).
- MCP tool-name short-prefix scheme (independent task).
- boto3 sync-stream → asyncio bridge latency tuning.