### PR TITLE
feat(skills): per-coworker skills with DB-backed projection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,10 @@ testpaths = ["tests"]
 # Exclude integration tests by default. They require a live Docker daemon
 # and pull alpine on first run; PR CI stays fast, nightly runs them via
 # `uv run pytest -m integration` (or `-m ""` to include everything).
-addopts = "-m 'not integration'"
+addopts = "-m 'not integration and not e2e'"
 markers = [
     "integration: end-to-end tests that require a live Docker daemon",
+    "e2e: real-model end-to-end tests requiring Anthropic API + Docker",
 ]
 
 [tool.mypy]

--- a/src/pi/coding_agent/core/sdk.py
+++ b/src/pi/coding_agent/core/sdk.py
@@ -30,6 +30,36 @@ from pi.coding_agent.core.resource_loader import (
 )
 from pi.coding_agent.core.session_manager import SessionManager
 from pi.coding_agent.core.settings_manager import SettingsManager
+from pi.coding_agent.core.skills import format_skills_for_prompt
+
+
+def _assemble_system_prompt(resource_loader: Any) -> str:
+    """Compose the agent's system_prompt from the resource_loader's pieces.
+
+    Order: ``get_system_prompt()`` → ``get_append_system_prompt()`` parts
+    → skills XML block (per Agent Skills standard).
+
+    Without this assembly the AgentState was created with
+    ``system_prompt=""`` and every author-supplied prompt + every
+    loaded skill description was silently dropped on the floor — the
+    model received nothing but the user's first message.
+    """
+    pieces: list[str] = []
+    base = resource_loader.get_system_prompt() if resource_loader else None
+    if base:
+        pieces.append(base)
+    if resource_loader:
+        for chunk in resource_loader.get_append_system_prompt():
+            if chunk:
+                pieces.append(chunk)
+        skills = list(resource_loader.get_skills().values()) if hasattr(
+            resource_loader, "get_skills"
+        ) else []
+        if skills:
+            block = format_skills_for_prompt(skills).lstrip("\n")
+            if block:
+                pieces.append(block)
+    return "\n\n".join(pieces)
 
 
 @dataclass
@@ -266,7 +296,7 @@ async def create_agent_session(
 
     # Create agent
     initial_state = AgentState(
-        system_prompt="",
+        system_prompt=_assemble_system_prompt(resource_loader),
         model=model or Model(),
         thinking_level=thinking_level or "off",
         tools=active_tools,

--- a/src/pi/coding_agent/core/sdk.py
+++ b/src/pi/coding_agent/core/sdk.py
@@ -33,7 +33,11 @@ from pi.coding_agent.core.settings_manager import SettingsManager
 from pi.coding_agent.core.skills import format_skills_for_prompt
 
 
-def _assemble_system_prompt(resource_loader: Any) -> str:
+def _assemble_system_prompt(
+    resource_loader: Any,
+    *,
+    has_read_tool: bool = True,
+) -> str:
     """Compose the agent's system_prompt from the resource_loader's pieces.
 
     Order: ``get_system_prompt()`` → ``get_append_system_prompt()`` parts
@@ -43,6 +47,12 @@ def _assemble_system_prompt(resource_loader: Any) -> str:
     ``system_prompt=""`` and every author-supplied prompt + every
     loaded skill description was silently dropped on the floor — the
     model received nothing but the user's first message.
+
+    Skills are only injected when the read tool is available — the
+    block tells the model "Use the read tool to load a skill's
+    file...", and Pi's own ``build_system_prompt`` for the default
+    branch gates the block on the same condition. Telling the model
+    about skills it cannot read is worse than not telling it at all.
     """
     pieces: list[str] = []
     base = resource_loader.get_system_prompt() if resource_loader else None
@@ -52,13 +62,14 @@ def _assemble_system_prompt(resource_loader: Any) -> str:
         for chunk in resource_loader.get_append_system_prompt():
             if chunk:
                 pieces.append(chunk)
-        skills = list(resource_loader.get_skills().values()) if hasattr(
-            resource_loader, "get_skills"
-        ) else []
-        if skills:
-            block = format_skills_for_prompt(skills).lstrip("\n")
-            if block:
-                pieces.append(block)
+        if has_read_tool:
+            skills = list(resource_loader.get_skills().values()) if hasattr(
+                resource_loader, "get_skills"
+            ) else []
+            if skills:
+                block = format_skills_for_prompt(skills).lstrip("\n")
+                if block:
+                    pieces.append(block)
     return "\n\n".join(pieces)
 
 
@@ -296,7 +307,10 @@ async def create_agent_session(
 
     # Create agent
     initial_state = AgentState(
-        system_prompt=_assemble_system_prompt(resource_loader),
+        system_prompt=_assemble_system_prompt(
+            resource_loader,
+            has_read_tool="read" in initial_tool_names,
+        ),
         model=model or Model(),
         thinking_level=thinking_level or "off",
         tools=active_tools,

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -142,6 +142,54 @@ class ContainerAgentExecutor:
         tenant_id = inp.tenant_id or coworker.tenant_id
         conversation_id = inp.conversation_id or ""
 
+        try:
+            return await self._execute_after_setup(
+                inp,
+                on_process,
+                on_output,
+                coworker=coworker,
+                tenant_id=tenant_id,
+                conversation_id=conversation_id,
+                job_id=job_id,
+                start_time=start_time,
+                start_epoch_ms=start_epoch_ms,
+            )
+        finally:
+            # Outer safety net for the per-spawn skills directory.
+            # The inner ``_execute_after_setup`` explicitly cleans up
+            # at each ``return`` for prompt disk reuse on the happy
+            # paths, but exceptions raised by ``build_container_spec``,
+            # ``self._runtime.run``, the approval/safety loaders, or
+            # any other line bypass those returns. ``cleanup_spawn_skills``
+            # is idempotent, so duplicating with the inner calls is
+            # harmless — this finally just guarantees no orphan dir
+            # is left behind regardless of how the function exits.
+            cleanup_spawn_skills(job_id)
+
+    async def _execute_after_setup(
+        self,
+        inp: AgentInput,
+        on_process: Callable[[str, str], None],
+        on_output: Callable[[AgentOutput], Awaitable[None]] | None,
+        *,
+        coworker: Coworker,
+        tenant_id: str,
+        conversation_id: str,
+        job_id: str,
+        start_time: float,
+        start_epoch_ms: int,
+    ) -> AgentOutput:
+        """Spawn the container and drive the conversation.
+
+        Split out from ``execute`` so the outer ``try/finally`` in the
+        public method can guarantee ``cleanup_spawn_skills(job_id)``
+        runs on every exit path — including exceptions raised by
+        ``build_container_spec``, ``self._runtime.run``, the
+        approval / safety loaders, or any other line in this body.
+        The explicit ``cleanup_spawn_skills`` calls below remain so
+        disk is reclaimed promptly on the happy paths; the outer
+        finally only kicks in when something raises.
+        """
         # Ensure coworker directory exists
         coworker_dir = DATA_DIR / "tenants" / tenant_id / "coworkers" / coworker.folder
         coworker_dir.mkdir(parents=True, exist_ok=True)

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -23,6 +23,10 @@ from rolemesh.container.runner import (
     build_container_spec,
     build_volume_mounts,
 )
+from rolemesh.container.skill_projection import (
+    cleanup_spawn_skills,
+    materialize_skills_for_spawn,
+)
 from rolemesh.container.runtime import CONTAINER_HOST_GATEWAY
 from rolemesh.core.config import (
     CONTAINER_MAX_OUTPUT_SIZE,
@@ -147,6 +151,27 @@ class ContainerAgentExecutor:
             coworker, tenant_id, conversation_id,
             permissions=permissions, backend_config=self._config,
         )
+
+        # Materialize per-coworker skills to a per-spawn build dir
+        # and bind-mount it read-only at the backend's skill path.
+        # Returns None if there are no enabled skills, in which case
+        # we skip the mount entirely. Cleanup happens in the finally
+        # below — including on exceptions raised before the
+        # container is even started.
+        try:
+            skill_mount = await materialize_skills_for_spawn(
+                coworker, job_id, backend=self._config.name,
+            )
+        except Exception as exc:  # noqa: BLE001 — projection bugs must not crash spawn
+            logger.warning(
+                "Skill projection failed; spawning without skills",
+                coworker=coworker.name,
+                job_id=job_id,
+                error=str(exc),
+            )
+            skill_mount = None
+        if skill_mount is not None:
+            mounts.append(skill_mount)
         safe_name = re.sub(r"[^a-zA-Z0-9-]", "-", inp.group_folder)
         container_name = f"rolemesh-{safe_name}-{start_epoch_ms}"
 
@@ -493,6 +518,7 @@ class ContainerAgentExecutor:
                     duration=duration_ms,
                     code=code,
                 )
+                cleanup_spawn_skills(job_id)
                 return AgentOutput(
                     status="success",
                     result=None,
@@ -506,6 +532,7 @@ class ContainerAgentExecutor:
                 duration=duration_ms,
                 code=code,
             )
+            cleanup_spawn_skills(job_id)
             return AgentOutput(
                 status="error",
                 result=None,
@@ -570,6 +597,7 @@ class ContainerAgentExecutor:
                 stderr=stderr_buf,
                 log_file=str(log_file),
             )
+            cleanup_spawn_skills(job_id)
             return AgentOutput(
                 status="error",
                 result=None,
@@ -582,6 +610,7 @@ class ContainerAgentExecutor:
             duration=duration_ms,
             new_session_id=new_session_id,
         )
+        cleanup_spawn_skills(job_id)
         return AgentOutput(
             status="success",
             result=None,

--- a/src/rolemesh/container/runner.py
+++ b/src/rolemesh/container/runner.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 import os
 import platform
-import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -187,16 +186,6 @@ def build_volume_mounts(
             + "\n",
             encoding="utf-8",
         )
-
-    # Sync skills
-    skills_src = project_root / "container" / "skills"
-    skills_dst = claude_sessions_dir / "skills"
-    if skills_src.exists():
-        for skill_dir in skills_src.iterdir():
-            if not skill_dir.is_dir():
-                continue
-            dst_dir = skills_dst / skill_dir.name
-            shutil.copytree(str(skill_dir), str(dst_dir), dirs_exist_ok=True)
 
     mounts.append(
         VolumeMount(

--- a/src/rolemesh/container/skill_projection.py
+++ b/src/rolemesh/container/skill_projection.py
@@ -1,0 +1,316 @@
+"""Project DB-stored skills to a host directory and return a
+read-only bind mount for the agent container.
+
+The flow is described in detail in docs/skills-architecture.md
+"Container Projection". Brief recap:
+
+* Per-spawn build dir: ``<DATA_DIR>/spawns/<job_id>/skills/``.
+* Each skill writes into ``<build_dir>/.partial/<skill.name>/`` then
+  the whole subtree is atomically renamed to
+  ``<build_dir>/<skill.name>/`` once flushed. The model never sees
+  a half-populated skill folder, even if the container starts in
+  parallel with projection.
+* SKILL.md frontmatter is merged from the active backend's section
+  of ``frontmatter_backend`` plus all of ``frontmatter_common``;
+  fields scoped to other backends are dropped.
+* Path traversal is blocked at three layers: DB CHECK, application
+  validator (``rolemesh.core.skills``), and projection-time
+  ``Path.resolve()`` + symlink rejection.
+
+The mount target inside the container depends on the backend:
+
+* ``claude`` / ``claude-code`` → ``/home/agent/.claude/skills``
+* ``pi``                       → ``/home/agent/.pi/agent/skills``
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rolemesh.container.runtime import VolumeMount
+from rolemesh.core.config import DATA_DIR
+from rolemesh.core.logger import get_logger
+from rolemesh.core.skills import (
+    SkillValidationError,
+    merge_frontmatter_for_backend,
+    serialize_skill_md,
+    validate_skill_file_path,
+    validate_skill_name,
+)
+from rolemesh.db.pg import list_skills_for_coworker
+
+if TYPE_CHECKING:
+    from rolemesh.core.types import Coworker, Skill, SkillFile
+
+
+logger = get_logger()
+
+
+# Root on the host where every spawn directory lives. Each spawn
+# (one per agent invocation) gets its own subtree keyed by job_id.
+SPAWN_ROOT: Path = DATA_DIR / "spawns"
+
+CONTAINER_TARGETS: dict[str, str] = {
+    "claude": "/home/agent/.claude/skills",
+    "claude-code": "/home/agent/.claude/skills",
+    "pi": "/home/agent/.pi/agent/skills",
+}
+
+
+def _spawn_skills_dir(job_id: str) -> Path:
+    """Return the per-spawn skills build directory.
+
+    Caller is responsible for creating and cleaning it; this helper
+    just centralizes the path layout so cleanup and projection see
+    the same root.
+    """
+    return SPAWN_ROOT / job_id / "skills"
+
+
+def _verify_no_symlink(path: Path, root: Path) -> None:
+    """Walk every component from ``path`` up to (but not including)
+    ``root`` and assert none is a symlink.
+
+    v1 does not allow symlinks in skill folders. They cannot
+    legitimately appear (the splitter only writes regular files), so
+    encountering one is always a signal that something is wrong —
+    either a stale spawn dir, a host-level tampering, or a bug.
+    """
+    p = path
+    while True:
+        if p == root or p.parent == p:
+            return
+        if p.is_symlink():
+            raise SkillValidationError(
+                f"refusing to write through symlink at {p}"
+            )
+        p = p.parent
+
+
+def _resolved_path_inside(root: Path, target: Path) -> Path:
+    """Return ``target.resolve()`` if it stays inside ``root``,
+    otherwise raise.
+
+    This is the projection-time mirror of the DB CHECK + application
+    validator. Even if a malicious row managed to bypass both
+    earlier layers, the resolved-path check catches escape attempts.
+    """
+    real = target.resolve(strict=False)
+    real_root = root.resolve(strict=False)
+    try:
+        real.relative_to(real_root)
+    except ValueError as exc:
+        raise SkillValidationError(
+            f"projected path {real} escapes spawn root {real_root}"
+        ) from exc
+    return real
+
+
+def _materialize_one_skill(
+    skill: Skill,
+    backend: str,
+    partial_root: Path,
+    final_root: Path,
+) -> None:
+    """Build one skill into ``partial_root/<name>/`` then rename to
+    ``final_root/<name>/`` atomically.
+
+    Pre-conditions enforced at higher layers (DB CHECK + validators)
+    are re-asserted here because the projector is the last line of
+    defense before bytes hit the disk.
+    """
+    validate_skill_name(skill.name)
+    skill_partial = partial_root / skill.name
+    skill_final = final_root / skill.name
+
+    # If a previous failed projection left a stale .partial subtree,
+    # remove it first so we always start clean.
+    if skill_partial.exists() or skill_partial.is_symlink():
+        shutil.rmtree(skill_partial, ignore_errors=True)
+    skill_partial.mkdir(parents=True, exist_ok=False)
+
+    if "SKILL.md" not in skill.files:
+        raise SkillValidationError(
+            f"skill {skill.name!r} is missing SKILL.md (application invariant)"
+        )
+
+    for path, file in skill.files.items():
+        validate_skill_file_path(path)
+        target = skill_partial / path
+        # Each segment must clear the symlink check; the parent dirs
+        # are created below.
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Re-resolve and confirm stay-inside *before* writing, in
+        # case the regex was somehow widened to allow an escape.
+        _resolved_path_inside(skill_partial, target)
+        _verify_no_symlink(target.parent, skill_partial)
+
+        if path == "SKILL.md":
+            merged = merge_frontmatter_for_backend(
+                skill.frontmatter_common,
+                skill.frontmatter_backend,
+                backend,
+            )
+            content: str = serialize_skill_md(merged, file.content)
+        else:
+            content = file.content
+
+        # Atomic-per-file write inside the still-private partial dir.
+        # Even though the whole skill rename is atomic, this guards
+        # against partial flushes if the host crashes mid-projection.
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(content, encoding="utf-8")
+        os.chmod(tmp, 0o644)
+        tmp.replace(target)
+
+    # Whole-skill atomic publish. If something raised mid-loop, the
+    # partial dir is left for the orphan cleaner to remove next pass.
+    if skill_final.exists() or skill_final.is_symlink():
+        shutil.rmtree(skill_final, ignore_errors=True)
+    skill_partial.rename(skill_final)
+
+
+async def materialize_skills_for_spawn(
+    coworker: Coworker,
+    job_id: str,
+    *,
+    backend: str,
+) -> VolumeMount | None:
+    """Project a coworker's enabled skills to host disk and return a
+    read-only bind mount spec.
+
+    Returns ``None`` when the coworker has no enabled skills — saves
+    a redundant empty-directory mount and lets the caller branch
+    cleanly.
+
+    The caller is responsible for adding the returned mount to the
+    container spec and for invoking ``cleanup_spawn_skills(job_id)``
+    when the container exits (or letting the orphan cleaner sweep
+    the directory on a subsequent run).
+    """
+    if backend not in CONTAINER_TARGETS:
+        raise SkillValidationError(
+            f"unknown backend {backend!r}; "
+            f"must be one of {sorted(CONTAINER_TARGETS)}"
+        )
+
+    skills = await list_skills_for_coworker(
+        coworker.id,
+        tenant_id=coworker.tenant_id,
+        enabled_only=True,
+        with_files=True,
+    )
+    if not skills:
+        return None
+
+    build_dir = _spawn_skills_dir(job_id)
+    partial_root = build_dir / ".partial"
+    # build_dir.parent = <SPAWN_ROOT>/<job_id>; create with
+    # restrictive perms on parent so other tenants' agents (running
+    # as the same UID) can't peek at sibling spawns by guessing IDs.
+    SPAWN_ROOT.mkdir(parents=True, exist_ok=True)
+    if build_dir.parent.is_symlink() or SPAWN_ROOT.is_symlink():
+        # Tampering — refuse to operate on a path that has a symlink
+        # in any ancestor. v1 never writes symlinks, so encountering
+        # one is always wrong.
+        raise SkillValidationError(
+            f"refusing to project into spawn root with symlink ancestor: {build_dir}"
+        )
+    build_dir.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(build_dir.parent, 0o711)
+    if build_dir.is_symlink():
+        # Pre-existing symlink at the build dir is a red flag — aborts
+        # rather than silently following or unlinking, so a tampering
+        # attempt is loudly visible in logs.
+        raise SkillValidationError(
+            f"refusing to project: {build_dir} is a symlink"
+        )
+    if build_dir.exists():
+        # Stale spawn dir from a prior aborted job reusing the same
+        # job_id (extremely unlikely — job_ids carry a uuid suffix).
+        # Remove rather than leak content into the new spawn.
+        shutil.rmtree(build_dir)
+    build_dir.mkdir(parents=True, exist_ok=False)
+    partial_root.mkdir(parents=True, exist_ok=False)
+
+    for skill in skills:
+        _materialize_one_skill(skill, backend, partial_root, build_dir)
+
+    # Drop the now-empty .partial dir so the container only ever sees
+    # final skills. Empty dir → rmdir, never recursive removal here.
+    try:
+        partial_root.rmdir()
+    except OSError:
+        # Something left behind a half-projection. Leave it for the
+        # orphan cleaner; do not block the spawn — the user-facing
+        # skills are already in place.
+        logger.warning(
+            "skills .partial dir not empty after projection",
+            job_id=job_id,
+        )
+
+    container_target = CONTAINER_TARGETS[backend]
+    logger.info(
+        "Skills projected",
+        job_id=job_id,
+        backend=backend,
+        skill_count=len(skills),
+        host_path=str(build_dir),
+        container_path=container_target,
+    )
+    return VolumeMount(
+        host_path=str(build_dir),
+        container_path=container_target,
+        readonly=True,
+    )
+
+
+def cleanup_spawn_skills(job_id: str) -> None:
+    """Remove the build directory for a spawn.
+
+    Called from the container executor's cleanup path after the
+    container exits. Idempotent — missing dir is not an error.
+    """
+    spawn_dir = SPAWN_ROOT / job_id
+    if not spawn_dir.exists():
+        return
+    try:
+        shutil.rmtree(spawn_dir)
+    except OSError as exc:
+        logger.warning(
+            "Failed to remove spawn skills dir",
+            job_id=job_id,
+            path=str(spawn_dir),
+            error=str(exc),
+        )
+
+
+def cleanup_orphan_spawns(active_job_ids: set[str]) -> int:
+    """Sweep build dirs whose job_id is not in ``active_job_ids``.
+
+    Run periodically from the orchestrator (e.g. once per minute or
+    at startup). Protects against ``kill -9`` of the orchestrator
+    process: the per-spawn finalizer never ran, but the build dir
+    is still on disk. Returns the count of removed directories.
+    """
+    if not SPAWN_ROOT.exists():
+        return 0
+    removed = 0
+    for entry in SPAWN_ROOT.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.name in active_job_ids:
+            continue
+        try:
+            shutil.rmtree(entry)
+            removed += 1
+        except OSError as exc:
+            logger.warning(
+                "Failed to remove orphan spawn dir",
+                path=str(entry),
+                error=str(exc),
+            )
+    return removed

--- a/src/rolemesh/container/skill_projection.py
+++ b/src/rolemesh/container/skill_projection.py
@@ -126,10 +126,24 @@ def _materialize_one_skill(
     skill_partial = partial_root / skill.name
     skill_final = final_root / skill.name
 
-    # If a previous failed projection left a stale .partial subtree,
-    # remove it first so we always start clean.
-    if skill_partial.exists() or skill_partial.is_symlink():
-        shutil.rmtree(skill_partial, ignore_errors=True)
+    # Refuse to operate on a pre-existing symlink — same contract as
+    # the outer build_dir handling. ``shutil.rmtree(.., ignore_errors
+    # =True)`` SILENTLY DOES NOT remove a symlink (it raises "Cannot
+    # call rmtree on a symbolic link", which ignore_errors swallows),
+    # leaving the link in place; the next ``mkdir(exist_ok=False)``
+    # then explodes with FileExistsError. Aborting loudly here is
+    # both safer (tampering visible in logs) and matches the design
+    # invariant that v1 never writes symlinks.
+    if skill_partial.is_symlink():
+        raise SkillValidationError(
+            f"refusing to project skill {skill.name!r}: "
+            f"{skill_partial} is a symlink"
+        )
+    if skill_partial.exists():
+        # A prior aborted projection in this same spawn could have
+        # left a stale partial subtree (the orphan cleaner only sweeps
+        # whole spawn dirs). Remove it cleanly — no ignore_errors.
+        shutil.rmtree(skill_partial)
     skill_partial.mkdir(parents=True, exist_ok=False)
 
     if "SKILL.md" not in skill.files:
@@ -168,8 +182,16 @@ def _materialize_one_skill(
 
     # Whole-skill atomic publish. If something raised mid-loop, the
     # partial dir is left for the orphan cleaner to remove next pass.
-    if skill_final.exists() or skill_final.is_symlink():
-        shutil.rmtree(skill_final, ignore_errors=True)
+    # Same symlink-aware cleanup as above: rmtree+ignore_errors does
+    # not remove symlinks, and ``rename`` over a non-empty / symlinked
+    # target has undefined behaviour on POSIX.
+    if skill_final.is_symlink():
+        raise SkillValidationError(
+            f"refusing to publish skill {skill.name!r}: "
+            f"{skill_final} is a symlink"
+        )
+    if skill_final.exists():
+        shutil.rmtree(skill_final)
     skill_partial.rename(skill_final)
 
 
@@ -295,11 +317,19 @@ def cleanup_orphan_spawns(active_job_ids: set[str]) -> int:
     at startup). Protects against ``kill -9`` of the orchestrator
     process: the per-spawn finalizer never ran, but the build dir
     is still on disk. Returns the count of removed directories.
+
+    Materialize the directory listing before removing — POSIX
+    ``readdir`` semantics around concurrent removal are
+    implementation-defined (entries can be skipped or revisited),
+    and ``shutil.rmtree`` mid-iteration would otherwise expose us to
+    that. ``list(SPAWN_ROOT.iterdir())`` snapshots the directory
+    while it's still consistent.
     """
     if not SPAWN_ROOT.exists():
         return 0
     removed = 0
-    for entry in SPAWN_ROOT.iterdir():
+    entries = list(SPAWN_ROOT.iterdir())
+    for entry in entries:
         if not entry.is_dir():
             continue
         if entry.name in active_job_ids:

--- a/src/rolemesh/core/orchestrator_state.py
+++ b/src/rolemesh/core/orchestrator_state.py
@@ -30,7 +30,6 @@ class CoworkerConfig:
     max_concurrent: int
     role_config: dict[str, object] = field(default_factory=dict)
     tools: list[McpServerConfig] = field(default_factory=list)
-    skills: list[str] = field(default_factory=list)
     agent_role: str = "agent"
     permissions: AgentPermissions | None = None  # filled by __post_init__; always non-None after init
 

--- a/src/rolemesh/core/skills.py
+++ b/src/rolemesh/core/skills.py
@@ -1,0 +1,310 @@
+"""Skill-related domain helpers: name / path validation, frontmatter
+parsing-on-write, frontmatter merging-at-projection.
+
+The DB schema enforces the same rules at write time via CHECK
+constraints and triggers, but doing the validation in the application
+layer first gives clean 400 errors instead of relying on a generic
+``IntegrityError`` from psycopg.
+
+The three public entry points are:
+
+* ``validate_skill_name`` — applied before any insert.
+* ``validate_skill_file_path`` — applied to every file path in a
+  skill payload.
+* ``parse_inbound_skill_md`` — accepts the raw ``files["SKILL.md"]``
+  text plus optional structured ``frontmatter_common`` /
+  ``frontmatter_backend`` from the request body, returns
+  ``(frontmatter_common, frontmatter_backend, body)`` for storage.
+* ``merge_frontmatter_for_backend`` — combines stored common +
+  backend-specific frontmatter for a target backend, drops other
+  backends' keys. Used by the projector at spawn time.
+* ``serialize_skill_md`` — wraps the merged frontmatter in
+  ``---`` markers and appends body. Used by the projector.
+
+The frontmatter field allowlist is intentionally explicit: unknown
+keys are rejected so the design has to be touched whenever an SDK
+introduces a new frontmatter knob.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Allowlists
+# ---------------------------------------------------------------------------
+
+# Common: read by both runtimes.
+COMMON_FRONTMATTER_KEYS: frozenset[str] = frozenset({"name", "description"})
+
+# Claude Agent SDK accepts these per its skills documentation.
+CLAUDE_FRONTMATTER_KEYS: frozenset[str] = frozenset(
+    {
+        "argument-hint",
+        "model",
+        "allowed-tools",
+    }
+)
+
+# Pi (pi-mono) skill loader.
+PI_FRONTMATTER_KEYS: frozenset[str] = frozenset({"disable_model_invocation"})
+
+# Backend names registered in ``frontmatter_backend`` JSONB. Adding a
+# new backend means adding its name here and a matching key set above.
+KNOWN_BACKENDS: frozenset[str] = frozenset({"claude", "pi"})
+
+# All known backend-specific keys, used to reject keys-with-no-home.
+_BACKEND_KEYS_BY_NAME: dict[str, frozenset[str]] = {
+    "claude": CLAUDE_FRONTMATTER_KEYS,
+    "pi": PI_FRONTMATTER_KEYS,
+}
+
+DESCRIPTION_MIN_LENGTH = 20
+DESCRIPTION_MAX_LENGTH = 1024
+
+# Skill name regex matches the DB CHECK in pg.py — keep them in sync.
+_SKILL_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$")
+
+# Skill file path: positive whitelist. Each path segment must start
+# with [A-Za-z0-9_] and only contain [A-Za-z0-9_.\-]. The DB enforces
+# the same regex; this is the application-layer mirror.
+_SKILL_FILE_PATH_RE = re.compile(
+    r"^[A-Za-z0-9_][A-Za-z0-9_.-]*(/[A-Za-z0-9_][A-Za-z0-9_.-]*)*$"
+)
+# Defense in depth: forbid any segment that is purely dots
+# (`.`, `..`, `...`). Even if the whitelist regex above is widened
+# accidentally, this still rejects traversal segments.
+_SKILL_FILE_PATH_DOT_SEGMENT_RE = re.compile(r"(^|/)\.+($|/)")
+
+SKILL_MD_FILENAME = "SKILL.md"
+
+
+class SkillValidationError(ValueError):
+    """Domain validation error. REST handlers translate to 400."""
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+def validate_skill_name(name: str) -> None:
+    if not isinstance(name, str) or not _SKILL_NAME_RE.match(name):
+        raise SkillValidationError(
+            f"invalid skill name {name!r}: must match "
+            r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$"
+        )
+
+
+def validate_skill_file_path(path: str) -> None:
+    if not isinstance(path, str) or len(path) == 0:
+        raise SkillValidationError("skill file path must be non-empty")
+    if not _SKILL_FILE_PATH_RE.match(path):
+        raise SkillValidationError(
+            f"invalid skill file path {path!r}: each segment must start with "
+            "an alphanumeric or underscore and contain only A-Za-z0-9, _, ., -"
+        )
+    if _SKILL_FILE_PATH_DOT_SEGMENT_RE.search(path):
+        raise SkillValidationError(
+            f"invalid skill file path {path!r}: dot-only segments are forbidden"
+        )
+
+
+def _validate_description(value: object) -> str:
+    if not isinstance(value, str):
+        raise SkillValidationError("frontmatter 'description' must be a string")
+    if len(value) < DESCRIPTION_MIN_LENGTH:
+        raise SkillValidationError(
+            f"frontmatter 'description' too short ({len(value)} chars); "
+            f"minimum is {DESCRIPTION_MIN_LENGTH}"
+        )
+    if len(value) > DESCRIPTION_MAX_LENGTH:
+        raise SkillValidationError(
+            f"frontmatter 'description' too long ({len(value)} chars); "
+            f"maximum is {DESCRIPTION_MAX_LENGTH}"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing on write
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_BLOCK_RE = re.compile(
+    r"\A---\r?\n(?P<yaml>.*?)\r?\n---\r?\n?(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
+def _split_frontmatter_block(text: str) -> tuple[dict[str, Any] | None, str]:
+    """Return (parsed_frontmatter, body). If no leading ``---`` block,
+    returns (None, text).
+    """
+    m = _FRONTMATTER_BLOCK_RE.match(text)
+    if m is None:
+        return None, text
+    try:
+        parsed = yaml.safe_load(m.group("yaml"))
+    except yaml.YAMLError as exc:
+        raise SkillValidationError(f"SKILL.md frontmatter is not valid YAML: {exc}") from exc
+    if parsed is None:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        raise SkillValidationError(
+            "SKILL.md frontmatter must be a YAML mapping"
+        )
+    return parsed, m.group("body")
+
+
+def _route_frontmatter_keys(
+    raw: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    """Route an unstructured frontmatter dict into (common, backend).
+
+    Unknown keys raise SkillValidationError with the offending key.
+    """
+    common: dict[str, Any] = {}
+    backend: dict[str, dict[str, Any]] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            raise SkillValidationError(
+                f"frontmatter keys must be strings, got {type(key).__name__}"
+            )
+        if key in COMMON_FRONTMATTER_KEYS:
+            common[key] = value
+            continue
+        placed = False
+        for backend_name, allowed in _BACKEND_KEYS_BY_NAME.items():
+            if key in allowed:
+                backend.setdefault(backend_name, {})[key] = value
+                placed = True
+                break
+        if not placed:
+            raise SkillValidationError(
+                f"unknown frontmatter key {key!r}: not in common or any "
+                f"registered backend allowlist (claude/pi)"
+            )
+    return common, backend
+
+
+def parse_inbound_skill_md(
+    skill_md_text: str,
+    *,
+    frontmatter_common_override: dict[str, Any] | None = None,
+    frontmatter_backend_override: dict[str, dict[str, Any]] | None = None,
+    expected_skill_name: str,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]], str]:
+    """Parse a SKILL.md payload into separated storage form.
+
+    The returned ``(frontmatter_common, frontmatter_backend, body)``
+    triple is what the DB stores: JSONB columns for the two
+    frontmatter dicts, ``skill_files.SKILL.md.content`` for the body
+    (no leading ``---`` block).
+
+    Top-level overrides win over inline frontmatter.
+
+    Validates:
+    - YAML well-formedness
+    - All keys are in the common or a backend allowlist
+    - All known backends in ``frontmatter_backend_override`` are in KNOWN_BACKENDS
+    - ``frontmatter_common.name`` (if set) equals ``expected_skill_name``
+    - ``frontmatter_common.description`` is present and length-bounded
+    """
+    parsed_inline, body = _split_frontmatter_block(skill_md_text)
+    if parsed_inline is None:
+        common: dict[str, Any] = {}
+        backend: dict[str, dict[str, Any]] = {}
+    else:
+        common, backend = _route_frontmatter_keys(parsed_inline)
+
+    if frontmatter_common_override:
+        for k in frontmatter_common_override:
+            if k not in COMMON_FRONTMATTER_KEYS:
+                raise SkillValidationError(
+                    f"frontmatter_common override has key {k!r} which is not "
+                    "in the common allowlist"
+                )
+        common.update(frontmatter_common_override)
+
+    if frontmatter_backend_override:
+        for backend_name, fields in frontmatter_backend_override.items():
+            if backend_name not in KNOWN_BACKENDS:
+                raise SkillValidationError(
+                    f"unknown backend {backend_name!r} in frontmatter_backend; "
+                    f"must be one of {sorted(KNOWN_BACKENDS)}"
+                )
+            allowed = _BACKEND_KEYS_BY_NAME[backend_name]
+            for k in fields:
+                if k not in allowed:
+                    raise SkillValidationError(
+                        f"frontmatter_backend.{backend_name}.{k} is not in the "
+                        f"{backend_name} allowlist"
+                    )
+            backend.setdefault(backend_name, {}).update(fields)
+
+    common.setdefault("name", expected_skill_name)
+    if common.get("name") != expected_skill_name:
+        raise SkillValidationError(
+            f"frontmatter 'name' ({common['name']!r}) does not match the "
+            f"skill's name ({expected_skill_name!r})"
+        )
+
+    if "description" not in common:
+        raise SkillValidationError(
+            "frontmatter 'description' is required (in inline SKILL.md "
+            "frontmatter or in frontmatter_common)"
+        )
+    _validate_description(common["description"])
+
+    return common, backend, body
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter merging at projection time
+# ---------------------------------------------------------------------------
+
+
+def merge_frontmatter_for_backend(
+    frontmatter_common: dict[str, Any],
+    frontmatter_backend: dict[str, dict[str, Any]],
+    target_backend: str,
+) -> dict[str, Any]:
+    """Build the per-backend frontmatter to write into SKILL.md.
+
+    Keys from other backends are dropped — that's the whole point of
+    the structured storage. ``target_backend`` accepts canonical
+    backend names and the alias ``claude-code`` (which maps to
+    ``claude`` in our storage).
+    """
+    canonical = "claude" if target_backend in ("claude", "claude-code") else target_backend
+    if canonical not in KNOWN_BACKENDS:
+        raise SkillValidationError(
+            f"unknown target backend {target_backend!r}; "
+            f"must be one of {sorted(KNOWN_BACKENDS) + ['claude-code']}"
+        )
+    merged: dict[str, Any] = dict(frontmatter_common)
+    merged.update(frontmatter_backend.get(canonical, {}))
+    return merged
+
+
+def serialize_skill_md(merged_frontmatter: dict[str, Any], body: str) -> str:
+    """Emit the SKILL.md text written into the spawn directory.
+
+    Uses ``yaml.safe_dump`` with ``sort_keys=False`` to preserve the
+    field order callers care about (``name`` and ``description``
+    typically come first); the DB row stores frontmatter as JSONB so
+    we cannot rely on Python's dict insertion order surviving — but
+    when the splitter parses an inline block it does preserve order
+    via ``yaml.safe_load``'s default mapping handler.
+    """
+    yaml_text = yaml.safe_dump(
+        merged_frontmatter,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=True,
+    ).rstrip("\n")
+    return f"---\n{yaml_text}\n---\n{body}"

--- a/src/rolemesh/core/skills.py
+++ b/src/rolemesh/core/skills.py
@@ -134,8 +134,13 @@ def _validate_description(value: object) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Tolerate a BOM (﻿, common in Windows-edited UTF-8 files) and
+# any leading whitespace before the opening ``---``. Without this the
+# splitter silently treats the entire file as body and the YAML
+# frontmatter is dropped on the floor — every author who edits with a
+# tool that adds a BOM gets a confusing "description required" error.
 _FRONTMATTER_BLOCK_RE = re.compile(
-    r"\A---\r?\n(?P<yaml>.*?)\r?\n---\r?\n?(?P<body>.*)\Z",
+    r"\A﻿?[ \t\r\n]*---\r?\n(?P<yaml>.*?)\r?\n---\r?\n?(?P<body>.*)\Z",
     re.DOTALL,
 )
 
@@ -160,6 +165,18 @@ def _split_frontmatter_block(text: str) -> tuple[dict[str, Any] | None, str]:
     return parsed, m.group("body")
 
 
+# PyYAML uses YAML 1.1 by default, which interprets bare ``on``,
+# ``off``, ``yes``, ``no``, ``y``, ``n``, ``true``, ``false``, plus
+# their case variants, as booleans. A user who writes ``name: on``
+# meaning the literal string ``"on"`` gets ``True`` instead — the
+# downstream "name does not match" error is real but useless to debug.
+# Catch the common case (string-typed fields receiving a bool) and
+# point at the YAML 1.1 footgun.
+_STRING_TYPED_FRONTMATTER_KEYS: frozenset[str] = frozenset(
+    {"name", "description", "argument-hint", "model"}
+)
+
+
 def _route_frontmatter_keys(
     raw: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
@@ -173,6 +190,16 @@ def _route_frontmatter_keys(
         if not isinstance(key, str):
             raise SkillValidationError(
                 f"frontmatter keys must be strings, got {type(key).__name__}"
+            )
+        if key in _STRING_TYPED_FRONTMATTER_KEYS and isinstance(value, bool):
+            # Catch the YAML 1.1 boolean trap before routing — the
+            # downstream type errors are confusing because the source
+            # text looked like a string.
+            raise SkillValidationError(
+                f"frontmatter {key!r} parsed as boolean ({value}); YAML 1.1 "
+                f"interprets bare on/off/yes/no/true/false (case-insensitive) "
+                f"as booleans. Quote the value explicitly: "
+                f'``{key}: "your-value"``'
             )
         if key in COMMON_FRONTMATTER_KEYS:
             common[key] = value

--- a/src/rolemesh/core/types.py
+++ b/src/rolemesh/core/types.py
@@ -155,6 +155,40 @@ class Coworker:
 
 
 @dataclass
+class SkillFile:
+    """One file within a skill folder. ``path`` is POSIX-relative
+    to the skill root; ``content`` is text-only in v1.
+    """
+
+    path: str
+    content: str
+    mime_type: str = "text/plain"
+    updated_at: str = ""
+
+
+@dataclass
+class Skill:
+    """A per-coworker skill folder. ``frontmatter_common`` carries the
+    keys both backends accept (at least ``name`` and ``description``);
+    ``frontmatter_backend`` has the shape ``{"claude": {...}, "pi": {...}}``
+    for backend-specific overrides. ``files`` is keyed by relative path,
+    always contains ``SKILL.md``.
+    """
+
+    id: str
+    tenant_id: str
+    coworker_id: str
+    name: str
+    frontmatter_common: dict[str, object] = field(default_factory=dict)
+    frontmatter_backend: dict[str, dict[str, object]] = field(default_factory=dict)
+    enabled: bool = True
+    created_at: str = ""
+    updated_at: str = ""
+    created_by: str | None = None
+    files: dict[str, SkillFile] = field(default_factory=dict)
+
+
+@dataclass
 class ChannelBinding:
     """Per-coworker per-channel-type bot credentials."""
 

--- a/src/rolemesh/core/types.py
+++ b/src/rolemesh/core/types.py
@@ -140,7 +140,6 @@ class Coworker:
     agent_backend: str = "claude-code"
     system_prompt: str | None = None
     tools: list[McpServerConfig] = field(default_factory=list)
-    skills: list[str] = field(default_factory=list)
     container_config: ContainerConfig | None = None
     max_concurrent: int = 2
     status: str = "active"

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -180,7 +180,6 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
             agent_backend TEXT DEFAULT 'claude-code',
             system_prompt TEXT,
             tools JSONB DEFAULT '[]',
-            skills JSONB DEFAULT '[]',
             container_config JSONB,
             max_concurrent INT DEFAULT 2,
             status TEXT DEFAULT 'active',
@@ -201,22 +200,24 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
                 ("agent_backend", "'claude-code'"),
                 ("system_prompt", "NULL"),
                 ("tools", "'[]'::jsonb"),
-                ("skills", "'[]'::jsonb"),
             ]:
                 await conn.execute(
                     f"ALTER TABLE coworkers ADD COLUMN IF NOT EXISTS {col} "
-                    f"{'JSONB' if col in ('tools', 'skills') else 'TEXT'} DEFAULT {default}"
+                    f"{'JSONB' if col == 'tools' else 'TEXT'} DEFAULT {default}"
                 )
             await conn.execute("""
                 UPDATE coworkers SET
                     agent_backend = r.agent_backend,
                     system_prompt = r.system_prompt,
-                    tools = r.tools,
-                    skills = r.skills
+                    tools = r.tools
                 FROM roles r WHERE coworkers.role_id = r.id
             """)
             await conn.execute("ALTER TABLE coworkers DROP COLUMN role_id")
         await conn.execute("DROP TABLE IF EXISTS roles CASCADE")
+    # Drop the legacy `skills` JSONB column on existing dev databases.
+    # The skill system is moving to dedicated `skills` / `skill_files` tables;
+    # the old per-coworker JSONB list was never consumed by the runner.
+    await conn.execute("ALTER TABLE coworkers DROP COLUMN IF EXISTS skills")
     # --- Auth: add agent_role + permissions to coworkers ---
     await conn.execute(
         "ALTER TABLE coworkers ADD COLUMN IF NOT EXISTS agent_role TEXT DEFAULT 'agent'"
@@ -1623,7 +1624,6 @@ async def create_coworker(
     agent_backend: str = "claude-code",
     system_prompt: str | None = None,
     tools: list[McpServerConfig] | None = None,
-    skills: list[str] | None = None,
     container_config: ContainerConfig | None = None,
     max_concurrent: int = 2,
     agent_role: str = "agent",
@@ -1646,8 +1646,8 @@ async def create_coworker(
         row = await conn.fetchrow(
             """
             INSERT INTO coworkers (tenant_id, name, folder, agent_backend, system_prompt,
-                tools, skills, container_config, max_concurrent, agent_role, permissions)
-            VALUES ($1::uuid, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9, $10, $11::jsonb)
+                tools, container_config, max_concurrent, agent_role, permissions)
+            VALUES ($1::uuid, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $10::jsonb)
             RETURNING *
             """,
             tenant_id,
@@ -1670,7 +1670,6 @@ async def create_coworker(
                 if tools
                 else []
             ),
-            json.dumps(skills or []),
             cc_json,
             max_concurrent,
             agent_role,
@@ -1707,7 +1706,6 @@ def _record_to_coworker(row: asyncpg.Record) -> Coworker:
                 )
             )
         # Skip legacy string entries silently
-    skills_raw = row.get("skills")
 
     # Parse agent_role and permissions (new auth fields)
     agent_role = row.get("agent_role") or "agent"
@@ -1726,7 +1724,6 @@ def _record_to_coworker(row: asyncpg.Record) -> Coworker:
         agent_backend=row.get("agent_backend") or "claude-code",
         system_prompt=row.get("system_prompt"),
         tools=tools,
-        skills=skills_raw if isinstance(skills_raw, list) else json.loads(skills_raw) if skills_raw else [],
         container_config=_parse_container_config(row["container_config"]),
         max_concurrent=row["max_concurrent"],
         status=row["status"] or "active",
@@ -1789,7 +1786,6 @@ async def update_coworker(
     name: str | None = None,
     system_prompt: str | None = None,
     tools: list[McpServerConfig] | None = None,
-    skills: list[str] | None = None,
     max_concurrent: int | None = None,
     status: str | None = None,
     agent_role: str | None = None,
@@ -1825,10 +1821,6 @@ async def update_coworker(
                 ]
             )
         )
-        param_idx += 1
-    if skills is not None:
-        fields.append(f"skills = ${param_idx}::jsonb")
-        values.append(json.dumps(skills))
         param_idx += 1
     if max_concurrent is not None:
         fields.append(f"max_concurrent = ${param_idx}")

--- a/src/rolemesh/db/pg.py
+++ b/src/rolemesh/db/pg.py
@@ -25,6 +25,8 @@ from rolemesh.core.types import (
     NewMessage,
     RegisteredGroup,
     ScheduledTask,
+    Skill,
+    SkillFile,
     TaskRunLog,
     Tenant,
     User,
@@ -256,6 +258,85 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     """)
     await conn.execute("CREATE INDEX IF NOT EXISTS idx_uaa_user ON user_agent_assignments(user_id)")
     await conn.execute("CREATE INDEX IF NOT EXISTS idx_uaa_coworker ON user_agent_assignments(coworker_id)")
+
+    # Skills: per-coworker capability folders. SKILL.md (frontmatter +
+    # body) lives in the row keyed by ``path = 'SKILL.md'`` in
+    # ``skill_files``. Frontmatter is split between common (carries
+    # name/description for both runtimes) and backend-specific
+    # (Claude SDK or Pi loader). See docs/skills-architecture.md.
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS skills (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+            coworker_id UUID NOT NULL REFERENCES coworkers(id) ON DELETE CASCADE,
+            name TEXT NOT NULL CHECK (name ~ '^[a-zA-Z][a-zA-Z0-9_-]{0,63}$'),
+            frontmatter_common JSONB NOT NULL DEFAULT '{}',
+            frontmatter_backend JSONB NOT NULL DEFAULT '{}',
+            enabled BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+            UNIQUE (coworker_id, name)
+        )
+    """)
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_skills_coworker ON skills(coworker_id, enabled)"
+    )
+
+    # skill_files holds the file tree. Path validation: positive
+    # whitelist (each segment alphanumeric-led, only [A-Za-z0-9_.-]),
+    # plus a defense-in-depth regex that rejects any segment that is
+    # purely dots. The application-layer validator in
+    # rolemesh.core.skills mirrors these rules. Raw triple-quoted
+    # string keeps PG-side regex escapes (``\.``) intact without
+    # triggering Python SyntaxWarnings.
+    await conn.execute(r"""
+        CREATE TABLE IF NOT EXISTS skill_files (
+            skill_id UUID NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+            path TEXT NOT NULL CHECK (length(path) > 0
+                AND path ~ '^[A-Za-z0-9_][A-Za-z0-9_.-]*(/[A-Za-z0-9_][A-Za-z0-9_.-]*)*$'
+                AND path !~ '(^|/)\.+($|/)'),
+            content TEXT NOT NULL,
+            mime_type TEXT NOT NULL DEFAULT 'text/plain',
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (skill_id, path)
+        )
+    """)
+
+    # SECURITY DEFINER trigger: prevents writing a skill whose
+    # ``coworker_id`` belongs to a different tenant than its own
+    # ``tenant_id``. Without DEFINER, the trigger would run RLS-bound
+    # on coworkers and would not be able to see a foreign tenant's
+    # coworker (cw_tenant comes back NULL), missing the attack.
+    # ``IS DISTINCT FROM`` handles NULL safely either way.
+    await conn.execute("""
+        CREATE OR REPLACE FUNCTION skills_check_coworker_tenant()
+        RETURNS TRIGGER
+        SECURITY DEFINER
+        SET search_path = pg_catalog, public
+        LANGUAGE plpgsql AS $func$
+        DECLARE
+            cw_tenant UUID;
+        BEGIN
+            SELECT tenant_id INTO cw_tenant FROM coworkers WHERE id = NEW.coworker_id;
+            IF cw_tenant IS DISTINCT FROM NEW.tenant_id THEN
+                RAISE EXCEPTION
+                    'skills.coworker_id % belongs to a different tenant '
+                    '(or does not exist)', NEW.coworker_id;
+            END IF;
+            RETURN NEW;
+        END
+        $func$;
+    """)
+    await conn.execute(
+        "DROP TRIGGER IF EXISTS trg_skills_check_coworker_tenant ON skills"
+    )
+    await conn.execute("""
+        CREATE TRIGGER trg_skills_check_coworker_tenant
+            BEFORE INSERT OR UPDATE OF coworker_id, tenant_id ON skills
+            FOR EACH ROW EXECUTE FUNCTION skills_check_coworker_tenant();
+    """)
+
     # Password hash for future builtin auth
     await conn.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash TEXT")
 
@@ -1024,6 +1105,39 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "user_agent_assignments")
     await _enable_rls_on(conn, "users")                # D9
     await _enable_rls_on(conn, "oidc_user_tokens")     # D10 (tenant_id backfilled above)
+    await _enable_rls_on(conn, "skills")               # skills feature: standard tenant_id scope
+    await _enable_rls_on_transitive_skill_files(conn)
+
+
+async def _enable_rls_on_transitive_skill_files(
+    conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record],
+) -> None:
+    """RLS for ``skill_files`` keyed transitively through the parent ``skills`` row.
+
+    ``skill_files`` does not carry its own ``tenant_id`` — its parent
+    ``skills`` row does. The EXISTS subquery is itself RLS-bound on
+    ``skills``, so a tenant A session looking up a tenant B
+    skill_file sees zero matches and the row is hidden / write
+    rejected. See docs/skills-architecture.md "RLS" section for the
+    rationale on not denormalizing tenant_id onto this table.
+    """
+    table = "skill_files"
+    await conn.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+    await conn.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
+    parent_check = (
+        "EXISTS (SELECT 1 FROM skills "
+        "WHERE skills.id = skill_files.skill_id "
+        "AND skills.tenant_id = current_tenant_id())"
+    )
+    for op, body in (
+        ("SELECT", f"USING ({parent_check})"),
+        ("INSERT", f"WITH CHECK ({parent_check})"),
+        ("UPDATE", f"USING ({parent_check}) WITH CHECK ({parent_check})"),
+        ("DELETE", f"USING ({parent_check})"),
+    ):
+        policy = f"rls_{op.lower()}"
+        await conn.execute(f"DROP POLICY IF EXISTS {policy} ON {table}")
+        await conn.execute(f"CREATE POLICY {policy} ON {table} FOR {op} {body}")
 
 
 async def _enable_rls_on(
@@ -1115,6 +1229,8 @@ async def _init_test_database(
         await conn.execute("DROP TABLE IF EXISTS approval_policies CASCADE")
         await conn.execute("DROP TABLE IF EXISTS oidc_user_tokens CASCADE")
         await conn.execute("DROP TABLE IF EXISTS external_tenant_map CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS skill_files CASCADE")
+        await conn.execute("DROP TABLE IF EXISTS skills CASCADE")
         await conn.execute("DROP TABLE IF EXISTS user_agent_assignments CASCADE")
         await conn.execute("DROP TABLE IF EXISTS task_run_logs CASCADE")
         await conn.execute("DROP TABLE IF EXISTS messages CASCADE")
@@ -4376,3 +4492,379 @@ async def list_safety_decisions(
             }
         )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Skills (per-coworker capability folders)
+# ---------------------------------------------------------------------------
+
+
+def _record_to_skill(row: asyncpg.Record, files: list[SkillFile] | None = None) -> Skill:
+    """Build a ``Skill`` dataclass from a ``skills`` row.
+
+    ``files`` is optional — set it when the caller has already
+    fetched ``skill_files`` for this skill. Otherwise the dataclass
+    has an empty ``files`` map; callers that only need metadata can
+    skip the second query.
+    """
+    fc_raw = row["frontmatter_common"]
+    fb_raw = row["frontmatter_backend"]
+    fc = json.loads(fc_raw) if isinstance(fc_raw, str) else (fc_raw or {})
+    fb = json.loads(fb_raw) if isinstance(fb_raw, str) else (fb_raw or {})
+    return Skill(
+        id=str(row["id"]),
+        tenant_id=str(row["tenant_id"]),
+        coworker_id=str(row["coworker_id"]),
+        name=row["name"],
+        frontmatter_common=fc,
+        frontmatter_backend=fb,
+        enabled=bool(row["enabled"]),
+        created_at=row["created_at"].isoformat() if row["created_at"] else "",
+        updated_at=row["updated_at"].isoformat() if row["updated_at"] else "",
+        created_by=str(row["created_by"]) if row["created_by"] else None,
+        files={f.path: f for f in (files or [])},
+    )
+
+
+def _record_to_skill_file(row: asyncpg.Record) -> SkillFile:
+    return SkillFile(
+        path=row["path"],
+        content=row["content"],
+        mime_type=row["mime_type"],
+        updated_at=row["updated_at"].isoformat() if row["updated_at"] else "",
+    )
+
+
+async def create_skill(
+    *,
+    tenant_id: str,
+    coworker_id: str,
+    name: str,
+    frontmatter_common: dict[str, Any],
+    frontmatter_backend: dict[str, dict[str, Any]],
+    files: dict[str, SkillFile],
+    enabled: bool = True,
+    created_by: str | None = None,
+) -> Skill:
+    """Create a skill plus its files in a single transaction.
+
+    Caller is expected to have run the frontmatter splitter and
+    ``validate_skill_*`` helpers from ``rolemesh.core.skills``
+    already; the DB CHECK constraints and SECURITY DEFINER trigger
+    are the second line of defense.
+
+    The ``files`` map must contain ``SKILL.md`` (the application
+    invariant). The DB does not enforce this directly because we
+    cannot express "every skill has a row with path = 'SKILL.md'"
+    as a single CHECK; the application enforces it on every write.
+    """
+    if "SKILL.md" not in files:
+        raise ValueError("skill files must contain SKILL.md")
+    fc_json = json.dumps(frontmatter_common)
+    fb_json = json.dumps(frontmatter_backend)
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO skills (tenant_id, coworker_id, name,
+                                frontmatter_common, frontmatter_backend,
+                                enabled, created_by)
+            VALUES ($1::uuid, $2::uuid, $3, $4::jsonb, $5::jsonb, $6,
+                    $7::uuid)
+            RETURNING *
+            """,
+            tenant_id,
+            coworker_id,
+            name,
+            fc_json,
+            fb_json,
+            enabled,
+            created_by,
+        )
+        assert row is not None
+        skill_id = row["id"]
+        # Insert all files in a single batch
+        await conn.executemany(
+            """
+            INSERT INTO skill_files (skill_id, path, content, mime_type)
+            VALUES ($1::uuid, $2, $3, $4)
+            """,
+            [
+                (skill_id, f.path, f.content, f.mime_type)
+                for f in files.values()
+            ],
+        )
+        # Fetch back files (canonical updated_at from server clock)
+        file_rows = await conn.fetch(
+            "SELECT * FROM skill_files WHERE skill_id = $1::uuid ORDER BY path",
+            skill_id,
+        )
+    return _record_to_skill(row, [_record_to_skill_file(r) for r in file_rows])
+
+
+async def get_skill(
+    skill_id: str, *, tenant_id: str, with_files: bool = True
+) -> Skill | None:
+    """Fetch a skill by id, scoped to ``tenant_id``.
+
+    The explicit ``AND tenant_id`` is the application-layer defense
+    in depth alongside RLS, matching the convention used elsewhere
+    in this module (see ``get_coworker``).
+    """
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM skills WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            skill_id,
+            tenant_id,
+        )
+        if row is None:
+            return None
+        files: list[SkillFile] = []
+        if with_files:
+            file_rows = await conn.fetch(
+                "SELECT * FROM skill_files WHERE skill_id = $1::uuid ORDER BY path",
+                skill_id,
+            )
+            files = [_record_to_skill_file(r) for r in file_rows]
+    return _record_to_skill(row, files)
+
+
+async def list_skills_for_coworker(
+    coworker_id: str,
+    *,
+    tenant_id: str,
+    enabled_only: bool = False,
+    with_files: bool = False,
+) -> list[Skill]:
+    """List all skills for a coworker.
+
+    ``enabled_only`` filters to projection-eligible skills (used by
+    the orchestrator at spawn time). ``with_files`` controls whether
+    the ``files`` map is populated — admin REST list responses skip
+    file content; the projector needs it.
+    """
+    async with tenant_conn(tenant_id) as conn:
+        if enabled_only:
+            rows = await conn.fetch(
+                "SELECT * FROM skills WHERE coworker_id = $1::uuid "
+                "AND tenant_id = $2::uuid AND enabled = TRUE ORDER BY name",
+                coworker_id,
+                tenant_id,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT * FROM skills WHERE coworker_id = $1::uuid "
+                "AND tenant_id = $2::uuid ORDER BY name",
+                coworker_id,
+                tenant_id,
+            )
+        result: list[Skill] = []
+        if with_files and rows:
+            ids = [r["id"] for r in rows]
+            file_rows = await conn.fetch(
+                "SELECT * FROM skill_files WHERE skill_id = ANY($1::uuid[]) "
+                "ORDER BY skill_id, path",
+                ids,
+            )
+            files_by_skill: dict[str, list[SkillFile]] = {}
+            for fr in file_rows:
+                files_by_skill.setdefault(str(fr["skill_id"]), []).append(
+                    _record_to_skill_file(fr)
+                )
+            for r in rows:
+                result.append(
+                    _record_to_skill(r, files_by_skill.get(str(r["id"]), []))
+                )
+        else:
+            for r in rows:
+                result.append(_record_to_skill(r))
+    return result
+
+
+async def update_skill(
+    skill_id: str,
+    *,
+    tenant_id: str,
+    frontmatter_common: dict[str, Any] | None = None,
+    frontmatter_backend: dict[str, dict[str, Any]] | None = None,
+    enabled: bool | None = None,
+    files: dict[str, SkillFile] | None = None,
+) -> Skill | None:
+    """Update a skill's frontmatter, enabled flag, and/or files.
+
+    Files semantics: if ``files`` is provided, it is treated as a
+    full replacement of the skill's file set. SKILL.md must be
+    present in the new map. Use ``set_skill_file`` /
+    ``delete_skill_file`` for surgical edits.
+    """
+    fields: list[str] = []
+    values: list[Any] = []
+    param_idx = 1
+    if frontmatter_common is not None:
+        fields.append(f"frontmatter_common = ${param_idx}::jsonb")
+        values.append(json.dumps(frontmatter_common))
+        param_idx += 1
+    if frontmatter_backend is not None:
+        fields.append(f"frontmatter_backend = ${param_idx}::jsonb")
+        values.append(json.dumps(frontmatter_backend))
+        param_idx += 1
+    if enabled is not None:
+        fields.append(f"enabled = ${param_idx}")
+        values.append(enabled)
+        param_idx += 1
+
+    if files is not None and "SKILL.md" not in files:
+        raise ValueError("skill files must contain SKILL.md")
+
+    async with tenant_conn(tenant_id) as conn:
+        if fields:
+            fields.append("updated_at = now()")
+            values.append(skill_id)
+            tenant_param = param_idx + 1
+            values.append(tenant_id)
+            sql = (
+                f"UPDATE skills SET {', '.join(fields)} "
+                f"WHERE id = ${param_idx}::uuid AND tenant_id = ${tenant_param}::uuid "
+                f"RETURNING *"
+            )
+            row = await conn.fetchrow(sql, *values)
+        else:
+            row = await conn.fetchrow(
+                "SELECT * FROM skills WHERE id = $1::uuid "
+                "AND tenant_id = $2::uuid",
+                skill_id,
+                tenant_id,
+            )
+        if row is None:
+            return None
+        if files is not None:
+            await conn.execute(
+                "DELETE FROM skill_files WHERE skill_id = $1::uuid", skill_id
+            )
+            await conn.executemany(
+                """
+                INSERT INTO skill_files (skill_id, path, content, mime_type)
+                VALUES ($1::uuid, $2, $3, $4)
+                """,
+                [
+                    (skill_id, f.path, f.content, f.mime_type)
+                    for f in files.values()
+                ],
+            )
+            # Touch updated_at so list views reflect file changes too,
+            # even if no metadata fields changed.
+            row = await conn.fetchrow(
+                "UPDATE skills SET updated_at = now() WHERE id = $1::uuid "
+                "AND tenant_id = $2::uuid RETURNING *",
+                skill_id,
+                tenant_id,
+            )
+            assert row is not None
+        file_rows = await conn.fetch(
+            "SELECT * FROM skill_files WHERE skill_id = $1::uuid ORDER BY path",
+            skill_id,
+        )
+    return _record_to_skill(row, [_record_to_skill_file(r) for r in file_rows])
+
+
+async def delete_skill(skill_id: str, *, tenant_id: str) -> bool:
+    """Hard-delete a skill (cascades to skill_files). Returns True if a
+    row was actually deleted, False if the skill did not exist for this
+    tenant.
+    """
+    async with tenant_conn(tenant_id) as conn:
+        result = await conn.execute(
+            "DELETE FROM skills WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            skill_id,
+            tenant_id,
+        )
+    # asyncpg returns "DELETE n" — parse the count
+    return result.endswith(" 1")
+
+
+async def set_skill_file(
+    skill_id: str,
+    path: str,
+    *,
+    tenant_id: str,
+    content: str,
+    mime_type: str = "text/plain",
+) -> SkillFile | None:
+    """Upsert a single file in a skill. Returns the new ``SkillFile`` or
+    ``None`` if the parent skill does not belong to ``tenant_id``.
+
+    The application-layer SKILL.md invariant is enforced by the REST
+    layer, not here — so callers can use this for both fresh adds and
+    edits. The DB's CHECK on ``path`` rejects traversal.
+    """
+    async with tenant_conn(tenant_id) as conn:
+        # Verify the parent skill belongs to this tenant before inserting.
+        # Explicit AND tenant_id is the application-layer mirror of the
+        # RLS policy — the test pool runs as superuser and bypasses RLS,
+        # so without this clause cross-tenant attempts would slip through
+        # in tests even though they're blocked in production.
+        exists = await conn.fetchval(
+            "SELECT 1 FROM skills WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            skill_id,
+            tenant_id,
+        )
+        if not exists:
+            return None
+        row = await conn.fetchrow(
+            """
+            INSERT INTO skill_files (skill_id, path, content, mime_type)
+            VALUES ($1::uuid, $2, $3, $4)
+            ON CONFLICT (skill_id, path) DO UPDATE
+                SET content = EXCLUDED.content,
+                    mime_type = EXCLUDED.mime_type,
+                    updated_at = now()
+            RETURNING *
+            """,
+            skill_id,
+            path,
+            content,
+            mime_type,
+        )
+        await conn.execute(
+            "UPDATE skills SET updated_at = now() WHERE id = $1::uuid "
+            "AND tenant_id = $2::uuid",
+            skill_id,
+            tenant_id,
+        )
+    assert row is not None
+    return _record_to_skill_file(row)
+
+
+async def delete_skill_file(
+    skill_id: str, path: str, *, tenant_id: str
+) -> bool:
+    """Remove a single file from a skill.
+
+    Refuses to delete ``SKILL.md`` — that is the application-layer
+    invariant. Returns True if a row was actually deleted.
+    """
+    if path == "SKILL.md":
+        raise ValueError("SKILL.md cannot be deleted from a skill")
+    async with tenant_conn(tenant_id) as conn:
+        # Defense in depth: verify the parent skill belongs to this
+        # tenant before deleting (the EXISTS subquery on skills carries
+        # the tenant_id check). RLS on skill_files would reject a
+        # cross-tenant delete in production, but the test pool runs as
+        # superuser — explicit AND tenant_id closes that gap.
+        result = await conn.execute(
+            "DELETE FROM skill_files USING skills "
+            "WHERE skill_files.skill_id = $1::uuid AND skill_files.path = $2 "
+            "AND skills.id = skill_files.skill_id "
+            "AND skills.tenant_id = $3::uuid",
+            skill_id,
+            path,
+            tenant_id,
+        )
+        if result.endswith(" 1"):
+            await conn.execute(
+                "UPDATE skills SET updated_at = now() WHERE id = $1::uuid "
+                "AND tenant_id = $2::uuid",
+                skill_id,
+                tenant_id,
+            )
+            return True
+    return False

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -208,7 +208,6 @@ def _coworker_from_state(cw_state: CoworkerState) -> Coworker:
         agent_backend=c.agent_backend,
         system_prompt=c.system_prompt,
         tools=c.tools,
-        skills=c.skills,
         max_concurrent=c.max_concurrent,
     )
 
@@ -420,7 +419,6 @@ async def _load_state() -> None:
             container_image=None,
             max_concurrent=cw.max_concurrent,
             tools=cw.tools,
-            skills=cw.skills,
             agent_role=cw.agent_role,
             permissions=cw.permissions,
         )

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid as _uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Annotated
 
@@ -1658,6 +1659,12 @@ async def create_skill(
         content=body_text,
         mime_type=files["SKILL.md"].mime_type or "text/markdown",
     )
+    # Bootstrap admin has user_id="bootstrap" (not a real UUID).
+    # Store NULL in created_by rather than letting asyncpg blow up.
+    try:
+        created_by_uuid: str | None = str(_uuid.UUID(user.user_id))
+    except (ValueError, AttributeError):
+        created_by_uuid = None
     try:
         skill = await pg.create_skill(
             tenant_id=user.tenant_id,
@@ -1667,7 +1674,7 @@ async def create_skill(
             frontmatter_backend=backend,
             files=files,
             enabled=body.enabled,
-            created_by=user.user_id,
+            created_by=created_by_uuid,
         )
     except asyncpg.UniqueViolationError as exc:
         raise HTTPException(

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -13,7 +13,13 @@ from rolemesh.approval.engine import ApprovalEngine, ConflictError, ForbiddenErr
 from rolemesh.auth.permissions import AgentPermissions
 from rolemesh.auth.provider import AuthenticatedUser
 from rolemesh.core.group_folder import is_valid_group_folder
-from rolemesh.core.types import McpServerConfig
+from rolemesh.core.skills import (
+    SkillValidationError,
+    parse_inbound_skill_md,
+    validate_skill_file_path,
+    validate_skill_name,
+)
+from rolemesh.core.types import McpServerConfig, SkillFile
 from rolemesh.db import pg
 from webui.dependencies import (
     get_current_user,
@@ -43,6 +49,12 @@ from webui.schemas import (
     SafetyRuleCreate,
     SafetyRuleResponse,
     SafetyRuleUpdate,
+    SkillCreate,
+    SkillFileInPayload,
+    SkillFileUpdate,
+    SkillResponse,
+    SkillSummary,
+    SkillUpdate,
     TaskResponse,
     TenantResponse,
     TenantUpdate,
@@ -56,7 +68,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from rolemesh.approval.types import ApprovalAuditEntry, ApprovalPolicy, ApprovalRequest
-    from rolemesh.core.types import ChannelBinding, Conversation, Coworker, ScheduledTask, Tenant, User
+    from rolemesh.core.types import ChannelBinding, Conversation, Coworker, ScheduledTask, Skill, Tenant, User
     from rolemesh.safety.types import Rule as SafetyRule
 
 # Annotated dependency types (avoids B008 lint warnings)
@@ -211,7 +223,6 @@ def _coworker_to_response(cw: Coworker) -> AgentResponse:
             }
             for t in cw.tools
         ],
-        skills=cw.skills,
         max_concurrent=cw.max_concurrent,
         status=cw.status,
         agent_role=cw.agent_role,
@@ -448,7 +459,6 @@ async def create_agent(
             agent_backend=body.agent_backend,
             system_prompt=body.system_prompt,
             tools=tools,
-            skills=body.skills or None,
             max_concurrent=body.max_concurrent,
             agent_role=body.agent_role,
             permissions=permissions,
@@ -493,7 +503,6 @@ async def update_agent(
         name=body.name,
         system_prompt=body.system_prompt,
         tools=tools,
-        skills=body.skills,
         max_concurrent=body.max_concurrent,
         status=body.status,
         agent_role=body.agent_role,
@@ -1546,3 +1555,298 @@ async def export_safety_decisions_csv(
             "Content-Disposition": f'attachment; filename="{filename}"',
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# Skills (per-coworker capability folders)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_files(
+    files_in: dict[str, str | SkillFileInPayload],
+) -> dict[str, SkillFile]:
+    """Accept either ``{path: content_str}`` or ``{path: {content, mime_type}}``
+    and return a uniform ``dict[path, SkillFile]``.
+    """
+    out: dict[str, SkillFile] = {}
+    for path, value in files_in.items():
+        validate_skill_file_path(path)
+        if isinstance(value, str):
+            out[path] = SkillFile(path=path, content=value)
+        else:
+            out[path] = SkillFile(
+                path=path, content=value.content, mime_type=value.mime_type
+            )
+    return out
+
+
+def _skill_to_response(s: Skill) -> SkillResponse:
+    return SkillResponse(
+        id=s.id,
+        coworker_id=s.coworker_id,
+        name=s.name,
+        frontmatter_common=s.frontmatter_common,
+        frontmatter_backend=s.frontmatter_backend,
+        enabled=s.enabled,
+        created_at=s.created_at,
+        updated_at=s.updated_at,
+        created_by=s.created_by,
+        files={
+            p: SkillFileInPayload(content=f.content, mime_type=f.mime_type)
+            for p, f in s.files.items()
+        },
+    )
+
+
+def _skill_to_summary(s: Skill) -> SkillSummary:
+    desc_raw = s.frontmatter_common.get("description", "")
+    description = desc_raw if isinstance(desc_raw, str) else ""
+    return SkillSummary(
+        id=s.id,
+        coworker_id=s.coworker_id,
+        name=s.name,
+        description=description,
+        enabled=s.enabled,
+        created_at=s.created_at,
+        updated_at=s.updated_at,
+    )
+
+
+@router.get(
+    "/agents/{agent_id}/skills",
+    response_model=list[SkillSummary],
+)
+async def list_skills(
+    agent_id: str,
+    user: AdminUser,
+) -> list[SkillSummary]:
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    skills = await pg.list_skills_for_coworker(
+        agent_id, tenant_id=user.tenant_id, enabled_only=False, with_files=False,
+    )
+    return [_skill_to_summary(s) for s in skills]
+
+
+@router.post(
+    "/agents/{agent_id}/skills",
+    response_model=SkillResponse,
+    status_code=201,
+)
+async def create_skill(
+    agent_id: str,
+    body: SkillCreate,
+    user: AdminUser,
+) -> SkillResponse:
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    try:
+        validate_skill_name(body.name)
+        files = _normalize_files(body.files)
+        if "SKILL.md" not in files:
+            raise SkillValidationError("payload must include SKILL.md in 'files'")
+        common, backend, body_text = parse_inbound_skill_md(
+            files["SKILL.md"].content,
+            frontmatter_common_override=body.frontmatter_common,
+            frontmatter_backend_override=body.frontmatter_backend,
+            expected_skill_name=body.name,
+        )
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # Replace SKILL.md content with the body-only form so the splitter
+    # round-trips cleanly: frontmatter lives in the JSONB columns.
+    files["SKILL.md"] = SkillFile(
+        path="SKILL.md",
+        content=body_text,
+        mime_type=files["SKILL.md"].mime_type or "text/markdown",
+    )
+    try:
+        skill = await pg.create_skill(
+            tenant_id=user.tenant_id,
+            coworker_id=agent_id,
+            name=body.name,
+            frontmatter_common=common,
+            frontmatter_backend=backend,
+            files=files,
+            enabled=body.enabled,
+            created_by=user.user_id,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Skill with name {body.name!r} already exists on this agent",
+        ) from exc
+    except asyncpg.CheckViolationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _skill_to_response(skill)
+
+
+@router.get(
+    "/agents/{agent_id}/skills/{skill_id}",
+    response_model=SkillResponse,
+)
+async def get_skill_detail(
+    agent_id: str,
+    skill_id: str,
+    user: AdminUser,
+) -> SkillResponse:
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    skill = await pg.get_skill(skill_id, tenant_id=user.tenant_id)
+    if skill is None or skill.coworker_id != agent_id:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    return _skill_to_response(skill)
+
+
+@router.patch(
+    "/agents/{agent_id}/skills/{skill_id}",
+    response_model=SkillResponse,
+)
+async def update_skill(
+    agent_id: str,
+    skill_id: str,
+    body: SkillUpdate,
+    user: AdminUser,
+) -> SkillResponse:
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    existing = await pg.get_skill(skill_id, tenant_id=user.tenant_id)
+    if existing is None or existing.coworker_id != agent_id:
+        raise HTTPException(status_code=404, detail="Skill not found")
+
+    files: dict[str, SkillFile] | None = None
+    common: dict[str, object] | None = None
+    backend: dict[str, dict[str, object]] | None = None
+    try:
+        if body.files is not None:
+            files = _normalize_files(body.files)
+            if "SKILL.md" not in files:
+                raise SkillValidationError("'files' must include SKILL.md")
+            # Re-parse SKILL.md frontmatter (overrides applied on top).
+            parsed_common, parsed_backend, body_text = parse_inbound_skill_md(
+                files["SKILL.md"].content,
+                frontmatter_common_override=body.frontmatter_common,
+                frontmatter_backend_override=body.frontmatter_backend,
+                expected_skill_name=existing.name,
+            )
+            common, backend = parsed_common, parsed_backend
+            files["SKILL.md"] = SkillFile(
+                path="SKILL.md",
+                content=body_text,
+                mime_type=files["SKILL.md"].mime_type or "text/markdown",
+            )
+        elif body.frontmatter_common is not None or body.frontmatter_backend is not None:
+            # Frontmatter-only update: re-validate against existing
+            # body so description bounds stay consistent. Pull body
+            # text from the stored SKILL.md row to feed the splitter.
+            current_md = existing.files.get("SKILL.md")
+            current_body = current_md.content if current_md else ""
+            parsed_common, parsed_backend, _ = parse_inbound_skill_md(
+                current_body,
+                frontmatter_common_override=(
+                    {**existing.frontmatter_common, **(body.frontmatter_common or {})}
+                ),
+                frontmatter_backend_override=body.frontmatter_backend
+                or existing.frontmatter_backend,
+                expected_skill_name=existing.name,
+            )
+            common, backend = parsed_common, parsed_backend
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        updated = await pg.update_skill(
+            skill_id,
+            tenant_id=user.tenant_id,
+            frontmatter_common=common,
+            frontmatter_backend=backend,
+            enabled=body.enabled,
+            files=files,
+        )
+    except asyncpg.CheckViolationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    return _skill_to_response(updated)
+
+
+@router.delete(
+    "/agents/{agent_id}/skills/{skill_id}",
+    status_code=204,
+)
+async def delete_skill(
+    agent_id: str,
+    skill_id: str,
+    user: AdminUser,
+) -> None:
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    skill = await pg.get_skill(skill_id, tenant_id=user.tenant_id, with_files=False)
+    if skill is None or skill.coworker_id != agent_id:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    await pg.delete_skill(skill_id, tenant_id=user.tenant_id)
+
+
+@router.patch(
+    "/agents/{agent_id}/skills/{skill_id}/files/{path:path}",
+    response_model=SkillResponse,
+)
+async def update_skill_file(
+    agent_id: str,
+    skill_id: str,
+    path: str,
+    body: SkillFileUpdate,
+    user: AdminUser,
+) -> SkillResponse:
+    """Upsert a single file in a skill. ``path`` is path-encoded so
+    ``scripts/helper.py`` works as a URL segment.
+    """
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    skill = await pg.get_skill(skill_id, tenant_id=user.tenant_id, with_files=False)
+    if skill is None or skill.coworker_id != agent_id:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    try:
+        validate_skill_file_path(path)
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
+        result = await pg.set_skill_file(
+            skill_id,
+            path,
+            tenant_id=user.tenant_id,
+            content=body.content,
+            mime_type=body.mime_type,
+        )
+    except asyncpg.CheckViolationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if result is None:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    refreshed = await pg.get_skill(skill_id, tenant_id=user.tenant_id)
+    assert refreshed is not None
+    return _skill_to_response(refreshed)
+
+
+@router.delete(
+    "/agents/{agent_id}/skills/{skill_id}/files/{path:path}",
+    status_code=204,
+)
+async def delete_skill_file(
+    agent_id: str,
+    skill_id: str,
+    path: str,
+    user: AdminUser,
+) -> None:
+    """Remove a single file from a skill. SKILL.md is rejected to
+    enforce the application invariant.
+    """
+    await _get_agent_or_404(agent_id, user.tenant_id)
+    skill = await pg.get_skill(skill_id, tenant_id=user.tenant_id, with_files=False)
+    if skill is None or skill.coworker_id != agent_id:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    if path == "SKILL.md":
+        raise HTTPException(
+            status_code=400,
+            detail="SKILL.md cannot be deleted; delete the whole skill or update it",
+        )
+    try:
+        validate_skill_file_path(path)
+    except SkillValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    deleted = await pg.delete_skill_file(skill_id, path, tenant_id=user.tenant_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="File not found in skill")

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -1744,13 +1744,28 @@ async def update_skill(
             # text from the stored SKILL.md row to feed the splitter.
             current_md = existing.files.get("SKILL.md")
             current_body = current_md.content if current_md else ""
+            # Important: ``A or B`` treats an explicitly-empty dict as
+            # "not provided" because ``{}`` is falsy. Use ``is not None``
+            # so a caller can clear all backend overrides by sending
+            # ``frontmatter_backend: {}`` rather than silently keeping
+            # the existing dict. Same applies to common.
+            common_override = (
+                body.frontmatter_common
+                if body.frontmatter_common is not None
+                else {}
+            )
+            backend_override = (
+                body.frontmatter_backend
+                if body.frontmatter_backend is not None
+                else existing.frontmatter_backend
+            )
             parsed_common, parsed_backend, _ = parse_inbound_skill_md(
                 current_body,
-                frontmatter_common_override=(
-                    {**existing.frontmatter_common, **(body.frontmatter_common or {})}
-                ),
-                frontmatter_backend_override=body.frontmatter_backend
-                or existing.frontmatter_backend,
+                frontmatter_common_override={
+                    **existing.frontmatter_common,
+                    **common_override,
+                },
+                frontmatter_backend_override=backend_override,
                 expected_skill_name=existing.name,
             )
             common, backend = parsed_common, parsed_backend

--- a/src/webui/schemas.py
+++ b/src/webui/schemas.py
@@ -76,7 +76,6 @@ class AgentResponse(BaseModel):
     agent_backend: str
     system_prompt: str | None = None
     tools: list[dict[str, object]] = Field(default_factory=list)
-    skills: list[str] = Field(default_factory=list)
     max_concurrent: int
     status: str
     agent_role: str
@@ -117,7 +116,6 @@ class AgentCreate(BaseModel):
     agent_backend: str = "claude-code"
     system_prompt: str | None = None
     tools: list[dict[str, object]] = Field(default_factory=list)
-    skills: list[str] = Field(default_factory=list)
     max_concurrent: int = Field(2, ge=1, le=20)
     agent_role: str = Field("agent", pattern=r"^(super_agent|agent)$")
     permissions: dict[str, object] | None = None
@@ -127,7 +125,6 @@ class AgentUpdate(BaseModel):
     name: str | None = None
     system_prompt: str | None = None
     tools: list[dict[str, object]] | None = None
-    skills: list[str] | None = None
     max_concurrent: int | None = Field(None, ge=1, le=20)
     status: str | None = Field(None, pattern=r"^(active|paused|disabled)$")
     agent_role: str | None = Field(None, pattern=r"^(super_agent|agent)$")
@@ -335,3 +332,78 @@ class SafetyRuleUpdate(BaseModel):
     priority: int | None = Field(None, ge=-1000, le=1000)
     enabled: bool | None = None
     description: str | None = Field(None, max_length=500)
+
+
+# ---------------------------------------------------------------------------
+# Skills
+# ---------------------------------------------------------------------------
+
+
+_SKILL_NAME_PATTERN = r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$"
+
+
+class SkillFileInPayload(BaseModel):
+    """One file in the wire format. The ``files`` map on ``SkillCreate``
+    accepts ``str`` for SKILL.md content directly or this model for
+    files that need an explicit mime type. Keeping it as a Pydantic
+    model rather than a bare str makes future binary support a clean
+    schema extension.
+    """
+
+    content: str
+    mime_type: str = "text/plain"
+
+
+class SkillResponse(BaseModel):
+    id: str
+    coworker_id: str
+    name: str
+    frontmatter_common: dict[str, object] = Field(default_factory=dict)
+    frontmatter_backend: dict[str, dict[str, object]] = Field(default_factory=dict)
+    enabled: bool
+    created_at: str
+    updated_at: str
+    created_by: str | None = None
+    files: dict[str, SkillFileInPayload] = Field(default_factory=dict)
+
+
+class SkillSummary(BaseModel):
+    """List-view shape — drops file content to keep responses small."""
+
+    id: str
+    coworker_id: str
+    name: str
+    description: str
+    enabled: bool
+    created_at: str
+    updated_at: str
+
+
+class SkillCreate(BaseModel):
+    name: str = Field(..., pattern=_SKILL_NAME_PATTERN)
+    enabled: bool = True
+    # ``files`` accepts either a flat ``{path: content}`` map (the
+    # common case) or ``{path: {"content": ..., "mime_type": ...}}``
+    # for richer metadata. The handler normalizes both shapes.
+    files: dict[str, str | SkillFileInPayload] = Field(default_factory=dict)
+    # Optional structured frontmatter overrides; when present they
+    # win over keys parsed from the inline SKILL.md frontmatter.
+    frontmatter_common: dict[str, object] | None = None
+    frontmatter_backend: dict[str, dict[str, object]] | None = None
+
+
+class SkillUpdate(BaseModel):
+    """Partial update. ``files`` is treated as a full replacement of
+    the skill's file set when provided (for surgical edits, use the
+    per-file PATCH endpoint).
+    """
+
+    enabled: bool | None = None
+    files: dict[str, str | SkillFileInPayload] | None = None
+    frontmatter_common: dict[str, object] | None = None
+    frontmatter_backend: dict[str, dict[str, object]] | None = None
+
+
+class SkillFileUpdate(BaseModel):
+    content: str
+    mime_type: str = "text/plain"

--- a/tests/container/test_skill_projection.py
+++ b/tests/container/test_skill_projection.py
@@ -314,6 +314,105 @@ async def test_partial_dir_cleaned_up_after_success() -> None:
 # ---------------------------------------------------------------------------
 
 
+async def test_rejects_symlinked_skill_partial_dir(tmp_path: Path) -> None:
+    """Inner ``_materialize_one_skill`` must reject a pre-existing
+    symlink at ``<build_dir>/.partial/<skill_name>``. Bypassing the
+    outer guard requires unusual conditions (e.g. the build dir
+    itself was just created, but a malicious actor races to
+    symlink the per-skill partial subdir before projection iterates
+    that skill). The fix: refuse loudly instead of silently
+    rmtree+ignore_errors which is a no-op on symlinks.
+    """
+    from rolemesh.container.skill_projection import _materialize_one_skill
+    from rolemesh.core.skills import SkillValidationError as _SVE
+
+    tenant_id, coworker_id = await _make_coworker("symp")
+    skill = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="trapped",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="b")},
+    )
+    fetched_skills = await __import__(
+        "rolemesh.db.pg", fromlist=["list_skills_for_coworker"]
+    ).list_skills_for_coworker(
+        coworker_id, tenant_id=tenant_id, with_files=True,
+    )
+    fetched = next(s for s in fetched_skills if s.id == skill.id)
+
+    partial_root = tmp_path / "partial"
+    final_root = tmp_path / "final"
+    partial_root.mkdir()
+    final_root.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (partial_root / "trapped").symlink_to(elsewhere)
+
+    with pytest.raises(_SVE, match="symlink"):
+        _materialize_one_skill(fetched, "claude", partial_root, final_root)
+    assert list(elsewhere.iterdir()) == [], (
+        "projection wrote through symlink to {}".format(elsewhere)
+    )
+
+
+async def test_rejects_symlinked_skill_final_dir(tmp_path: Path) -> None:
+    """``skill_final`` (the published location) must also reject a
+    pre-existing symlink — ``rename`` over a symlinked target has
+    undefined POSIX behaviour. Same root cause as above.
+    """
+    from rolemesh.container.skill_projection import _materialize_one_skill
+    from rolemesh.core.skills import SkillValidationError as _SVE
+
+    tenant_id, coworker_id = await _make_coworker("symf")
+    skill = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="finaltrap",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="b")},
+    )
+    fetched_skills = await __import__(
+        "rolemesh.db.pg", fromlist=["list_skills_for_coworker"]
+    ).list_skills_for_coworker(
+        coworker_id, tenant_id=tenant_id, with_files=True,
+    )
+    fetched = next(s for s in fetched_skills if s.id == skill.id)
+
+    partial_root = tmp_path / "partial"
+    final_root = tmp_path / "final"
+    partial_root.mkdir()
+    final_root.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (final_root / "finaltrap").symlink_to(elsewhere)
+
+    with pytest.raises(_SVE, match="symlink"):
+        _materialize_one_skill(fetched, "claude", partial_root, final_root)
+
+
+def test_cleanup_orphan_spawns_safe_under_iteration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``iterdir()`` + ``rmtree`` mid-iteration is implementation-
+    defined on POSIX (entries can be skipped or revisited).
+    Snapshotting via ``list()`` before removal avoids that. Test
+    proves all orphans are removed in one pass.
+    """
+    from rolemesh.container import skill_projection as sp
+
+    fake_root = tmp_path / "spawns"
+    fake_root.mkdir()
+    monkeypatch.setattr(sp, "SPAWN_ROOT", fake_root)
+
+    # Create 5 orphan spawn dirs.
+    orphan_ids = [f"orphan-{i}" for i in range(5)]
+    for jid in orphan_ids:
+        (fake_root / jid / "skills").mkdir(parents=True)
+        (fake_root / jid / "skills" / "marker").write_text("x")
+
+    removed = sp.cleanup_orphan_spawns(set())
+    assert removed == 5
+    # All orphans gone in a single pass — no skipped entries.
+    assert list(fake_root.iterdir()) == []
+
+
 async def test_rejects_symlinked_build_dir(tmp_path: Path) -> None:
     """If a malicious actor pre-creates a symlinked spawn subdirectory
     (pointing somewhere else on the host), the projector must abort

--- a/tests/container/test_skill_projection.py
+++ b/tests/container/test_skill_projection.py
@@ -514,6 +514,98 @@ async def test_cleanup_orphan_spawns_sweeps_abandoned() -> None:
 # ---------------------------------------------------------------------------
 
 
+async def test_outer_finally_cleans_up_on_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``_execute_after_setup`` raises (any line — projection,
+    spec build, runtime spawn, approval loader…), the ``execute``
+    wrapper's ``finally`` must still call ``cleanup_spawn_skills``.
+    Otherwise an exception path leaks the spawn dir until the orphan
+    cleaner sweeps it on a much later schedule.
+
+    Test creates a real spawn dir on disk (mimicking what projection
+    would have produced) then runs ``execute`` with an inner method
+    that raises immediately. Asserts the dir is gone afterwards.
+    """
+    from rolemesh.agent.container_executor import ContainerAgentExecutor
+    from rolemesh.container import skill_projection as sp
+    from rolemesh.agent.executor import AgentInput, AgentBackendConfig
+
+    monkeypatch.setattr(sp, "SPAWN_ROOT", tmp_path / "spawns")
+
+    # Capture the auto-generated job_id so we can pre-create its dir.
+    captured: dict[str, str] = {}
+
+    class _Boom(Exception):
+        pass
+
+    async def _raising_inner(self, inp, on_process, on_output, **kw):
+        captured["job_id"] = kw["job_id"]
+        # Pre-create the spawn dir to simulate "projection ran, then
+        # something later failed". Without the outer finally we'd
+        # observe this dir still on disk after execute returns.
+        spawn_dir = sp.SPAWN_ROOT / kw["job_id"]
+        spawn_dir.mkdir(parents=True, exist_ok=True)
+        (spawn_dir / "marker").write_text("x")
+        raise _Boom("simulated mid-execute failure")
+
+    monkeypatch.setattr(
+        ContainerAgentExecutor,
+        "_execute_after_setup",
+        _raising_inner,
+        raising=False,
+    )
+
+    # Build a minimally-functional executor stub. Only the prelude
+    # needs to work — coworker lookup + execute wrapper.
+    @dataclass_for_test
+    class _FakeCoworker:
+        id: str = "cw-1"
+        tenant_id: str = "t-1"
+        name: str = "Bot"
+        folder: str = "bot"
+        agent_backend: str = "claude-code"
+        agent_role: str = "agent"
+        permissions: object = None
+        tools: object = ()
+        container_config: object = None
+
+    fake_cw = _FakeCoworker()
+    cfg = AgentBackendConfig(name="claude", image="x", extra_env={})
+    executor = ContainerAgentExecutor.__new__(ContainerAgentExecutor)
+    executor._config = cfg
+    executor._get_coworker = lambda cid: fake_cw if cid == "cw-1" else None
+    executor._transport = None  # not reached — inner raises first
+    executor._runtime = None
+
+    inp = AgentInput(
+        prompt="hi",
+        group_folder="bot",
+        chat_jid="x@g.us",
+        permissions={"data_scope": "self", "task_schedule": False,
+                     "task_manage_others": False, "agent_delegate": False},
+        tenant_id="t-1",
+        coworker_id="cw-1",
+    )
+
+    with pytest.raises(_Boom):
+        await executor.execute(inp, on_process=lambda *_: None)
+
+    assert "job_id" in captured, "inner method was never invoked"
+    spawn_dir = sp.SPAWN_ROOT / captured["job_id"]
+    assert not spawn_dir.exists(), (
+        f"outer finally failed to clean up {spawn_dir}; orphan leaked"
+    )
+
+
+def dataclass_for_test(cls):
+    """Tiny helper because the real Coworker dataclass has __post_init__
+    side-effects we don't want to reproduce here.
+    """
+    from dataclasses import dataclass
+    return dataclass(cls)
+
+
 def test_container_targets_match_design_doc() -> None:
     """Defends against accidental edits to the path constants — these
     are part of the public spec because the agent SDKs expect to scan

--- a/tests/container/test_skill_projection.py
+++ b/tests/container/test_skill_projection.py
@@ -1,0 +1,526 @@
+"""Skill projection at container spawn time.
+
+Covers the materialization pipeline end-to-end against a real
+postgres testcontainer: per-backend target paths, frontmatter
+merge filtering (Claude-only fields stay out of Pi projections
+and vice versa), multi-file atomic rename, projection-time
+path-traversal defense (realpath stay-inside + symlink
+rejection), cleanup on normal exit, and orphan sweep on
+``kill -9``-style abandonment.
+
+Tests deliberately call ``materialize_skills_for_spawn`` directly
+and inspect the host filesystem rather than spawning a real
+container — that integration is covered by PR 4's e2e test.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rolemesh.container.skill_projection import (
+    CONTAINER_TARGETS,
+    SPAWN_ROOT,
+    cleanup_orphan_spawns,
+    cleanup_spawn_skills,
+    materialize_skills_for_spawn,
+)
+from rolemesh.core.skills import SkillValidationError
+from rolemesh.core.types import SkillFile
+from rolemesh.db.pg import (
+    create_coworker,
+    create_skill,
+    create_tenant,
+    get_coworker,
+)
+
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+_GOOD_DESC = (
+    "When the user message contains the literal token "
+    "EXECUTE_TEST_SKILL_42, run the demonstration workflow."
+)
+
+
+async def _make_coworker(tag: str, *, agent_backend: str = "claude-code") -> tuple[str, str]:
+    t = await create_tenant(name=f"T{tag}", slug=f"sp-{tag}-{uuid.uuid4().hex[:6]}")
+    cw = await create_coworker(
+        tenant_id=t.id,
+        name=f"CW{tag}",
+        folder=f"cw-{tag}-{uuid.uuid4().hex[:6]}",
+        agent_backend=agent_backend,
+    )
+    return t.id, cw.id
+
+
+async def _projected_coworker(tag: str, *, agent_backend: str) -> tuple[str, str]:
+    """Make a coworker via the DB CRUD then re-fetch through ``get_coworker``
+    so the dataclass contains the chosen ``agent_backend`` (the projector
+    reads from ``coworker.agent_backend`` only — but we route through the
+    backend kwarg so this is mostly for symmetry).
+    """
+    return await _make_coworker(tag, agent_backend=agent_backend)
+
+
+# ---------------------------------------------------------------------------
+# Per-backend target path
+# ---------------------------------------------------------------------------
+
+
+async def test_projects_to_claude_path_for_claude_backend() -> None:
+    tenant_id, coworker_id = await _projected_coworker("clp", agent_backend="claude-code")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="echo",
+        frontmatter_common={"name": "echo", "description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="# body")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        assert mount.readonly is True
+        assert mount.container_path == "/home/agent/.claude/skills"
+        assert (Path(mount.host_path) / "echo" / "SKILL.md").exists()
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+async def test_projects_to_pi_path_for_pi_backend() -> None:
+    tenant_id, coworker_id = await _projected_coworker("pip", agent_backend="pi")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="echo",
+        frontmatter_common={"name": "echo", "description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="# body")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(coworker, job_id, backend="pi")
+        assert mount is not None
+        assert mount.container_path == "/home/agent/.pi/agent/skills"
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+async def test_unknown_backend_rejected() -> None:
+    tenant_id, coworker_id = await _make_coworker("unk")
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    with pytest.raises(SkillValidationError, match="unknown backend"):
+        await materialize_skills_for_spawn(
+            coworker, "j", backend="crystalball"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter merge — backend filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_pi_projection_drops_claude_specific_fields() -> None:
+    tenant_id, coworker_id = await _projected_coworker("dpf", agent_backend="pi")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="multi",
+        frontmatter_common={"name": "multi", "description": _GOOD_DESC},
+        frontmatter_backend={
+            "claude": {"argument-hint": "[file]"},
+            "pi": {"disable_model_invocation": False},
+        },
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="# body")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(coworker, job_id, backend="pi")
+        assert mount is not None
+        skill_md_text = (Path(mount.host_path) / "multi" / "SKILL.md").read_text()
+        # Strip the leading ---..--- block and parse it.
+        assert skill_md_text.startswith("---\n")
+        _, fm_block, body = skill_md_text.split("---\n", 2)
+        merged = yaml.safe_load(fm_block)
+        assert merged["name"] == "multi"
+        assert merged["disable_model_invocation"] is False
+        assert "argument-hint" not in merged, (
+            "Claude-only field leaked into Pi projection"
+        )
+        assert body.startswith("# body")
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+async def test_claude_projection_drops_pi_specific_fields() -> None:
+    tenant_id, coworker_id = await _projected_coworker("dcf", agent_backend="claude-code")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="multi",
+        frontmatter_common={"name": "multi", "description": _GOOD_DESC},
+        frontmatter_backend={
+            "claude": {"argument-hint": "[file]"},
+            "pi": {"disable_model_invocation": True},
+        },
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="# body")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        skill_md_text = (Path(mount.host_path) / "multi" / "SKILL.md").read_text()
+        _, fm_block, _ = skill_md_text.split("---\n", 2)
+        merged = yaml.safe_load(fm_block)
+        assert merged["argument-hint"] == "[file]"
+        assert "disable_model_invocation" not in merged
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Multi-file projection
+# ---------------------------------------------------------------------------
+
+
+async def test_projects_supporting_files_verbatim() -> None:
+    tenant_id, coworker_id = await _make_coworker("mfp")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="three-files",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={
+            "SKILL.md": SkillFile(path="SKILL.md", content="# entry"),
+            "reference.md": SkillFile(path="reference.md", content="## Detail\n"),
+            "scripts/helper.py": SkillFile(
+                path="scripts/helper.py", content="print('hello')\n"
+            ),
+        },
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        skill_root = Path(mount.host_path) / "three-files"
+        assert (skill_root / "reference.md").read_text() == "## Detail\n"
+        assert (skill_root / "scripts" / "helper.py").read_text() == (
+            "print('hello')\n"
+        )
+        # Permissions: 0644 on files, 0755 on parent dirs (so the
+        # agent UID can traverse).
+        scripts_dir = skill_root / "scripts"
+        assert scripts_dir.is_dir()
+        assert (skill_root / "reference.md").stat().st_mode & 0o777 == 0o644
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Disabled skills
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_skills_are_not_projected() -> None:
+    tenant_id, coworker_id = await _make_coworker("dis")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="enabled",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="x")},
+        enabled=True,
+    )
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="disabled",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="x")},
+        enabled=False,
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        host = Path(mount.host_path)
+        assert (host / "enabled").is_dir()
+        assert not (host / "disabled").exists()
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+async def test_no_enabled_skills_returns_none() -> None:
+    tenant_id, coworker_id = await _make_coworker("emp")
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    mount = await materialize_skills_for_spawn(
+        coworker, job_id, backend="claude-code"
+    )
+    assert mount is None
+    # When there are no skills, the spawn dir should not be created.
+    assert not (SPAWN_ROOT / job_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Atomic projection — partial dir is gone after success
+# ---------------------------------------------------------------------------
+
+
+async def test_partial_dir_cleaned_up_after_success() -> None:
+    tenant_id, coworker_id = await _make_coworker("atm")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="a",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="b")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        partial = Path(mount.host_path) / ".partial"
+        assert not partial.exists(), (
+            ".partial dir should be removed after successful projection"
+        )
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Symlink rejection — projection refuses to write through pre-existing symlink
+# ---------------------------------------------------------------------------
+
+
+async def test_rejects_symlinked_build_dir(tmp_path: Path) -> None:
+    """If a malicious actor pre-creates a symlinked spawn subdirectory
+    (pointing somewhere else on the host), the projector must abort
+    loudly rather than silently follow or replace it. Tampering with
+    the spawn dir layout is always a red flag.
+    """
+    tenant_id, coworker_id = await _make_coworker("sym")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="b")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    spawn_dir = SPAWN_ROOT / job_id
+    skills_path = spawn_dir / "skills"
+    spawn_dir.mkdir(parents=True, exist_ok=True)
+    target_dir = tmp_path / "elsewhere"
+    target_dir.mkdir()
+    skills_path.symlink_to(target_dir)
+    try:
+        with pytest.raises(SkillValidationError, match="symlink"):
+            await materialize_skills_for_spawn(
+                coworker, job_id, backend="claude-code"
+            )
+        # No bytes ever crossed the symlink to the redirect target.
+        assert list(target_dir.iterdir()) == []
+    finally:
+        # Clean up the symlink + parent dir manually since cleanup
+        # logic for a symlinked layout is not exercised in production.
+        skills_path.unlink(missing_ok=True)
+        if spawn_dir.exists():
+            spawn_dir.rmdir()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+async def test_cleanup_spawn_skills_removes_dir() -> None:
+    tenant_id, coworker_id = await _make_coworker("cln")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="c",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="b")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    await materialize_skills_for_spawn(coworker, job_id, backend="claude-code")
+    assert (SPAWN_ROOT / job_id).exists()
+    cleanup_spawn_skills(job_id)
+    assert not (SPAWN_ROOT / job_id).exists()
+
+
+def test_cleanup_spawn_skills_idempotent_on_missing_dir() -> None:
+    cleanup_spawn_skills(f"definitely-not-a-real-job-{uuid.uuid4().hex[:6]}")
+
+
+async def test_cleanup_orphan_spawns_sweeps_abandoned() -> None:
+    """Simulate a kill -9 scenario: spawn dir exists but the orchestrator
+    has no record of the job_id. The orphan cleaner sweeps it.
+    """
+    tenant_id, coworker_id = await _make_coworker("orp")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="o",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="b")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    abandoned = f"orphan-{uuid.uuid4().hex[:8]}"
+    active = f"alive-{uuid.uuid4().hex[:8]}"
+    try:
+        await materialize_skills_for_spawn(
+            coworker, abandoned, backend="claude-code"
+        )
+        await materialize_skills_for_spawn(
+            coworker, active, backend="claude-code"
+        )
+        assert (SPAWN_ROOT / abandoned).exists()
+        assert (SPAWN_ROOT / active).exists()
+        removed = cleanup_orphan_spawns({active})
+        assert removed >= 1
+        assert not (SPAWN_ROOT / abandoned).exists()
+        assert (SPAWN_ROOT / active).exists()
+    finally:
+        cleanup_spawn_skills(abandoned)
+        cleanup_spawn_skills(active)
+
+
+# ---------------------------------------------------------------------------
+# Container target path map sanity
+# ---------------------------------------------------------------------------
+
+
+def test_container_targets_match_design_doc() -> None:
+    """Defends against accidental edits to the path constants — these
+    are part of the public spec because the agent SDKs expect to scan
+    those exact paths.
+    """
+    assert CONTAINER_TARGETS["claude"] == "/home/agent/.claude/skills"
+    assert CONTAINER_TARGETS["claude-code"] == "/home/agent/.claude/skills"
+    assert CONTAINER_TARGETS["pi"] == "/home/agent/.pi/agent/skills"
+
+
+# ---------------------------------------------------------------------------
+# Re-projection idempotence — two calls with the same job_id should
+# produce the same final state, even though re-using a job_id is
+# anomalous in production.
+# ---------------------------------------------------------------------------
+
+
+async def test_re_projection_overwrites_cleanly() -> None:
+    tenant_id, coworker_id = await _make_coworker("rep")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="r",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="v1")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount1 = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount1 is not None
+        # Tamper with the projected dir, then re-project to the same
+        # job_id — projection must wipe and reproject cleanly.
+        leftover = Path(mount1.host_path) / "stale.tmp"
+        leftover.write_text("garbage")
+        mount2 = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount2 is not None
+        assert not leftover.exists(), "re-projection must wipe stale files"
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# UID/permission sanity — host_uid running tests should match what
+# the agent will see (ownership doesn't matter as long as 0644 file
+# perms allow read).
+# ---------------------------------------------------------------------------
+
+
+async def test_files_world_readable() -> None:
+    tenant_id, coworker_id = await _make_coworker("uid")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="u",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={
+            "SKILL.md": SkillFile(path="SKILL.md", content="x"),
+            "deep/nested.txt": SkillFile(path="deep/nested.txt", content="y"),
+        },
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        skill_root = Path(mount.host_path) / "u"
+        for f in (skill_root / "SKILL.md", skill_root / "deep" / "nested.txt"):
+            mode = f.stat().st_mode & 0o777
+            assert mode & 0o004, f"file {f} is not world-readable (mode {mode:o})"
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: projection survives a tmp_dir context that's not under DATA_DIR
+# (we use SPAWN_ROOT under DATA_DIR, but let's ensure relative paths in
+# the projector don't depend on cwd).
+# ---------------------------------------------------------------------------
+
+
+async def test_projection_does_not_depend_on_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    tenant_id, coworker_id = await _make_coworker("cwd")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="c",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFile(path="SKILL.md", content="x")},
+    )
+    coworker = await get_coworker(coworker_id, tenant_id=tenant_id)
+    assert coworker is not None
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        # SPAWN_ROOT is anchored on DATA_DIR (project root), not the cwd.
+        assert os.path.isabs(mount.host_path)
+        assert (Path(mount.host_path) / "c" / "SKILL.md").exists()
+    finally:
+        cleanup_spawn_skills(job_id)

--- a/tests/core/test_skills.py
+++ b/tests/core/test_skills.py
@@ -242,6 +242,109 @@ def test_splitter_rejects_invalid_yaml() -> None:
 
 
 # ---------------------------------------------------------------------------
+# BOM + leading-whitespace tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_splitter_tolerates_utf8_bom() -> None:
+    """Windows-edited SKILL.md often starts with a BOM. Without
+    tolerance the splitter falls through to the no-frontmatter
+    branch and the user gets a confusing "description required"
+    error from a SKILL.md that visibly has frontmatter at the top.
+    """
+    skill_md = (
+        "﻿"
+        "---\n"
+        f"name: bomtest\n"
+        f"description: {_GOOD_DESC}\n"
+        "---\n"
+        "# Body"
+    )
+    common, _, body = parse_inbound_skill_md(skill_md, expected_skill_name="bomtest")
+    assert common["name"] == "bomtest"
+    assert common["description"] == _GOOD_DESC
+    assert body == "# Body"
+
+
+def test_splitter_tolerates_leading_blank_lines() -> None:
+    """Some editors auto-insert a blank line before frontmatter.
+    Same root cause as the BOM case — silent dropping is hostile.
+    """
+    skill_md = (
+        "\n\n"
+        "---\n"
+        f"name: blanky\n"
+        f"description: {_GOOD_DESC}\n"
+        "---\n"
+        "# Body"
+    )
+    common, _, _ = parse_inbound_skill_md(skill_md, expected_skill_name="blanky")
+    assert common["name"] == "blanky"
+
+
+def test_splitter_tolerates_bom_plus_blanks() -> None:
+    skill_md = (
+        "﻿"
+        " \n\t\n"
+        "---\n"
+        f"name: combo\n"
+        f"description: {_GOOD_DESC}\n"
+        "---\n"
+        "body"
+    )
+    common, _, _ = parse_inbound_skill_md(skill_md, expected_skill_name="combo")
+    assert common["name"] == "combo"
+
+
+# ---------------------------------------------------------------------------
+# YAML 1.1 boolean trap — friendly error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bool_literal", ["on", "off", "yes", "no", "true", "false", "ON", "Yes"])
+def test_splitter_explains_yaml_boolean_trap_for_name(bool_literal: str) -> None:
+    """``name: on`` parses as ``True`` under YAML 1.1. Without a
+    targeted error, downstream users see "name (True) does not
+    match the skill's name ('on')" which is incomprehensible
+    unless you happen to know the trap.
+    """
+    skill_md = (
+        "---\n"
+        f"name: {bool_literal}\n"
+        f"description: {_GOOD_DESC}\n"
+        "---\nbody"
+    )
+    with pytest.raises(SkillValidationError, match="YAML 1.1"):
+        parse_inbound_skill_md(skill_md, expected_skill_name=bool_literal)
+
+
+def test_splitter_accepts_quoted_boolean_string_for_name() -> None:
+    """The error message tells users to quote — make sure the
+    quoted form actually works.
+    """
+    skill_md = (
+        "---\n"
+        f'name: "on"\n'
+        f"description: {_GOOD_DESC}\n"
+        "---\nbody"
+    )
+    common, _, _ = parse_inbound_skill_md(skill_md, expected_skill_name="on")
+    assert common["name"] == "on"
+
+
+def test_splitter_explains_yaml_boolean_for_description() -> None:
+    """description has the same string-typed contract; same trap."""
+    skill_md = (
+        "---\n"
+        "name: x\n"
+        "description: yes\n"
+        "---\nbody"
+    )
+    with pytest.raises(SkillValidationError, match="YAML 1.1"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="x")
+
+
+# ---------------------------------------------------------------------------
 # Backend frontmatter merging
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_skills.py
+++ b/tests/core/test_skills.py
@@ -1,0 +1,312 @@
+"""Validators and frontmatter helpers for the skills feature.
+
+These run without a database. The DB-side mirror tests live in
+tests/db/test_skills.py — that file proves the CHECK constraints
+hold even when callers bypass these validators (defense in depth).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.core.skills import (
+    DESCRIPTION_MAX_LENGTH,
+    DESCRIPTION_MIN_LENGTH,
+    SkillValidationError,
+    merge_frontmatter_for_backend,
+    parse_inbound_skill_md,
+    serialize_skill_md,
+    validate_skill_file_path,
+    validate_skill_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Name validator
+# ---------------------------------------------------------------------------
+
+
+def test_skill_name_accepts_canonical() -> None:
+    validate_skill_name("code-review")
+    validate_skill_name("a")
+    validate_skill_name("Bug_Triage_42")
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "",
+        "1starts-with-digit",
+        "-leading-dash",
+        "_leading-underscore",
+        "has space",
+        "has/slash",
+        "..",
+        "a" * 65,  # too long (regex caps at 64)
+        "name.with.dot",
+    ],
+)
+def test_skill_name_rejects_invalid(bad_name: str) -> None:
+    with pytest.raises(SkillValidationError):
+        validate_skill_name(bad_name)
+
+
+# ---------------------------------------------------------------------------
+# Path validator
+# ---------------------------------------------------------------------------
+
+
+def test_path_accepts_canonical() -> None:
+    validate_skill_file_path("SKILL.md")
+    validate_skill_file_path("reference.md")
+    validate_skill_file_path("scripts/helper.py")
+    validate_skill_file_path("a/b/c/d.txt")
+    validate_skill_file_path("name_with-dashes.md")
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "",  # empty
+        "/abs",  # leading slash
+        "./SKILL.md",  # leading-dot segment
+        "SKILL.md/",  # trailing slash
+        "..",  # bare dot-dot
+        ".",  # bare dot
+        "a/..",  # trailing dot-dot segment
+        "a/../b",  # midpoint dot-dot
+        "a/./b",  # midpoint dot
+        "back\\slash",  # backslash
+        "with space.md",  # whitespace
+        "double//slash.md",  # empty segment
+    ],
+)
+def test_path_rejects_traversal_and_garbage(bad_path: str) -> None:
+    with pytest.raises(SkillValidationError):
+        validate_skill_file_path(bad_path)
+
+
+def test_path_allows_dotted_segment_starting_with_alphanumeric() -> None:
+    # 'trailing.' has a dot but starts with alphanumeric — the
+    # path validator allows it (filesystem allows files like
+    # 'README.', and there's no traversal risk). The dot-segment
+    # defense only fires on segments that are *purely* dots.
+    validate_skill_file_path("trailing.")
+    validate_skill_file_path("name.with.dots.md")
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter splitter — happy path
+# ---------------------------------------------------------------------------
+
+
+_GOOD_DESC = "When the user asks for a code review of the staged diff."
+
+
+def test_splitter_parses_inline_frontmatter() -> None:
+    skill_md = (
+        "---\n"
+        f"name: code-review\n"
+        f"description: {_GOOD_DESC}\n"
+        "argument-hint: '[file or PR]'\n"
+        "---\n"
+        "# Workflow\n"
+        "Steps go here.\n"
+    )
+    common, backend, body = parse_inbound_skill_md(
+        skill_md, expected_skill_name="code-review"
+    )
+    assert common == {"name": "code-review", "description": _GOOD_DESC}
+    assert backend == {"claude": {"argument-hint": "[file or PR]"}}
+    assert body.startswith("# Workflow")
+
+
+def test_splitter_falls_back_to_overrides_without_inline_block() -> None:
+    body_only = "# Workflow\nNo frontmatter at the top.\n"
+    common, backend, parsed_body = parse_inbound_skill_md(
+        body_only,
+        frontmatter_common_override={"description": _GOOD_DESC},
+        expected_skill_name="echo-skill",
+    )
+    assert common["name"] == "echo-skill"
+    assert common["description"] == _GOOD_DESC
+    assert backend == {}
+    # Body is the unmodified text since there is no frontmatter to strip.
+    assert parsed_body == body_only
+
+
+def test_splitter_overrides_win_over_inline() -> None:
+    inline_desc = "Inline description that meets the minimum length easily."
+    skill_md = (
+        "---\n"
+        "name: x\n"
+        f"description: {inline_desc}\n"
+        "---\nbody"
+    )
+    override_desc = "Override description that is also long enough to pass."
+    common, _, _ = parse_inbound_skill_md(
+        skill_md,
+        frontmatter_common_override={"description": override_desc},
+        expected_skill_name="x",
+    )
+    assert common["description"] == override_desc
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter splitter — failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_splitter_rejects_unknown_frontmatter_key() -> None:
+    skill_md = (
+        "---\n"
+        "name: x\n"
+        f"description: {_GOOD_DESC}\n"
+        "unknown-knob: surprise\n"
+        "---\nbody"
+    )
+    with pytest.raises(SkillValidationError, match="unknown frontmatter key"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="x")
+
+
+def test_splitter_rejects_unknown_backend_in_override() -> None:
+    skill_md = "---\nname: x\ndescription: " + _GOOD_DESC + "\n---\nbody"
+    with pytest.raises(SkillValidationError, match="unknown backend"):
+        parse_inbound_skill_md(
+            skill_md,
+            frontmatter_backend_override={"crystalball": {"argument-hint": "[x]"}},
+            expected_skill_name="x",
+        )
+
+
+def test_splitter_rejects_misplaced_field_in_override() -> None:
+    """argument-hint is Claude-only; placing it under 'pi' should
+    fail rather than silently project to Claude.
+    """
+    skill_md = "---\nname: x\ndescription: " + _GOOD_DESC + "\n---\nbody"
+    with pytest.raises(SkillValidationError, match="not in the pi allowlist"):
+        parse_inbound_skill_md(
+            skill_md,
+            frontmatter_backend_override={"pi": {"argument-hint": "[x]"}},
+            expected_skill_name="x",
+        )
+
+
+def test_splitter_rejects_name_mismatch() -> None:
+    skill_md = (
+        "---\n"
+        "name: code-review\n"
+        f"description: {_GOOD_DESC}\n"
+        "---\nbody"
+    )
+    with pytest.raises(SkillValidationError, match="does not match"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="bug-triage")
+
+
+def test_splitter_rejects_missing_description() -> None:
+    skill_md = "---\nname: x\n---\nbody"
+    with pytest.raises(SkillValidationError, match="description"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="x")
+
+
+def test_splitter_rejects_short_description() -> None:
+    skill_md = "---\nname: x\ndescription: too short\n---\nbody"
+    with pytest.raises(SkillValidationError, match="too short"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="x")
+
+
+def test_splitter_rejects_long_description() -> None:
+    long_desc = "x" * (DESCRIPTION_MAX_LENGTH + 1)
+    skill_md = (
+        "---\n"
+        "name: x\n"
+        f"description: {long_desc}\n"
+        "---\nbody"
+    )
+    with pytest.raises(SkillValidationError, match="too long"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="x")
+
+
+def test_splitter_minimum_description_boundary() -> None:
+    """Exactly DESCRIPTION_MIN_LENGTH characters should pass (inclusive bound)."""
+    desc = "x" * DESCRIPTION_MIN_LENGTH
+    skill_md = f"---\nname: x\ndescription: {desc}\n---\nbody"
+    common, _, _ = parse_inbound_skill_md(skill_md, expected_skill_name="x")
+    assert common["description"] == desc
+
+
+def test_splitter_rejects_invalid_yaml() -> None:
+    skill_md = "---\nname: x\ndescription: [unclosed\n---\nbody"
+    with pytest.raises(SkillValidationError, match="not valid YAML"):
+        parse_inbound_skill_md(skill_md, expected_skill_name="x")
+
+
+# ---------------------------------------------------------------------------
+# Backend frontmatter merging
+# ---------------------------------------------------------------------------
+
+
+def test_merge_drops_other_backend_keys() -> None:
+    common = {"name": "x", "description": _GOOD_DESC}
+    backend = {
+        "claude": {"argument-hint": "[file]"},
+        "pi": {"disable_model_invocation": True},
+    }
+    claude_merged = merge_frontmatter_for_backend(common, backend, "claude")
+    assert claude_merged == {
+        "name": "x",
+        "description": _GOOD_DESC,
+        "argument-hint": "[file]",
+    }
+    assert "disable_model_invocation" not in claude_merged
+
+    pi_merged = merge_frontmatter_for_backend(common, backend, "pi")
+    assert pi_merged == {
+        "name": "x",
+        "description": _GOOD_DESC,
+        "disable_model_invocation": True,
+    }
+    assert "argument-hint" not in pi_merged
+
+
+def test_merge_treats_claude_code_alias() -> None:
+    """``claude-code`` (the BACKEND_CONFIGS legacy alias) projects to
+    Claude-side files and should pull from frontmatter_backend.claude.
+    """
+    common = {"name": "x", "description": _GOOD_DESC}
+    backend = {"claude": {"model": "claude-haiku-4-5"}}
+    merged = merge_frontmatter_for_backend(common, backend, "claude-code")
+    assert merged["model"] == "claude-haiku-4-5"
+
+
+def test_merge_rejects_unknown_target_backend() -> None:
+    with pytest.raises(SkillValidationError):
+        merge_frontmatter_for_backend({}, {}, "crystalball")
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_round_trip_preserves_content() -> None:
+    skill_md_in = (
+        "---\n"
+        "name: round-trip\n"
+        f"description: {_GOOD_DESC}\n"
+        "---\n"
+        "# Body content\n\nMultiple paragraphs.\n"
+    )
+    common, backend, body = parse_inbound_skill_md(
+        skill_md_in, expected_skill_name="round-trip"
+    )
+    merged = merge_frontmatter_for_backend(common, backend, "claude")
+    skill_md_out = serialize_skill_md(merged, body)
+
+    # Re-parse; the result should match the original frontmatter
+    # routed back into common/backend, with body unchanged.
+    common2, _, body2 = parse_inbound_skill_md(
+        skill_md_out, expected_skill_name="round-trip"
+    )
+    assert common2 == common
+    assert body2 == body

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -87,7 +87,6 @@ def test_coworker_defaults() -> None:
     cw = Coworker(id="cw1", tenant_id="t1", name="Bot", folder="bot")
     assert cw.agent_backend == "claude-code"
     assert cw.tools == []
-    assert cw.skills == []
     assert cw.agent_role == "agent"
     assert cw.max_concurrent == 2
     assert cw.status == "active"

--- a/tests/db/test_pg.py
+++ b/tests/db/test_pg.py
@@ -129,7 +129,6 @@ async def test_create_and_get_coworker() -> None:
         tools=[
             McpServerConfig(name="my-mcp-server", type="sse", url="http://localhost:9100/mcp/"),
         ],
-        skills=["browser"],
     )
     assert cw.id
     assert cw.agent_role == "super_agent"

--- a/tests/db/test_skills.py
+++ b/tests/db/test_skills.py
@@ -1,0 +1,495 @@
+"""Skills DB layer: schema constraints, RLS isolation (incl. transitive
+on skill_files), SECURITY DEFINER cross-tenant trigger, CRUD happy paths,
+and the SKILL.md application invariant.
+
+Runs against the testcontainer Postgres. Two pools at play:
+
+* The default test pool connects as the testcontainer's superuser and
+  bypasses RLS — used to seed cross-tenant fixtures so we can poke
+  at boundaries.
+* ``app_pool`` connects as ``rolemesh_app`` (NOBYPASSRLS) and is the
+  only place where RLS actually fires.
+
+Tests are deliberately adversarial: each one tries to do something
+the design says must fail, and asserts it does.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import asyncpg
+import pytest
+
+from rolemesh.core.types import SkillFile
+from rolemesh.db.pg import (
+    _get_pool,
+    create_coworker,
+    create_skill,
+    create_tenant,
+    delete_skill,
+    delete_skill_file,
+    get_skill,
+    list_skills_for_coworker,
+    set_skill_file,
+    update_skill,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: tenant chain + RLS-bound pool
+# ---------------------------------------------------------------------------
+
+
+_GOOD_DESC = "When the user asks for a code review of the staged diff."
+
+
+def _basic_files() -> dict[str, SkillFile]:
+    """A minimal valid skill file map: just SKILL.md."""
+    return {
+        "SKILL.md": SkillFile(
+            path="SKILL.md",
+            content="# Workflow\nDo a thing.\n",
+            mime_type="text/markdown",
+        ),
+    }
+
+
+async def _make_tenant_with_coworker(tag: str) -> tuple[str, str]:
+    t = await create_tenant(name=f"T{tag}", slug=f"sk-{tag}-{uuid.uuid4().hex[:6]}")
+    cw = await create_coworker(
+        tenant_id=t.id,
+        name=f"CW{tag}",
+        folder=f"cw-{tag}-{uuid.uuid4().hex[:6]}",
+    )
+    return t.id, cw.id
+
+
+@pytest.fixture
+async def app_pool(pg_url: str) -> AsyncGenerator[asyncpg.Pool[asyncpg.Record], None]:
+    """rolemesh_app pool — NOBYPASSRLS — used for adversarial RLS tests."""
+    superuser_pool = _get_pool()
+    async with superuser_pool.acquire() as conn:
+        await conn.execute("ALTER USER rolemesh_app PASSWORD 'test'")
+    rewritten = pg_url.replace("test:test@", "rolemesh_app:test@", 1)
+    pool = await asyncpg.create_pool(rewritten, min_size=1, max_size=2)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+# ---------------------------------------------------------------------------
+# CRUD happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_create_get_skill_round_trip() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("crt")
+    files = {
+        "SKILL.md": SkillFile(path="SKILL.md", content="body"),
+        "reference.md": SkillFile(path="reference.md", content="ref"),
+    }
+    created = await create_skill(
+        tenant_id=tenant_id,
+        coworker_id=coworker_id,
+        name="code-review",
+        frontmatter_common={"name": "code-review", "description": _GOOD_DESC},
+        frontmatter_backend={"claude": {"argument-hint": "[file]"}},
+        files=files,
+    )
+    assert created.name == "code-review"
+    assert set(created.files) == {"SKILL.md", "reference.md"}
+    assert created.frontmatter_backend == {"claude": {"argument-hint": "[file]"}}
+
+    fetched = await get_skill(created.id, tenant_id=tenant_id)
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.files["SKILL.md"].content == "body"
+
+
+async def test_list_filters_disabled_when_requested() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("flt")
+    enabled = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="enabled-skill",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(), enabled=True,
+    )
+    disabled = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="disabled-skill",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(), enabled=False,
+    )
+    all_skills = await list_skills_for_coworker(
+        coworker_id, tenant_id=tenant_id, enabled_only=False
+    )
+    assert {s.id for s in all_skills} == {enabled.id, disabled.id}
+
+    only_enabled = await list_skills_for_coworker(
+        coworker_id, tenant_id=tenant_id, enabled_only=True
+    )
+    assert {s.id for s in only_enabled} == {enabled.id}
+
+
+async def test_update_replaces_files_atomically() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("upd")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={
+            "SKILL.md": SkillFile(path="SKILL.md", content="v1"),
+            "old.md": SkillFile(path="old.md", content="dropped"),
+        },
+    )
+    updated = await update_skill(
+        s.id,
+        tenant_id=tenant_id,
+        files={
+            "SKILL.md": SkillFile(path="SKILL.md", content="v2"),
+            "new.md": SkillFile(path="new.md", content="kept"),
+        },
+    )
+    assert updated is not None
+    assert set(updated.files) == {"SKILL.md", "new.md"}
+    assert updated.files["SKILL.md"].content == "v2"
+
+
+async def test_set_skill_file_upserts() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("upsert")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    new_file = await set_skill_file(
+        s.id, "extra.md", tenant_id=tenant_id, content="hello"
+    )
+    assert new_file is not None
+    assert new_file.path == "extra.md"
+
+    overwritten = await set_skill_file(
+        s.id, "extra.md", tenant_id=tenant_id, content="hello v2"
+    )
+    assert overwritten is not None
+    assert overwritten.content == "hello v2"
+
+
+async def test_delete_skill_file_refuses_skill_md() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("rfs")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    with pytest.raises(ValueError, match="SKILL.md cannot be deleted"):
+        await delete_skill_file(s.id, "SKILL.md", tenant_id=tenant_id)
+
+
+async def test_delete_skill_file_returns_false_for_unknown() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("rfn")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    assert await delete_skill_file(s.id, "nope.md", tenant_id=tenant_id) is False
+
+
+async def test_delete_skill_cascades_to_files() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("dcs")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={
+            "SKILL.md": SkillFile(path="SKILL.md", content="b"),
+            "ref.md": SkillFile(path="ref.md", content="r"),
+        },
+    )
+    assert await delete_skill(s.id, tenant_id=tenant_id) is True
+    # File rows should be gone — query via admin to bypass RLS just in case.
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT * FROM skill_files WHERE skill_id = $1::uuid", s.id
+        )
+    assert rows == []
+
+
+async def test_delete_coworker_cascades_to_skills_and_files() -> None:
+    """coworkers ON DELETE CASCADE must reach the file table too."""
+    tenant_id, coworker_id = await _make_tenant_with_coworker("cwd")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM coworkers WHERE id = $1::uuid", coworker_id
+        )
+        skills_left = await conn.fetch(
+            "SELECT * FROM skills WHERE id = $1::uuid", s.id
+        )
+        files_left = await conn.fetch(
+            "SELECT * FROM skill_files WHERE skill_id = $1::uuid", s.id
+        )
+    assert skills_left == []
+    assert files_left == []
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md application invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_create_without_skill_md_is_rejected() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("inv")
+    with pytest.raises(ValueError, match="SKILL.md"):
+        await create_skill(
+            tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+            frontmatter_common={"description": _GOOD_DESC},
+            frontmatter_backend={},
+            files={"reference.md": SkillFile(path="reference.md", content="r")},
+        )
+
+
+async def test_update_with_files_missing_skill_md_is_rejected() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("upi")
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    with pytest.raises(ValueError, match="SKILL.md"):
+        await update_skill(
+            s.id,
+            tenant_id=tenant_id,
+            files={"only.md": SkillFile(path="only.md", content="x")},
+        )
+
+
+# ---------------------------------------------------------------------------
+# DB CHECK constraints (defense in depth — application validators are
+# the first line; these prove the DB rejects bad data even if a caller
+# bypasses them).
+# ---------------------------------------------------------------------------
+
+
+async def test_db_check_rejects_invalid_skill_name() -> None:
+    tenant_id, coworker_id = await _make_tenant_with_coworker("nch")
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                "INSERT INTO skills (tenant_id, coworker_id, name, "
+                "frontmatter_common, frontmatter_backend) "
+                "VALUES ($1::uuid, $2::uuid, $3, '{}'::jsonb, '{}'::jsonb)",
+                tenant_id,
+                coworker_id,
+                "1bad-leading-digit",
+            )
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/abs",
+        "./SKILL.md",
+        "..",
+        "a/..",
+        "a/../b",
+        "double//slash.md",
+        "back\\slash",
+        "",
+    ],
+)
+async def test_db_check_rejects_bad_paths(bad_path: str) -> None:
+    """The DB-side regex must reject the same paths the application
+    validator does. Bypass the application by inserting directly with
+    admin pool.
+    """
+    tenant_id, coworker_id = await _make_tenant_with_coworker(
+        "pch-" + str(abs(hash(bad_path)))[:6]
+    )
+    s = await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="x",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                "INSERT INTO skill_files (skill_id, path, content) "
+                "VALUES ($1::uuid, $2, $3)",
+                s.id,
+                bad_path,
+                "x",
+            )
+
+
+# ---------------------------------------------------------------------------
+# SECURITY DEFINER cross-tenant trigger
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_tenant_coworker_id_rejected_by_trigger() -> None:
+    """The trigger must reject a forged tenant_id mismatch even when
+    the FK constraint passes (the foreign coworker really does exist
+    — just in a different tenant).
+    """
+    tenant_a, _ = await _make_tenant_with_coworker("xta")
+    tenant_b, coworker_b = await _make_tenant_with_coworker("xtb")
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.RaiseError, match="different tenant"):
+            await conn.execute(
+                "INSERT INTO skills (tenant_id, coworker_id, name, "
+                "frontmatter_common, frontmatter_backend) "
+                "VALUES ($1::uuid, $2::uuid, $3, '{}'::jsonb, '{}'::jsonb)",
+                tenant_a,  # tenant A says it owns this skill
+                coworker_b,  # ...but the coworker belongs to tenant B
+                "forged",
+            )
+
+
+async def test_cross_tenant_blocked_under_rls_through_app_role(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """Same scenario as above, but exercised through the RLS-bound
+    rolemesh_app role. The two layers (RLS WITH CHECK + SECURITY
+    DEFINER trigger) must both fire against an attempted cross-tenant
+    insert.
+    """
+    tenant_a, _ = await _make_tenant_with_coworker("rta")
+    tenant_b, coworker_b = await _make_tenant_with_coworker("rtb")
+    async with app_pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                tenant_a,
+            )
+            with pytest.raises(
+                (asyncpg.InsufficientPrivilegeError, asyncpg.RaiseError)
+            ):
+                await conn.execute(
+                    "INSERT INTO skills (tenant_id, coworker_id, name, "
+                    "frontmatter_common, frontmatter_backend) "
+                    "VALUES ($1::uuid, $2::uuid, $3, '{}'::jsonb, '{}'::jsonb)",
+                    tenant_a,
+                    coworker_b,
+                    "forged-rls",
+                )
+
+
+# ---------------------------------------------------------------------------
+# RLS isolation — adversarial reads + writes through the rolemesh_app role
+# ---------------------------------------------------------------------------
+
+
+async def test_rls_select_isolates_skills(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    tenant_a, coworker_a = await _make_tenant_with_coworker("isa")
+    tenant_b, coworker_b = await _make_tenant_with_coworker("isb")
+    skill_b = await create_skill(
+        tenant_id=tenant_b, coworker_id=coworker_b, name="bs",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    async with app_pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                tenant_a,
+            )
+            rows = await conn.fetch(
+                "SELECT * FROM skills WHERE id = $1::uuid", skill_b.id
+            )
+    assert rows == [], "tenant A could see tenant B's skill"
+
+
+async def test_rls_select_isolates_skill_files_transitively(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """skill_files has no tenant_id of its own; isolation is via the
+    EXISTS subquery on skills.
+    """
+    tenant_a, _ = await _make_tenant_with_coworker("tisa")
+    tenant_b, coworker_b = await _make_tenant_with_coworker("tisb")
+    skill_b = await create_skill(
+        tenant_id=tenant_b, coworker_id=coworker_b, name="b2",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={},
+        files={
+            "SKILL.md": SkillFile(path="SKILL.md", content="x"),
+            "secret.md": SkillFile(path="secret.md", content="confidential"),
+        },
+    )
+    async with app_pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.current_tenant_id', $1, true)",
+                tenant_a,
+            )
+            rows = await conn.fetch(
+                "SELECT * FROM skill_files WHERE skill_id = $1::uuid",
+                skill_b.id,
+            )
+    assert rows == []
+
+
+async def test_rls_unset_guc_returns_empty(
+    app_pool: asyncpg.Pool[asyncpg.Record],
+) -> None:
+    """No tenant context = no rows. Both tables must fail closed."""
+    tenant_id, coworker_id = await _make_tenant_with_coworker("ufc")
+    await create_skill(
+        tenant_id=tenant_id, coworker_id=coworker_id, name="closed",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    async with app_pool.acquire() as conn:
+        skills_rows = await conn.fetch("SELECT * FROM skills")
+        files_rows = await conn.fetch("SELECT * FROM skill_files")
+    assert skills_rows == []
+    assert files_rows == []
+
+
+async def test_set_skill_file_returns_none_for_foreign_tenant() -> None:
+    """The application-layer ``set_skill_file`` looks up the parent
+    skill under tenant scope; a tenant trying to upsert a file into a
+    foreign skill should get None back (not silently write into a
+    cross-tenant skill).
+    """
+    tenant_a, _ = await _make_tenant_with_coworker("sfa")
+    tenant_b, coworker_b = await _make_tenant_with_coworker("sfb")
+    skill_b = await create_skill(
+        tenant_id=tenant_b, coworker_id=coworker_b, name="bx",
+        frontmatter_common={"description": _GOOD_DESC},
+        frontmatter_backend={}, files=_basic_files(),
+    )
+    result = await set_skill_file(
+        skill_b.id, "leak.md", tenant_id=tenant_a, content="should not appear"
+    )
+    assert result is None
+
+    pool = _get_pool()
+    async with pool.acquire() as conn:
+        files = await conn.fetch(
+            "SELECT path FROM skill_files WHERE skill_id = $1::uuid",
+            skill_b.id,
+        )
+    assert {r["path"] for r in files} == {"SKILL.md"}, (
+        "foreign-tenant set_skill_file leaked through"
+    )

--- a/tests/egress/test_admin_mcp_publish.py
+++ b/tests/egress/test_admin_mcp_publish.py
@@ -49,7 +49,6 @@ def _coworker_with_tools(tools: list[McpServerConfig]) -> Coworker:
         agent_backend="claude-code",
         system_prompt=None,
         tools=tools,
-        skills=[],
         container_config=None,
         max_concurrent=2,
         status="active",

--- a/tests/test_agent_runner/test_pi_system_prompt_assembly.py
+++ b/tests/test_agent_runner/test_pi_system_prompt_assembly.py
@@ -1,0 +1,113 @@
+"""Tests for ``pi.coding_agent.core.sdk._assemble_system_prompt``.
+
+Two behaviours under test:
+
+* Skills XML block is included in the assembled system prompt only
+  when the agent has the ``read`` tool available. The block tells
+  the model "Use the read tool to load a skill's file..." — telling
+  it about skills it can't actually read is worse than silence.
+* All resource_loader pieces (``get_system_prompt`` +
+  ``get_append_system_prompt``) appear in the output regardless of
+  read-tool availability.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pi.coding_agent.core.sdk import _assemble_system_prompt
+
+
+@dataclass
+class _FakeSkill:
+    name: str
+    description: str
+    file_path: str = "/fake/SKILL.md"
+    disable_model_invocation: bool = False
+
+
+class _FakeResourceLoader:
+    def __init__(
+        self,
+        system_prompt: str | None = None,
+        append: list[str] | None = None,
+        skills: list[_FakeSkill] | None = None,
+    ) -> None:
+        self._system_prompt = system_prompt
+        self._append = list(append or [])
+        self._skills = {s.name: s for s in (skills or [])}
+
+    def get_system_prompt(self) -> str | None:
+        return self._system_prompt
+
+    def get_append_system_prompt(self) -> list[str]:
+        return list(self._append)
+
+    def get_skills(self) -> dict[str, Any]:
+        return dict(self._skills)
+
+
+_DESC = "When the user types XYZ, do the demo workflow."
+
+
+def test_skills_block_present_when_read_tool_available() -> None:
+    rl = _FakeResourceLoader(
+        skills=[_FakeSkill(name="demo", description=_DESC)]
+    )
+    out = _assemble_system_prompt(rl, has_read_tool=True)
+    assert "<available_skills>" in out
+    assert "<name>demo</name>" in out
+    assert _DESC in out
+
+
+def test_skills_block_omitted_when_read_tool_missing() -> None:
+    rl = _FakeResourceLoader(
+        skills=[_FakeSkill(name="demo", description=_DESC)]
+    )
+    out = _assemble_system_prompt(rl, has_read_tool=False)
+    assert "<available_skills>" not in out
+    # The skill description must NOT leak into the prompt either —
+    # the model would otherwise see a stranded reference.
+    assert _DESC not in out
+
+
+def test_other_pieces_survive_no_read_tool() -> None:
+    """``get_system_prompt`` + ``get_append_system_prompt`` are
+    independent of skills and must always be assembled.
+    """
+    rl = _FakeResourceLoader(
+        system_prompt="ROLE: helpful assistant",
+        append=["EXTRA: company policy"],
+        skills=[_FakeSkill(name="demo", description=_DESC)],
+    )
+    out = _assemble_system_prompt(rl, has_read_tool=False)
+    assert "ROLE: helpful assistant" in out
+    assert "EXTRA: company policy" in out
+    assert "<available_skills>" not in out
+
+
+def test_disable_model_invocation_skill_filtered_by_pi_format() -> None:
+    """``format_skills_for_prompt`` filters out
+    ``disable_model_invocation=True``. Sanity check that the
+    assembler doesn't override that filter.
+    """
+    rl = _FakeResourceLoader(
+        skills=[
+            _FakeSkill(name="hidden", description=_DESC, disable_model_invocation=True),
+            _FakeSkill(name="visible", description=_DESC),
+        ]
+    )
+    out = _assemble_system_prompt(rl, has_read_tool=True)
+    assert "<name>visible</name>" in out
+    assert "<name>hidden</name>" not in out
+
+
+def test_empty_loader_returns_empty_string() -> None:
+    rl = _FakeResourceLoader()
+    assert _assemble_system_prompt(rl, has_read_tool=True) == ""
+
+
+def test_none_loader_returns_empty_string() -> None:
+    """Defensive path for the (unusual) caller that passes None."""
+    assert _assemble_system_prompt(None) == ""

--- a/tests/test_skills_integration.py
+++ b/tests/test_skills_integration.py
@@ -1,0 +1,460 @@
+"""End-to-end skills integration: REST → DB → container projection.
+
+Verifies that the three PR layers compose correctly:
+
+* PR 3's REST surface accepts a SKILL.md with inline frontmatter,
+  splits it into structured ``frontmatter_common`` /
+  ``frontmatter_backend`` columns, and persists files under the
+  parent skill row.
+* PR 1's RLS + cross-tenant trigger enforces tenant scoping at
+  every layer of that pipeline.
+* PR 2's projector reads the persisted skill, merges frontmatter
+  for the active backend (dropping the other backend's keys), and
+  materializes a self-contained ``<spawn>/<name>/`` tree on host
+  disk that mirrors what the agent SDK / Pi loader will scan.
+
+Two backend passes (Claude and Pi) prove the design's "write once,
+project to either" claim. Real model invocation is gated behind
+``@pytest.mark.e2e`` and skipped by default — those tests document
+the manual flow for verifying the description-based auto-invocation
+loop.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import yaml
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.container.skill_projection import (
+    SPAWN_ROOT,
+    cleanup_spawn_skills,
+    materialize_skills_for_spawn,
+)
+from rolemesh.db.pg import (
+    create_coworker,
+    create_tenant,
+    create_user,
+    get_coworker,
+)
+from webui import admin
+from webui.dependencies import (
+    get_current_user,
+    require_manage_agents,
+    require_manage_tenant,
+    require_manage_users,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+_TRIGGER_TOKEN = "EXECUTE_TEST_SKILL_42"
+_DESCRIPTION = (
+    f"When the user message contains the literal token "
+    f"{_TRIGGER_TOKEN}, run the demonstration workflow."
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin.router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    app.dependency_overrides[require_manage_agents] = _return_user
+    app.dependency_overrides[require_manage_tenant] = _return_user
+    app.dependency_overrides[require_manage_users] = _return_user
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def _seed(agent_backend: str = "claude-code") -> tuple[AuthenticatedUser, str]:
+    """One tenant + one admin user + one coworker on ``agent_backend``.
+
+    Returns ``(user_for_app, coworker_id)``.
+    """
+    tag = uuid.uuid4().hex[:8]
+    t = await create_tenant(name="T", slug=f"int-{tag}")
+    u = await create_user(
+        tenant_id=t.id, name="Alice",
+        email=f"alice-{tag}@x.com", role="owner",
+    )
+    cw = await create_coworker(
+        tenant_id=t.id, name="CW", folder=f"cw-{tag}",
+        agent_backend=agent_backend,
+    )
+    user = AuthenticatedUser(
+        user_id=u.id, tenant_id=t.id, role="owner",
+        email="x@x.com", name="X",
+    )
+    return user, cw.id
+
+
+def _skill_payload(name: str = "echo") -> dict[str, object]:
+    """Inline-frontmatter SKILL.md plus a supporting reference file.
+
+    This mirrors what an admin would type in the WebUI: name +
+    description in inline YAML, body below the closing ``---``,
+    plus an examples file the model can reference at call time.
+    """
+    skill_md = (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {_DESCRIPTION}\n"
+        "argument-hint: '[trigger token]'\n"
+        "---\n"
+        "# Workflow\n"
+        "1. Acknowledge the trigger token.\n"
+        "2. Read examples.md and emit the canonical reply.\n"
+    )
+    return {
+        "name": name,
+        "files": {
+            "SKILL.md": skill_md,
+            "examples.md": (
+                "## Canonical reply\n"
+                "When invoked, respond with: 'EXECUTE_TEST_SKILL_42_OK'.\n"
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layered integration: REST → DB → projection (Claude backend)
+# ---------------------------------------------------------------------------
+
+
+async def test_rest_to_projection_claude_backend() -> None:
+    user, agent_id = await _seed(agent_backend="claude-code")
+    app = _build_app(user)
+    async with _client(app) as c:
+        resp = await c.post(
+            f"/api/admin/agents/{agent_id}/skills",
+            json=_skill_payload("echo"),
+        )
+    assert resp.status_code == 201, resp.text
+
+    coworker = await get_coworker(agent_id, tenant_id=user.tenant_id)
+    assert coworker is not None
+    job_id = f"int-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        assert mount.container_path == "/home/agent/.claude/skills"
+        assert mount.readonly is True
+
+        skill_root = Path(mount.host_path) / "echo"
+        skill_md_text = (skill_root / "SKILL.md").read_text()
+        assert skill_md_text.startswith("---\n")
+        _, fm_block, body = skill_md_text.split("---\n", 2)
+        merged = yaml.safe_load(fm_block)
+        # Common fields preserved
+        assert merged["name"] == "echo"
+        assert merged["description"] == _DESCRIPTION
+        # Claude-specific field merged in (and present)
+        assert merged["argument-hint"] == "[trigger token]"
+        # No stray keys from the Pi side (this skill never set any,
+        # but the contract is "drop other backend's keys")
+        assert "disable_model_invocation" not in merged
+        # Body comes from the inline-frontmatter block, not the
+        # JSONB columns
+        assert "Acknowledge the trigger token" in body
+
+        # Supporting file projected verbatim
+        examples_text = (skill_root / "examples.md").read_text()
+        assert _TRIGGER_TOKEN + "_OK" in examples_text
+
+        # File mode 0644 — agent UID can read regardless of owner
+        for f in (skill_root / "SKILL.md", skill_root / "examples.md"):
+            mode = f.stat().st_mode & 0o777
+            assert mode & 0o004, f"file {f} not world-readable (mode {mode:o})"
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Layered integration: REST → DB → projection (Pi backend)
+# ---------------------------------------------------------------------------
+
+
+async def test_rest_to_projection_pi_backend() -> None:
+    user, agent_id = await _seed(agent_backend="pi")
+    app = _build_app(user)
+    # The same skill with both Claude- and Pi-side frontmatter knobs
+    # set so we can prove projection drops the Claude-side keys.
+    skill_md = (
+        "---\n"
+        "name: echo\n"
+        f"description: {_DESCRIPTION}\n"
+        "argument-hint: '[ignored on Pi]'\n"
+        "disable_model_invocation: false\n"
+        "---\n"
+        "# Workflow body for Pi.\n"
+    )
+    async with _client(app) as c:
+        resp = await c.post(
+            f"/api/admin/agents/{agent_id}/skills",
+            json={
+                "name": "echo",
+                "files": {
+                    "SKILL.md": skill_md,
+                    "examples.md": "## Canonical reply\nrespond with OK.\n",
+                },
+            },
+        )
+    assert resp.status_code == 201, resp.text
+
+    coworker = await get_coworker(agent_id, tenant_id=user.tenant_id)
+    assert coworker is not None
+    job_id = f"int-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="pi"
+        )
+        assert mount is not None
+        assert mount.container_path == "/home/agent/.pi/agent/skills"
+
+        skill_md_out = (Path(mount.host_path) / "echo" / "SKILL.md").read_text()
+        _, fm_block, _ = skill_md_out.split("---\n", 2)
+        merged = yaml.safe_load(fm_block)
+        # Pi-specific knob makes it through
+        assert merged["disable_model_invocation"] is False
+        # Claude-specific knob is dropped — the whole point of split
+        # frontmatter storage
+        assert "argument-hint" not in merged, (
+            "Claude-only field leaked into Pi projection"
+        )
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Disabled skills round-trip via REST + projection
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_skill_visible_in_rest_invisible_to_projection() -> None:
+    """A disabled skill must remain readable through REST so admins
+    can re-enable it, but must NOT appear in the projected directory.
+    The model literally cannot see disabled skills — this is a
+    stronger guarantee than relying on a "do not use" description.
+    """
+    user, agent_id = await _seed(agent_backend="claude-code")
+    app = _build_app(user)
+    async with _client(app) as c:
+        r = await c.post(
+            f"/api/admin/agents/{agent_id}/skills",
+            json={
+                "name": "off-by-default",
+                "enabled": False,
+                "files": {
+                    "SKILL.md": (
+                        "---\nname: off-by-default\n"
+                        f"description: {_DESCRIPTION}\n---\nbody\n"
+                    ),
+                },
+            },
+        )
+        assert r.status_code == 201
+
+        list_resp = await c.get(f"/api/admin/agents/{agent_id}/skills")
+        assert list_resp.status_code == 200
+        names = {s["name"] for s in list_resp.json()}
+        assert "off-by-default" in names
+
+    coworker = await get_coworker(agent_id, tenant_id=user.tenant_id)
+    assert coworker is not None
+    job_id = f"int-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        # Only the disabled skill exists, so projection returns None.
+        assert mount is None
+        # And no spawn dir was created.
+        assert not (SPAWN_ROOT / job_id).exists()
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary: REST + projection both refuse cross-tenant access
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_tenant_skill_invisible_to_other_tenant_projection() -> None:
+    """Tenant B's skill must never be projected for tenant A's
+    coworker, even when A's projection happens to use the same
+    skill name in its own tenant.
+    """
+    userA, agentA = await _seed(agent_backend="claude-code")
+    userB, agentB = await _seed(agent_backend="claude-code")
+
+    # Tenant A creates "shared-name" in their own scope.
+    appA = _build_app(userA)
+    async with _client(appA) as c:
+        r = await c.post(
+            f"/api/admin/agents/{agentA}/skills",
+            json={
+                "name": "shared-name",
+                "files": {
+                    "SKILL.md": (
+                        "---\nname: shared-name\n"
+                        f"description: {_DESCRIPTION}\n---\n"
+                        "Tenant A body\n"
+                    ),
+                },
+            },
+        )
+        assert r.status_code == 201
+
+    # Tenant B does the same — different content, same name, in B's tenant.
+    appB = _build_app(userB)
+    async with _client(appB) as c:
+        r = await c.post(
+            f"/api/admin/agents/{agentB}/skills",
+            json={
+                "name": "shared-name",
+                "files": {
+                    "SKILL.md": (
+                        "---\nname: shared-name\n"
+                        f"description: {_DESCRIPTION}\n---\n"
+                        "Tenant B body\n"
+                    ),
+                },
+            },
+        )
+        assert r.status_code == 201
+
+    # Project for tenant A — should only see A's content.
+    cwA = await get_coworker(agentA, tenant_id=userA.tenant_id)
+    assert cwA is not None
+    job_id = f"int-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            cwA, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        skill_md = (Path(mount.host_path) / "shared-name" / "SKILL.md").read_text()
+        assert "Tenant A body" in skill_md
+        assert "Tenant B body" not in skill_md
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Full round-trip: edit a single file via REST and re-project
+# ---------------------------------------------------------------------------
+
+
+async def test_per_file_patch_visible_in_next_projection() -> None:
+    user, agent_id = await _seed(agent_backend="claude-code")
+    app = _build_app(user)
+    async with _client(app) as c:
+        r = await c.post(
+            f"/api/admin/agents/{agent_id}/skills",
+            json={
+                "name": "iterative",
+                "files": {
+                    "SKILL.md": (
+                        "---\nname: iterative\n"
+                        f"description: {_DESCRIPTION}\n---\nv1 body\n"
+                    ),
+                },
+            },
+        )
+        sid = r.json()["id"]
+        # Add a supporting file via the per-file PATCH endpoint.
+        r2 = await c.patch(
+            f"/api/admin/agents/{agent_id}/skills/{sid}/files/notes.md",
+            json={"content": "## v2 notes\nadded later\n"},
+        )
+        assert r2.status_code == 200
+
+    coworker = await get_coworker(agent_id, tenant_id=user.tenant_id)
+    assert coworker is not None
+    job_id = f"int-{uuid.uuid4().hex[:8]}"
+    try:
+        mount = await materialize_skills_for_spawn(
+            coworker, job_id, backend="claude-code"
+        )
+        assert mount is not None
+        skill_root = Path(mount.host_path) / "iterative"
+        # The PATCH content must be present in the next projection.
+        notes = (skill_root / "notes.md").read_text()
+        assert "added later" in notes
+    finally:
+        cleanup_spawn_skills(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Real-model E2E (skipped by default)
+#
+# These tests require:
+#   * A reachable Anthropic API or self-hosted Claude proxy
+#   * Docker + the rolemesh-agent image built
+#   * NATS available to the orchestrator
+#
+# They are documented here as the canonical proof of the
+# auto-invocation contract: the model decides to call a skill
+# purely from its frontmatter ``description``, then reads
+# supporting files referenced from SKILL.md. To run:
+#
+#   pytest -m e2e tests/test_skills_integration.py
+#
+# Run on a dedicated CI lane that has the dependencies wired up,
+# not on per-PR CI.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    os.environ.get("ROLEMESH_E2E_SKILLS") != "1",
+    reason="Real-model skill e2e — set ROLEMESH_E2E_SKILLS=1 to enable",
+)
+async def test_e2e_model_invokes_skill_claude() -> None:
+    """The model receives a prompt containing the trigger token,
+    autonomously calls the skill (Claude SDK loads the projected
+    SKILL.md and the model decides), reads ``examples.md``, and
+    emits the canonical reply.
+
+    Implementation lives outside this module — this stub is the
+    place to plumb in the live runner. Marked skipped to avoid
+    spurious failures on CI without the right wiring.
+    """
+    pytest.skip("Live-model e2e wiring intentionally not bundled in PR 4.")
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    os.environ.get("ROLEMESH_E2E_SKILLS") != "1",
+    reason="Real-model skill e2e — set ROLEMESH_E2E_SKILLS=1 to enable",
+)
+async def test_e2e_model_invokes_skill_pi() -> None:
+    """Pi backend variant of the live-model test."""
+    pytest.skip("Live-model e2e wiring intentionally not bundled in PR 4.")

--- a/tests/webui/test_skills_api.py
+++ b/tests/webui/test_skills_api.py
@@ -357,6 +357,48 @@ class TestUpdate:
         assert set(r2.json()["files"]) == {"SKILL.md", "new.md"}
 
     @pytest.mark.asyncio
+    async def test_clear_backend_overrides_with_empty_dict(self) -> None:
+        """PATCH with ``frontmatter_backend: {}`` must clear the dict,
+        not silently keep the existing one. Caused by the previous
+        ``body.frontmatter_backend or existing.frontmatter_backend``
+        which treated an explicit empty dict as falsy.
+        """
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "with-overrides",
+                    "files": {
+                        "SKILL.md": (
+                            "---\nname: with-overrides\n"
+                            f"description: {_GOOD_DESC}\n"
+                            "argument-hint: '[before]'\n"
+                            "---\nbody\n"
+                        ),
+                    },
+                },
+            )
+            assert r.status_code == 201
+            sid = r.json()["id"]
+            # Confirm Claude override is currently set.
+            assert r.json()["frontmatter_backend"] == {
+                "claude": {"argument-hint": "[before]"}
+            }
+
+            # Now PATCH with an explicit empty dict — must wipe.
+            r2 = await c.patch(
+                f"/api/admin/agents/{aid}/skills/{sid}",
+                json={"frontmatter_backend": {}},
+            )
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["frontmatter_backend"] == {}, (
+                "explicit empty frontmatter_backend should clear, "
+                "not silently keep existing"
+            )
+
+    @pytest.mark.asyncio
     async def test_replace_files_must_include_skill_md(self) -> None:
         tid, uid, aid = await _seed()
         app = _build_app(_authed_user(tid, uid))

--- a/tests/webui/test_skills_api.py
+++ b/tests/webui/test_skills_api.py
@@ -1,0 +1,520 @@
+"""REST API tests for /api/admin/agents/{id}/skills endpoints.
+
+Hits the FastAPI router via httpx ASGI transport (no live server) and
+exercises:
+
+* CRUD happy path for both flat ``files`` map and structured payloads
+* per-file PATCH / DELETE — including refusal to delete SKILL.md
+* payload validation (description min/max, name regex, unknown
+  frontmatter key rejection, path traversal)
+* cross-tenant isolation: tenant A admin cannot read or mutate
+  tenant B's skills (404, not 403, to avoid leaking existence)
+* 404 when ``agent_id`` doesn't exist or is in another tenant
+* the disabled-skill round-trip (admin can read disabled skills,
+  PATCH them re-enabled)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db.pg import (
+    create_coworker,
+    create_tenant,
+    create_user,
+)
+from webui import admin
+from webui.dependencies import (
+    get_current_user,
+    require_manage_agents,
+    require_manage_tenant,
+    require_manage_users,
+)
+
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+_GOOD_DESC = (
+    "When the user message contains the literal token "
+    "EXECUTE_TEST_SKILL_42, run the demonstration workflow."
+)
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin.router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    app.dependency_overrides[require_manage_agents] = _return_user
+    app.dependency_overrides[require_manage_tenant] = _return_user
+    app.dependency_overrides[require_manage_users] = _return_user
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def _seed() -> tuple[str, str, str]:
+    """One tenant, one user, one coworker — return (tenant, user, agent) ids."""
+    t = await create_tenant(name="T", slug=f"sk-api-{uuid.uuid4().hex[:8]}")
+    u = await create_user(
+        tenant_id=t.id, name="Alice",
+        email=f"alice-{uuid.uuid4().hex[:6]}@x.com", role="owner",
+    )
+    cw = await create_coworker(
+        tenant_id=t.id, name="CW", folder=f"cw-{uuid.uuid4().hex[:8]}",
+    )
+    return t.id, u.id, cw.id
+
+
+def _authed_user(tenant_id: str, user_id: str, role: str = "owner") -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id, tenant_id=tenant_id, role=role,
+        email="x@x.com", name="X",
+    )
+
+
+def _skill_md_text(name: str = "code-review", desc: str = _GOOD_DESC) -> str:
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {desc}\n"
+        "---\n"
+        "# Workflow\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSkill:
+    @pytest.mark.asyncio
+    async def test_minimal_skill(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "code-review",
+                    "files": {"SKILL.md": _skill_md_text()},
+                },
+            )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["name"] == "code-review"
+        assert body["coworker_id"] == aid
+        assert body["enabled"] is True
+        assert "SKILL.md" in body["files"]
+        # SKILL.md content is body-only after the splitter normalizes.
+        assert "---" not in body["files"]["SKILL.md"]["content"]
+
+    @pytest.mark.asyncio
+    async def test_with_supporting_files(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "with-helper",
+                    "files": {
+                        "SKILL.md": _skill_md_text("with-helper"),
+                        "reference.md": "## Reference\nDetails.\n",
+                        "scripts/helper.py": "print('x')\n",
+                    },
+                },
+            )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert set(body["files"]) == {"SKILL.md", "reference.md", "scripts/helper.py"}
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_skill_name(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "1bad-leading-digit",
+                    "files": {"SKILL.md": _skill_md_text("1bad-leading-digit")},
+                },
+            )
+        # Pydantic-level validation fires first with 422 because the
+        # schema regex rejects the name. Either 422 or 400 is acceptable
+        # — the user gets a structured error either way.
+        assert resp.status_code in (400, 422)
+
+    @pytest.mark.asyncio
+    async def test_rejects_short_description(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        skill_md = (
+            "---\nname: x\ndescription: short\n---\nbody"
+        )
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "x", "files": {"SKILL.md": skill_md}},
+            )
+        assert resp.status_code == 400
+        assert "too short" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_frontmatter_key(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        skill_md = (
+            "---\n"
+            "name: x\n"
+            f"description: {_GOOD_DESC}\n"
+            "unknown-knob: surprise\n"
+            "---\nbody"
+        )
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "x", "files": {"SKILL.md": skill_md}},
+            )
+        assert resp.status_code == 400
+        assert "unknown frontmatter key" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_skill_md(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "x", "files": {"only.md": "no entrypoint"}},
+            )
+        assert resp.status_code == 400
+        assert "SKILL.md" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "trav",
+                    "files": {
+                        "SKILL.md": _skill_md_text("trav"),
+                        "../escape.md": "naughty",
+                    },
+                },
+            )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_duplicate_name_returns_409(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        payload = {"name": "dup", "files": {"SKILL.md": _skill_md_text("dup")}}
+        async with _client(app) as c:
+            r1 = await c.post(f"/api/admin/agents/{aid}/skills", json=payload)
+            assert r1.status_code == 201
+            r2 = await c.post(f"/api/admin/agents/{aid}/skills", json=payload)
+            assert r2.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_returns_404(self) -> None:
+        tid, uid, _ = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{uuid.uuid4()}/skills",
+                json={"name": "x", "files": {"SKILL.md": _skill_md_text("x")}},
+            )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# List + get
+# ---------------------------------------------------------------------------
+
+
+class TestListGet:
+    @pytest.mark.asyncio
+    async def test_list_includes_disabled(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r1 = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "always-on",
+                    "files": {"SKILL.md": _skill_md_text("always-on")},
+                },
+            )
+            assert r1.status_code == 201, r1.text
+            r2 = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "shut-off",
+                    "enabled": False,
+                    "files": {"SKILL.md": _skill_md_text("shut-off")},
+                },
+            )
+            assert r2.status_code == 201, r2.text
+            resp = await c.get(f"/api/admin/agents/{aid}/skills")
+        assert resp.status_code == 200
+        names = {s["name"] for s in resp.json()}
+        assert names == {"always-on", "shut-off"}
+
+    @pytest.mark.asyncio
+    async def test_get_returns_files(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "g",
+                    "files": {
+                        "SKILL.md": _skill_md_text("g"),
+                        "ref.md": "ref",
+                    },
+                },
+            )
+            sid = r.json()["id"]
+            resp = await c.get(f"/api/admin/agents/{aid}/skills/{sid}")
+        assert resp.status_code == 200
+        assert "ref.md" in resp.json()["files"]
+        assert resp.json()["files"]["ref.md"]["content"] == "ref"
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+class TestUpdate:
+    @pytest.mark.asyncio
+    async def test_toggle_enabled_round_trip(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "t", "files": {"SKILL.md": _skill_md_text("t")}},
+            )
+            sid = r.json()["id"]
+            r2 = await c.patch(
+                f"/api/admin/agents/{aid}/skills/{sid}", json={"enabled": False}
+            )
+            assert r2.status_code == 200
+            assert r2.json()["enabled"] is False
+
+            r3 = await c.patch(
+                f"/api/admin/agents/{aid}/skills/{sid}", json={"enabled": True}
+            )
+            assert r3.json()["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_replace_files(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "r",
+                    "files": {
+                        "SKILL.md": _skill_md_text("r"),
+                        "old.md": "drop",
+                    },
+                },
+            )
+            sid = r.json()["id"]
+            r2 = await c.patch(
+                f"/api/admin/agents/{aid}/skills/{sid}",
+                json={
+                    "files": {
+                        "SKILL.md": _skill_md_text("r"),
+                        "new.md": "kept",
+                    },
+                },
+            )
+        assert r2.status_code == 200
+        assert set(r2.json()["files"]) == {"SKILL.md", "new.md"}
+
+    @pytest.mark.asyncio
+    async def test_replace_files_must_include_skill_md(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "r", "files": {"SKILL.md": _skill_md_text("r")}},
+            )
+            sid = r.json()["id"]
+            r2 = await c.patch(
+                f"/api/admin/agents/{aid}/skills/{sid}",
+                json={"files": {"only.md": "no entrypoint"}},
+            )
+        assert r2.status_code == 400
+        assert "SKILL.md" in r2.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Per-file edit
+# ---------------------------------------------------------------------------
+
+
+class TestPerFile:
+    @pytest.mark.asyncio
+    async def test_patch_single_file(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "p", "files": {"SKILL.md": _skill_md_text("p")}},
+            )
+            sid = r.json()["id"]
+            r2 = await c.patch(
+                f"/api/admin/agents/{aid}/skills/{sid}/files/extra.md",
+                json={"content": "added"},
+            )
+            assert r2.status_code == 200
+            assert "extra.md" in r2.json()["files"]
+            assert r2.json()["files"]["extra.md"]["content"] == "added"
+
+    @pytest.mark.asyncio
+    async def test_delete_file(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={
+                    "name": "d",
+                    "files": {
+                        "SKILL.md": _skill_md_text("d"),
+                        "del.md": "remove me",
+                    },
+                },
+            )
+            sid = r.json()["id"]
+            r2 = await c.delete(
+                f"/api/admin/agents/{aid}/skills/{sid}/files/del.md"
+            )
+            assert r2.status_code == 204
+            check = await c.get(f"/api/admin/agents/{aid}/skills/{sid}")
+        assert "del.md" not in check.json()["files"]
+
+    @pytest.mark.asyncio
+    async def test_delete_skill_md_refused(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "k", "files": {"SKILL.md": _skill_md_text("k")}},
+            )
+            sid = r.json()["id"]
+            r2 = await c.delete(
+                f"/api/admin/agents/{aid}/skills/{sid}/files/SKILL.md"
+            )
+        assert r2.status_code == 400
+        assert "SKILL.md" in r2.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Delete skill
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_then_get_404(self) -> None:
+        tid, uid, aid = await _seed()
+        app = _build_app(_authed_user(tid, uid))
+        async with _client(app) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aid}/skills",
+                json={"name": "d", "files": {"SKILL.md": _skill_md_text("d")}},
+            )
+            sid = r.json()["id"]
+            r2 = await c.delete(f"/api/admin/agents/{aid}/skills/{sid}")
+            assert r2.status_code == 204
+            r3 = await c.get(f"/api/admin/agents/{aid}/skills/{sid}")
+        assert r3.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTenantIsolation:
+    @pytest.mark.asyncio
+    async def test_cannot_read_foreign_skill(self) -> None:
+        tA, uA, aA = await _seed()
+        tB, uB, aB = await _seed()
+        # Tenant B creates a skill under their own coworker.
+        appB = _build_app(_authed_user(tB, uB))
+        async with _client(appB) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aB}/skills",
+                json={"name": "secret", "files": {"SKILL.md": _skill_md_text("secret")}},
+            )
+            sid = r.json()["id"]
+
+        # Tenant A tries to read tenant B's skill via its own agent path
+        # AND via the foreign agent path. Both must 404.
+        appA = _build_app(_authed_user(tA, uA))
+        async with _client(appA) as c:
+            r1 = await c.get(f"/api/admin/agents/{aA}/skills/{sid}")
+            assert r1.status_code == 404
+            r2 = await c.get(f"/api/admin/agents/{aB}/skills/{sid}")
+            assert r2.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_cannot_create_under_foreign_agent(self) -> None:
+        tA, uA, _ = await _seed()
+        _, _, aB = await _seed()
+        appA = _build_app(_authed_user(tA, uA))
+        async with _client(appA) as c:
+            resp = await c.post(
+                f"/api/admin/agents/{aB}/skills",
+                json={"name": "x", "files": {"SKILL.md": _skill_md_text("x")}},
+            )
+        # Either 404 (the tenant cannot see foreign agent) or 403/400
+        # if some other layer fires. The point: it must NOT be 201.
+        assert resp.status_code != 201
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_cannot_delete_foreign_skill(self) -> None:
+        tA, uA, _ = await _seed()
+        tB, uB, aB = await _seed()
+        appB = _build_app(_authed_user(tB, uB))
+        async with _client(appB) as c:
+            r = await c.post(
+                f"/api/admin/agents/{aB}/skills",
+                json={"name": "x", "files": {"SKILL.md": _skill_md_text("x")}},
+            )
+            sid = r.json()["id"]
+        appA = _build_app(_authed_user(tA, uA))
+        async with _client(appA) as c:
+            r = await c.delete(f"/api/admin/agents/{aB}/skills/{sid}")
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary

Adds per-coworker [Agent Skills](https://docs.claude.com/en/docs/claude-code/skills) so admins can configure capability folders that both backends (Claude SDK + Pi) auto-invoke based on frontmatter `description`. The DB is the single source of truth; per-spawn projection writes the right files to the right backend's path inside each agent container.

- **DB layer**: `skills` + `skill_files` tables, RLS (transitive on `skill_files`), `SECURITY DEFINER` cross-tenant trigger on `skills.coworker_id`, frontmatter splitter that stores common vs backend-specific keys separately, full CRUD with explicit tenant scoping as defense-in-depth alongside RLS.
- **Container projection**: per-spawn build dir at `<DATA_DIR>/spawns/<job_id>/skills/`; each skill staged into `.partial/<name>/` and atomically renamed; backend-aware target path (`/home/agent/.claude/skills` or `/home/agent/.pi/agent/skills`); read-only bind mount; symlink-rejecting projector; orphan cleaner; outer `try/finally` guarantees cleanup on every exit path including exceptions.
- **REST API**: `/api/admin/agents/{id}/skills` + per-file PATCH/DELETE; gated by existing `require_manage_agents` (NOT `AgentPermissions`); description min/max validation; explicit-empty-dict clears overrides.
- **Pi runtime fix (drive-by)**: `create_agent_session` was hardcoding `system_prompt=""`, dropping every author-supplied prompt + every loaded skill on the floor. Now assembles from the resource loader's pieces, gated on `read` tool availability for the skills XML block.

Manual end-to-end verification on a live Slack-bound coworker: both Claude (Adam, Anthropic) and Pi (运营1号, OpenAI gpt-4o-mini) autonomously invoked a test skill from its frontmatter description and read its supporting file. Sequence documented in the conversation that produced this branch.

Design doc lives at `docs/skills-architecture.md` (gitignored — local working spec).

## Commits

- `chore(coworker)` — remove unused `coworkers.skills` JSONB column + propagation (pre-clean before the new subsystem lands)
- `feat(skills) PR 1` — DB schema, RLS, frontmatter splitter, CRUD
- `feat(skills) PR 2` — container projection + bind mount
- `feat(skills) PR 3` — admin REST API
- `test(skills) PR 4` — integration suite + e2e marker scaffolding
- `fix(skills)` x4 — non-UUID user_id, inner symlink rejection, safe orphan iteration, explicit-empty-dict semantics
- `fix(skills)` x1 — outer try/finally for cleanup on exception paths
- `fix(skills)` x1 — BOM tolerance + YAML 1.1 boolean trap diagnostic
- `fix(pi)` x2 — assemble system_prompt from resource_loader, gate skills on read tool

## Test plan

- [ ] `pytest tests/core/test_skills.py tests/db/test_skills.py tests/container/test_skill_projection.py tests/webui/test_skills_api.py tests/test_skills_integration.py tests/test_agent_runner/test_pi_system_prompt_assembly.py` — 144 cases, all green locally.
- [ ] `pytest tests/` full suite — 22 700+ pre-existing tests still green.
- [ ] Manual e2e against Slack: post a skill via REST, send the trigger phrase to a coworker, observe the model invoke the skill and read a supporting file. Done for both Claude and Pi backends locally.
- [ ] Verify schema migrates cleanly on a fresh dev DB: `_create_schema` adds the new tables and `ALTER TABLE coworkers DROP COLUMN IF EXISTS skills` cleans the old field idempotently.
- [ ] Verify on a live container: `docker exec <agent> ls /home/agent/.claude/skills/` (or `.pi/agent/skills/`) shows the projected skill folder; attempted write returns `EROFS`.

## Known follow-ups (not blocking this PR)

- Author-friendly skill auth: any non-`bootstrap` admin user already works via the REST routes; the bootstrap-token UUID guard is a stopgap until OIDC / builtin auth provisions a real admin row.
- Skills `name` is immutable post-creation (delete + recreate to rename). Add a rename endpoint once a use case appears.
- `cleanup_orphan_spawns` is wired but no scheduler invokes it yet — current cleanup runs at every container exit via the executor's `try/finally`. Add a periodic sweep when an orphan-survival window is observed.
- Frontmatter field allowlists (`COMMON_FRONTMATTER_KEYS`, `CLAUDE_FRONTMATTER_KEYS`, `PI_FRONTMATTER_KEYS`) need a schema PR every time the SDKs add a new knob — that friction is intentional but a config-driven extension point is cheap to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)