### PR TITLE
fix(webui/v1): subscribe to web.outbound + forward web.stream kind=status

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -2722,6 +2722,62 @@ components:
           additionalProperties: true
           nullable: true
 
+    WsServerEventRunProgress:
+      type: object
+      required: [type, run_id, status]
+      properties:
+        type: { type: string, enum: [event.run.progress] }
+        run_id: { type: string, format: uuid }
+        status:
+          type: string
+          description: |
+            Granular phase of the active run. Today's set:
+            `running`, `tool_use`, `queued`, `container_starting`.
+            Kept as an open string (not an enum) so a new
+            orchestrator progress kind doesn't have to fail
+            validation before the SPA learns about it; unknown
+            values render via the fallback label.
+        tool:
+          type: string
+          nullable: true
+          description: |
+            Tool name when `status == tool_use`. Null otherwise.
+        input_preview:
+          type: string
+          nullable: true
+          description: |
+            Truncated preview of the tool input (orchestrator
+            truncates server-side; the name carries the semantic).
+            Null for non-tool statuses.
+
+    WsServerEventMessageAppended:
+      type: object
+      required: [type, content, source, timestamp]
+      properties:
+        type: { type: string, enum: [event.message.appended] }
+        content: { type: string }
+        source:
+          type: string
+          enum: [scheduled_task]
+          description: |
+            What pushed this message. Currently only scheduled-task
+            replies; future side-channel deliveries (cross-chat,
+            agent-to-agent) extend the enum.
+        timestamp:
+          type: string
+          format: date-time
+          description: |
+            Server clock at forward time. The SPA uses this for
+            bubble ordering when no DB read has happened yet (the
+            persisted row's authoritative timestamp may differ
+            slightly; the next reload will reconcile via GET
+            /api/v1/conversations/{id}/messages).
+        # No run_id: out-of-band agent messages aren't bound to a
+        # user-initiated request.run lifecycle. The SPA renders them
+        # the same way it renders messages fetched from REST on
+        # reload — synthesising a fake run_id would pollute the
+        # client-side run map and confuse the cancel/stop paths.
+
     # Server → client. Discriminated on `type`; clients can pattern
     # match on the literal and TS narrows to the matching member.
     WsServerEvent:
@@ -2730,6 +2786,8 @@ components:
         - $ref: '#/components/schemas/WsServerEventRunToken'
         - $ref: '#/components/schemas/WsServerEventRunCompleted'
         - $ref: '#/components/schemas/WsServerEventRunError'
+        - $ref: '#/components/schemas/WsServerEventRunProgress'
+        - $ref: '#/components/schemas/WsServerEventMessageAppended'
       discriminator:
         propertyName: type
         mapping:
@@ -2737,6 +2795,8 @@ components:
           event.run.token: '#/components/schemas/WsServerEventRunToken'
           event.run.completed: '#/components/schemas/WsServerEventRunCompleted'
           event.run.error: '#/components/schemas/WsServerEventRunError'
+          event.run.progress: '#/components/schemas/WsServerEventRunProgress'
+          event.message.appended: '#/components/schemas/WsServerEventMessageAppended'
 
     WsClientFrameRequestRun:
       type: object

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -795,6 +795,29 @@ class WsServerEventRunError(BaseModel):
     details: dict[str, object] | None = None
 
 
+class WsServerEventRunProgress(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["event.run.progress"]
+    run_id: str
+    # Mirrors the orchestrator's progress status set: running,
+    # tool_use, queued, container_starting. Kept as a free string
+    # rather than an enum here so a new orch progress kind doesn't
+    # immediately bounce off pydantic validation in production while
+    # the FE is rolled out separately. The SPA's renderer falls back
+    # to a generic label for unknown values.
+    status: str
+    tool: str | None = None
+    input_preview: str | None = None
+
+
+class WsServerEventMessageAppended(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["event.message.appended"]
+    content: str
+    source: Literal["scheduled_task"]
+    timestamp: str
+
+
 # Tagged union over ``type``. Pydantic v2's Field discriminator picks
 # the right member based on the literal value, giving validation
 # errors that name the offending field (rather than the generic
@@ -804,6 +827,8 @@ WsServerEventModel = (
     | WsServerEventRunToken
     | WsServerEventRunCompleted
     | WsServerEventRunError
+    | WsServerEventRunProgress
+    | WsServerEventMessageAppended
 )
 
 

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -144,6 +144,68 @@ async def _send_event(ws: WebSocket, frame: dict[str, Any]) -> None:
         await ws.send_json(frame)
 
 
+def _build_outbound_frame(*, text: str, timestamp: str) -> dict[str, Any]:
+    """Build an ``event.message.appended`` frame for an out-of-band
+    agent reply (scheduled-task reminder, future cross-chat
+    notification, etc).
+
+    Deliberately carries no ``run_id``: out-of-band messages aren't
+    bound to a user-initiated request.run lifecycle, and synthesising
+    a fake one would pollute the runs table on the SPA side. The
+    chat-panel renders these the same way it renders messages fetched
+    from ``GET /api/v1/conversations/{id}/messages`` on reload.
+    """
+    return {
+        "type": "event.message.appended",
+        "content": text,
+        "source": "scheduled_task",
+        "timestamp": timestamp,
+    }
+
+
+def _build_progress_frame_or_none(
+    active_run_id: str | None, payload: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Build an ``event.run.progress`` frame from a status payload, or
+    ``None`` when there's no active run to anchor it to.
+
+    The orchestrator publishes per-turn progress indicators
+    (``running`` / ``tool_use`` / ``queued`` / ``container_starting``)
+    on ``web.stream.{...}`` as a ``kind="status"`` chunk whose
+    ``content`` carries a JSON-serialised payload like
+    ``{"status": "tool_use", "tool": "Read", "input": "..."}``.
+    Legacy ``/ws/chat`` forwarded this; v1 dropped the branch and the
+    SPA stopped seeing "Calling Read…" / "Starting container…" labels.
+
+    Restore the path here with explicit field whitelisting so a future
+    metadata addition on the orch side doesn't accidentally leak
+    internal-only keys to the browser. ``tool`` and ``input_preview``
+    are populated only for ``tool_use`` payloads (matches the
+    ``ToolUseEvent`` metadata shape in agent_runner.main).
+    """
+    if active_run_id is None:
+        return None
+    status = payload.get("status")
+    if not isinstance(status, str) or not status:
+        return None
+    frame: dict[str, Any] = {
+        "type": "event.run.progress",
+        "run_id": active_run_id,
+        "status": status,
+    }
+    tool = payload.get("tool")
+    if isinstance(tool, str) and tool:
+        frame["tool"] = tool
+    # agent_runner publishes the truncated preview under ``input``
+    # (see ToolUseEvent → ContainerOutput.metadata). Rename here so
+    # the wire field name carries the truncation semantics explicitly
+    # — the SPA shouldn't think it's getting the full input.
+    input_preview = payload.get("input")
+    if isinstance(input_preview, str) and input_preview:
+        frame["input_preview"] = input_preview
+    return frame
+
+
 async def _terminate_run_completed(
     *, run_id: str, tenant_id: str, usage: Any | None
 ) -> None:
@@ -259,6 +321,17 @@ async def stream(
         ordered_consumer=True,
         deliver_policy=DeliverPolicy.NEW,
     )
+    # ``web.outbound.*`` carries complete agent replies that bypass
+    # the streaming path — today's only producer is the scheduled-task
+    # send_message IPC bridge in ``rolemesh.main``. Legacy ``/ws/chat``
+    # subscribed here; v1 missed it during the 2026-05-20 cutover, so
+    # scheduled-task reminders only appeared after a page reload
+    # (DB persistence kept the message; live push was silently dropped).
+    outbound_sub = await js.subscribe(
+        f"web.outbound.{binding_id}.{conv.channel_chat_id}",
+        ordered_consumer=True,
+        deliver_policy=DeliverPolicy.NEW,
+    )
 
     async def _forward_stream() -> None:
         """Fan NATS stream chunks to ``event.run.*`` frames.
@@ -321,6 +394,20 @@ async def stream(
                             "run_id": run_id,
                         },
                     )
+                elif kind == "status":
+                    # Per-turn progress indicator (running / tool_use /
+                    # queued / container_starting). Legacy ``/ws/chat``
+                    # forwarded these; the v1 cutover dropped the
+                    # branch, so the SPA stopped seeing "Calling Read…"
+                    # and "Starting container…" labels even though the
+                    # orchestrator kept publishing them. See
+                    # ``_build_progress_frame_or_none`` for the wire
+                    # contract — None is returned when no run is
+                    # active OR the payload lacks a ``status`` field.
+                    inner = json.loads(data.get("content", "{}"))
+                    progress = _build_progress_frame_or_none(run_id, inner)
+                    if progress is not None:
+                        await _send_event(ws, progress)
                 elif kind == "safety_blocked":
                     inner = json.loads(data.get("content", "{}"))
                     # Same ordering rationale as ``done`` above.
@@ -353,7 +440,37 @@ async def stream(
                 with contextlib.suppress(OSError, RuntimeError):
                     await msg.ack()
 
-    fwd_task = asyncio.create_task(_forward_stream())
+    async def _forward_outbound() -> None:
+        """Fan ``web.outbound.*`` payloads to ``event.message.appended``
+        frames. Independent of ``active_run_id`` — these messages are
+        agent-initiated side-channel deliveries (scheduled-task
+        reminders today; cross-chat notifications in the future) and
+        don't belong to any user-initiated run. See
+        ``_build_outbound_frame`` for the frame contract rationale.
+        """
+        async for msg in outbound_sub.messages:
+            try:
+                data = json.loads(msg.data)
+                text = data.get("text")
+                if isinstance(text, str) and text:
+                    await _send_event(
+                        ws,
+                        _build_outbound_frame(
+                            text=text,
+                            timestamp=datetime.now(UTC).isoformat(),
+                        ),
+                    )
+                await msg.ack()
+            except (WebSocketDisconnect, RuntimeError):
+                return
+            except (OSError, ValueError, TypeError, KeyError):
+                with contextlib.suppress(OSError, RuntimeError):
+                    await msg.ack()
+
+    fwd_tasks = [
+        asyncio.create_task(_forward_stream()),
+        asyncio.create_task(_forward_outbound()),
+    ]
 
     try:
         while True:
@@ -400,11 +517,14 @@ async def stream(
         # and the next GET /runs/{id} reports the truth.
         pass
     finally:
-        fwd_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await fwd_task
-        with contextlib.suppress(Exception):
-            await stream_sub.unsubscribe()
+        for t in fwd_tasks:
+            t.cancel()
+        for t in fwd_tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await t
+        for sub in (stream_sub, outbound_sub):
+            with contextlib.suppress(Exception):
+                await sub.unsubscribe()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webui/test_v1_ws_side_channel_subs.py
+++ b/tests/webui/test_v1_ws_side_channel_subs.py
@@ -1,0 +1,343 @@
+"""v1 WS must forward ``web.outbound.*`` and ``web.stream.* kind=status``.
+
+Background — v1.1 refactor (2026-05-20) created two silent gaps:
+
+* Legacy ``/ws/chat`` subscribed to ``web.stream.*`` AND
+  ``web.outbound.*``. ``web.outbound`` carries complete agent replies
+  that don't fit the streaming chunk path — canonical example: a
+  scheduled-task reminder fires outside any user request.run, so
+  there's no streaming context for the reply to attach to.
+* Legacy's ``web.stream.*`` handler routed FOUR kinds — ``text``,
+  ``done``, ``status``, ``safety_blocked``. v1 ``ws_stream.py`` only
+  handled three; the ``status`` branch was dropped, so the
+  per-turn progress indicators (``tool_use`` with the tool name,
+  ``container_starting``, ``queued``, ``running``) silently vanished
+  even though the orchestrator kept publishing them. The SPA's
+  "Calling Read…" / "Starting container…" labels stopped rendering.
+
+This file pins:
+
+1. ``web.outbound.{binding}.{chat}`` publishes arrive as
+   ``event.message.appended`` frames. The frame is run-id-free by
+   design — out-of-band agent messages aren't tied to a user-initiated
+   run lifecycle, so forcing a run_id would require synthesising a
+   fake one or dropping the message.
+2. ``web.stream.{binding}.{chat}`` ``type=status`` payloads arrive as
+   ``event.run.progress`` frames AND are dropped when no
+   ``active_run_id`` is set. Progress without a run has no meaningful
+   client side-effect — the indicator is anchored to the running bubble.
+
+A regression that re-drops either branch would surface here
+immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from rolemesh.auth.bootstrap_users import (
+    BootstrapUserSpec,
+    _reset_for_tests,
+    ensure_bootstrap_user_row,
+    init_bootstrap_users,
+)
+from webui.v1 import ws_stream
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+# Shared with tests/webui/test_ws_v1_handshake.py — both files use
+# ``os.environ.setdefault`` so the first to import wins. Using the
+# same secret string keeps the two test modules interoperable when
+# pytest loads them in either order (alphabetical collection puts
+# this file first, which used to break the handshake tests when
+# the secrets diverged).
+_TEST_SECRET = "v1-ws-handshake-secret-only-for-tests"
+os.environ.setdefault("WS_TICKET_SECRET", _TEST_SECRET)
+
+
+# ---------------------------------------------------------------------------
+# Pure builders — exercised directly so regressions in shape surface fast
+# ---------------------------------------------------------------------------
+
+
+def test_build_outbound_frame_has_required_shape() -> None:
+    """The frame must carry the canonical 4 fields the SPA renders. A
+    rename / drop here breaks the chat-panel handler silently — there's
+    no runtime validator on outgoing frames (see ``_send_event``)."""
+    frame = ws_stream._build_outbound_frame(
+        text="⏰ reminder", timestamp="2026-05-31T12:00:00+00:00"
+    )
+    assert frame == {
+        "type": "event.message.appended",
+        "content": "⏰ reminder",
+        "source": "scheduled_task",
+        "timestamp": "2026-05-31T12:00:00+00:00",
+    }
+
+
+def test_build_progress_frame_or_none_returns_none_without_run() -> None:
+    """No active_run_id → no frame. The SPA's progress indicator is
+    anchored to a run; emitting frames without one would either crash
+    the renderer (run_id is required by the discriminated union) or
+    force the SPA to handle an orphan state. Dropping at the source
+    is the only sane semantic."""
+    assert (
+        ws_stream._build_progress_frame_or_none(None, {"status": "tool_use"})
+        is None
+    )
+
+
+def test_build_progress_frame_or_none_returns_none_for_payload_without_status() -> None:
+    """Malformed payload (missing or non-string ``status`` field) is
+    treated the same as "no progress to forward". Without this guard
+    the orch's send_status with an empty payload would emit a frame
+    with no status string and the SPA's renderer would have nothing
+    to map to a label."""
+    assert ws_stream._build_progress_frame_or_none("run-1", {}) is None
+    assert (
+        ws_stream._build_progress_frame_or_none("run-1", {"status": ""}) is None
+    )
+    assert (
+        ws_stream._build_progress_frame_or_none("run-1", {"status": 123}) is None
+    )
+
+
+def test_build_progress_frame_or_none_returns_bare_frame_for_running() -> None:
+    """Status payloads without tool metadata produce a minimal frame:
+    just type / run_id / status. ``tool`` and ``input_preview`` are
+    omitted (not nulled) so the wire stays compact and the SPA's
+    "key in object" checks work."""
+    frame = ws_stream._build_progress_frame_or_none(
+        "run-abc", {"status": "running"}
+    )
+    assert frame == {
+        "type": "event.run.progress",
+        "run_id": "run-abc",
+        "status": "running",
+    }
+
+
+def test_build_progress_frame_or_none_returns_enriched_frame_for_tool_use() -> None:
+    """``tool_use`` payloads carry tool name and an input preview from
+    agent_runner's ``ToolUseEvent`` metadata. Both fields are pulled
+    through; the truncation-semantics renaming (``input`` →
+    ``input_preview``) makes it explicit to the SPA that the preview
+    is not the full input."""
+    frame = ws_stream._build_progress_frame_or_none(
+        "run-abc",
+        {"status": "tool_use", "tool": "Read", "input": "file=README.md ...(trunc)"},
+    )
+    assert frame == {
+        "type": "event.run.progress",
+        "run_id": "run-abc",
+        "status": "tool_use",
+        "tool": "Read",
+        "input_preview": "file=README.md ...(trunc)",
+    }
+
+
+def test_build_progress_frame_or_none_ignores_non_string_tool_or_input() -> None:
+    """Defensive filtering: orch publishes from a dict[str, object]
+    so a metadata field could be any type. The forwarder must not
+    coerce — drop the field instead so a junk value never reaches
+    the SPA's TS-typed handler."""
+    frame = ws_stream._build_progress_frame_or_none(
+        "run-abc",
+        {"status": "tool_use", "tool": 123, "input": None},
+    )
+    assert frame == {
+        "type": "event.run.progress",
+        "run_id": "run-abc",
+        "status": "tool_use",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Integration: drive a preloaded NATS message through subscribe → WS frame
+# ---------------------------------------------------------------------------
+
+
+class _FakeMsg:
+    """Stand-in for ``nats.aio.msg.Msg``. Only the two attributes the
+    forward loop touches are populated (``data`` is consumed via
+    ``json.loads``; ``ack`` is awaited)."""
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def ack(self) -> None:
+        return None
+
+
+class _PreloadedSub:
+    """Subscription stub that delivers a fixed list of messages then
+    suspends forever. Mirrors how a real ephemeral JetStream consumer
+    behaves: returns whatever's queued when iterated, then blocks
+    waiting for the next publish. The infinite sleep keeps the
+    forwarding task alive without busy-spinning so the WS handler's
+    main loop can run undisturbed."""
+
+    def __init__(self, preloaded: list[_FakeMsg]) -> None:
+        self._queued = list(preloaded)
+        self.unsubscribed = False
+
+    @property
+    def messages(self):  # type: ignore[no-untyped-def]
+        return self
+
+    def __aiter__(self):  # type: ignore[no-untyped-def]
+        return self
+
+    async def __anext__(self):  # type: ignore[no-untyped-def]
+        if self._queued:
+            return self._queued.pop(0)
+        await asyncio.sleep(3600)
+        raise StopAsyncIteration
+
+    async def unsubscribe(self) -> None:
+        self.unsubscribed = True
+
+
+class _ControlledJS:
+    """JetStream stub that routes ``subscribe(subject)`` to per-subject
+    preloaded message lists. Tests stuff the list before connecting
+    the WS so messages are "already there" when the forward task
+    starts iterating — avoids the cross-event-loop hazards that come
+    with using ``asyncio.Queue`` between TestClient's WS thread and
+    the test body."""
+
+    def __init__(self) -> None:
+        self.preloaded: dict[str, list[_FakeMsg]] = {}
+        self.published: list[tuple[str, bytes]] = []
+        self.subs: dict[str, _PreloadedSub] = {}
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.published.append((subject, payload))
+
+    async def subscribe(self, subject: str, **_kwargs: Any) -> _PreloadedSub:
+        sub = _PreloadedSub(self.preloaded.get(subject, []))
+        self.subs[subject] = sub
+        return sub
+
+
+@pytest.fixture
+def js_stub():  # type: ignore[no-untyped-def]
+    js = _ControlledJS()
+    ws_stream.set_jetstream(js)  # type: ignore[arg-type]
+    try:
+        yield js
+    finally:
+        ws_stream.set_jetstream(None)
+
+
+class _StubConv:
+    """Minimal duck-typed conversation; mirrors ``test_ws_v1_handshake``
+    pattern. Only the four fields the handler reads."""
+
+    def __init__(
+        self, conv_id: str, tenant_id: str, binding_id: str, chat_id: str
+    ) -> None:
+        self.id = conv_id
+        self.tenant_id = tenant_id
+        self.channel_binding_id = binding_id
+        self.channel_chat_id = chat_id
+
+
+@pytest.fixture
+def stub_conv(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    holder: dict[str, _StubConv] = {}
+
+    async def _fake(conversation_id: str, *, tenant_id: str) -> _StubConv | None:
+        return holder.get("conv")
+
+    monkeypatch.setattr(ws_stream, "get_conversation", _fake)
+    return holder
+
+
+def _mint_ticket(*, tenant_id: str, conv_id: str, user_id: str) -> str:
+    payload = {
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+        "exp": int((datetime.now(timezone.utc) + timedelta(seconds=60)).timestamp()),
+        "aud": "rolemesh-ws",
+        "sub": user_id,
+        "tenant_id": tenant_id,
+        "conversation_id": conv_id,
+    }
+    return jwt.encode(payload, _TEST_SECRET, algorithm="HS256")
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    ws_stream.register_routes(app)
+    return app
+
+
+def _make_bootstrap_user(tenant_id: str, user_id: str) -> None:
+    """Seed a bootstrap user row so the ticket's ``sub`` resolves
+    against ``users``. The handshake doesn't query this directly but
+    downstream code in ``register_routes`` may; copy the pattern
+    used in ``test_ws_v1_handshake``."""
+    _reset_for_tests()
+    init_bootstrap_users(
+        [BootstrapUserSpec(token="t", name="U", tenant_slug=f"sl-{user_id[:6]}")]
+    )
+
+
+def test_web_outbound_publish_is_forwarded_as_event_message_appended(
+    js_stub: _ControlledJS,
+    stub_conv: dict[str, _StubConv],
+) -> None:
+    """End-to-end happy path: orchestrator publishes a scheduled-task
+    reply on ``web.outbound.{binding}.{chat}`` → v1 WS subscriber
+    receives the bytes → forward task emits an
+    ``event.message.appended`` frame on the SPA's WebSocket.
+
+    Pre-fix, no such subscription existed: the publish landed at NATS
+    with no consumer, JetStream stored it (a separate non-issue), and
+    the SPA never saw it.
+    """
+    conv_id = str(uuid.uuid4())
+    tenant_id = str(uuid.uuid4())
+    binding_id = str(uuid.uuid4())
+    chat_id = "chat-outbound-test"
+    user_id = str(uuid.uuid4())
+    stub_conv["conv"] = _StubConv(conv_id, tenant_id, binding_id, chat_id)
+
+    # Preload BEFORE the WS connects — subscribe() happens inside the
+    # handshake. The preloaded message will be delivered as soon as
+    # _forward_outbound starts iterating.
+    js_stub.preloaded[f"web.outbound.{binding_id}.{chat_id}"] = [
+        _FakeMsg(json.dumps({"text": "⏰ reminder fired"}).encode())
+    ]
+
+    ticket = _mint_ticket(
+        tenant_id=tenant_id, conv_id=conv_id, user_id=user_id
+    )
+    app = _build_app()
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            f"/api/v1/conversations/{conv_id}/stream?ticket={ticket}"
+        ) as ws:
+            frame = ws.receive_json()
+            assert frame["type"] == "event.message.appended", (
+                f"expected event.message.appended, got {frame!r}. "
+                "If you see this fail with no frame received at all, "
+                "the v1 ws_stream regressed and stopped subscribing to "
+                "web.outbound.* — the original 2026-05-20 v1.1 cutover "
+                "bug returned."
+            )
+            assert frame["content"] == "⏰ reminder fired"
+            assert frame["source"] == "scheduled_task"
+            assert "timestamp" in frame

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1720,7 +1720,57 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
-        WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"];
+        WsServerEventRunProgress: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "event.run.progress";
+            /** Format: uuid */
+            run_id: string;
+            /**
+             * @description Granular phase of the active run. Today's set:
+             *     `running`, `tool_use`, `queued`, `container_starting`.
+             *     Kept as an open string (not an enum) so a new
+             *     orchestrator progress kind doesn't have to fail
+             *     validation before the SPA learns about it; unknown
+             *     values render via the fallback label.
+             */
+            status: string;
+            /** @description Tool name when `status == tool_use`. Null otherwise. */
+            tool?: string | null;
+            /**
+             * @description Truncated preview of the tool input (orchestrator
+             *     truncates server-side; the name carries the semantic).
+             *     Null for non-tool statuses.
+             */
+            input_preview?: string | null;
+        };
+        WsServerEventMessageAppended: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "event.message.appended";
+            content: string;
+            /**
+             * @description What pushed this message. Currently only scheduled-task
+             *     replies; future side-channel deliveries (cross-chat,
+             *     agent-to-agent) extend the enum.
+             * @enum {string}
+             */
+            source: "scheduled_task";
+            /**
+             * Format: date-time
+             * @description Server clock at forward time. The SPA uses this for
+             *     bubble ordering when no DB read has happened yet (the
+             *     persisted row's authoritative timestamp may differ
+             *     slightly; the next reload will reconcile via GET
+             *     /api/v1/conversations/{id}/messages).
+             */
+            timestamp: string;
+        };
+        WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"] | components["schemas"]["WsServerEventRunProgress"] | components["schemas"]["WsServerEventMessageAppended"];
         WsClientFrameRequestRun: {
             /**
              * @description discriminator enum property added by openapi-typescript

--- a/web/src/components/chat-panel.test.ts
+++ b/web/src/components/chat-panel.test.ts
@@ -120,3 +120,123 @@ describe('ChatPanel — Stop vs Cancel routing (design §4.1)', () => {
     expect(i.runState).toBe('running');
   });
 });
+
+
+// ---------------------------------------------------------------------------
+// Side-channel events: event.message.appended + event.run.thinking
+//
+// Pinning the v1 protocol's two non-run-bound additions (PR #38). Both
+// were missing from the original v1.1 cutover — scheduled-task replies
+// never reached the SPA live, and the typing indicator disappeared
+// entirely. A regression that drops the chat-panel handlers (or breaks
+// the run_id guard on thinking) would surface here.
+// ---------------------------------------------------------------------------
+
+
+interface InternalsWithEvents extends Internals {
+  messages: Array<{ role: string; content: string; streaming?: boolean }>;
+  agentStatus: { label: string } | null;
+  handleV1Event(e: unknown): void;
+}
+
+
+describe('ChatPanel — side-channel events (PR #38)', () => {
+  it('event.message.appended pushes a new assistant bubble', () => {
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.messages = [{ role: 'user', content: 'hi' }];
+
+    i.handleV1Event({
+      type: 'event.message.appended',
+      content: '⏰ 2 minutes up!',
+      source: 'scheduled_task',
+      timestamp: '2026-05-31T12:00:00+00:00',
+    });
+
+    expect(i.messages).toHaveLength(2);
+    expect(i.messages[1]).toEqual({
+      role: 'assistant',
+      content: '⏰ 2 minutes up!',
+    });
+    // Side-channel push must NOT touch run state — there's no
+    // user-initiated run associated with a scheduled-task reminder.
+    expect(i.runState).toBe('idle');
+  });
+
+  it('event.message.appended with empty content is ignored', () => {
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.messages = [];
+
+    i.handleV1Event({
+      type: 'event.message.appended',
+      content: '',
+      source: 'scheduled_task',
+      timestamp: '2026-05-31T12:00:00+00:00',
+    });
+
+    // An empty bubble would render as a blank rectangle; defensive
+    // drop keeps malformed orchestrator publishes from polluting
+    // the conversation.
+    expect(i.messages).toEqual([]);
+  });
+
+  it('event.run.progress renders a tool_use label when run_id matches', () => {
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.activeRunId = 'run-current';
+    i.agentStatus = null;
+
+    i.handleV1Event({
+      type: 'event.run.progress',
+      run_id: 'run-current',
+      status: 'tool_use',
+      tool: 'Read',
+      input_preview: 'file=README.md',
+    });
+    expect(i.agentStatus).toEqual({ label: 'Calling Read…' });
+  });
+
+  it('event.run.progress maps known statuses to canonical labels', () => {
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.activeRunId = 'r1';
+
+    const cases: Array<[Record<string, unknown>, string]> = [
+      [{ status: 'running' }, 'Thinking…'],
+      [{ status: 'container_starting' }, 'Starting container…'],
+      [{ status: 'queued' }, 'Queued…'],
+      [{ status: 'tool_use' }, 'Calling tool…'],
+      // Unknown status falls back to a generic label rather than
+      // leaking the raw kind to end users (e.g. ``compaction_started``
+      // would look like a bug to a non-engineer).
+      [{ status: 'unknown_kind_xyz' }, 'Working…'],
+    ];
+    for (const [extra, expectedLabel] of cases) {
+      i.agentStatus = null;
+      i.handleV1Event({ type: 'event.run.progress', run_id: 'r1', ...extra });
+      expect(i.agentStatus).toEqual({ label: expectedLabel });
+    }
+  });
+
+  it('event.run.progress from a stale run is ignored', () => {
+    // JetStream redelivery on reconnect can replay an old progress
+    // frame after the user has moved on to a new turn. Without the
+    // run_id guard, the SPA would briefly flash a phase that's
+    // already passed — visually disorienting and a clear regression
+    // signal in QA.
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.activeRunId = 'run-current';
+    i.agentStatus = null;
+
+    i.handleV1Event({
+      type: 'event.run.progress',
+      run_id: 'run-previous',
+      status: 'tool_use',
+      tool: 'Read',
+    });
+
+    expect(i.agentStatus).toBeNull();
+  });
+});

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -295,6 +295,43 @@ export class ChatPanel extends LitElement {
         }
         break;
       }
+      case 'event.run.progress': {
+        // Per-turn progress label (tool_use / running / queued /
+        // container_starting). The orchestrator emits these on
+        // ``web.stream.* type=status``; legacy /ws/chat forwarded
+        // them, the v1 cutover dropped the branch, so until this
+        // handler landed the SPA stopped showing "Calling Read…"
+        // and similar phase indicators between event.run.started
+        // and the first event.run.token.
+        //
+        // Scope to the active run so a redelivered stale frame
+        // doesn't briefly flash a phase that already passed.
+        const progressRunId =
+          typeof (e as { run_id?: unknown }).run_id === 'string'
+            ? (e as { run_id: string }).run_id
+            : null;
+        if (progressRunId && progressRunId === this.activeRunId) {
+          this.agentStatus = { label: this.formatProgressLabel(e) };
+        }
+        break;
+      }
+      case 'event.message.appended': {
+        // Out-of-band agent push (today: scheduled-task reminder).
+        // Append as a new assistant bubble, mirroring how messages
+        // fetched from GET /messages on reload are rendered. Does
+        // NOT touch run state — these arrive outside any user run.
+        const content =
+          typeof (e as { content?: unknown }).content === 'string'
+            ? (e as { content: string }).content
+            : '';
+        if (content) {
+          this.messages = [
+            ...this.messages,
+            { role: 'assistant', content },
+          ];
+        }
+        break;
+      }
       case 'event.run.error': {
         const message =
           typeof (e as { message?: unknown }).message === 'string'
@@ -351,6 +388,33 @@ export class ChatPanel extends LitElement {
         // dev/QA and will be re-wired when the engine starts emitting
         // the event. Forward-compat: unknown event types are ignored.
         break;
+    }
+  }
+
+  /** Map an ``event.run.progress`` payload to the human-readable
+   *  string shown in the progress line. Unknown statuses fall back
+   *  to a "Working…" label rather than the raw kind so a new orch
+   *  progress type doesn't surface as e.g. ``compaction_started``
+   *  to end users. Keeping the map here (not in the protocol) lets
+   *  copy iterate without bumping the wire schema. */
+  private formatProgressLabel(e: ServerEvent): string {
+    const ev = e as {
+      status?: unknown;
+      tool?: unknown;
+    };
+    const status = typeof ev.status === 'string' ? ev.status : '';
+    const tool = typeof ev.tool === 'string' && ev.tool ? ev.tool : null;
+    switch (status) {
+      case 'running':
+        return 'Thinking…';
+      case 'tool_use':
+        return tool ? `Calling ${tool}…` : 'Calling tool…';
+      case 'container_starting':
+        return 'Starting container…';
+      case 'queued':
+        return 'Queued…';
+      default:
+        return 'Working…';
     }
   }
 


### PR DESCRIPTION
## Summary

Two silent gaps created by the 2026-05-20 v1.1 cutover: the v1 WS endpoint (`/api/v1/conversations/{id}/stream`) stopped consuming publishes that the orchestrator kept emitting.

| Gap | Symptom | Fix |
|---|---|---|
| **`web.outbound.{binding}.{chat}` not subscribed** | Scheduled-task reminders never reach the SPA live; only visible after page reload (DB persistence from PR #36 saved the row, but live push silently dropped) | Add subscription + `_forward_outbound` → emit `event.message.appended` |
| **`web.stream.* kind="status"` branch missing** | "Calling Read…", "Starting container…", "Queued…" labels gone from the SPA's composer-area progress line. The chat-panel `AgentStatusState` comment even acknowledged the loss ("the new protocol does not carry the same tool-use detail (yet)") | Add `elif kind == "status"` to `_forward_stream` → emit `event.run.progress` |

## Why progress, not typing

An earlier iteration of this PR added `web.typing.*` handling as `event.run.thinking`. Two issues surfaced:

1. The typing on/off signal is **largely redundant** with what `event.run.started` / `event.run.token` already gives the SPA client-side (the "Thinking…" label between message-sent and first-token).
2. The actual user-visible regression is the **missing tool-use labels**, which travel on `web.stream` `type=status` — not on `web.typing`.

Pivoted to fix the real gap.

## Protocol additions

Two new types on the discriminated `WsServerEvent` oneOf:

```ts
WsServerEventMessageAppended  // no run_id by design — out-of-band
WsServerEventRunProgress      // run_id + status + optional tool/input_preview
```

`event.run.progress` keeps `status` as an open string (not an enum) so a new orchestrator progress kind doesn't break SPA validation on rollout — unknown values render via a "Working…" fallback label.

## Test plan

- [x] `tests/webui/test_v1_ws_side_channel_subs.py` (7 tests):
  - Pure builder unit tests pin the wire shape (including the **no-active-run → drop** semantic and the **defensive field whitelist** that filters non-string tool/input).
  - Integration test drives a preloaded `web.outbound.*` message through a TestClient WS connection and asserts the forwarded `event.message.appended` frame.
- [x] `web/src/components/chat-panel.test.ts` (+5 tests):
  - Appended bubble append + empty-content drop.
  - Progress label mapping for every known status + unknown-status fallback.
  - Stale-run drop (defensive against JetStream redelivery on reconnect).
- [x] Existing `test_ws_v1_handshake.py` (7 tests) still pass.
- [x] Manual verification on local stack:
  - "Remind me in 1 min" reaches the chat bubble **without page reload**.
  - "Read README.md" prompt shows "**Calling Read…**" mid-turn in the composer-area progress line.

## Known issue out of scope

The Stop button still rides on the legacy `/ws/chat` AgentClient (chat-panel.ts:53-56 comment). Removing that — and the entire legacy `webui/ws.py` — is tracked separately as PR-B in the design discussion that produced this PR.