### PR TITLE
chore(auth): add 30s leeway to JWT validation

### DIFF
--- a/src/rolemesh/auth/external_jwt_provider.py
+++ b/src/rolemesh/auth/external_jwt_provider.py
@@ -52,6 +52,7 @@ class ExternalJwtProvider:
             kwargs: dict[str, object] = {
                 "algorithms": self._algorithms,
                 "options": options,
+                "leeway": 30,
             }
             if self._issuer:
                 kwargs["issuer"] = self._issuer

--- a/src/rolemesh/auth/oidc/provider.py
+++ b/src/rolemesh/auth/oidc/provider.py
@@ -78,6 +78,7 @@ class OIDCAuthProvider:
                 algorithms=list(ALLOWED_ALGORITHMS),
                 issuer=disc.issuer,
                 audience=self._audience,
+                leeway=30,
             )
         except jwt.InvalidTokenError as exc:
             logger.debug("OIDC token validation failed", error=str(exc))

--- a/tests/auth/test_oidc_provider.py
+++ b/tests/auth/test_oidc_provider.py
@@ -432,6 +432,68 @@ async def test_oidc_authenticate_rejects_expired_token(
     assert await provider.authenticate(token) is None
 
 
+async def test_oidc_authenticate_accepts_token_within_leeway(
+    patch_jwks, oidc_env, mock_db, make_token
+):
+    """Tokens expired up to 30s ago are still accepted — clock-skew tolerance."""
+    import time
+
+    from rolemesh.auth.oidc.adapter import DefaultOIDCAdapter
+    from rolemesh.auth.oidc.config import OIDCConfig
+    from rolemesh.auth.oidc.provider import OIDCAuthProvider
+
+    provider = OIDCAuthProvider(
+        OIDCConfig(
+            discovery_url="https://test.example.com/.well-known/openid-configuration",
+            client_id="test-client",
+            audience="test-client",
+        ),
+        adapter=DefaultOIDCAdapter.from_env(),
+    )
+    now = int(time.time())
+    token = make_token(
+        {
+            "sub": "user-leeway-inside",
+            "iss": "https://test.example.com/",
+            "aud": "test-client",
+            "exp": now - 10,
+            "iat": now - 600,
+        }
+    )
+    assert await provider.authenticate(token) is not None
+
+
+async def test_oidc_authenticate_rejects_token_outside_leeway(
+    patch_jwks, oidc_env, mock_db, make_token
+):
+    """A token expired 60s ago is past the 30s leeway window and rejected."""
+    import time
+
+    from rolemesh.auth.oidc.adapter import DefaultOIDCAdapter
+    from rolemesh.auth.oidc.config import OIDCConfig
+    from rolemesh.auth.oidc.provider import OIDCAuthProvider
+
+    provider = OIDCAuthProvider(
+        OIDCConfig(
+            discovery_url="https://test.example.com/.well-known/openid-configuration",
+            client_id="test-client",
+            audience="test-client",
+        ),
+        adapter=DefaultOIDCAdapter.from_env(),
+    )
+    now = int(time.time())
+    token = make_token(
+        {
+            "sub": "user-leeway-outside",
+            "iss": "https://test.example.com/",
+            "aud": "test-client",
+            "exp": now - 60,
+            "iat": now - 600,
+        }
+    )
+    assert await provider.authenticate(token) is None
+
+
 async def test_oidc_authenticate_rejects_garbage_token(patch_jwks, oidc_env, mock_db):
     from rolemesh.auth.oidc.adapter import DefaultOIDCAdapter
     from rolemesh.auth.oidc.config import OIDCConfig


### PR DESCRIPTION
## Summary

- Set `leeway=30` on both `jwt.decode` call sites (`oidc/provider.py:75` and `external_jwt_provider.py:59`). PyJWT defaults to 0, so any clock skew between the IdP and rolemesh — even one second of NTP drift or a slow container boot — surfaces as `ExpiredSignatureError` / `ImmatureSignatureError` / `InvalidIssuedAtError`.
- PyJWT applies leeway symmetrically to `exp` / `nbf` / `iat`. 30s is well below typical OIDC token lifetimes (≥1h), so the security boundary moves only marginally while real-world skew is absorbed.
- OIDC and external-JWT paths now share the same skew tolerance — operationally easier to reason about than per-path values.

## Test plan

- [x] `tests/auth/test_oidc_provider.py::test_oidc_authenticate_accepts_token_within_leeway` — token expired 10s ago authenticates.
- [x] `tests/auth/test_oidc_provider.py::test_oidc_authenticate_rejects_token_outside_leeway` — token expired 60s ago still rejected.
- [x] Existing `test_oidc_authenticate_rejects_expired_token` (uses `exp=100`) still passes — far outside any leeway window.
- [x] `uv run pytest tests/auth/test_oidc_provider.py` — 16 passed.
- [x] `uv run ruff check` on touched files — clean.