### PR TITLE
refactor(state): collapse CoworkerConfig into Coworker

### DIFF
--- a/src/rolemesh/core/orchestrator_state.py
+++ b/src/rolemesh/core/orchestrator_state.py
@@ -11,38 +11,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from rolemesh.auth.permissions import AgentPermissions
-    from rolemesh.core.types import ChannelBinding, Conversation, McpServerConfig, Tenant
+    from rolemesh.core.types import ChannelBinding, Conversation, Coworker, Tenant
 
 
-@dataclass
-class CoworkerConfig:
-    """Runtime config loaded from coworkers table."""
-
-    id: str
-    tenant_id: str
-    name: str
-    folder: str
-    system_prompt: str | None
-    trigger_pattern: re.Pattern[str]
-    agent_backend: str
-    container_image: str | None
-    max_concurrent: int
-    role_config: dict[str, object] = field(default_factory=dict)
-    tools: list[McpServerConfig] = field(default_factory=list)
-    agent_role: str = "agent"
-    permissions: AgentPermissions | None = None  # filled by __post_init__; always non-None after init
-
-    def __post_init__(self) -> None:
-        if self.permissions is None:
-            from rolemesh.auth.permissions import AgentPermissions as _AgentPermissions
-
-            self.permissions = _AgentPermissions.for_role(self.agent_role)
-
-    @staticmethod
-    def build_trigger_pattern(name: str) -> re.Pattern[str]:
-        """Build trigger pattern from coworker name."""
-        return re.compile(rf"@{re.escape(name)}\b", re.IGNORECASE)
+def build_trigger_pattern(name: str) -> re.Pattern[str]:
+    """Build the @-mention regex for a coworker name."""
+    return re.compile(rf"@{re.escape(name)}\b", re.IGNORECASE)
 
 
 @dataclass
@@ -56,11 +30,26 @@ class ConversationState:
 
 @dataclass
 class CoworkerState:
-    """Per-coworker runtime state."""
+    """Per-coworker runtime state.
 
-    config: CoworkerConfig
+    ``config`` is the DB-row shape (``Coworker``) used as the single source of
+    truth for all coworker fields. Derived/computed values such as the
+    @-mention ``trigger_pattern`` live as sibling fields here, not on
+    ``config`` — keeping the DB shape and the runtime cache cleanly separated.
+    """
+
+    config: Coworker
+    trigger_pattern: re.Pattern[str]
     conversations: dict[str, ConversationState] = field(default_factory=dict)
     channel_bindings: dict[str, ChannelBinding] = field(default_factory=dict)
+
+    @staticmethod
+    def from_coworker(cw: Coworker) -> CoworkerState:
+        """Build a fresh ``CoworkerState`` from a ``Coworker`` DB row."""
+        return CoworkerState(
+            config=cw,
+            trigger_pattern=build_trigger_pattern(cw.name),
+        )
 
 
 class OrchestratorState:

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -70,7 +70,6 @@ from rolemesh.core.config import (
 from rolemesh.core.logger import get_logger
 from rolemesh.core.orchestrator_state import (
     ConversationState,
-    CoworkerConfig,
     CoworkerState,
     OrchestratorState,
 )
@@ -406,22 +405,7 @@ async def _load_state() -> None:
         convs_by_coworker.setdefault(c.coworker_id, []).append(c)
 
     for cw in all_coworkers:
-        config = CoworkerConfig(
-            id=cw.id,
-            tenant_id=cw.tenant_id,
-            name=cw.name,
-            folder=cw.folder,
-            system_prompt=cw.system_prompt,
-            trigger_pattern=CoworkerConfig.build_trigger_pattern(cw.name),
-            agent_backend=cw.agent_backend,
-            container_image=None,
-            max_concurrent=cw.max_concurrent,
-            tools=cw.tools,
-            agent_role=cw.agent_role,
-            permissions=cw.permissions,
-        )
-
-        cw_state = CoworkerState(config=config)
+        cw_state = CoworkerState.from_coworker(cw)
 
         # Load channel bindings
         for b in bindings_by_coworker.get(cw.id, []):
@@ -567,7 +551,7 @@ async def _handle_incoming(
     # Only store the message if it's relevant to THIS coworker:
     # - conversation doesn't require trigger (DM or admin), OR
     # - message content matches this coworker's trigger pattern
-    if is_group and conv.requires_trigger and not cw_state.config.trigger_pattern.search(text.strip()):
+    if is_group and conv.requires_trigger and not cw_state.trigger_pattern.search(text.strip()):
         return  # Not for this coworker — skip silently
 
     # Sender allowlist check
@@ -623,7 +607,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
     if config.agent_role != "super_agent" and conv.requires_trigger:
         allowlist_cfg = load_sender_allowlist()
         has_trigger = any(
-            config.trigger_pattern.search(m.content.strip())
+            cw_state.trigger_pattern.search(m.content.strip())
             and (m.is_from_me or is_trigger_allowed(conv.channel_chat_id, m.sender, allowlist_cfg))
             for m in missed_messages
         )
@@ -1179,7 +1163,7 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                         conv_messages = [msg for cid, msg in results if cid == conv_id]
                         allowlist_cfg = load_sender_allowlist()
                         has_trigger = any(
-                            config.trigger_pattern.search(m.content.strip())
+                            cw_state.trigger_pattern.search(m.content.strip())
                             and (m.is_from_me or is_trigger_allowed(chat_id, m.sender, allowlist_cfg))
                             for m in conv_messages
                         )

--- a/tests/core/test_coworker_state.py
+++ b/tests/core/test_coworker_state.py
@@ -1,0 +1,54 @@
+"""Tests for ``CoworkerState.from_coworker``.
+
+The contract: ``cs.config`` must be the same ``Coworker`` instance the
+caller passed in, so any field added to ``Coworker`` is automatically
+reachable via ``cs.config.<field>`` without a projection step.
+"""
+
+from __future__ import annotations
+
+from rolemesh.core.orchestrator_state import CoworkerState
+from rolemesh.core.types import Coworker
+
+
+def test_from_coworker_preserves_db_row_identity() -> None:
+    cw = Coworker(
+        id="11111111-1111-1111-1111-111111111111",
+        tenant_id="22222222-2222-2222-2222-222222222222",
+        name="trader",
+        folder="trader",
+        agent_backend="claude",
+        system_prompt="You trade.",
+        max_concurrent=2,
+        status="active",
+        created_at="2024-01-01T00:00:00Z",
+        agent_role="agent",
+    )
+    cs = CoworkerState.from_coworker(cw)
+
+    # cs.config must be the same instance, not a field-by-field copy —
+    # this is what makes the projection drift-proof.
+    assert cs.config is cw
+
+    assert cs.config.status == "active"
+    assert cs.config.created_at == "2024-01-01T00:00:00Z"
+    assert cs.config.container_config is None
+
+    # Coworker.__post_init__ fills permissions from agent_role when None.
+    assert cs.config.permissions is not None
+
+    # Conversations / bindings start empty.
+    assert cs.conversations == {}
+    assert cs.channel_bindings == {}
+
+
+def test_from_coworker_trigger_pattern_is_case_insensitive() -> None:
+    cw = Coworker(
+        id="cw1", tenant_id="t1", name="Trader", folder="trader",
+    )
+    cs = CoworkerState.from_coworker(cw)
+
+    assert cs.trigger_pattern.search("ping @TRADER")
+    assert cs.trigger_pattern.search("ping @trader")
+    assert cs.trigger_pattern.search("ping @Trader")
+    assert not cs.trigger_pattern.search("ping @other")

--- a/tests/test_multi_tenant_e2e.py
+++ b/tests/test_multi_tenant_e2e.py
@@ -20,9 +20,9 @@ import pytest
 
 from rolemesh.core.orchestrator_state import (
     ConversationState,
-    CoworkerConfig,
     CoworkerState,
     OrchestratorState,
+    build_trigger_pattern,
 )
 from rolemesh.core.types import (
     ChannelBinding,
@@ -129,19 +129,7 @@ def _build_coworker_state(
     conversations: list[Conversation],
 ) -> CoworkerState:
     """Build runtime CoworkerState from DB entities."""
-    config = CoworkerConfig(
-        id=cw.id,
-        tenant_id=cw.tenant_id,
-        name=cw.name,
-        folder=cw.folder,
-        system_prompt=cw.system_prompt,
-        trigger_pattern=CoworkerConfig.build_trigger_pattern(cw.name),
-        agent_backend=cw.agent_backend,
-        container_image=None,
-        max_concurrent=cw.max_concurrent,
-        agent_role=cw.agent_role,
-    )
-    state = CoworkerState(config=config)
+    state = CoworkerState.from_coworker(cw)
     state.channel_bindings[binding.channel_type] = binding
     for conv in conversations:
         state.conversations[conv.id] = ConversationState(conversation=conv)
@@ -577,18 +565,15 @@ class TestThreeLevelConcurrency:
         state = OrchestratorState(global_limit=10)
         state.tenants["t1"] = Tenant(id="t1", name="T", max_concurrent_containers=10)
 
-        cw_config = CoworkerConfig(
+        cw = Coworker(
             id="cw1",
             tenant_id="t1",
             name="Bot",
             folder="bot",
-            system_prompt=None,
-            trigger_pattern=CoworkerConfig.build_trigger_pattern("Bot"),
             agent_backend="claude",
-            container_image=None,
             max_concurrent=1,
         )
-        state.coworkers["cw1"] = CoworkerState(config=cw_config)
+        state.coworkers["cw1"] = CoworkerState.from_coworker(cw)
 
         assert state.can_start_container("t1", "cw1") is True
         state.increment_active("t1", "cw1")
@@ -1077,7 +1062,7 @@ class TestTaskSchedulingPerCoworker:
 class TestTriggerPatternFromName:
     def test_trigger_pattern_matches_coworker_name(self) -> None:
         """Trigger pattern derived from coworker name, case-insensitive."""
-        pattern = CoworkerConfig.build_trigger_pattern("Sales AI")
+        pattern = build_trigger_pattern("Sales AI")
         assert pattern.search("@Sales AI what's our revenue?")
         assert pattern.search("@sales ai please help")
         assert not pattern.search("Hey sales team")  # No @mention
@@ -1085,7 +1070,7 @@ class TestTriggerPatternFromName:
 
     def test_trigger_pattern_with_dot_in_name(self) -> None:
         """Dots in names are literal, not regex wildcards."""
-        pattern = CoworkerConfig.build_trigger_pattern("Bot.v2")
+        pattern = build_trigger_pattern("Bot.v2")
         assert pattern.search("@Bot.v2 help me")
         assert not pattern.search("@BotXv2 help me")  # Dot must be literal
 
@@ -1095,13 +1080,13 @@ class TestTriggerPatternFromName:
         This is a regex limitation. In practice, coworker names rarely end with
         special chars. Document the behavior rather than work around it.
         """
-        pattern = CoworkerConfig.build_trigger_pattern("Bot (v2.0)")
+        pattern = build_trigger_pattern("Bot (v2.0)")
         # \b after ) is a non-word/non-word boundary, so it doesn't fire before space
         assert pattern.search("@Bot (v2.0)") is None  # Known limitation
 
     def test_trigger_pattern_boundary(self) -> None:
         """@mention must be word-bounded (not just a prefix)."""
-        pattern = CoworkerConfig.build_trigger_pattern("Andy")
+        pattern = build_trigger_pattern("Andy")
         assert pattern.search("@Andy help")
         assert not pattern.search("@Andybot help")  # "Andy" is prefix but not word
 
@@ -1126,18 +1111,15 @@ class TestOrchestratorStateLookups:
             channel_binding_id="b1",
             channel_chat_id="-1001",
         )
-        config = CoworkerConfig(
+        cw = Coworker(
             id="cw1",
             tenant_id="t1",
             name="Bot",
             folder="bot",
-            system_prompt=None,
-            trigger_pattern=CoworkerConfig.build_trigger_pattern("Bot"),
             agent_backend="claude",
-            container_image=None,
             max_concurrent=2,
         )
-        cw_state = CoworkerState(config=config)
+        cw_state = CoworkerState.from_coworker(cw)
         cw_state.channel_bindings["telegram"] = binding
         cw_state.conversations["conv1"] = ConversationState(conversation=conv)
         state.coworkers["cw1"] = cw_state
@@ -1157,18 +1139,15 @@ class TestOrchestratorStateLookups:
         """Known binding but wrong chat_id returns None."""
         state = OrchestratorState()
         binding = ChannelBinding(id="b1", coworker_id="cw1", tenant_id="t1", channel_type="telegram")
-        config = CoworkerConfig(
+        cw = Coworker(
             id="cw1",
             tenant_id="t1",
             name="Bot",
             folder="bot",
-            system_prompt=None,
-            trigger_pattern=CoworkerConfig.build_trigger_pattern("Bot"),
             agent_backend="claude",
-            container_image=None,
             max_concurrent=2,
         )
-        cw_state = CoworkerState(config=config)
+        cw_state = CoworkerState.from_coworker(cw)
         cw_state.channel_bindings["telegram"] = binding
         # No conversations registered
         state.coworkers["cw1"] = cw_state
@@ -1178,18 +1157,15 @@ class TestOrchestratorStateLookups:
     def test_get_coworker_by_folder(self) -> None:
         """Lookup by tenant + folder returns correct coworker."""
         state = OrchestratorState()
-        config = CoworkerConfig(
+        cw = Coworker(
             id="cw1",
             tenant_id="t1",
             name="Bot",
             folder="my-bot",
-            system_prompt=None,
-            trigger_pattern=CoworkerConfig.build_trigger_pattern("Bot"),
             agent_backend="claude",
-            container_image=None,
             max_concurrent=2,
         )
-        state.coworkers["cw1"] = CoworkerState(config=config)
+        state.coworkers["cw1"] = CoworkerState.from_coworker(cw)
 
         found = state.get_coworker_by_folder("t1", "my-bot")
         assert found is not None


### PR DESCRIPTION
## Summary

- Collapse the duplicated `CoworkerConfig` dataclass into the existing `Coworker` (DB-row shape). `CoworkerState.config` is now a `Coworker`, removing the silent field-drift surface that hid `Coworker.status` / `created_at` / `container_config` from the in-memory state.
- Drop the two dead fields (`container_image` always `None`, `role_config` never written/read on this dataclass) and the duplicated `__post_init__` permissions default.
- Move `trigger_pattern` (the only genuinely derived value) to a sibling field on `CoworkerState`; `build_trigger_pattern` is now a module-level public helper used by both `CoworkerState.from_coworker` and the regex-semantic tests.

No behavioral change; preparation for follow-up feature work that adds new columns to `coworkers`.

## Test plan

- [x] `uv run pytest` — 23734 passed (the single pre-existing failure in `test_amazon_bedrock_tool_limit.py::test_realistic_long_mcp_name_raises` is also broken on `main`, unrelated to this PR).
- [x] `uv run mypy src` — zero errors in `orchestrator_state.py`; pre-existing `main.py` error count went down from 16 to 11.
- [x] `uv run ruff check` on touched files — clean.
- [x] New `tests/core/test_coworker_state.py` locks in the `cs.config is cw` projection-identity invariant and the `__post_init__` permissions default.
- [x] Verified by grep: `main.py` is the only `_state.coworkers` writer — no admin paths needed updating.