### PR TITLE
fix(scheduler): key scheduled tasks by conversation_id (not channel_chat_id)

### DIFF
--- a/src/rolemesh/orchestration/task_scheduler.py
+++ b/src/rolemesh/orchestration/task_scheduler.py
@@ -96,6 +96,25 @@ class SchedulerDependencies(Protocol):
 _TASK_CLOSE_DELAY_S: float = 10.0
 
 
+def _compute_queue_key(task: ScheduledTask) -> str:
+    """Return the ``GroupQueue`` key for a scheduled task.
+
+    Must match what ``main.py`` uses for ``enqueue_message_check`` /
+    ``notify_idle`` / ``request_shutdown`` so the same conversation
+    ends up in the same ``_GroupState`` entry. The initial commit
+    (38e79d8) keyed everything on ``chat_jid``; the multi-tenant
+    refactor (058eb10) migrated the messaging side to
+    ``conversation_id`` but accidentally left the scheduler keyed
+    on ``channel_chat_id``, splitting one conversation into two
+    state entries and breaking warm-container preemption.
+
+    Falls back to ``coworker_id`` only when no conversation is bound
+    — that's the legitimate "coworker-scoped reminder" shape and
+    keeps such tasks queued under a stable identifier.
+    """
+    return task.conversation_id or task.coworker_id
+
+
 async def _run_task(
     task: ScheduledTask,
     deps: SchedulerDependencies,
@@ -140,8 +159,19 @@ async def _run_task(
     permissions = coworker.permissions
     transport = deps.transport
 
-    # Find conversation for chat_jid routing
+    # Two derived values share an origin (the bound Conversation) but
+    # are used for different things:
+    #   queue_key — identity inside ``GroupQueue._groups``. Must equal
+    #     ``main.py``'s message-side key (``conversation_id``) so a
+    #     warm message container and an incoming scheduled task share
+    #     the same ``_GroupState``. See ``_compute_queue_key`` for the
+    #     058eb10 regression backstory.
+    #   chat_jid — destination address for the channel gateway when
+    #     the task's reply goes out (Telegram chat id, web chat uuid,
+    #     ...). Comes from ``Conversation.channel_chat_id``; stays
+    #     channel-specific.
     conversation_id = task.conversation_id or ""
+    queue_key = _compute_queue_key(task)
     chat_jid = ""
 
     # Find the coworker state for context
@@ -188,7 +218,7 @@ async def _run_task(
         loop = asyncio.get_running_loop()
         close_handle = loop.call_later(
             _TASK_CLOSE_DELAY_S,
-            lambda: deps.queue.request_shutdown(chat_jid),
+            lambda: deps.queue.request_shutdown(queue_key),
         )
 
     try:
@@ -204,10 +234,10 @@ async def _run_task(
                 # Only release idle-gating once the run_prompt batch settles.
                 # With the is_final contract, per-prompt replies arrive as
                 # is_final=False and must not fire notify_idle — otherwise a
-                # concurrently pending task on the same chat_jid would preempt
+                # concurrently pending task on the same queue_key would preempt
                 # (request_shutdown) the container mid-batch.
                 if streamed_output.is_final:
-                    deps.queue.notify_idle(chat_jid)
+                    deps.queue.notify_idle(queue_key)
                 _schedule_close()
             if streamed_output.status == "error":
                 error = streamed_output.error or "Unknown error"
@@ -230,7 +260,7 @@ async def _run_task(
                 user_id=task.created_by_user_id or "",
             ),
             lambda container_name, job_id: deps.on_process(
-                chat_jid, container_name, coworker.folder, job_id
+                queue_key, container_name, coworker.folder, job_id
             ),
             _on_output,
         )
@@ -278,6 +308,40 @@ async def _run_task(
 _scheduler_running: bool = False
 
 
+async def _enqueue_due_tasks(
+    due_tasks: list[ScheduledTask], deps: SchedulerDependencies
+) -> None:
+    """Push one tick worth of due tasks into the ``GroupQueue``.
+
+    Extracted from ``_loop`` so the queue-key contract
+    (``_compute_queue_key``) can be exercised against a real DB row
+    without spinning up the infinite scheduler poll loop.
+
+    Re-fetches each row's current status before enqueueing — between
+    ``get_due_tasks`` and this call the row may have been cancelled
+    or completed by another process. Skipping the stale ones keeps
+    a status race from firing an already-cancelled reminder.
+    """
+    for task in due_tasks:
+        current_task = await get_task_by_id(task.id, tenant_id=task.tenant_id)
+        if not current_task or current_task.status != "active":
+            continue
+
+        def _make_fn(t: ScheduledTask) -> Callable[[], Awaitable[None]]:
+            async def _task_fn() -> None:
+                await _run_task(t, deps)
+
+            return _task_fn
+
+        deps.queue.enqueue_task(
+            _compute_queue_key(current_task),
+            current_task.id,
+            _make_fn(current_task),
+            tenant_id=current_task.tenant_id,
+            coworker_id=current_task.coworker_id,
+        )
+
+
 def start_scheduler_loop(deps: SchedulerDependencies) -> asyncio.Task[None]:
     """Launch an asyncio task that polls for due scheduled tasks."""
     global _scheduler_running
@@ -296,34 +360,7 @@ def start_scheduler_loop(deps: SchedulerDependencies) -> asyncio.Task[None]:
                 due_tasks = await get_due_tasks()
                 if due_tasks:
                     logger.info("Found due tasks", count=len(due_tasks))
-
-                for task in due_tasks:
-                    current_task = await get_task_by_id(task.id, tenant_id=task.tenant_id)
-                    if not current_task or current_task.status != "active":
-                        continue
-
-                    def _make_fn(t: ScheduledTask) -> Callable[[], Awaitable[None]]:
-                        async def _task_fn() -> None:
-                            await _run_task(t, deps)
-
-                        return _task_fn
-
-                    # Use conversation's channel_chat_id as the queue key
-                    queue_key = ""
-                    if current_task.conversation_id:
-                        orch = deps.orchestrator_state
-                        found = orch.get_conversation(current_task.conversation_id)
-                        if found:
-                            _, conv_state = found
-                            queue_key = conv_state.conversation.channel_chat_id
-
-                    deps.queue.enqueue_task(
-                        queue_key or current_task.coworker_id,
-                        current_task.id,
-                        _make_fn(current_task),
-                        tenant_id=current_task.tenant_id,
-                        coworker_id=current_task.coworker_id,
-                    )
+                await _enqueue_due_tasks(due_tasks, deps)
             except (OSError, RuntimeError, ValueError):
                 logger.exception("Error in scheduler loop")
 

--- a/tests/orchestration/test_scheduled_task_queue_key.py
+++ b/tests/orchestration/test_scheduled_task_queue_key.py
@@ -1,0 +1,266 @@
+"""Scheduler must use ``conversation_id`` as the GroupQueue key.
+
+Regression for commit 058eb10 (``feat: add multi-tenant support``):
+the initial implementation (38e79d8) keyed every queue interaction
+on ``chat_jid``. The multi-tenant refactor introduced the
+``Conversation`` model and migrated ``main.py``'s
+``enqueue_message_check`` / ``notify_idle`` / ``request_shutdown`` to
+use ``conversation_id`` as the queue key, but ``task_scheduler.py``
+was updated to *derive* ``channel_chat_id`` from the conversation
+and keep using that. The two halves ended up keyed on different
+values for the same conversation, splitting ``GroupQueue._groups``
+into two ``_GroupState`` entries:
+
+* ``_groups[conversation_id]``  ← active container, ``idle_waiting=True``
+* ``_groups[channel_chat_id]``  ← pending scheduled task
+
+``notify_idle``'s preempt check
+(``state.pending_tasks`` non-empty → ``request_shutdown``) runs on
+the ``conversation_id`` entry, sees no tasks, doesn't fire. The
+task waits on the ``channel_chat_id`` entry until the 30-min
+``IDLE_TIMEOUT`` finally kills the warm container, frees the
+per-coworker concurrency slot, and lets the task spawn its own
+container.
+
+For web conversations the symptom is "scheduled task never shows
+up"; for Telegram the queue split exists too but Telegram's server
+delivers the reminder out-of-band, masking the bug.
+
+These tests pin the contract: the scheduler MUST enqueue under
+``conversation_id`` (falling back to ``coworker_id`` only when no
+conversation is bound). A regression that re-introduces
+``channel_chat_id`` here would silently bring back the split.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+import pytest
+
+from rolemesh.core.types import ScheduledTask
+from rolemesh.db import (
+    create_channel_binding,
+    create_conversation,
+    create_coworker,
+    create_task,
+    create_tenant,
+)
+from rolemesh.orchestration.task_scheduler import (
+    _compute_queue_key,
+    _enqueue_due_tasks,
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: queue-key derivation
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    *, conversation_id: str | None, coworker_id: str = "cw-X"
+) -> ScheduledTask:
+    """Build a minimal in-memory ScheduledTask. The DB row schema has
+    more fields but ``_compute_queue_key`` only reads two."""
+    return ScheduledTask(
+        id="t-1",
+        tenant_id="t-1",
+        coworker_id=coworker_id,
+        conversation_id=conversation_id,
+        prompt="ping",
+        schedule_type="once",
+        schedule_value="2026-01-01T00:00:00",
+        next_run=None,
+        last_run=None,
+        last_result=None,
+        status="active",
+        created_at="",
+        context_mode="group",
+        created_by_user_id=None,
+    )
+
+
+def test_queue_key_uses_conversation_id_when_present() -> None:
+    """Pinning the post-058eb10 fix: queue key must equal
+    conversation_id (the value that main.py uses for
+    enqueue_message_check / notify_idle / request_shutdown).
+    Using channel_chat_id here would split GroupQueue state and
+    silently break warm-container preemption."""
+    task = _make_task(conversation_id="conv-A", coworker_id="cw-X")
+    assert _compute_queue_key(task) == "conv-A"
+
+
+def test_queue_key_falls_back_to_coworker_id_when_no_conversation() -> None:
+    """Tasks created without a conversation binding (e.g. legacy
+    coworker-scoped reminders) still need *some* queue key so the
+    GroupQueue can serialize them. ``coworker_id`` is the only stable
+    identifier available — fallback matches the pre-fix behaviour
+    for this branch so we don't accidentally widen the scope."""
+    task = _make_task(conversation_id=None, coworker_id="cw-X")
+    assert _compute_queue_key(task) == "cw-X"
+
+    # Empty string treated the same as None — matches DB shape where
+    # the column is nullable but some callers might pass "".
+    task_empty = _make_task(conversation_id="", coworker_id="cw-Y")
+    assert _compute_queue_key(task_empty) == "cw-Y"
+
+
+# ---------------------------------------------------------------------------
+# Integration: drive _enqueue_due_tasks against a recording queue
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RecordingQueue:
+    """Stand-in for ``GroupQueue.enqueue_task``. Records the
+    ``group_jid`` passed by the scheduler so the test can verify it
+    matches the conversation_id, not channel_chat_id.
+    """
+
+    enqueued: list[tuple[str, str, str, str]] = field(default_factory=list)
+
+    def enqueue_task(
+        self,
+        group_jid: str,
+        task_id: str,
+        fn,  # type: ignore[no-untyped-def]
+        *,
+        tenant_id: str = "",
+        coworker_id: str = "",
+    ) -> None:
+        self.enqueued.append((group_jid, task_id, tenant_id, coworker_id))
+
+
+@dataclass
+class _DepsStub:
+    """Minimal SchedulerDependencies surface for _enqueue_due_tasks.
+
+    Only ``queue`` is exercised — the other Protocol members are needed
+    so the closure created by ``_make_fn`` can reference ``deps``, but
+    that closure is never invoked in these tests (we assert on the
+    enqueue, not on container spawn).
+    """
+
+    queue: _RecordingQueue
+    orchestrator_state: object = None
+    transport: object = None
+    executor: object = None
+
+    def get_coworker(self, coworker_id: str) -> object:
+        return None
+
+    def get_session(self, conversation_id: str) -> str | None:
+        return None
+
+    def on_process(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    async def send_message(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def get_executor(self, backend_name: str) -> object:
+        return None
+
+
+async def test_enqueue_due_tasks_uses_conversation_id_even_when_distinct_from_channel_chat_id() -> None:
+    """End-to-end against real DB: when conversation_id and
+    channel_chat_id are different (typical for web — both are UUIDs
+    but distinct), the queue key MUST be conversation_id. Before the
+    fix this branch would deterministically pass channel_chat_id and
+    split the GroupQueue.
+    """
+    t = await create_tenant(name="T", slug=f"sk-{uuid.uuid4().hex[:6]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="CW", folder=f"cw-{uuid.uuid4().hex[:6]}"
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id, tenant_id=t.id, channel_type="web"
+    )
+    # Deliberately make channel_chat_id != conversation_id so the
+    # test fails loudly if the scheduler reverts to the old key.
+    channel_chat_id = f"chat-{uuid.uuid4().hex[:8]}"
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id=channel_chat_id,
+    )
+    assert conv.id != channel_chat_id, (
+        "test precondition: the two UUIDs must differ to exercise the bug"
+    )
+
+    task = ScheduledTask(
+        id=str(uuid.uuid4()),
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        conversation_id=conv.id,
+        prompt="ping",
+        schedule_type="once",
+        schedule_value="2026-01-01T00:00:00",
+        next_run="2026-01-01T00:00:00",
+        last_run=None,
+        last_result=None,
+        status="active",
+        created_at="",
+        context_mode="group",
+        created_by_user_id=None,
+    )
+    await create_task(task)
+
+    queue = _RecordingQueue()
+    deps = _DepsStub(queue=queue)
+
+    await _enqueue_due_tasks([task], deps)
+
+    assert len(queue.enqueued) == 1
+    group_jid, _task_id, _tid, _cwid = queue.enqueued[0]
+    assert group_jid == conv.id, (
+        f"queue key must be conversation_id ({conv.id!r}); got {group_jid!r}. "
+        f"If you see {channel_chat_id!r} here, the 058eb10 multi-tenant "
+        "key-split regression has returned."
+    )
+
+
+async def test_enqueue_due_tasks_skips_inactive_tasks() -> None:
+    """Regression guard for the in-loop status re-check: between
+    ``get_due_tasks`` and ``enqueue_task`` the DB row may have been
+    cancelled or completed by another process. ``_enqueue_due_tasks``
+    re-fetches and skips non-active rows so a status race doesn't
+    fire an already-cancelled reminder. Pinned alongside the queue
+    key contract because both live in the same loop body — a
+    refactor that touches one tends to touch the other.
+    """
+    t = await create_tenant(name="T", slug=f"sk-skip-{uuid.uuid4().hex[:6]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="CW", folder=f"cw-{uuid.uuid4().hex[:6]}"
+    )
+    task = ScheduledTask(
+        id=str(uuid.uuid4()),
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        conversation_id=None,
+        prompt="ping",
+        schedule_type="once",
+        schedule_value="2026-01-01T00:00:00",
+        next_run="2026-01-01T00:00:00",
+        last_run=None,
+        last_result=None,
+        status="cancelled",  # ← not active
+        created_at="",
+        context_mode="group",
+        created_by_user_id=None,
+    )
+    await create_task(task)
+
+    queue = _RecordingQueue()
+    deps = _DepsStub(queue=queue)
+
+    await _enqueue_due_tasks([task], deps)
+
+    assert queue.enqueued == [], (
+        "tasks whose status is no longer 'active' (re-checked inside "
+        "the loop after get_due_tasks) must not be enqueued"
+    )


### PR DESCRIPTION
## Summary

The scheduler's \`GroupQueue\` key didn't match the messaging side, so a warm message container and an incoming scheduled task for the same conversation ended up in two separate \`_GroupState\` entries:

\`\`\`
_groups[conversation_id]  ← message container active, idle_waiting=True
_groups[channel_chat_id]  ← pending scheduled task, no container
\`\`\`

\`notify_idle\`'s preempt check ran on the \`conversation_id\` entry, saw no pending tasks, didn't fire \`request_shutdown\`. The task waited on the \`channel_chat_id\` entry until the 30-min \`IDLE_TIMEOUT\` finally killed the warm container, freed the per-coworker concurrency slot, and let the task spawn its own container.

Web conversations made the symptom obvious ("reminder doesn't arrive until 30 min later"); Telegram has the same key split but its server delivers reminders out-of-band so nobody noticed.

## History

| Commit | When | Effect |
|---|---|---|
| \`38e79d8\` initial | 2026-03-30 | Keyed everything on \`chat_jid\` consistently — no bug |
| \`058eb10\` feat: add multi-tenant support | 2026-03-30 | Introduced \`Conversation\` model. Migrated \`main.py\`'s queue ops to \`conversation_id\`, but left \`task_scheduler.py\` deriving \`channel_chat_id\` from the conversation and using *that*. **Regression introduced here.** |
| 2 months silent | | Telegram out-of-band delivery masked the bug |
| This PR | 2026-05-31 | Re-aligns the scheduler key with \`conversation_id\` |

## Fix

- New helper \`_compute_queue_key(task) → task.conversation_id or task.coworker_id\`. Matches \`main.py\`'s \`enqueue_message_check\` / \`notify_idle\` convention.
- Extracted \`_enqueue_due_tasks(due_tasks, deps)\` from the infinite \`_loop()\` so the queue-key contract is exercisable in tests without driving the polling loop.
- \`_run_task\` now keeps \`queue_key\` and \`chat_jid\` separate:
  - \`queue_key\` → \`GroupQueue\` ops (\`request_shutdown\`, \`notify_idle\`, \`on_process\`)
  - \`chat_jid\` → channel-gateway messaging address (\`deps.send_message\`, \`AgentInput.chat_jid\`)

## Test plan

- [x] \`tests/orchestration/test_scheduled_task_queue_key.py\` (4 tests, all passing):
  - \`_compute_queue_key\` returns \`conversation_id\` when present
  - Falls back to \`coworker_id\` when no conversation (both \`None\` and \`""\`)
  - \`_enqueue_due_tasks\` against real Postgres with \`conversation_id != channel_chat_id\` pins the bug
  - Inactive-status race re-check stays pinned
- [x] Existing \`tests/orchestration/test_task_scheduler.py\`, \`tests/test_handle_agent_message_ipc.py\`, \`tests/test_scheduled_task_created_by.py\` all pass (19 tests)
- [x] Manual verification on local stack: a "remind me in 2 min" on a web conversation fires within **~40 s** of the due time (one scheduler poll interval), not after the 30-min \`IDLE_TIMEOUT\`. Orchestrator log confirms \`Found due tasks\` → \`Running scheduled task\` → \`Task completed\` happens in ~20 s end-to-end.

## Known issue out of scope

Live WS push for scheduled-task replies still uses \`DeliverPolicy.NEW\` with no replay-on-reconnect. If the browser's WS happens to be mid-reconnect at the exact publish moment, the message is missed on the wire (DB persist from PR #36 saves the day — reload shows it). Separate from this PR; discussed earlier as "Option C" (resumable WS) and "Browser Notification API" follow-up.