### PR TITLE
fix(tests): unblock default pytest collection (3 hygiene fixes)

### DIFF
--- a/src/rolemesh/approval/executor.py
+++ b/src/rolemesh/approval/executor.py
@@ -85,10 +85,22 @@ class ApprovalWorker:
         js: JetStreamContext,
         channel_sender: ChannelSender,
         proxy_base_url: str | None = None,
+        durable_name: str = "orch-approval-worker",
     ) -> None:
         self._js = js
         self._channel = channel_sender
         self._proxy_base = (proxy_base_url or _CREDENTIAL_PROXY_URL).rstrip("/")
+        # Durable consumer name. Production keeps the default so a worker
+        # restart resumes from where the prior process left off (the
+        # whole point of using ``durable=`` rather than ephemeral). The
+        # eval / e2e harness overrides with a uuid-suffixed name so
+        # consecutive tests on the same NATS instance don't collide:
+        # nats-py's ``js.subscribe`` raises ``"consumer is already bound
+        # to a subscription"`` when the server still has ``push_bound``
+        # set from the prior test's connection (server-side cleanup of
+        # a closed deliver_subject lags behind the connection close by
+        # tens of seconds).
+        self._durable_name = durable_name
         self._sub: Any = None
         self._task: asyncio.Task[None] | None = None
         self._stop = asyncio.Event()
@@ -101,7 +113,7 @@ class ApprovalWorker:
         # batches don't trigger redelivery mid-execution.
         self._sub = await self._js.subscribe(
             "approval.decided.*",
-            durable="orch-approval-worker",
+            durable=self._durable_name,
             manual_ack=True,
             config=ConsumerConfig(ack_wait=_ACK_WAIT_SECONDS),
         )

--- a/tests/approval/e2e/conftest.py
+++ b/tests/approval/e2e/conftest.py
@@ -4,6 +4,16 @@ The ``test_db`` fixture comes from the repo-level ``tests/conftest.py``
 (recreates schema per test). ``nats_url`` here assumes the dev NATS
 server is reachable; the test suite as a whole will skip this module
 if NATS is not available.
+
+Auto-applies the ``e2e`` marker to every test in this directory so the
+default ``addopts = "-m 'not integration and not e2e'"`` in
+``pyproject.toml`` actually keeps these out of fast PR runs. Without
+this hook, the ``e2e`` directory name is just convention — pytest sees
+plain unmarked tests and runs them, which (a) requires NATS / Docker
+on every CI worker and (b) sequentially exercises overlapping
+JetStream consumers across the harness's per-test ephemeral runs.
+Operators who want the e2e tests opt back in with ``pytest -m e2e``
+or ``pytest -m ""`` (include everything).
 """
 
 from __future__ import annotations
@@ -47,6 +57,21 @@ if not _nats_reachable(_NATS_URL):
         "Start with: docker compose -f docker-compose.dev.yml up -d",
         allow_module_level=True,
     )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Stamp every test under this directory with the ``e2e`` marker.
+
+    Pytest auto-loads the nearest conftest, so this hook only fires
+    for items collected under ``tests/approval/e2e/``. Done at the
+    conftest level rather than by adding ``pytestmark`` to every file
+    so a new test file in this dir gets the marker by default and
+    can't accidentally leak into a fast PR run.
+    """
+    for item in items:
+        item.add_marker(pytest.mark.e2e)
 
 
 @pytest.fixture

--- a/tests/approval/e2e/harness.py
+++ b/tests/approval/e2e/harness.py
@@ -391,10 +391,16 @@ async def orchestrator_harness(
         publisher=js, channel_sender=channel, resolver=resolver
     )
     admin_module.set_approval_engine(engine)
+    # Per-test uuid'd durable name so consecutive tests on the same
+    # NATS instance don't collide — nats-py's ``js.subscribe`` rejects
+    # binding to a durable that the server still flags push_bound from
+    # the prior test's (now-closed) connection.
+    worker_durable = f"orch-approval-worker-{uuid.uuid4().hex[:8]}"
     worker = ApprovalWorker(
         js=js,
         channel_sender=channel,
         proxy_base_url=f"http://127.0.0.1:{proxy_port}",
+        durable_name=worker_durable,
     )
     await worker.start()
 
@@ -408,12 +414,14 @@ async def orchestrator_harness(
     )
 
     # --- Subscriptions that mirror main._handle_tasks / _on_cancel_for_job ---
-    task_sub = await js.subscribe(
-        "agent.*.tasks", durable=f"e2e-tasks-{uuid.uuid4().hex[:8]}"
-    )
+    # Hold onto the durable names so teardown can ``delete_consumer``
+    # them — see the cleanup block below for why ``unsubscribe`` alone
+    # is not sufficient.
+    task_durable = f"e2e-tasks-{uuid.uuid4().hex[:8]}"
+    cancel_durable = f"e2e-cancel-{uuid.uuid4().hex[:8]}"
+    task_sub = await js.subscribe("agent.*.tasks", durable=task_durable)
     cancel_sub = await js.subscribe(
-        "approval.cancel_for_job.*",
-        durable=f"e2e-cancel-{uuid.uuid4().hex[:8]}",
+        "approval.cancel_for_job.*", durable=cancel_durable,
     )
 
     async def _task_loop() -> None:
@@ -509,6 +517,19 @@ async def orchestrator_harness(
         with suppress(asyncio.CancelledError):
             await maintenance_task
         await worker.stop()
+        # Explicitly delete the per-test durables we created. ``unsubscribe``
+        # only severs the local sub; the durable stays on the server until
+        # something deletes it. Without this, every test run permanently
+        # leaks 3 durables (task / cancel / worker) on the dev NATS
+        # instance — empirically observed at >250 stale consumers on
+        # ``approval-ipc`` after a few iterations.
+        for stream, name in (
+            ("agent-ipc", task_durable),
+            ("approval-ipc", cancel_durable),
+            ("approval-ipc", worker_durable),
+        ):
+            with suppress(Exception):
+                await js.delete_consumer(stream, name)
         admin_module.set_approval_engine(None)
         await mcp.stop()
         with suppress(Exception):

--- a/tests/safety/e2e/conftest.py
+++ b/tests/safety/e2e/conftest.py
@@ -1,0 +1,26 @@
+"""E2E fixtures for safety tests.
+
+Auto-applies the ``e2e`` marker to every test in this directory so the
+default ``addopts = "-m 'not integration and not e2e'"`` in
+``pyproject.toml`` actually keeps these out of fast PR runs. Without
+this hook, the ``e2e`` directory name is just convention — pytest sees
+plain unmarked tests and runs them, which requires the safety
+framework's RPC server / DB / orchestrator side state on every PR
+worker. Operators who want the e2e tests opt back in with
+``pytest -m e2e`` or ``pytest -m ""`` (include everything).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Stamp every test under this directory with the ``e2e`` marker.
+
+    See ``tests/approval/e2e/conftest.py`` for the rationale.
+    """
+    for item in items:
+        item.add_marker(pytest.mark.e2e)

--- a/tests/test_agent_runner/test_amazon_bedrock_tool_limit.py
+++ b/tests/test_agent_runner/test_amazon_bedrock_tool_limit.py
@@ -18,7 +18,7 @@ import pytest
 boto3 = pytest.importorskip("boto3")  # noqa: F841
 
 from pi.ai.providers.amazon_bedrock import _convert_tool_config
-from pi.ai.tool import Tool
+from pi.ai.types import Tool
 
 
 def _tool(name: str) -> Tool:


### PR DESCRIPTION
## Summary

Three independent test-suite-hygiene bugs that, in combination, made
``pytest tests/`` fail before any real assertion could run on a fresh
checkout. Each bug is one commit so they can be reverted / cherry-picked
independently.

* **04f669b** — bedrock tool-limit test imports ``from pi.ai.tool``,
  which doesn't exist (``Tool`` lives at ``pi.ai.types``). Pytest
  collection ``ModuleNotFoundError`` blocked the entire
  ``tests/test_agent_runner/`` directory.
* **c1c0c38** — ``pyproject.toml`` declares an ``e2e`` marker and
  defaults ``-m 'not integration and not e2e'``, but **0** of 15
  ``tests/approval/e2e/`` files and **0** of 8 ``tests/safety/e2e/``
  files actually carried the marker. Default fast PR runs were
  picking up 56 e2e tests that needed NATS / Docker / a live safety
  RPC server. Fix is one ``pytest_collection_modifyitems`` hook per
  conftest — auto-stamps the marker so a future test file gets the
  filter for free.
* **bf6564a** — every consecutive ``pytest -m e2e tests/approval/e2e/``
  run failed at ``ApprovalWorker.start()`` with
  ``consumer is already bound to a subscription``. Production code
  hardcoded durable name ``orch-approval-worker``; nats-py's
  ``js.subscribe`` checks ``push_bound`` against the prior test's
  (still-server-side-attached) connection. Fix opens a
  ``durable_name`` knob on the worker (default unchanged for
  production) and has the harness pass a uuid'd name. Same commit
  also closes a slow consumer-leak in the harness teardown
  (``unsubscribe`` doesn't delete the durable; we observed >250 stale
  consumers piling up on the dev NATS instance).

After this PR ``pytest tests/`` (default fast filter) actually runs.

## Test plan

- [x] ``uv run --extra pi pytest tests/test_agent_runner/test_amazon_bedrock_tool_limit.py --collect-only`` → 12 collected (was: collection error).
- [x] ``uv run pytest tests/approval/e2e/ --collect-only`` → 0 collected, 17 deselected (was: 17 collected).
- [x] ``uv run pytest tests/safety/e2e/ --collect-only`` → 0 collected, 39 deselected.
- [x] ``uv run pytest -m e2e tests/approval/e2e/ tests/safety/e2e/ --collect-only`` → 56 collected (round-trip works).
- [x] ``uv run pytest -m e2e tests/approval/e2e/`` (full sequential e2e) → 17 passed in 87s, 0 leftover consumers on agent-ipc / approval-ipc.

## Notes

- ``test_realistic_long_mcp_name_raises`` exposes a separate
  pre-existing data bug (sample MCP name is exactly 64 chars but the
  assertion checks ``> 64``) that becomes visible once collection
  works. Out of scope for this PR — flagged in 04f669b's commit body.
- The 3 ``BLE001`` ruff warnings on ``tests/approval/e2e/harness.py``
  are pre-existing on main; this PR doesn't touch the offending
  blocks.