### PR TITLE
fix(egress): rewrite localhost in *_BASE_URL gateway env (Bug 5 third boundary)

### DIFF
--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -228,6 +228,17 @@ def _gateway_env() -> list[str]:
     The allowlist below MUST mirror the keys ``rolemesh.core.env``'s
     .env-fallback path looks for via ``reverse_proxy.start_credential_proxy``;
     a missing pair silently produces an unconfigured provider.
+
+    Loopback-rewrite contract (Bug 5 family): every forwarded value
+    that holds a URL must be passed through
+    ``rewrite_loopback_to_host_gateway`` because container-internal
+    ``localhost`` is the container's loopback, not the host. The
+    set ``_URL_FORWARDABLE_KEYS`` declares which forwardable keys
+    are URL-typed and need this treatment; everything else (tokens,
+    DNS server lists) is forwarded verbatim. Token-shaped values
+    are intentionally NOT rewritten because string ``replace`` on a
+    secret could silently corrupt it on the (rare) chance the
+    bytes contain ``://localhost:``.
     """
     import os as _os
 
@@ -245,10 +256,24 @@ def _gateway_env() -> list[str]:
         "ANTHROPIC_AUTH_TOKEN",
         "ANTHROPIC_BASE_URL",
         "PI_OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
         "PI_GOOGLE_API_KEY",
+        "GOOGLE_BASE_URL",
     )
+    # Subset of ``forwardable_keys`` that hold URLs and therefore
+    # need loopback rewrite at the publish boundary. Adding a new
+    # base-URL forwarder is two lines: one in ``forwardable_keys``,
+    # one here.
+    _URL_FORWARDABLE_KEYS = frozenset({
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_BASE_URL",
+        "GOOGLE_BASE_URL",
+    })
     for key in forwardable_keys:
         value = _os.environ.get(key)
-        if value:
-            env_pairs.append(f"{key}={value}")
+        if not value:
+            continue
+        if key in _URL_FORWARDABLE_KEYS:
+            value = rewrite_loopback_to_host_gateway(value)
+        env_pairs.append(f"{key}={value}")
     return env_pairs

--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -213,6 +214,50 @@ def _extra_hosts() -> dict[str, str]:
     return get_host_gateway_extra_hosts()
 
 
+# ---------------------------------------------------------------------------
+# Forwardable env spec — single source of truth for "what env reaches
+# the gateway container, and which ones are URLs that need loopback
+# rewrite at the publish boundary"
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ForwardSpec:
+    """One env var to forward into the gateway container.
+
+    ``key`` is the variable name. ``is_url`` flags values that need
+    ``rewrite_loopback_to_host_gateway`` applied at the publish
+    boundary (Bug 5 family — container-internal ``localhost`` is
+    the container's loopback, not the host).
+
+    Token-shaped specs leave ``is_url=False`` and are forwarded
+    verbatim. We deliberately do NOT run ``string.replace`` on
+    every value: a secret that happens to contain ``://localhost:``
+    bytes would otherwise be silently corrupted.
+    """
+
+    key: str
+    is_url: bool = False
+
+
+# Forward-only allowlist. MUST mirror the keys
+# ``reverse_proxy.start_credential_proxy`` reads from os.environ — a
+# divergence shows up here in code review rather than at runtime.
+# Adding a new forwarder is one line; flipping ``is_url`` to True is
+# the only thing needed to wire the loopback rewrite for URLs.
+_FORWARDABLE: tuple[_ForwardSpec, ...] = (
+    _ForwardSpec("EGRESS_UPSTREAM_DNS"),
+    _ForwardSpec("ANTHROPIC_API_KEY"),
+    _ForwardSpec("CLAUDE_CODE_OAUTH_TOKEN"),
+    _ForwardSpec("ANTHROPIC_AUTH_TOKEN"),
+    _ForwardSpec("ANTHROPIC_BASE_URL", is_url=True),
+    _ForwardSpec("PI_OPENAI_API_KEY"),
+    _ForwardSpec("OPENAI_BASE_URL", is_url=True),
+    _ForwardSpec("PI_GOOGLE_API_KEY"),
+    _ForwardSpec("GOOGLE_BASE_URL", is_url=True),
+)
+
+
 def _gateway_env() -> list[str]:
     """Build the Env block for the gateway container.
 
@@ -225,20 +270,10 @@ def _gateway_env() -> list[str]:
     environment variables the reverse-proxy path will actually
     consume.
 
-    The allowlist below MUST mirror the keys ``rolemesh.core.env``'s
-    .env-fallback path looks for via ``reverse_proxy.start_credential_proxy``;
-    a missing pair silently produces an unconfigured provider.
-
-    Loopback-rewrite contract (Bug 5 family): every forwarded value
-    that holds a URL must be passed through
-    ``rewrite_loopback_to_host_gateway`` because container-internal
-    ``localhost`` is the container's loopback, not the host. The
-    set ``_URL_FORWARDABLE_KEYS`` declares which forwardable keys
-    are URL-typed and need this treatment; everything else (tokens,
-    DNS server lists) is forwarded verbatim. Token-shaped values
-    are intentionally NOT rewritten because string ``replace`` on a
-    secret could silently corrupt it on the (rare) chance the
-    bytes contain ``://localhost:``.
+    Forwarder spec lives in ``_FORWARDABLE`` (module-level) — single
+    source of truth for both "which env vars cross the boundary" AND
+    "which ones need loopback rewrite". See ``_ForwardSpec`` for the
+    rationale.
     """
     import os as _os
 
@@ -246,34 +281,11 @@ def _gateway_env() -> list[str]:
 
     env_pairs: list[str] = [f"NATS_URL={rewrite_loopback_to_host_gateway(_NATS_URL)}"]
 
-    # Forward-only allowlist of variables the gateway might need.
-    # Declared close to the consumer (reverse_proxy's secret list) so
-    # a divergence is caught in code review rather than at runtime.
-    forwardable_keys = (
-        "EGRESS_UPSTREAM_DNS",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "PI_OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-        "PI_GOOGLE_API_KEY",
-        "GOOGLE_BASE_URL",
-    )
-    # Subset of ``forwardable_keys`` that hold URLs and therefore
-    # need loopback rewrite at the publish boundary. Adding a new
-    # base-URL forwarder is two lines: one in ``forwardable_keys``,
-    # one here.
-    _URL_FORWARDABLE_KEYS = frozenset({
-        "ANTHROPIC_BASE_URL",
-        "OPENAI_BASE_URL",
-        "GOOGLE_BASE_URL",
-    })
-    for key in forwardable_keys:
-        value = _os.environ.get(key)
+    for spec in _FORWARDABLE:
+        value = _os.environ.get(spec.key)
         if not value:
             continue
-        if key in _URL_FORWARDABLE_KEYS:
+        if spec.is_url:
             value = rewrite_loopback_to_host_gateway(value)
-        env_pairs.append(f"{key}={value}")
+        env_pairs.append(f"{spec.key}={value}")
     return env_pairs

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -136,7 +136,7 @@ def _build_provider_registry(
     openai_key = secrets.get("PI_OPENAI_API_KEY", "")
     if openai_key:
         registry["openai"] = _ProviderConfig(
-            upstream="https://api.openai.com/v1",
+            upstream=secrets.get("OPENAI_BASE_URL", "https://api.openai.com/v1"),
             secret_key=openai_key,
             header_name="authorization",
             header_format="Bearer {key}",
@@ -145,7 +145,9 @@ def _build_provider_registry(
     google_key = secrets.get("PI_GOOGLE_API_KEY", "")
     if google_key:
         registry["google"] = _ProviderConfig(
-            upstream="https://generativelanguage.googleapis.com",
+            upstream=secrets.get(
+                "GOOGLE_BASE_URL", "https://generativelanguage.googleapis.com"
+            ),
             secret_key=google_key,
             header_name="x-goog-api-key",
             header_format="{key}",
@@ -269,7 +271,9 @@ async def start_credential_proxy(
                 "ANTHROPIC_AUTH_TOKEN",
                 "ANTHROPIC_BASE_URL",
                 "PI_OPENAI_API_KEY",
+                "OPENAI_BASE_URL",
                 "PI_GOOGLE_API_KEY",
+                "GOOGLE_BASE_URL",
             )
         )
         if v

--- a/tests/egress/test_launcher.py
+++ b/tests/egress/test_launcher.py
@@ -214,3 +214,121 @@ class TestWaitForGatewayReady:
 # tests/container/test_runtime.py. The launcher only references the
 # helper at one site (NATS_URL injection) and the integration is
 # exercised by tests/egress/integration.
+
+
+# ---------------------------------------------------------------------------
+# _gateway_env — base-URL loopback rewrite + token pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayEnvBaseUrlRewrite:
+    """Bug-5 family: every URL forwarded into the gateway container's
+    Env block must go through ``rewrite_loopback_to_host_gateway``,
+    because container-internal ``localhost`` is the container's own
+    loopback. Tokens forwarded alongside must NOT be touched — string
+    ``replace`` on a secret could silently corrupt it.
+    """
+
+    def _env_dict(self, env_pairs: list[str]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for pair in env_pairs:
+            k, _, v = pair.partition("=")
+            out[k] = v
+        return out
+
+    def test_anthropic_base_url_localhost_is_rewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Direct regression for the bug: operator pointed Anthropic
+        # at a local proxy; without rewrite, the gateway dials its
+        # own loopback and the entire Anthropic path 503s.
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://localhost:11434")
+        env = self._env_dict(_gateway_env())
+        assert env["ANTHROPIC_BASE_URL"] == "http://host.docker.internal:11434"
+
+    def test_openai_base_url_localhost_is_rewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same bug class, different forwarder. Must apply to every
+        # *_BASE_URL key, not just Anthropic.
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://127.0.0.1:8080/v1")
+        env = self._env_dict(_gateway_env())
+        assert env["OPENAI_BASE_URL"] == "http://host.docker.internal:8080/v1"
+
+    def test_google_base_url_localhost_is_rewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.setenv("GOOGLE_BASE_URL", "http://localhost:9000")
+        env = self._env_dict(_gateway_env())
+        assert env["GOOGLE_BASE_URL"] == "http://host.docker.internal:9000"
+
+    def test_remote_base_url_is_left_alone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Negative case: production URLs (api.anthropic.com etc.)
+        # must pass through unchanged.
+        from rolemesh.egress.launcher import _gateway_env
+
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+        env = self._env_dict(_gateway_env())
+        assert env["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
+
+    def test_token_with_localhost_substring_is_NOT_rewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tokens are forwarded verbatim — the rewrite path is opt-in
+        # via _URL_FORWARDABLE_KEYS, NOT a blanket replace. This test
+        # pins the asymmetry contract so a future "let's just rewrite
+        # every value" refactor doesn't quietly mangle a secret.
+        # (Concrete token strings shouldn't contain "://localhost:"
+        # in practice; this test forces the case to lock the contract.)
+        from rolemesh.egress.launcher import _gateway_env
+
+        weird_token = "sk-prefix-://localhost:1234-suffix"
+        monkeypatch.setenv("ANTHROPIC_API_KEY", weird_token)
+        env = self._env_dict(_gateway_env())
+        assert env["ANTHROPIC_API_KEY"] == weird_token
+
+    def test_unset_base_url_is_not_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empty string shouldn't pollute the container Env. The
+        # registry on the gateway side falls back to the public URL
+        # default when *_BASE_URL is absent.
+        from rolemesh.egress.launcher import _gateway_env
+
+        for key in (
+            "ANTHROPIC_BASE_URL",
+            "OPENAI_BASE_URL",
+            "GOOGLE_BASE_URL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        env = self._env_dict(_gateway_env())
+        for key in (
+            "ANTHROPIC_BASE_URL",
+            "OPENAI_BASE_URL",
+            "GOOGLE_BASE_URL",
+        ):
+            assert key not in env
+
+    def test_nats_url_still_rewritten_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # NATS_URL has its own line of code (not in forwardable_keys
+        # because it's required, not optional). Sanity-check the
+        # refactor didn't break it.
+        from rolemesh.egress.launcher import _gateway_env
+
+        env = self._env_dict(_gateway_env())
+        assert "NATS_URL" in env
+        # Default is nats://localhost:4222 in dev → must be rewritten.
+        if "localhost" in env["NATS_URL"] or "127.0.0.1" in env["NATS_URL"]:
+            raise AssertionError(
+                f"NATS_URL not rewritten: {env['NATS_URL']!r}"
+            )

--- a/tests/egress/test_launcher.py
+++ b/tests/egress/test_launcher.py
@@ -332,3 +332,76 @@ class TestGatewayEnvBaseUrlRewrite:
             raise AssertionError(
                 f"NATS_URL not rewritten: {env['NATS_URL']!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# _FORWARDABLE spec contract — single-source-of-truth structural tests
+# ---------------------------------------------------------------------------
+
+
+class TestForwardableSpec:
+    """``_FORWARDABLE`` is the single source of truth for "what crosses
+    the gateway env boundary AND which entries need loopback rewrite".
+    These tests pin the structural contract so a future refactor can't
+    silently drop the rewrite flag from a URL forwarder (re-introducing
+    the Bug 5 family).
+    """
+
+    def test_every_base_url_key_is_marked_url(self) -> None:
+        # Heuristic but load-bearing: any key matching ``*_BASE_URL``
+        # MUST have ``is_url=True``. This catches the most common
+        # drift mode — adding a new ``MISTRAL_BASE_URL`` forwarder
+        # but forgetting to flip the flag.
+        from rolemesh.egress.launcher import _FORWARDABLE
+
+        offenders = [
+            spec for spec in _FORWARDABLE
+            if spec.key.endswith("_BASE_URL") and not spec.is_url
+        ]
+        assert offenders == [], (
+            f"_FORWARDABLE entries match *_BASE_URL but is_url=False: "
+            f"{[s.key for s in offenders]}. Loopback rewrite will not "
+            f"fire for these — Bug 5 family will return."
+        )
+
+    def test_no_token_key_is_marked_url(self) -> None:
+        # Inverse of the above: ``API_KEY`` / ``OAUTH_TOKEN`` /
+        # ``AUTH_TOKEN`` shaped keys must NEVER carry ``is_url=True``,
+        # because string.replace on a secret could corrupt it.
+        from rolemesh.egress.launcher import _FORWARDABLE
+
+        token_suffixes = ("_API_KEY", "_OAUTH_TOKEN", "_AUTH_TOKEN")
+        offenders = [
+            spec for spec in _FORWARDABLE
+            if any(spec.key.endswith(s) for s in token_suffixes)
+            and spec.is_url
+        ]
+        assert offenders == [], (
+            f"_FORWARDABLE marks token-shaped keys as URLs: "
+            f"{[s.key for s in offenders]}. Tokens must never go through "
+            f"loopback rewrite — string.replace could corrupt the secret."
+        )
+
+    def test_keys_are_unique(self) -> None:
+        # Cheap sanity: spec is a tuple, so duplicates wouldn't error
+        # at construction. A duplicate would emit the env var twice in
+        # the gateway container (last write wins) and obscure intent.
+        from rolemesh.egress.launcher import _FORWARDABLE
+
+        keys = [spec.key for spec in _FORWARDABLE]
+        assert len(keys) == len(set(keys)), (
+            f"_FORWARDABLE has duplicate keys: {keys}"
+        )
+
+    def test_known_url_forwarders_carry_is_url_true(self) -> None:
+        # Direct positive coverage of the three known URL forwarders
+        # at the time of this PR. New URL forwarders should be added
+        # here as they ship.
+        from rolemesh.egress.launcher import _FORWARDABLE
+
+        url_keys = {spec.key for spec in _FORWARDABLE if spec.is_url}
+        assert {
+            "ANTHROPIC_BASE_URL",
+            "OPENAI_BASE_URL",
+            "GOOGLE_BASE_URL",
+        }.issubset(url_keys)

--- a/tests/egress/test_provider_registry.py
+++ b/tests/egress/test_provider_registry.py
@@ -1,0 +1,132 @@
+"""Tests for ``_build_provider_registry`` — multi-provider upstream
+URL resolution + base-URL overrides.
+
+These pin the contract that operators can point a provider at a
+local/private upstream (e.g. an LLM proxy on a VPC-internal host)
+via ``*_BASE_URL`` env. The gateway's registry must honour the
+override; the launcher's ``_gateway_env`` then does the loopback
+rewrite at the publish boundary so the URL still resolves inside
+the container.
+"""
+
+from __future__ import annotations
+
+from rolemesh.egress.reverse_proxy import _build_provider_registry
+
+
+# ---------------------------------------------------------------------------
+# Anthropic — already supported pre-this-PR, kept as a regression
+# baseline so a future refactor can't quietly break the override.
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_base_url_override_takes_effect() -> None:
+    secrets = {
+        "ANTHROPIC_API_KEY": "sk-ant-...",
+        "ANTHROPIC_BASE_URL": "https://my.anthropic-proxy.example.com",
+    }
+    registry = _build_provider_registry(secrets, "api-key")
+    assert (
+        registry["anthropic"].upstream
+        == "https://my.anthropic-proxy.example.com"
+    )
+
+
+def test_anthropic_default_when_no_override() -> None:
+    secrets = {"ANTHROPIC_API_KEY": "sk-ant-..."}
+    registry = _build_provider_registry(secrets, "api-key")
+    assert registry["anthropic"].upstream == "https://api.anthropic.com"
+
+
+# ---------------------------------------------------------------------------
+# OpenAI base URL override (added in this PR)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_base_url_override_takes_effect() -> None:
+    secrets = {
+        "PI_OPENAI_API_KEY": "sk-...",
+        "OPENAI_BASE_URL": "https://my.openai-compat.example.com/v1",
+    }
+    registry = _build_provider_registry(secrets, "api-key")
+    assert (
+        registry["openai"].upstream
+        == "https://my.openai-compat.example.com/v1"
+    )
+
+
+def test_openai_default_when_no_override() -> None:
+    secrets = {"PI_OPENAI_API_KEY": "sk-..."}
+    registry = _build_provider_registry(secrets, "api-key")
+    assert registry["openai"].upstream == "https://api.openai.com/v1"
+
+
+def test_openai_base_url_ignored_without_api_key() -> None:
+    # If the API key isn't set, no openai entry exists at all —
+    # base_url override on its own should not synthesise a half-
+    # configured provider.
+    secrets = {"OPENAI_BASE_URL": "https://my.openai-compat.example.com/v1"}
+    registry = _build_provider_registry(secrets, "api-key")
+    assert "openai" not in registry
+
+
+# ---------------------------------------------------------------------------
+# Google base URL override (added in this PR)
+# ---------------------------------------------------------------------------
+
+
+def test_google_base_url_override_takes_effect() -> None:
+    secrets = {
+        "PI_GOOGLE_API_KEY": "AIza...",
+        "GOOGLE_BASE_URL": "https://my.gemini-proxy.example.com",
+    }
+    registry = _build_provider_registry(secrets, "api-key")
+    assert (
+        registry["google"].upstream
+        == "https://my.gemini-proxy.example.com"
+    )
+
+
+def test_google_default_when_no_override() -> None:
+    secrets = {"PI_GOOGLE_API_KEY": "AIza..."}
+    registry = _build_provider_registry(secrets, "api-key")
+    assert (
+        registry["google"].upstream
+        == "https://generativelanguage.googleapis.com"
+    )
+
+
+def test_google_base_url_ignored_without_api_key() -> None:
+    secrets = {"GOOGLE_BASE_URL": "https://my.gemini-proxy.example.com"}
+    registry = _build_provider_registry(secrets, "api-key")
+    assert "google" not in registry
+
+
+# ---------------------------------------------------------------------------
+# Header / format invariants — base URL override must not affect
+# the credential injection contract
+# ---------------------------------------------------------------------------
+
+
+def test_openai_override_keeps_bearer_header_format() -> None:
+    secrets = {
+        "PI_OPENAI_API_KEY": "sk-test",
+        "OPENAI_BASE_URL": "https://my.example.com/v1",
+    }
+    registry = _build_provider_registry(secrets, "api-key")
+    cfg = registry["openai"]
+    assert cfg.header_name == "authorization"
+    assert cfg.header_format == "Bearer {key}"
+    assert cfg.secret_key == "sk-test"
+
+
+def test_google_override_keeps_x_goog_api_key_header() -> None:
+    secrets = {
+        "PI_GOOGLE_API_KEY": "AIza-test",
+        "GOOGLE_BASE_URL": "https://my.example.com",
+    }
+    registry = _build_provider_registry(secrets, "api-key")
+    cfg = registry["google"]
+    assert cfg.header_name == "x-goog-api-key"
+    assert cfg.header_format == "{key}"
+    assert cfg.secret_key == "AIza-test"


### PR DESCRIPTION
## Summary

Closes the third publish boundary missed by the Bug 5 fix family. The previous fix (commit e4a912c) covered NATS snapshot + hot-reload; ``_gateway_env`` only ran loopback rewrite on ``NATS_URL``, so any ``ANTHROPIC_BASE_URL=http://localhost:N`` (operator points Anthropic at a local LLM proxy for debugging) was forwarded verbatim into the gateway container, where ``localhost`` is the gateway's own loopback → ``Connection refused``.

Same fix family also enables OpenAI / Google base URL overrides so reaching for a local OpenAI-compat proxy doesn't trip the same bug a third time.

## Changes

| File | What |
|------|------|
| ``src/rolemesh/egress/launcher.py`` | ``_gateway_env`` adds ``_URL_FORWARDABLE_KEYS`` set (Anthropic + OpenAI + Google base URLs); loop runs ``rewrite_loopback_to_host_gateway`` on URL keys, leaves tokens / DNS lists verbatim. ``forwardable_keys`` adds ``OPENAI_BASE_URL`` + ``GOOGLE_BASE_URL`` |
| ``src/rolemesh/egress/reverse_proxy.py`` | ``_build_provider_registry`` honours ``OPENAI_BASE_URL`` / ``GOOGLE_BASE_URL`` as upstream overrides (mirroring existing ``ANTHROPIC_BASE_URL`` behaviour); secrets dict reads them from os.environ |

## Why opt-in (per-key) rewrite, not blanket rewrite

Tokens are forwarded alongside URLs in the same loop. A blanket ``string.replace`` on every value could silently corrupt a token if it ever contained ``://localhost:`` — possibly nonsensical in practice but trivially eliminated by making rewrite opt-in via the ``_URL_FORWARDABLE_KEYS`` set. Adding a new base-URL forwarder is two lines (forwardable_keys + URL set).

## Test plan

- [x] ``tests/egress/test_launcher.py::TestGatewayEnvBaseUrlRewrite`` (7): Anthropic/OpenAI/Google localhost + 127.0.0.1 URLs all rewritten; remote URL untouched; **token-shaped value containing literal ``://localhost:`` NOT rewritten** (pins asymmetry contract); unset ``*_BASE_URL`` → not emitted; ``NATS_URL`` still rewritten (regression sanity).
- [x] ``tests/egress/test_provider_registry.py`` (new, 10 cases): Anthropic regression baseline; OpenAI & Google override-takes-effect / default-fallback / base-URL-alone does NOT synthesise half-config; credential header contract preserved.
- [x] Egress unit suite: 102 → 119 (17 new), 0 failures.
- [x] Egress integration suite (live Docker): 14/14 still green.

## Risk

Low. Default configuration (``*_BASE_URL`` unset or pointing at public endpoints) is unchanged. Localhost values previously broke under EC-2; this fix makes them work. Token forwarding semantics explicitly tested unchanged.