### PR TITLE
fix(egress): shared gateway bootstrap so eval / non-daemon callers get DNS protection

### DIFF
--- a/src/rolemesh/egress/bootstrap.py
+++ b/src/rolemesh/egress/bootstrap.py
@@ -1,0 +1,227 @@
+"""Idempotent EC-2 egress bootstrap shared by every code path that
+spins up a ``ContainerRuntime`` and intends to spawn agent containers.
+
+The orchestrator daemon (``rolemesh.main``) has historically been the
+only caller, so the gateway-launch + DNS-IP-register logic lived
+inline in ``main.py:_launch_egress_gateway_once_ready``. Other entry
+points that started their own runtime (the eval CLI, future admin
+scripts) silently inherited the runner's ``_EGRESS_GATEWAY_DNS_IP``
+unset state and emitted "DNS exfil protection is inactive" warnings
+on every container spawn, with no way for the caller to know they
+needed to call the setter.
+
+This module turns the missing step into a function call. The flow
+is now:
+
+* ``runtime.ensure_available()``  — dockerd version gate (caller)
+* ``runtime.ensure_agent_network(...)`` — agent bridge (caller)
+* ``runtime.ensure_egress_network(...)`` — outbound bridge (caller)
+* ``await ensure_gateway_running_and_register_dns(runtime)`` — this
+  module: idempotent gateway launch + DNS resolver registration.
+
+The first three are already idempotent methods on the runtime itself.
+The fourth was the only piece without a uniform entry point; this
+module adds it.
+
+Idempotence model
+-----------------
+
+* If the gateway container is already running and reachable, the
+  helper does NOT recreate it (which would tear down a working
+  gateway in use by other processes — e.g. the orchestrator daemon).
+  It just inspects the existing container's IP and registers it.
+* If the gateway is not running (fresh boot, or a prior crash left
+  no container behind), the helper calls ``launch_egress_gateway``
+  and ``wait_for_gateway_ready`` exactly as ``main.py`` did.
+
+Cross-process race: two processes calling this helper simultaneously
+on a host without a gateway can both try to launch one. Docker's
+``create_or_replace`` semantics tolerate the conflict (last writer
+wins), and ``wait_for_gateway_ready`` polls until /healthz responds,
+so the race is recoverable. In practice the orchestrator launches
+the gateway long before any second caller exists.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import aiodocker
+
+from rolemesh.core.config import (
+    CONTAINER_EGRESS_NETWORK_NAME,
+    CONTAINER_NETWORK_NAME,
+    CREDENTIAL_PROXY_PORT,
+    EGRESS_GATEWAY_CONTAINER_NAME,
+)
+from rolemesh.core.logger import get_logger
+from rolemesh.egress.launcher import launch_egress_gateway, wait_for_gateway_ready
+
+# ``rolemesh.container.runner`` imports from ``rolemesh.agent`` which
+# imports back into ``rolemesh.container.runner`` — module-level
+# imports here would race that cycle on first load. The setter is
+# pulled in inside the function body, exactly as ``main.py`` did
+# before this refactor extracted the bootstrap.
+
+if TYPE_CHECKING:
+    from rolemesh.container.runtime import ContainerRuntime
+
+
+logger = get_logger()
+
+
+def _gateway_agent_net_ip(info: dict[str, object]) -> str | None:
+    """Pull the gateway's agent-network IP from a docker inspect dict."""
+    networks_obj = info.get("NetworkSettings")
+    if not isinstance(networks_obj, dict):
+        return None
+    networks = networks_obj.get("Networks")
+    if not isinstance(networks, dict):
+        return None
+    net_info = networks.get(CONTAINER_NETWORK_NAME)
+    if not isinstance(net_info, dict):
+        return None
+    ip = net_info.get("IPAddress")
+    return ip if isinstance(ip, str) and ip else None
+
+
+async def _existing_gateway_ip(docker_client: aiodocker.Docker) -> str | None:
+    """If a running gateway container exists, return its agent-net IP.
+
+    Returns None when:
+      * the container does not exist,
+      * inspect raises (transient docker error),
+      * the container exists but is not in ``Running`` state,
+      * the inspect output lacks an agent-network IPAddress entry.
+
+    All non-running / unreachable cases drop through to a fresh
+    launch, which is the conservative behaviour: better to recreate
+    a broken gateway than to register the IP of a stopped one.
+    """
+    try:
+        container = docker_client.containers.container(EGRESS_GATEWAY_CONTAINER_NAME)
+        info = await container.show()
+    except aiodocker.exceptions.DockerError:
+        return None
+    state = info.get("State")
+    if not isinstance(state, dict) or not state.get("Running"):
+        return None
+    return _gateway_agent_net_ip(info)
+
+
+async def _registered_gateway_ip_after_launch(
+    docker_client: aiodocker.Docker,
+) -> str | None:
+    """Inspect the freshly-launched gateway and return its agent-net IP.
+
+    Separated from ``_existing_gateway_ip`` because the post-launch
+    expectations are different — here the container is known to
+    exist and an absent ``IPAddress`` is an unrecoverable error
+    rather than a "fall through to launch" signal.
+    """
+    container = docker_client.containers.container(EGRESS_GATEWAY_CONTAINER_NAME)
+    info = await container.show()
+    return _gateway_agent_net_ip(info)
+
+
+def _ec2_active(runtime: ContainerRuntime) -> bool:
+    """EC-2 is active when both the operator opted in
+    (``CONTAINER_NETWORK_NAME`` is non-empty) and the runtime
+    backend supports egress networks (Docker today; k8s grows its
+    own bootstrap path later).
+    """
+    return bool(
+        CONTAINER_NETWORK_NAME
+        and hasattr(runtime, "ensure_egress_network")
+        and hasattr(runtime, "verify_egress_gateway_reachable")
+    )
+
+
+async def ensure_gateway_running_and_register_dns(
+    runtime: ContainerRuntime,
+) -> str | None:
+    """Make sure the egress gateway is running and register its DNS
+    IP for this process's container spawns.
+
+    Returns the agent-network IP that was registered, or None when
+    EC-2 is not active (returns silently — the caller is operating
+    in rollback mode and there is nothing to register).
+
+    Safe to call from any entry point that spins up a ``ContainerRuntime``
+    independently of the orchestrator daemon — e.g. ``rolemesh-eval``,
+    ad-hoc admin scripts, CI workers. Reuses an already-running
+    gateway rather than recreating it, so concurrent callers (the
+    orchestrator daemon plus an eval CLI invoked alongside it) do not
+    disrupt each other.
+    """
+    if not _ec2_active(runtime):
+        return None
+
+    # Lazy import to break the runner ↔ agent.executor circular
+    # dependency at module load time. Safe at call time.
+    from rolemesh.container.runner import set_egress_gateway_dns_ip
+
+    docker_client = runtime._ensure_client()  # type: ignore[attr-defined]
+
+    # Reuse-if-running fast path. Skips ``launch_egress_gateway``'s
+    # destructive ``create_or_replace`` so a running gateway in use
+    # by other processes (orchestrator + eval CLI on the same host)
+    # is left alone.
+    existing_ip = await _existing_gateway_ip(docker_client)
+    if existing_ip is not None:
+        # Still verify reachability — a "Running" container with no
+        # responder behind /healthz would silently break agent egress
+        # otherwise. ``wait_for_gateway_ready`` polls for ~60s with
+        # short timeouts; the no-op case (gateway healthy) returns
+        # immediately on the first request.
+        with contextlib.suppress(Exception):
+            await wait_for_gateway_ready(
+                docker_client,
+                agent_network=CONTAINER_NETWORK_NAME,
+                gateway_service_name=EGRESS_GATEWAY_CONTAINER_NAME,
+                reverse_proxy_port=CREDENTIAL_PROXY_PORT,
+            )
+        set_egress_gateway_dns_ip(existing_ip)
+        logger.info(
+            "Egress gateway already running — registered DNS IP",
+            ip=existing_ip,
+            gateway=EGRESS_GATEWAY_CONTAINER_NAME,
+        )
+        return existing_ip
+
+    # No usable gateway — launch one and wait for it.
+    await launch_egress_gateway(
+        docker_client,
+        agent_network=CONTAINER_NETWORK_NAME,
+        egress_network=CONTAINER_EGRESS_NETWORK_NAME,
+    )
+    await wait_for_gateway_ready(
+        docker_client,
+        agent_network=CONTAINER_NETWORK_NAME,
+        gateway_service_name=EGRESS_GATEWAY_CONTAINER_NAME,
+        reverse_proxy_port=CREDENTIAL_PROXY_PORT,
+    )
+
+    fresh_ip = await _registered_gateway_ip_after_launch(docker_client)
+    if fresh_ip is None:
+        # The healthy /healthz reachable just succeeded but inspect
+        # has no IPAddress on agent-net — shouldn't happen with our
+        # network topology. Log error rather than raise: agents will
+        # fall back to Docker DNS, which is "broken" but not "down".
+        logger.error(
+            "Gateway healthy but its agent-net IP is missing from "
+            "inspect output — agents will fall back to Docker DNS "
+            "and the authoritative resolver will not see their queries",
+            gateway=EGRESS_GATEWAY_CONTAINER_NAME,
+            agent_network=CONTAINER_NETWORK_NAME,
+        )
+        return None
+
+    set_egress_gateway_dns_ip(fresh_ip)
+    logger.info(
+        "Egress gateway launched — registered DNS IP",
+        ip=fresh_ip,
+        gateway=EGRESS_GATEWAY_CONTAINER_NAME,
+    )
+    return fresh_ip

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1301,61 +1301,18 @@ async def _launch_egress_gateway_once_ready() -> None:
       * ``hasattr(_runtime, ...)`` — k8s runtime will grow its own
         gateway pod primitive and should not use this path.
     """
-    if (
-        CONTAINER_NETWORK_NAME
-        and hasattr(_runtime, "ensure_egress_network")
-        and hasattr(_runtime, "verify_egress_gateway_reachable")
-    ):
-        from rolemesh.container.runner import set_egress_gateway_dns_ip
-        from rolemesh.egress.launcher import launch_egress_gateway, wait_for_gateway_ready
+    # Idempotent bootstrap: ensure the gateway is running and register
+    # its agent-network IP so ``runner.build_container_spec`` can pin it
+    # as each agent container's DNS resolver. Lives in a shared module
+    # so other entry points that spin up their own ``ContainerRuntime``
+    # (eval CLI, ad-hoc admin scripts) get the same behaviour by
+    # calling one function instead of duplicating this block — the
+    # original inline code led to a real bug where eval-spawned
+    # containers silently fell back to Docker's default DNS resolver
+    # because no one called ``set_egress_gateway_dns_ip``.
+    from rolemesh.egress.bootstrap import ensure_gateway_running_and_register_dns
 
-        # Access the aiodocker client directly via the Docker runtime's
-        # adapter surface. For the k8s backend we'll wrap this differently.
-        docker_client = _runtime._ensure_client()  # type: ignore[attr-defined]
-        await launch_egress_gateway(
-            docker_client,
-            agent_network=CONTAINER_NETWORK_NAME,
-            egress_network=CONTAINER_EGRESS_NETWORK_NAME,
-        )
-        await wait_for_gateway_ready(
-            docker_client,
-            agent_network=CONTAINER_NETWORK_NAME,
-            gateway_service_name=EGRESS_GATEWAY_CONTAINER_NAME,
-            reverse_proxy_port=CREDENTIAL_PROXY_PORT,
-        )
-
-        # Discover the gateway's bridge IP on the agent network and
-        # register it so runner.build_container_spec can pin it as
-        # each agent container's DNS resolver. Without this step the
-        # authoritative DNS resolver built in EC-2 never sees agent
-        # traffic — queries go through Docker's embedded resolver
-        # (127.0.0.11) which forwards to the host. See EC-2 code
-        # review P1 finding.
-        gateway_container = docker_client.containers.container(
-            EGRESS_GATEWAY_CONTAINER_NAME
-        )
-        gateway_info = await gateway_container.show()
-        gateway_ip = (
-            gateway_info.get("NetworkSettings", {})
-            .get("Networks", {})
-            .get(CONTAINER_NETWORK_NAME, {})
-            .get("IPAddress", "")
-        )
-        if gateway_ip:
-            set_egress_gateway_dns_ip(gateway_ip)
-        else:
-            # Gateway is reachable by name (we just verified /healthz)
-            # but doesn't expose an IPAddress on agent-net in inspect
-            # output. Shouldn't happen in practice with our topology;
-            # log as an error because it means agent DNS will silently
-            # fall back to the embedded resolver.
-            logger.error(
-                "Gateway healthy but its agent-net IP is missing from "
-                "inspect output — agents will fall back to Docker DNS "
-                "and the authoritative resolver will not see their queries",
-                gateway=EGRESS_GATEWAY_CONTAINER_NAME,
-                agent_network=CONTAINER_NETWORK_NAME,
-            )
+    await ensure_gateway_running_and_register_dns(_runtime)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/container/test_startup_order.py
+++ b/tests/container/test_startup_order.py
@@ -166,11 +166,14 @@ async def test_launch_aborts_when_gateway_readiness_probe_fails() -> None:
     """Gateway binary up but not serving /healthz within budget → refuse
     to enter ready. Agents would only produce a cryptic failure later.
 
-    Same provenance as the launch-fails test: the contract followed the
-    code into ``_launch_egress_gateway_once_ready`` after the chicken-
-    and-egg fix.
+    Patches the bootstrap-module references because that's where the
+    launch + wait calls actually live now. ``rolemesh.egress.launcher``
+    is the source-of-truth module but bootstrap captures its imports
+    at module load via ``from launcher import ...``, so a patch on
+    launcher's surface doesn't reach the bootstrap call site.
     """
     from rolemesh import main as main_module
+    from rolemesh.egress import bootstrap
 
     rt = _make_runtime_mock()
     launch_mock = AsyncMock()
@@ -178,8 +181,8 @@ async def test_launch_aborts_when_gateway_readiness_probe_fails() -> None:
 
     with (
         patch.object(main_module, "_runtime", rt),
-        patch("rolemesh.egress.launcher.launch_egress_gateway", launch_mock),
-        patch("rolemesh.egress.launcher.wait_for_gateway_ready", wait_mock),
+        patch.object(bootstrap, "launch_egress_gateway", launch_mock),
+        patch.object(bootstrap, "wait_for_gateway_ready", wait_mock),
         pytest.raises(RuntimeError, match="probe exhausted"),
     ):
         await main_module._launch_egress_gateway_once_ready()
@@ -217,18 +220,24 @@ async def test_launch_skips_in_rollback_mode() -> None:
     must short-circuit ``_launch_egress_gateway_once_ready`` so launch +
     readiness probe + IP discovery are all skipped. Pre-Path-C, launch
     was attempted with an empty network name and crashed startup.
+
+    The rollback gate was moved into ``bootstrap._ec2_active`` after
+    the egress-helper extraction, so we patch
+    ``CONTAINER_NETWORK_NAME`` on the bootstrap module — patching
+    main's reference no longer reaches the read site.
     """
     from rolemesh import main as main_module
+    from rolemesh.egress import bootstrap
 
     rt = _make_runtime_mock()
     launch_mock = AsyncMock()
     wait_mock = AsyncMock()
 
     with (
-        patch.object(main_module, "CONTAINER_NETWORK_NAME", ""),
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", ""),
         patch.object(main_module, "_runtime", rt),
-        patch("rolemesh.egress.launcher.launch_egress_gateway", launch_mock),
-        patch("rolemesh.egress.launcher.wait_for_gateway_ready", wait_mock),
+        patch.object(bootstrap, "launch_egress_gateway", launch_mock),
+        patch.object(bootstrap, "wait_for_gateway_ready", wait_mock),
     ):
         await main_module._launch_egress_gateway_once_ready()
 

--- a/tests/egress/test_bootstrap.py
+++ b/tests/egress/test_bootstrap.py
@@ -1,0 +1,399 @@
+"""Tests for ``rolemesh.egress.bootstrap.ensure_gateway_running_and_register_dns``.
+
+The helper is the single shared entry point that every code path
+spinning up a ``ContainerRuntime`` must call so spawned agent
+containers get the gateway pinned as their DNS resolver. The
+production-blocking bug it fixes (eval CLI silently inheriting an
+unset ``_EGRESS_GATEWAY_DNS_IP`` and falling back to Docker's
+default resolver) makes the contract specifically:
+
+* Reuse a running gateway rather than recreating it (so concurrent
+  callers like the orchestrator daemon plus an eval CLI don't
+  disrupt each other).
+* Register the discovered IP via ``set_egress_gateway_dns_ip``.
+* Return None silently when EC-2 is inactive (rollback mode / k8s
+  runtime) — those callers don't need a gateway and registering
+  None would mask real config errors.
+* Be tolerant of inspect-format anomalies (running container with
+  no agent-net IP recorded): log an error, fall through to None,
+  do NOT raise — agents can still spawn, they just lose DNS-level
+  egress filtering.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiodocker.exceptions
+import pytest
+
+
+@pytest.fixture
+def _runner_module() -> Any:
+    """Import ``rolemesh.container.runner`` via a path that does NOT
+    re-trigger its own circular import.
+
+    ``runner`` imports ``rolemesh.agent.executor`` which transitively
+    imports ``container_executor`` which tries to pull
+    ``build_container_spec`` back out of ``runner`` — running fine in
+    production where main.py orchestrates the import order, but
+    blowing up if a test tries to import ``runner`` directly first
+    because ``container_executor`` runs before ``runner`` finishes
+    defining its symbols.
+
+    Loading ``rolemesh.agent.container_executor`` first defers the
+    inner import to a moment where it can be served from sys.modules
+    without entering an unfinished module body. Once that's done,
+    ``rolemesh.container.runner`` is fully loaded for the test's
+    ``patch.object`` calls.
+    """
+    import rolemesh.agent.container_executor  # noqa: F401
+    import rolemesh.container.runner as runner
+
+    return runner
+
+
+def _docker_error(status: int, msg: str = "") -> aiodocker.exceptions.DockerError:
+    return aiodocker.exceptions.DockerError(status, {"message": msg})
+
+
+def _make_runtime(*, ec2_capable: bool = True) -> MagicMock:
+    """A runtime mock that ``_ec2_active`` will accept (or reject)."""
+    runtime = MagicMock()
+    runtime._ensure_client = MagicMock(return_value=MagicMock())
+    if ec2_capable:
+        runtime.ensure_egress_network = MagicMock()
+        runtime.verify_egress_gateway_reachable = MagicMock()
+    else:
+        # ``hasattr`` is what ``_ec2_active`` checks, so we have to
+        # actively delete the attributes for the negative test —
+        # MagicMock auto-creates them on access.
+        del runtime.ensure_egress_network
+        del runtime.verify_egress_gateway_reachable
+    return runtime
+
+
+def _make_gateway_inspect(
+    *,
+    running: bool = True,
+    ip: str | None = "172.18.0.7",
+    network_name: str = "rolemesh-agent-net",
+) -> dict[str, Any]:
+    """Mimic the shape ``aiodocker.DockerContainer.show()`` returns."""
+    networks: dict[str, Any]
+    if ip is not None:
+        networks = {network_name: {"IPAddress": ip}}
+    else:
+        networks = {network_name: {}}  # exists but empty
+    return {
+        "State": {"Running": running},
+        "NetworkSettings": {"Networks": networks},
+    }
+
+
+def _wire_existing_gateway(
+    runtime: MagicMock, inspect_dict: dict[str, Any]
+) -> MagicMock:
+    """Install a containers.container() mock that returns an inspectable
+    gateway. Returns the inner container mock so tests can verify
+    delete/start were not called.
+    """
+    container = MagicMock()
+    container.show = AsyncMock(return_value=inspect_dict)
+    runtime._ensure_client.return_value.containers = MagicMock()
+    runtime._ensure_client.return_value.containers.container = MagicMock(
+        return_value=container
+    )
+    return container
+
+
+def _wire_no_existing_gateway(runtime: MagicMock) -> None:
+    """Make the first ``containers.container(...)`` raise — the helper
+    should fall through to launch.
+    """
+    runtime._ensure_client.return_value.containers = MagicMock()
+    runtime._ensure_client.return_value.containers.container = MagicMock(
+        side_effect=_docker_error(404, "no such container")
+    )
+
+
+# ---------------------------------------------------------------------------
+# EC-2 inactive — early return
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_runtime_lacks_ec2_methods() -> None:
+    """k8s runtime / dev runtime without egress methods returns
+    silently — registering None would shadow a real misconfiguration.
+    """
+    from rolemesh.egress.bootstrap import ensure_gateway_running_and_register_dns
+
+    runtime = _make_runtime(ec2_capable=False)
+    with patch(
+        "rolemesh.egress.bootstrap.CONTAINER_NETWORK_NAME", "rolemesh-agent-net"
+    ):
+        result = await ensure_gateway_running_and_register_dns(runtime)
+
+    assert result is None
+    runtime._ensure_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_container_network_name_unset() -> None:
+    """Rollback mode (operator turned EC off) — no-op."""
+    from rolemesh.egress.bootstrap import ensure_gateway_running_and_register_dns
+
+    runtime = _make_runtime(ec2_capable=True)
+    with patch("rolemesh.egress.bootstrap.CONTAINER_NETWORK_NAME", ""):
+        result = await ensure_gateway_running_and_register_dns(runtime)
+
+    assert result is None
+    runtime._ensure_client.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Reuse-if-running (the path that fixes the eval-CLI duplication bug)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reuses_running_gateway_without_relaunch(_runner_module: Any) -> None:
+    """The single most important assertion in this file.
+
+    A second caller (e.g. eval CLI starting up alongside the
+    orchestrator daemon) must NOT recreate the gateway — that would
+    tear down a working gateway in active use by other processes.
+    """
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+    _wire_existing_gateway(runtime, _make_gateway_inspect(running=True))
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()) as launch_mock,
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()),
+        patch.object(
+            _runner_module, "set_egress_gateway_dns_ip"
+        ) as set_dns_mock,
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result == "172.18.0.7"
+    set_dns_mock.assert_called_once_with("172.18.0.7")
+    launch_mock.assert_not_called(), (
+        "must not relaunch when an existing healthy gateway is found"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reuse_path_still_verifies_reachability(_runner_module: Any) -> None:
+    """A 'Running' container could be paused or have a broken
+    /healthz responder. Reuse-fast-path still polls reachability,
+    suppressing exceptions so a transient blip doesn't block
+    registration of an otherwise-good IP.
+    """
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+    _wire_existing_gateway(runtime, _make_gateway_inspect(running=True))
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()),
+        patch.object(
+            bootstrap, "wait_for_gateway_ready", AsyncMock()
+        ) as wait_mock,
+        patch.object(_runner_module, "set_egress_gateway_dns_ip"),
+    ):
+        await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    wait_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Launch path (no gateway running)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_launches_when_no_existing_gateway(_runner_module: Any) -> None:
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+
+    # First call: container() raises 404. Second call (post-launch):
+    # returns a freshly-spawned container. Track call count to switch
+    # behaviour mid-test without re-wiring mocks.
+    fresh_container = MagicMock()
+    fresh_container.show = AsyncMock(
+        return_value=_make_gateway_inspect(running=True, ip="172.18.0.42")
+    )
+    container_calls: list[Any] = []
+
+    def _container_factory(name: str) -> Any:
+        container_calls.append(name)
+        if len(container_calls) == 1:
+            raise _docker_error(404, "no such container")
+        return fresh_container
+
+    runtime._ensure_client.return_value.containers = MagicMock()
+    runtime._ensure_client.return_value.containers.container = MagicMock(
+        side_effect=_container_factory
+    )
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()) as launch_mock,
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()) as wait_mock,
+        patch.object(
+            _runner_module, "set_egress_gateway_dns_ip"
+        ) as set_dns_mock,
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result == "172.18.0.42"
+    launch_mock.assert_called_once()
+    wait_mock.assert_called_once()
+    set_dns_mock.assert_called_once_with("172.18.0.42")
+
+
+@pytest.mark.asyncio
+async def test_treats_stopped_container_as_no_gateway(_runner_module: Any) -> None:
+    """A container in 'Exited' state is unusable — fall through to
+    launch rather than registering its (stale) IP.
+    """
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+
+    stopped = MagicMock()
+    stopped.show = AsyncMock(
+        return_value=_make_gateway_inspect(running=False)
+    )
+    fresh = MagicMock()
+    fresh.show = AsyncMock(
+        return_value=_make_gateway_inspect(running=True, ip="172.18.0.99")
+    )
+    calls: list[int] = [0]
+
+    def _factory(name: str) -> Any:
+        calls[0] += 1
+        return stopped if calls[0] == 1 else fresh
+
+    runtime._ensure_client.return_value.containers = MagicMock()
+    runtime._ensure_client.return_value.containers.container = MagicMock(
+        side_effect=_factory
+    )
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()) as launch_mock,
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()),
+        patch.object(_runner_module, "set_egress_gateway_dns_ip"),
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result == "172.18.0.99"
+    launch_mock.assert_called_once(), (
+        "stopped container should trigger fresh launch, not be reused"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inspect-output anomalies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_launch_missing_ip_logs_error_and_returns_none(_runner_module: Any) -> None:
+    """Healthy /healthz but no IPAddress on agent-net is the worst
+    realistic case: the gateway answers but inspect can't tell us
+    its IP. Log an error and return None — agents will fall back
+    to Docker DNS, which is "broken-but-not-down".
+    """
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+
+    fresh = MagicMock()
+    fresh.show = AsyncMock(
+        return_value=_make_gateway_inspect(running=True, ip=None)
+    )
+    calls: list[int] = [0]
+
+    def _factory(name: str) -> Any:
+        calls[0] += 1
+        # Force the launch path so we exercise the post-launch
+        # inspect: first call raises (no existing), second returns
+        # the no-IP inspect.
+        if calls[0] == 1:
+            raise _docker_error(404, "no such container")
+        return fresh
+
+    runtime._ensure_client.return_value.containers = MagicMock()
+    runtime._ensure_client.return_value.containers.container = MagicMock(
+        side_effect=_factory
+    )
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()),
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()),
+        patch.object(
+            _runner_module, "set_egress_gateway_dns_ip"
+        ) as set_dns_mock,
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result is None
+    set_dns_mock.assert_not_called(), (
+        "must not register an empty/None IP — caller would silently "
+        "lose DNS protection without a config error to debug"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inspect_format_anomaly_falls_through_to_launch(_runner_module: Any) -> None:
+    """Reuse path: existing container's inspect output has a missing
+    IPAddress field. We treat this as 'no usable gateway' and fall
+    through to the launch path (rather than registering None).
+    """
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+
+    weird = MagicMock()
+    weird.show = AsyncMock(
+        return_value=_make_gateway_inspect(running=True, ip=None)
+    )
+    fresh = MagicMock()
+    fresh.show = AsyncMock(
+        return_value=_make_gateway_inspect(running=True, ip="172.18.0.7")
+    )
+    calls: list[int] = [0]
+
+    def _factory(name: str) -> Any:
+        calls[0] += 1
+        return weird if calls[0] == 1 else fresh
+
+    runtime._ensure_client.return_value.containers = MagicMock()
+    runtime._ensure_client.return_value.containers.container = MagicMock(
+        side_effect=_factory
+    )
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()) as launch_mock,
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()),
+        patch.object(_runner_module, "set_egress_gateway_dns_ip"),
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result == "172.18.0.7"
+    launch_mock.assert_called_once(), (
+        "missing IP in existing container's inspect should trigger "
+        "a fresh launch, not register a None IP"
+    )


### PR DESCRIPTION
## Summary

Closes the silent gap reported when running the eval CLI: every spawned agent container emitted ``No egress gateway DNS IP registered — DNS exfil protection is inactive``, because gateway-launch + DNS-IP register lived inline in ``rolemesh.main`` and nothing else called it. HTTP forward-proxy gating and Internal=true bridge isolation still worked; only the authoritative DNS resolver was off.

Extracts the block into ``rolemesh.egress.bootstrap.ensure_gateway_running_and_register_dns`` — a single ``await`` for any code path that spins up a ``ContainerRuntime`` independently of the daemon (eval CLI, ad-hoc admin scripts, future CI workers).

Idempotent across processes:
- Running gateway → inspect IP, register, no relaunch (so the daemon + eval CLI on the same host don't disrupt each other)
- No gateway → launch, wait, inspect, register
- EC-2 inactive → return None silently (rollback mode / k8s runtime opt out cleanly)
- Post-launch inspect missing IPAddress → log error, return None (don't register empty value)

## Adoption (separate)

The eval CLI on ``feat/eval`` now adopts the helper by adding one line after ``runtime.ensure_available()``:

```python
from rolemesh.egress.bootstrap import ensure_gateway_running_and_register_dns
await ensure_gateway_running_and_register_dns(runtime)
```

Not part of this PR — that change lands when ``feat/eval`` merges main.

## Commits

- ``21e8010 fix(egress): extract idempotent gateway-bootstrap so non-orchestrator entry points get DNS protection``

## Test plan

- [x] ``pytest tests/egress/test_bootstrap.py`` — 8 cases covering EC-2 inactive early-return, reuse-running fast path, launch path on missing or stopped container, and post-launch inspect anomalies. All pass.
- [x] ``pytest tests/container/test_startup_order.py`` — 8 cases including the two updated to patch ``rolemesh.egress.bootstrap`` rather than the launcher surface. All pass in isolation and as part of regression sweep.
- [x] Wider regression: ``pytest tests/container tests/agent tests/egress`` — 22 550 cases pass, no regressions from the refactor.
- [ ] Manual: rerun an eval and confirm the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)