### PR TITLE
fix(hitl): register approval subjects on the agent-ipc JetStream stream

### DIFF
--- a/src/rolemesh/ipc/nats_transport.py
+++ b/src/rolemesh/ipc/nats_transport.py
@@ -84,6 +84,15 @@ class NatsTransport:
                 # subjects because its retention profile matches (short
                 # buffer, consumer-driven drain).
                 "agent.*.safety_events",
+                # HITL approval IPC (docs/21-hitl-approval-plan.md §3). All
+                # three subjects ride JetStream: the container publishes
+                # approval_request / approval_cancel and js-subscribes the
+                # decision; the orchestrator js-subscribes request/cancel and
+                # publishes the decision. They must be in this stream or
+                # ``js.subscribe`` raises NotFoundError at orchestrator startup.
+                "agent.*.approval_request",
+                "agent.*.approval_decision",
+                "agent.*.approval_cancel",
             ],
             max_age=_STREAM_MAX_AGE_S,
         )


### PR DESCRIPTION
## Summary

Follow-up fix to the HITL approval feature (#41). The orchestrator **crashes on
startup against a real NATS server** because the three approval subjects were
never registered on the `agent-ipc` JetStream stream.

`_start_nats_ipc_subscriptions` does `js.subscribe("agent.*.approval_request")`
/ `approval_cancel` (and the container js-subscribes `approval_decision`), but
the `agent-ipc` `StreamConfig` in `ipc/nats_transport.py` only listed
`results / input / interrupt / messages / tasks / safety_events`. JetStream's
`subscribe()` calls `find_stream_name_by_subject`, finds no stream covering the
subject, and raises `NotFoundError` — taking down orchestrator startup.

```
File "src/rolemesh/main.py", line 1480, in _start_nats_ipc_subscriptions
    approval_request_sub = await transport.js.subscribe(
nats.js.errors.NotFoundError: nats: NotFoundError
```

## Why the S1–S5 tests missed it

The approval test suites stub/mock the NATS transport, so they never exercise
JetStream's "a subject must belong to a stream" constraint. It only surfaced
when running the full stack locally.

## Fix

Add `agent.*.approval_request` / `approval_decision` / `approval_cancel` to the
`agent-ipc` stream's `subjects`. The existing `add_stream` → `update_stream`
fallback applies them to an already-created stream — the same path used when
`agent.*.interrupt` was added.

## Verification (local stack)

- Before: orchestrator crashes at startup (`NotFoundError`), only the WebUI stays up.
- After: orchestrator starts clean (0 tracebacks), runs through full init.
- `stream_info("agent-ipc").config.subjects` now includes all three approval
  subjects.
- WebUI `GET /api/v1/approval-policies` → 401 (route wired + auth-gated);
  approval tables present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
