### PR TITLE
feat(hitl): approval UI — chat card, policies+inbox+Telegram, prototype styling, fail-closed visibility

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -59,6 +59,10 @@ COPY src/rolemesh/auth/permissions.py ./rolemesh/auth/permissions.py
 # audit + engine + loader's pg path and would fail at container
 # startup.
 COPY src/rolemesh/core/logger.py ./rolemesh/core/logger.py
+# core/config.py: agent_runner's HITL hook wiring imports APPROVAL_TIMEOUT
+# from here (single source of truth for the in-band await bound). Stdlib-only
+# (os + pathlib), so safe to ship to the agent image.
+COPY src/rolemesh/core/config.py ./rolemesh/core/config.py
 COPY src/rolemesh/safety/types.py ./rolemesh/safety/types.py
 COPY src/rolemesh/safety/errors.py ./rolemesh/safety/errors.py
 COPY src/rolemesh/safety/loader.py ./rolemesh/safety/loader.py

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -2227,6 +2227,7 @@ components:
         - condition_expr
         - enabled
         - priority
+        - created_at
         - updated_at
       properties:
         id: { type: string, format: uuid }
@@ -2240,6 +2241,7 @@ components:
         priority:
           type: integer
           description: Higher wins on multiple matches; ties break to newest.
+        created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
 
     ApprovalPolicyCreate:
@@ -2306,6 +2308,22 @@ components:
           nullable: true
         requested_at: { type: string, format: date-time }
         expires_at: { type: string, format: date-time }
+        params:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: |
+            Raw {tool_name→params} arguments snapshot — the decision input
+            (§1.2). Tenant-scoped endpoint, so never crosses a tenant edge.
+        coworker_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The coworker whose call is gated.
+        rationale:
+          type: string
+          nullable: true
+          description: The agent's free-text "why I'm calling this tool" (nullable).
 
     # -----------------------------------------------------------------
     # Skills (design §3 Phase 3 / docs/19-skills-architecture.md)
@@ -3033,6 +3051,43 @@ components:
             like event.message.appended — an approval can outlive the
             run that triggered it, and scheduled-task approvals have no
             run at all.
+        mcp_server_name:
+          type: string
+          nullable: true
+          description: The gated MCP server identity (§1.1).
+        tool_name:
+          type: string
+          nullable: true
+          description: The gated tool name (§1.1).
+        params:
+          type: object
+          additionalProperties: true
+          nullable: true
+          description: |
+            Raw tool input arguments — the decision input (§1.1). Without
+            it the card cannot be informative.
+        coworker_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: The coworker whose call is gated (§1.1).
+        conversation_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            Originating conversation; null for scheduled-task approvals
+            that have no live conversation (§1.1).
+        requested_at:
+          type: string
+          nullable: true
+          description: When the approval became pending (ISO-8601, §1.1).
+        rationale:
+          type: string
+          nullable: true
+          description: |
+            The agent's "why I'm calling this tool" (§1.1). Nullable; the
+            card omits the section when null.
         action_summary:
           type: string
           nullable: true
@@ -3050,10 +3105,12 @@ components:
         request_id: { type: string, format: uuid }
         outcome:
           type: string
-          enum: [approved, rejected, expired]
+          enum: [approved, rejected, expired, cancelled]
           description: |
             The orchestrator's deterministic terminal state (no LLM in
-            the loop). The SPA edits the card in place.
+            the loop). The SPA edits the card in place. `cancelled` =
+            the coworker's container withdrew the call (Stop / hook
+            exception), distinct from `expired` (no decision in time).
 
     # Server → client. Discriminated on `type`; clients can pattern
     # match on the literal and TS narrows to the matching member.

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -424,6 +424,33 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/conversations/{id}/approval-requests:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    get:
+      tags: [Conversations]
+      operationId: listConversationApprovalRequests
+      summary: List a conversation's approval requests (all states, for chat history)
+      description: |
+        The conversation's full HITL approval record — pending AND resolved
+        (approved / rejected / expired / cancelled) — oldest first, so the SPA
+        re-renders approval cards inline in the message stream on reload, not
+        just the pending ones. Tenant-scoped via the conversation row: a
+        conversation outside the caller's tenant returns 404.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ApprovalRequest' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/models:
     get:
       tags: [Models]
@@ -1177,7 +1204,7 @@ paths:
             application/json:
               schema:
                 type: array
-                items: { $ref: '#/components/schemas/PendingApprovalRequest' }
+                items: { $ref: '#/components/schemas/ApprovalRequest' }
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -2284,7 +2311,7 @@ components:
         enabled: { type: boolean }
         priority: { type: integer }
 
-    PendingApprovalRequest:
+    ApprovalRequest:
       type: object
       required:
         - request_id
@@ -2292,6 +2319,7 @@ components:
         - tool_name
         - requested_at
         - expires_at
+        - status
       properties:
         request_id:
           type: string
@@ -2324,6 +2352,23 @@ components:
           type: string
           nullable: true
           description: The agent's free-text "why I'm calling this tool" (nullable).
+        status:
+          type: string
+          enum: [pending, approved, rejected, expired, cancelled]
+          description: |
+            Lifecycle status. Always `pending` on the tenant-wide inbox read
+            (`GET /approval-requests`); the conversation sub-resource
+            (`GET /conversations/{id}/approval-requests`) returns every state so
+            resolved cards re-render inline in chat history.
+        decided_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the request was resolved; null while pending.
+        note:
+          type: string
+          nullable: true
+          description: The approver's note on a reject; null otherwise.
 
     # -----------------------------------------------------------------
     # Skills (design §3 Phase 3 / docs/19-skills-architecture.md)

--- a/src/agent_runner/approval/policy.py
+++ b/src/agent_runner/approval/policy.py
@@ -73,6 +73,10 @@ class ApprovalPolicy:
     enabled: bool
     priority: int
     updated_at: datetime
+    # Set from the row by the persistence layer; the matcher never reads it.
+    # Defaulted so the in-container snapshot builder (which has no created_at)
+    # and matcher tests need not supply it.
+    created_at: datetime | None = None
 
 
 # Binary leaf operators. Each takes (actual_field_value, policy_value) and

--- a/src/agent_runner/approval/policy.py
+++ b/src/agent_runner/approval/policy.py
@@ -37,6 +37,7 @@ __all__ = [
     "ApprovalPolicy",
     "ConditionValidationError",
     "evaluate_condition",
+    "evaluate_condition_explained",
     "find_matching_policy",
     "validate_condition_expr",
 ]
@@ -150,6 +151,17 @@ _OPS = {
 _MISSING = object()
 
 
+class _ConditionEvalError(Exception):
+    """A condition could not be evaluated at match time — e.g. it references a
+    field the tool call doesn't include (usually a policy typo). Carries a
+    human-readable ``reason`` so the fail-closed gate can explain itself rather
+    than silently gating every call."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
 def _eval(expr: Any, params: dict[str, Any]) -> bool:
     """Recursively evaluate one node. May raise — callers fail closed.
 
@@ -186,8 +198,42 @@ def _eval(expr: Any, params: dict[str, Any]) -> bool:
     fn = _OPS[op]           # KeyError on unknown op → fail closed
     actual = params.get(field, _MISSING)
     if actual is _MISSING:
-        raise KeyError(f"field {field!r} missing from params")
-    return bool(fn(actual, value))
+        raise _ConditionEvalError(
+            f"the condition references field '{field}', which this tool call "
+            f"does not include"
+        )
+    try:
+        return bool(fn(actual, value))
+    except _ConditionEvalError:
+        raise
+    except Exception as exc:  # re-raised as a fail-closed reason below
+        raise _ConditionEvalError(
+            f"the '{op}' comparison on field '{field}' could not be evaluated"
+        ) from exc
+
+
+def evaluate_condition_explained(
+    expr: dict[str, Any], params: dict[str, Any]
+) -> tuple[bool, str | None]:
+    """Whether ``expr`` matches ``params``, AND why when the match is forced.
+
+    Returns ``(matched, reason)``:
+
+    * ``(True, None)``  — the condition genuinely evaluated true (a real match).
+    * ``(False, None)`` — the condition genuinely evaluated false (no match).
+    * ``(True, reason)`` — the condition could NOT be evaluated, so the call is
+      gated as a precaution (§7 fail-closed). ``reason`` is a human-readable
+      explanation (most often: the condition names a field the tool call does
+      not include — i.e. a typo in the policy). The two ``True`` cases look
+      identical to the matcher but mean very different things; surfacing the
+      reason turns a silent "gate everything" typo into a fixable signal.
+    """
+    try:
+        return _eval(expr, params), None
+    except _ConditionEvalError as exc:
+        return True, exc.reason
+    except Exception:  # noqa: BLE001 — any other malformed expr also fails closed
+        return True, "the policy condition is malformed and could not be evaluated"
 
 
 def evaluate_condition(expr: dict[str, Any], params: dict[str, Any]) -> bool:
@@ -196,12 +242,10 @@ def evaluate_condition(expr: dict[str, Any], params: dict[str, Any]) -> bool:
     ``True`` means the policy condition is satisfied (this call needs
     approval). Any malformed expression, missing field, type mismatch, or
     unexpected exception also returns ``True`` (§7 fail-closed). Only a
-    cleanly-evaluated, definitively-false condition returns ``False``.
+    cleanly-evaluated, definitively-false condition returns ``False``. See
+    :func:`evaluate_condition_explained` for the accompanying reason channel.
     """
-    try:
-        return _eval(expr, params)
-    except Exception:  # noqa: BLE001 — fail-closed: any error ⇒ require approval
-        return True
+    return evaluate_condition_explained(expr, params)[0]
 
 
 def validate_condition_expr(expr: Any, *, _depth: int = 0) -> None:

--- a/src/agent_runner/hooks/handlers/approval.py
+++ b/src/agent_runner/hooks/handlers/approval.py
@@ -207,6 +207,9 @@ class ApprovalHookHandler:
                     "tool_name": tool,
                     "params": params,
                     "action_summary": _action_summary(server, tool, params),
+                    # Agent's "why" for this call. No fill mechanism yet — always
+                    # None for now; plumbed nullable end-to-end (HITL UI U1).
+                    "rationale": None,
                     "requested_at": requested_at.isoformat(),
                     "expires_at": expires_at.isoformat(),
                 },

--- a/src/agent_runner/hooks/handlers/approval.py
+++ b/src/agent_runner/hooks/handlers/approval.py
@@ -48,7 +48,11 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from agent_runner.approval.policy import ApprovalPolicy, find_matching_policy
+from agent_runner.approval.policy import (
+    ApprovalPolicy,
+    evaluate_condition_explained,
+    find_matching_policy,
+)
 
 from ..events import ToolCallVerdict
 
@@ -152,7 +156,26 @@ class ApprovalHookHandler:
             # No tenant policy gates this call — allow.
             return None
 
-        return await self._await_decision(server, tool, params, policy)
+        # Distinguish a genuine match from a fail-closed match (the policy's
+        # condition couldn't be evaluated — usually a typo'd field name, which
+        # otherwise silently gates *every* call). On the latter, carry the
+        # reason as the approval's rationale so the card / Telegram / log say
+        # WHY, instead of leaving the user with a phantom gate. A genuine match
+        # leaves the rationale None (the agent-supplied "why" is not wired yet).
+        _, gate_reason = evaluate_condition_explained(policy.condition_expr, params)
+        rationale: str | None = None
+        if gate_reason is not None:
+            _log.warning(
+                "approval gated by un-evaluable policy %s (%s.%s): %s",
+                policy.id, server, tool, gate_reason,
+            )
+            rationale = (
+                f"⚠ This approval policy's condition couldn't be evaluated "
+                f"({gate_reason}); the call was gated as a precaution. Check the "
+                f"policy's field names."
+            )
+
+        return await self._await_decision(server, tool, params, policy, rationale)
 
     # -- decision routing (called by the NATS decision subscription) ----
 
@@ -180,6 +203,7 @@ class ApprovalHookHandler:
         tool: str,
         params: dict[str, Any],
         policy: ApprovalPolicy,
+        rationale: str | None = None,
     ) -> ToolCallVerdict | None:
         request_id = self._id_factory()
         loop = asyncio.get_running_loop()
@@ -207,9 +231,11 @@ class ApprovalHookHandler:
                     "tool_name": tool,
                     "params": params,
                     "action_summary": _action_summary(server, tool, params),
-                    # Agent's "why" for this call. No fill mechanism yet — always
-                    # None for now; plumbed nullable end-to-end (HITL UI U1).
-                    "rationale": None,
+                    # The approval's "why". The agent-supplied rationale is not
+                    # wired yet (always None for a genuine match), but a
+                    # fail-closed match (un-evaluable condition) passes its
+                    # reason here so the user can see why the call was gated.
+                    "rationale": rationale,
                     "requested_at": requested_at.isoformat(),
                     "expires_at": expires_at.isoformat(),
                 },

--- a/src/rolemesh/channels/telegram_gateway.py
+++ b/src/rolemesh/channels/telegram_gateway.py
@@ -481,12 +481,17 @@ class _BotInstance:
             await self._app.bot.send_chat_action(chat_id, ChatAction.TYPING)
 
     async def send_approval_card(
-        self, chat_id: str, request_id: str, summary: str
+        self, chat_id: str, request_id: str, text: str
     ) -> int | None:
-        """Send the ✅/❌ approval card; return its ``message_id`` for later edit."""
+        """Send the ✅/❌ approval card; return its ``message_id`` for later edit.
+
+        ``text`` is the fully-rendered plain-text body (built upstream by
+        ``approval_notify.pending_card_text`` so the Telegram card mirrors the
+        web chat card). Sent with no ``parse_mode`` so user-supplied param
+        values need no MarkdownV2 escaping.
+        """
         if self._app is None:
             return None
-        text = f"⏳ Approval required for {summary}.\nApprove or reject this tool call."
         try:
             sent = await self._app.bot.send_message(
                 chat_id, text, reply_markup=_approval_keyboard(request_id)
@@ -543,14 +548,14 @@ class TelegramGateway:
         return self._bots_by_token.get(token)
 
     async def send_approval_card(
-        self, binding_id: str, chat_id: str, request_id: str, summary: str
+        self, binding_id: str, chat_id: str, request_id: str, text: str
     ) -> int | None:
         """Resolve the binding's bot and send an approval card."""
         bot = self._bot_for_binding(binding_id)
         if bot is None:
             logger.warning("No telegram bot for binding", binding_id=binding_id)
             return None
-        return await bot.send_approval_card(chat_id, request_id, summary)
+        return await bot.send_approval_card(chat_id, request_id, text)
 
     async def edit_approval_card(
         self, binding_id: str, chat_id: str, message_id: int, text: str

--- a/src/rolemesh/db/approval.py
+++ b/src/rolemesh/db/approval.py
@@ -35,6 +35,7 @@ __all__ = [
     "list_approval_policies",
     "list_pending_requests_all_tenants",
     "list_pending_requests_for_tenant",
+    "list_requests_for_conversation",
     "resolve_approval_request",
     "update_approval_policy",
 ]
@@ -362,6 +363,27 @@ async def list_pending_requests_for_tenant(
             "WHERE tenant_id = $1::uuid AND status = 'pending' "
             "ORDER BY requested_at ASC",
             tenant_id,
+        )
+    return [_record_to_request(r) for r in rows]
+
+
+async def list_requests_for_conversation(
+    conversation_id: str, *, tenant_id: str
+) -> list[ApprovalRequest]:
+    """All approval requests for one conversation, oldest first.
+
+    Unlike :func:`list_pending_requests_for_tenant` this returns every status
+    (pending + resolved) so the web chat can re-render the conversation's full
+    approval record inline. Tenant-scoped via ``tenant_conn`` (RLS) plus the
+    explicit ``tenant_id`` predicate (INV-1 belt).
+    """
+    async with tenant_conn(tenant_id) as conn:
+        rows = await conn.fetch(
+            "SELECT * FROM approval_requests "
+            "WHERE tenant_id = $1::uuid AND conversation_id = $2::uuid "
+            "ORDER BY requested_at ASC",
+            tenant_id,
+            conversation_id,
         )
     return [_record_to_request(r) for r in rows]
 

--- a/src/rolemesh/db/approval.py
+++ b/src/rolemesh/db/approval.py
@@ -59,6 +59,7 @@ class ApprovalRequest:
     mcp_server_name: str
     action: dict[str, Any]          # { tool_name, params }
     action_summary: str | None
+    rationale: str | None           # agent's "why" (nullable; no fill yet)
     status: str
     decided_by: str | None
     note: str | None
@@ -84,6 +85,7 @@ def _record_to_policy(row: asyncpg.Record) -> ApprovalPolicy:
         enabled=bool(row["enabled"]),
         priority=int(row["priority"]),
         updated_at=row["updated_at"],
+        created_at=row["created_at"],
     )
 
 
@@ -99,6 +101,7 @@ def _record_to_request(row: asyncpg.Record) -> ApprovalRequest:
         mcp_server_name=row["mcp_server_name"],
         action=_json_to_dict(row["action"]),
         action_summary=row["action_summary"],
+        rationale=row["rationale"],
         status=row["status"],
         decided_by=str(row["decided_by"]) if row["decided_by"] else None,
         note=row["note"],
@@ -260,6 +263,7 @@ async def create_approval_request(
     policy_id: str | None = None,
     user_id: str | None = None,
     action_summary: str | None = None,
+    rationale: str | None = None,
     request_id: str | None = None,
 ) -> ApprovalRequest:
     """Insert a ``pending`` approval request and return it.
@@ -283,11 +287,11 @@ async def create_approval_request(
                 INSERT INTO approval_requests (
                     id, tenant_id, coworker_id, conversation_id, policy_id,
                     user_id, job_id, mcp_server_name, action, action_summary,
-                    expires_at
+                    rationale, expires_at
                 )
                 VALUES (
                     $1::uuid, $2::uuid, $3::uuid, $4::uuid, $5::uuid,
-                    $6::uuid, $7, $8, $9::jsonb, $10, $11
+                    $6::uuid, $7, $8, $9::jsonb, $10, $11, $12
                 )
                 RETURNING *
                 """,
@@ -301,6 +305,7 @@ async def create_approval_request(
                 mcp_server_name,
                 json.dumps(action),
                 action_summary,
+                rationale,
                 expires_at,
             )
         else:
@@ -308,11 +313,12 @@ async def create_approval_request(
                 """
                 INSERT INTO approval_requests (
                     tenant_id, coworker_id, conversation_id, policy_id, user_id,
-                    job_id, mcp_server_name, action, action_summary, expires_at
+                    job_id, mcp_server_name, action, action_summary, rationale,
+                    expires_at
                 )
                 VALUES (
                     $1::uuid, $2::uuid, $3::uuid, $4::uuid, $5::uuid,
-                    $6, $7, $8::jsonb, $9, $10
+                    $6, $7, $8::jsonb, $9, $10, $11
                 )
                 RETURNING *
                 """,
@@ -325,6 +331,7 @@ async def create_approval_request(
                 mcp_server_name,
                 json.dumps(action),
                 action_summary,
+                rationale,
                 expires_at,
             )
     assert row is not None

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -1299,6 +1299,12 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "CREATE INDEX IF NOT EXISTS idx_approval_requests_job "
         "ON approval_requests (job_id)"
     )
+    # The agent's free-text "why I'm calling this tool" (nullable). Added after
+    # the table shipped, so use the idempotent ADD COLUMN IF NOT EXISTS form for
+    # pre-existing dev DBs. Default null; no agent-fill mechanism yet (HITL UI U1).
+    await conn.execute(
+        "ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS rationale TEXT"
+    )
 
     # Reference/seed data — see _seed_reference_data.
     await _seed_reference_data(conn)

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1434,13 +1434,13 @@ async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDeps
         )
 
     async def _tg_send_card(
-        binding_id: str, chat_id: str, request_id: str, summary: str
+        binding_id: str, chat_id: str, request_id: str, text: str
     ) -> int | None:
         tg = _gateways.get("telegram")
         if not isinstance(tg, TelegramGateway):
             return None
         return await tg.send_approval_card(
-            binding_id, chat_id, request_id, summary
+            binding_id, chat_id, request_id, text
         )
 
     async def _tg_edit_card(

--- a/src/rolemesh/orchestration/approval_coordinator.py
+++ b/src/rolemesh/orchestration/approval_coordinator.py
@@ -174,6 +174,8 @@ class ApprovalCoordinator:
         raw_params = payload.get("params")
         params = raw_params if isinstance(raw_params, dict) else {}
         action_summary = payload.get("action_summary")
+        raw_rationale = payload.get("rationale")
+        rationale = raw_rationale if isinstance(raw_rationale, str) else None
         key = approval_queue_key(conversation_id, coworker_id)
 
         # Server-side truth for the tenant; the payload value is only a fallback
@@ -225,6 +227,7 @@ class ApprovalCoordinator:
                 policy_id=policy_id,
                 user_id=user_id,
                 action_summary=action_summary,
+                rationale=rationale,
                 request_id=request_id,
             )
         except Exception:
@@ -269,11 +272,19 @@ class ApprovalCoordinator:
             return
         # The container initiated this; mark the row cancelled (first-wins) but
         # do NOT publish a decision back.
+        row: ApprovalRequest | None = None
         with contextlib.suppress(Exception):
-            await self._persistence.resolve_request(
+            row = await self._persistence.resolve_request(
                 request_id, tenant_id=pending.tenant_id, status="cancelled"
             )
         self._resolve_local(request_id)
+        # Flip the card in place for the user (same hard-channel path as
+        # reject/expired). Only when *this* cancel won the pending→terminal
+        # transition — a cancel racing a decision/expiry resolves zero rows and
+        # the winner already (or will) emit its own terminal event.
+        if row is not None and self._notify_hard is not None:
+            with contextlib.suppress(Exception):
+                await self._notify_hard(row, "cancelled")
 
     # -- decision intake (S4 channels call this; also used internally) ----
 

--- a/src/rolemesh/orchestration/approval_notify.py
+++ b/src/rolemesh/orchestration/approval_notify.py
@@ -50,6 +50,7 @@ _OUTCOME_TEXT = {
     "approved": "✅ Approved",
     "rejected": "❌ Rejected",
     "expired": "⏰ Expired (no decision in time)",
+    "cancelled": "⏰ Cancelled (the coworker withdrew this call)",
 }
 
 
@@ -158,12 +159,23 @@ class ApprovalNotifier:
                 message_id = None
             ref.telegram_message_id = message_id
         elif target.channel_type == "web":
+            # The decision-relevant payload (§1.1): the SPA renders an informative
+            # card from the WS push alone, before any REST read. ``action`` is the
+            # {tool_name, params} snapshot persisted on the row.
+            action = req.action if isinstance(req.action, dict) else {}
             await self._safe_publish_web(
                 target.binding_id,
                 target.chat_id,
                 {
                     "type": "approval.requested",
                     "request_id": req.id,
+                    "mcp_server_name": req.mcp_server_name,
+                    "tool_name": action.get("tool_name"),
+                    "params": action.get("params"),
+                    "coworker_id": req.coworker_id,
+                    "conversation_id": req.conversation_id,
+                    "requested_at": req.requested_at.isoformat(),
+                    "rationale": req.rationale,
                     "action_summary": req.action_summary,
                     "expires_at": req.expires_at.isoformat(),
                 },

--- a/src/rolemesh/orchestration/approval_notify.py
+++ b/src/rolemesh/orchestration/approval_notify.py
@@ -26,6 +26,7 @@ S3 coordinator documents).
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -59,10 +60,99 @@ def card_text_for_outcome(outcome: str) -> str:
     return _OUTCOME_TEXT.get(outcome, f"Resolved: {outcome}")
 
 
-def pending_card_text(action_summary: str | None) -> str:
-    """Body text for the pending approve/reject card."""
-    summary = action_summary or "an MCP tool call"
-    return f"⏳ Approval required for {summary}.\nApprove or reject this tool call."
+# Card-body sizing. Telegram caps a message at 4096 chars; we aim far lower so
+# the card stays scannable on a phone. Each param value is clipped, and the
+# whole params block is dropped-with-ellipsis once the running body would blow
+# its budget — so even a tool called with hundreds of huge params can't grow
+# the card past ``_MAX_CARD_LEN`` (+ the small fixed header/footer).
+_MAX_VALUE_LEN = 80
+_MAX_RATIONALE_LEN = 240
+_MAX_SUMMARY_LEN = 160
+_MAX_CARD_LEN = 1500
+_ELLIPSIS = "…"
+
+
+def _clip(text: str, limit: int) -> str:
+    """Cut ``text`` to ``limit`` chars, marking the cut with an ellipsis."""
+    if len(text) <= limit:
+        return text
+    if limit <= len(_ELLIPSIS):
+        return _ELLIPSIS[:limit]
+    return text[: limit - len(_ELLIPSIS)] + _ELLIPSIS
+
+
+def _render_value(value: Any) -> str:
+    """One-line, length-capped rendering of a single param value.
+
+    Strings pass through; everything else is compact-JSON-encoded (falling back
+    to ``str`` for non-serialisable values). Newlines are collapsed so one param
+    occupies exactly one line, then the result is clipped to ``_MAX_VALUE_LEN``.
+    """
+    if isinstance(value, str):
+        rendered = value
+    else:
+        try:
+            rendered = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError):
+            rendered = str(value)
+    return _clip(" ".join(rendered.split()), _MAX_VALUE_LEN)
+
+
+def pending_card_text(req: ApprovalRequest) -> str:
+    """Plain-text body for the pending approve/reject card (Telegram).
+
+    Mirrors the web chat card (spec §6): a ``server.tool`` chip, one
+    ``key: value`` line per param (each value clipped), an optional ``Why:``
+    rationale line (omitted when null/blank), and the approve/reject prompt.
+
+    Plain text — deliberately **not** MarkdownV2 — so user-supplied param values
+    never have to be escaped and can't trip Telegram's formatter. The body is
+    budgeted well under Telegram's 4096-char limit; params that would overflow
+    are dropped and the truncation is flagged with an ellipsis line.
+    """
+    summary = _clip(req.action_summary or "an MCP tool call", _MAX_SUMMARY_LEN)
+    action = req.action if isinstance(req.action, dict) else {}
+    tool_name = action.get("tool_name")
+    params = action.get("params")
+
+    header = f"⏳ Approval required for {summary}."
+    chip = f"{req.mcp_server_name}.{tool_name}" if tool_name else (req.mcp_server_name or "")
+    footer = "Approve or reject this tool call."
+
+    rationale = (req.rationale or "").strip()
+    rationale_line = (
+        f"Why: {_clip(rationale, _MAX_RATIONALE_LEN)}" if rationale else None
+    )
+
+    # Everything except the params block is fixed-size and always rendered; the
+    # params block gets whatever budget is left under the cap.
+    fixed_len = len(header) + len(chip) + len(footer)
+    if rationale_line:
+        fixed_len += len(rationale_line)
+
+    param_lines: list[str] = []
+    if isinstance(params, dict) and params:
+        budget = _MAX_CARD_LEN - fixed_len
+        truncated = False
+        for key, value in params.items():
+            line = f"{key}: {_render_value(value)}"
+            if budget - (len(line) + 1) < 0:
+                truncated = True
+                break
+            param_lines.append(line)
+            budget -= len(line) + 1
+        if truncated or len(param_lines) < len(params):
+            param_lines.append(_ELLIPSIS)
+
+    # Blocks are separated by a blank line; chip + params form one tight block.
+    detail = [chip, *param_lines] if chip else param_lines
+    blocks = [header]
+    if detail:
+        blocks.append("\n".join(detail))
+    if rationale_line:
+        blocks.append(rationale_line)
+    blocks.append(footer)
+    return "\n\n".join(blocks)
 
 
 @dataclass
@@ -151,7 +241,7 @@ class ApprovalNotifier:
                     target.binding_id,
                     target.chat_id,
                     req.id,
-                    req.action_summary or "an MCP tool call",
+                    pending_card_text(req),
                 )
             except Exception:
                 logger.exception("approval notify: telegram card send failed",

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -417,6 +417,7 @@ class ApprovalPolicy(BaseModel):
     condition_expr: dict[str, object]
     enabled: bool
     priority: int
+    created_at: str
     updated_at: str
 
 
@@ -482,6 +483,12 @@ class PendingApprovalRequest(BaseModel):
     action_summary: str | None = None
     requested_at: str
     expires_at: str
+    # §1.2: the decision input (raw params), the requesting coworker, and the
+    # agent's nullable rationale — so a reconnecting browser re-renders the same
+    # informative card the live WS push carried.
+    params: dict[str, object] | None = None
+    coworker_id: str | None = None
+    rationale: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -937,6 +944,17 @@ class WsServerEventApprovalRequested(BaseModel):
     model_config = ConfigDict(extra="forbid")
     type: Literal["event.approval.requested"]
     request_id: str
+    # Decision-relevant additions (§1.1). All additive/optional so existing
+    # clients ignore them; the SPA renders an informative card from this push
+    # alone, before any REST read. ``params`` is the raw tool input — the
+    # decision input. ``rationale``/``conversation_id`` are nullable.
+    mcp_server_name: str | None = None
+    tool_name: str | None = None
+    params: dict[str, object] | None = None
+    coworker_id: str | None = None
+    conversation_id: str | None = None
+    requested_at: str | None = None
+    rationale: str | None = None
     action_summary: str | None = None
     expires_at: str | None = None
 
@@ -952,7 +970,9 @@ class WsServerEventApprovalResolved(BaseModel):
     model_config = ConfigDict(extra="forbid")
     type: Literal["event.approval.resolved"]
     request_id: str
-    outcome: Literal["approved", "rejected", "expired"]
+    # ``cancelled`` = the coworker's container withdrew the call (Stop / hook
+    # exception); distinct from ``expired`` (no decision in time). §1.5.
+    outcome: Literal["approved", "rejected", "expired", "cancelled"]
 
 
 # Tagged union over ``type``. Pydantic v2's Field discriminator picks

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -464,14 +464,15 @@ class ApprovalPolicyUpdate(BaseModel):
     )
 
 
-class PendingApprovalRequest(BaseModel):
-    """Wire projection of a *pending* ``approval_requests`` row (§4.2).
+class ApprovalRequest(BaseModel):
+    """Wire projection of an ``approval_requests`` row (§4.2).
 
-    The web reconnect read (``GET /api/v1/approval-requests``) returns these so
-    a browser that dropped its socket can re-render the in-flight ✅/❌ cards
-    from the authoritative DB rows (the live ``event.approval.requested`` push
-    is fire-and-forget). Only pending rows are ever returned; a resolved request
-    is delivered as ``event.approval.resolved`` instead.
+    Two reads return these: the tenant-wide inbox read
+    (``GET /api/v1/approval-requests``) yields only ``pending`` rows; the
+    conversation sub-resource
+    (``GET /api/v1/conversations/{id}/approval-requests``) yields every state so
+    a reconnecting browser re-renders both pending and resolved cards inline in
+    chat history. ``status`` distinguishes them.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -489,6 +490,10 @@ class PendingApprovalRequest(BaseModel):
     params: dict[str, object] | None = None
     coworker_id: str | None = None
     rationale: str | None = None
+    # pending|approved|rejected|expired|cancelled — 'pending' on the inbox read.
+    status: str
+    decided_at: str | None = None
+    note: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/webui/v1/approvals.py
+++ b/src/webui/v1/approvals.py
@@ -20,7 +20,9 @@ from fastapi import APIRouter, Depends, Query, Response
 from agent_runner.approval.policy import ApprovalPolicy as ApprovalPolicyValue
 from rolemesh.auth.provider import AuthenticatedUser
 from rolemesh.db.approval import (
-    ApprovalRequest,
+    ApprovalRequest as ApprovalRequestRow,
+)
+from rolemesh.db.approval import (
     create_approval_policy,
     delete_approval_policy,
     get_approval_policy,
@@ -33,7 +35,7 @@ from webui.schemas_v1 import (
     ApprovalPolicy,
     ApprovalPolicyCreate,
     ApprovalPolicyUpdate,
-    PendingApprovalRequest,
+    ApprovalRequest,
 )
 from webui.v1.errors import raise_error_response
 
@@ -55,7 +57,7 @@ def _policy_to_response(p: ApprovalPolicyValue) -> ApprovalPolicy:
     )
 
 
-def _request_to_response(r: ApprovalRequest) -> PendingApprovalRequest:
+def _request_to_response(r: ApprovalRequestRow) -> ApprovalRequest:
     # ``action`` is the {tool_name, params} snapshot. The decision UX (§1.2)
     # needs the raw params to be informative — the user cannot meaningfully
     # approve a tool call they can't see the arguments of. The endpoint is
@@ -64,7 +66,7 @@ def _request_to_response(r: ApprovalRequest) -> PendingApprovalRequest:
     tool_name = str(action.get("tool_name", ""))
     raw_params = action.get("params")
     params = raw_params if isinstance(raw_params, dict) else None
-    return PendingApprovalRequest(
+    return ApprovalRequest(
         request_id=r.id,
         conversation_id=r.conversation_id,
         mcp_server_name=r.mcp_server_name,
@@ -75,6 +77,9 @@ def _request_to_response(r: ApprovalRequest) -> PendingApprovalRequest:
         params=params,
         coworker_id=r.coworker_id,
         rationale=r.rationale,
+        status=r.status,
+        decided_at=r.decided_at.isoformat() if r.decided_at else None,
+        note=r.note,
     )
 
 
@@ -195,7 +200,7 @@ async def delete_policy_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@requests_router.get("", response_model=list[PendingApprovalRequest])
+@requests_router.get("", response_model=list[ApprovalRequest])
 async def list_pending_requests_endpoint(
     conversation_id: str | None = Query(
         default=None,
@@ -206,7 +211,7 @@ async def list_pending_requests_endpoint(
         ),
     ),
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[PendingApprovalRequest]:
+) -> list[ApprovalRequest]:
     """Pending approval requests for the caller's tenant (oldest first).
 
     Authoritative source for re-rendering ✅/❌ cards after a socket drop. The

--- a/src/webui/v1/approvals.py
+++ b/src/webui/v1/approvals.py
@@ -50,14 +50,20 @@ def _policy_to_response(p: ApprovalPolicyValue) -> ApprovalPolicy:
         condition_expr=p.condition_expr,
         enabled=p.enabled,
         priority=p.priority,
+        created_at=p.created_at.isoformat() if p.created_at else "",
         updated_at=p.updated_at.isoformat() if p.updated_at else "",
     )
 
 
 def _request_to_response(r: ApprovalRequest) -> PendingApprovalRequest:
-    # ``action`` is the {tool_name, params} snapshot; the card only needs the
-    # tool name, never the raw params (which may carry sensitive arguments).
-    tool_name = str(r.action.get("tool_name", "")) if isinstance(r.action, dict) else ""
+    # ``action`` is the {tool_name, params} snapshot. The decision UX (§1.2)
+    # needs the raw params to be informative — the user cannot meaningfully
+    # approve a tool call they can't see the arguments of. The endpoint is
+    # already strictly tenant-scoped, so the params never cross a tenant edge.
+    action = r.action if isinstance(r.action, dict) else {}
+    tool_name = str(action.get("tool_name", ""))
+    raw_params = action.get("params")
+    params = raw_params if isinstance(raw_params, dict) else None
     return PendingApprovalRequest(
         request_id=r.id,
         conversation_id=r.conversation_id,
@@ -66,6 +72,9 @@ def _request_to_response(r: ApprovalRequest) -> PendingApprovalRequest:
         action_summary=r.action_summary,
         requested_at=r.requested_at.isoformat() if r.requested_at else "",
         expires_at=r.expires_at.isoformat() if r.expires_at else "",
+        params=params,
+        coworker_id=r.coworker_id,
+        rationale=r.rationale,
     )
 
 

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -28,14 +28,17 @@ from rolemesh.db import (
     get_channel_binding_for_coworker,
     get_conversation,
     get_conversations_for_coworker,
+    list_requests_for_conversation,
     tenant_conn,
 )
 from webui.dependencies import get_current_user
 from webui.schemas_v1 import (
+    ApprovalRequest,
     Conversation,
     ConversationCreate,
     Message,
 )
+from webui.v1.approvals import _request_to_response
 from webui.v1.coworkers import _get_coworker_or_404
 from webui.v1.errors import raise_error_response
 
@@ -236,6 +239,28 @@ async def list_conversation_messages(
             )
         )
     return out
+
+
+@conversations_router.get(
+    "/{conversation_id}/approval-requests",
+    response_model=list[ApprovalRequest],
+)
+async def list_conversation_approval_requests(
+    conversation_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> list[ApprovalRequest]:
+    """Return the conversation's full HITL approval record (all states).
+
+    Unlike the tenant-wide ``GET /api/v1/approval-requests`` (pending only, for
+    the inbox), this returns pending AND resolved requests oldest-first so the
+    chat re-renders resolved ✅/❌ cards inline on reload, not just in-flight
+    ones. Tenant-scoped: a conversation outside the caller's tenant is 404.
+    """
+    await _get_conversation_or_404(conversation_id, user.tenant_id)
+    rows = await list_requests_for_conversation(
+        conversation_id, tenant_id=user.tenant_id
+    )
+    return [_request_to_response(r) for r in rows]
 
 
 def _looks_like_uuid(value: str) -> bool:

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -226,16 +226,34 @@ def _build_approval_frame_or_none(
             "type": "event.approval.requested",
             "request_id": request_id,
         }
-        summary = payload.get("action_summary")
-        if isinstance(summary, str):
-            frame["action_summary"] = summary
+        # Decision-relevant fields (§1.1). String fields are added only when the
+        # carrier supplies a string (whitelist posture: an unexpected internal
+        # key can never reach the browser). ``params`` is the raw tool input dict
+        # — the decision input — and ``rationale``/``conversation_id`` are
+        # nullable, so they pass through as-is when present.
+        for key in ("mcp_server_name", "tool_name", "requested_at", "action_summary"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                frame[key] = value
+        coworker_id = payload.get("coworker_id")
+        if isinstance(coworker_id, str):
+            frame["coworker_id"] = coworker_id
+        if "params" in payload:
+            params = payload.get("params")
+            if isinstance(params, dict):
+                frame["params"] = params
+        for nullable_key in ("conversation_id", "rationale"):
+            if nullable_key in payload:
+                value = payload.get(nullable_key)
+                if value is None or isinstance(value, str):
+                    frame[nullable_key] = value
         expires_at = payload.get("expires_at")
         if isinstance(expires_at, str):
             frame["expires_at"] = expires_at
         return frame
     if kind == "approval.resolved":
         outcome = payload.get("outcome")
-        if outcome not in ("approved", "rejected", "expired"):
+        if outcome not in ("approved", "rejected", "expired", "cancelled"):
             return None
         return {
             "type": "event.approval.resolved",

--- a/tests/agent/test_approval_hook.py
+++ b/tests/agent/test_approval_hook.py
@@ -159,6 +159,59 @@ def test_mcp_tool_without_matching_policy_allows() -> None:
     assert broker.published == []
 
 
+# ---------------------------------------------------------------------------
+# rationale — a fail-closed gate (un-evaluable condition) explains itself
+# ---------------------------------------------------------------------------
+
+
+def test_unevaluable_policy_gates_with_a_reason_in_the_rationale() -> None:
+    # A typo'd field ('paht' for 'path') makes the condition un-evaluable, so
+    # the policy fail-closes and gates EVERY call. The published request must
+    # carry a rationale naming the bad field, so the card / Telegram / log say
+    # WHY instead of leaving a phantom gate.
+    broker = StubBroker()
+    handler = _handler(
+        broker,
+        [_policy(condition={"field": "paht", "op": "==", "value": "x.txt"})],
+    )
+
+    async def go() -> None:
+        task = asyncio.create_task(
+            handler.on_pre_tool_use(_event("mcp__email__send", {"path": "x.txt"}))
+        )
+        await _wait_for_requests(broker, 1)
+        rid = broker.requests[0]["request_id"]
+        handler.resolve_decision({"request_id": rid, "decision": "approve"})
+        await task
+
+    asyncio.run(go())
+    rationale = broker.requests[0]["rationale"]
+    assert rationale is not None
+    assert "paht" in rationale  # names the offending field so it can be fixed
+
+
+def test_genuine_match_leaves_rationale_none() -> None:
+    # A cleanly-true condition is a real match; rationale stays None (the
+    # agent-supplied "why" is not wired). Only fail-closed gates explain.
+    broker = StubBroker()
+    handler = _handler(
+        broker,
+        [_policy(condition={"field": "path", "op": "==", "value": "x.txt"})],
+    )
+
+    async def go() -> None:
+        task = asyncio.create_task(
+            handler.on_pre_tool_use(_event("mcp__email__send", {"path": "x.txt"}))
+        )
+        await _wait_for_requests(broker, 1)
+        rid = broker.requests[0]["request_id"]
+        handler.resolve_decision({"request_id": rid, "decision": "approve"})
+        await task
+
+    asyncio.run(go())
+    assert broker.requests[0]["rationale"] is None
+
+
 def test_empty_policy_snapshot_allows_all_mcp() -> None:
     broker = StubBroker()
     handler = _handler(broker, [])

--- a/tests/agent/test_approval_hook.py
+++ b/tests/agent/test_approval_hook.py
@@ -438,11 +438,14 @@ def test_approval_request_payload_contract() -> None:
     assert req["requested_at"] == _FIXED_NOW.isoformat()
     expected_expiry = (_FIXED_NOW + timedelta(milliseconds=300_000)).isoformat()
     assert req["expires_at"] == expected_expiry
+    # rationale is plumbed nullable; the hook has no fill mechanism yet, so it
+    # is always present and always None for now (HITL UI U1).
+    assert req["rationale"] is None
     # Forward-compat contract: exactly the §3.1 keys, no extras.
     assert set(req) == {
         "request_id", "tenant_id", "coworker_id", "conversation_id", "user_id",
         "job_id", "policy_id", "mcp_server_name", "tool_name", "params",
-        "action_summary", "requested_at", "expires_at",
+        "action_summary", "rationale", "requested_at", "expires_at",
     }
 
 

--- a/tests/agent/test_approval_policy.py
+++ b/tests/agent/test_approval_policy.py
@@ -24,6 +24,7 @@ import pytest
 from agent_runner.approval.policy import (
     ApprovalPolicy,
     evaluate_condition,
+    evaluate_condition_explained,
     find_matching_policy,
 )
 
@@ -138,6 +139,59 @@ def test_present_null_field_is_a_real_value_not_missing() -> None:
 )
 def test_unevaluable_conditions_fail_closed(expr: object, params: dict, why: str) -> None:
     assert evaluate_condition(expr, params) is True, f"should fail closed: {why}"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# evaluate_condition_explained — the reason channel (turns a silent gate into
+# a fixable signal). Invariant: reason is non-None EXACTLY when the True came
+# from fail-closed (couldn't evaluate), never from a genuine match.
+# ---------------------------------------------------------------------------
+
+
+def test_explained_clean_true_carries_no_reason() -> None:
+    assert evaluate_condition_explained({"always": True}, {}) == (True, None)
+    assert evaluate_condition_explained(
+        {"field": "x", "op": "==", "value": 1}, {"x": 1}
+    ) == (True, None)
+
+
+def test_explained_clean_false_carries_no_reason() -> None:
+    assert evaluate_condition_explained(
+        {"field": "x", "op": "==", "value": 1}, {"x": 2}
+    ) == (False, None)
+
+
+def test_explained_missing_field_gates_and_names_the_field() -> None:
+    # The real-world bug: a field typo ('paht' for 'path') makes the condition
+    # un-evaluable, so it fail-closes and gates every call. The reason must name
+    # the offending field so the user can fix the typo.
+    matched, reason = evaluate_condition_explained(
+        {"field": "paht", "op": "==", "value": "x.txt"}, {"path": "x.txt"}
+    )
+    assert matched is True
+    assert reason is not None
+    assert "paht" in reason
+
+
+def test_explained_missing_branch_in_and_still_reports_a_reason() -> None:
+    # First branch true (so AND evaluation reaches the second), second branch
+    # references a missing field: the whole AND fail-closes True and the reason
+    # points at the un-evaluable branch.
+    expr = {
+        "and": [
+            {"field": "amount", "op": ">", "value": 100},
+            {"field": "currancy", "op": "==", "value": "USD"},
+        ],
+    }
+    matched, reason = evaluate_condition_explained(expr, {"amount": 500})
+    assert matched is True
+    assert reason is not None and "currancy" in reason
+
+
+def test_explained_malformed_leaf_gates_with_a_generic_reason() -> None:
+    matched, reason = evaluate_condition_explained({"op": ">", "value": 1}, {"x": 1})
+    assert matched is True
+    assert reason is not None  # generic ("malformed") is fine here
 
 
 def test_empty_or_does_not_short_circuit_to_false() -> None:

--- a/tests/db/test_approval_crud.py
+++ b/tests/db/test_approval_crud.py
@@ -85,10 +85,13 @@ async def test_create_policy_defaults_to_always_true() -> None:
     assert p.condition_expr == {"always": True}
     assert p.enabled is True
     assert p.priority == 0
+    # created_at is now read off the row and exposed (policies-page §1.6).
+    assert p.created_at is not None
     # Round-trips through jsonb as a real dict, not a string.
     fetched = await get_approval_policy(p.id, tenant_id=t["tenant_id"])
     assert fetched is not None
     assert fetched.condition_expr == {"always": True}
+    assert fetched.created_at is not None
 
 
 async def test_create_policy_preserves_nested_condition_jsonb() -> None:
@@ -195,6 +198,28 @@ async def test_create_request_round_trips_action_and_null_approver() -> None:
     assert fetched is not None
     assert fetched.action == action
     assert fetched.action_summary == "charge $500"
+    # Default rationale is null when the caller omits it (no fill mechanism).
+    assert fetched.rationale is None
+
+
+async def test_create_request_round_trips_rationale() -> None:
+    # rationale is plumbed nullable end-to-end; a supplied value must survive
+    # the INSERT/SELECT round-trip (catches an off-by-one in the column list).
+    t = await _tenant_with_coworker("A")
+    req = await create_approval_request(
+        tenant_id=t["tenant_id"], coworker_id=t["coworker_id"], job_id="job-1",
+        mcp_server_name="stripe",
+        action={"tool_name": "charge", "params": {"amount": 500}},
+        expires_at=_future(), user_id=t["user_id"],
+        action_summary="charge $500",
+        rationale="refunding the duplicate order",
+    )
+    assert req.rationale == "refunding the duplicate order"
+    # And it projects out of the pending-list read the REST surface consumes.
+    pending = await list_pending_requests_for_tenant(t["tenant_id"])
+    assert len(pending) == 1
+    assert pending[0].rationale == "refunding the duplicate order"
+    assert pending[0].action == {"tool_name": "charge", "params": {"amount": 500}}
 
 
 async def test_create_request_pins_explicit_id() -> None:

--- a/tests/orchestration/test_approval_coordinator.py
+++ b/tests/orchestration/test_approval_coordinator.py
@@ -64,6 +64,7 @@ class _FakeStore:
         policy_id: str | None = None,
         user_id: str | None = None,
         action_summary: str | None = None,
+        rationale: str | None = None,
         request_id: str | None = None,
     ) -> ApprovalRequest:
         rid = request_id or str(uuid.uuid4())
@@ -78,6 +79,7 @@ class _FakeStore:
             mcp_server_name=mcp_server_name,
             action=action,
             action_summary=action_summary,
+            rationale=rationale,
             status="pending",
             decided_by=None,
             note=None,
@@ -336,6 +338,30 @@ async def test_notify_hard_fires_on_expiry_with_kind_expired() -> None:
     await coord.on_approval_request(_payload(expires_in_ms=30))
     await asyncio.sleep(0.08)
     assert hard == [("req1", "expired")]
+
+
+async def test_container_cancel_emits_cancelled_hard_event() -> None:
+    # §1.5: a container-side cancel (Stop / exception) must flip the card via
+    # the hard channel — otherwise the SPA's card stays pending forever.
+    coord, _q, store, decisions, hard = _make_with_notify()
+    await coord.on_approval_request(_payload())
+    await coord.on_approval_cancel({"request_id": "req1"})
+    assert store.rows["req1"].status == "cancelled"
+    assert hard == [("req1", "cancelled")]
+    # A cancel is NOT a decision: nothing is relayed back to the container.
+    assert decisions == []
+
+
+async def test_cancel_after_decision_does_not_emit_second_hard_event() -> None:
+    # A cancel that loses the pending→terminal race (a decision already won)
+    # resolves zero rows, so it must NOT fire a spurious ``cancelled`` flip on
+    # top of the decision's own terminal event.
+    coord, _q, _store, _decisions, hard = _make_with_notify()
+    await coord.on_approval_request(_payload())
+    await coord.decide("req1", decision="reject", decided_by="user1")
+    assert hard == [("req1", "rejected")]
+    await coord.on_approval_cancel({"request_id": "req1"})
+    assert hard == [("req1", "rejected")]  # no extra ("req1", "cancelled")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/orchestration/test_approval_decision_funnel.py
+++ b/tests/orchestration/test_approval_decision_funnel.py
@@ -65,6 +65,7 @@ class _Store:
             requested_at=_now(), decided_at=None,
             policy_id=kw.get("policy_id"), user_id=kw.get("user_id"),
             action_summary=kw.get("action_summary"),
+            rationale=kw.get("rationale"),
             conversation_id=kw.get("conversation_id"),
             tenant_id=kw["tenant_id"], coworker_id=kw["coworker_id"],
             job_id=kw["job_id"], mcp_server_name=kw["mcp_server_name"],

--- a/tests/orchestration/test_approval_decision_funnel.py
+++ b/tests/orchestration/test_approval_decision_funnel.py
@@ -187,7 +187,12 @@ async def test_telegram_approve_full_chain(monkeypatch: pytest.MonkeyPatch) -> N
 
     # 1. Container blocks → orchestrator suspends + delivers the card.
     await coord.on_approval_request(_request_payload())
-    assert ch.tg_sends == [("bind1", "chat1", "req1", "stripe.charge(amount)")]
+    assert len(ch.tg_sends) == 1
+    binding_id, chat_id, request_id, body = ch.tg_sends[0]
+    assert (binding_id, chat_id, request_id) == ("bind1", "chat1", "req1")
+    # The card body now mirrors the web card (server.tool chip + params).
+    assert "stripe.charge" in body
+    assert "amount: 500" in body
 
     # 2. User taps ✅. main funnel resolves identity + decides.
     toast = await main_module._telegram_approval_decision("req1", "approve", "7", "chat1")

--- a/tests/orchestration/test_approval_notify.py
+++ b/tests/orchestration/test_approval_notify.py
@@ -13,7 +13,10 @@ from typing import Any
 
 from rolemesh.core.types import ChannelBinding, Conversation
 from rolemesh.db.approval import ApprovalRequest
-from rolemesh.orchestration.approval_notify import ApprovalNotifier
+from rolemesh.orchestration.approval_notify import (
+    ApprovalNotifier,
+    pending_card_text,
+)
 
 
 def _req(
@@ -24,6 +27,8 @@ def _req(
     conversation_id: str | None = "conv1",
     action_summary: str | None = "stripe.charge(amount)",
     rationale: str | None = None,
+    action: dict[str, Any] | None = None,
+    mcp_server_name: str = "stripe",
 ) -> ApprovalRequest:
     now = datetime.now(tz=UTC)
     return ApprovalRequest(
@@ -34,8 +39,8 @@ def _req(
         policy_id="pol1",
         user_id="user1",
         job_id="job1",
-        mcp_server_name="stripe",
-        action={"tool_name": "charge", "params": {"amount": 500}},
+        mcp_server_name=mcp_server_name,
+        action=action if action is not None else {"tool_name": "charge", "params": {"amount": 500}},
         action_summary=action_summary,
         rationale=rationale,
         status="pending",
@@ -141,7 +146,8 @@ async def test_telegram_card_delivered_then_edited_on_reject() -> None:
     req = _req()
 
     await n.notify_status(req)
-    assert h.tg_sends == [("bind1", "chat1", "req1", "stripe.charge(amount)")]
+    assert len(h.tg_sends) == 1
+    assert h.tg_sends[0][:3] == ("bind1", "chat1", "req1")
     # The card location must be cached so the IDOR funnel can authorise the tap.
     ref = n.card_ref("req1")
     assert ref is not None
@@ -282,7 +288,8 @@ async def test_scheduled_task_falls_back_to_most_recent_conversation() -> None:
     )
     n = h.notifier()
     await n.notify_status(_req(conversation_id=None))
-    assert h.tg_sends == [("bind1", "chatNew", "req1", "stripe.charge(amount)")]
+    assert len(h.tg_sends) == 1
+    assert h.tg_sends[0][:3] == ("bind1", "chatNew", "req1")
 
 
 async def test_scheduled_task_with_no_conversations_sends_nothing() -> None:
@@ -310,3 +317,106 @@ async def test_mark_outcome_without_card_is_noop() -> None:
     n = h.notifier()
     await n.mark_outcome("never-delivered", "expired")
     assert h.tg_edits == [] and h.web_events == []
+
+
+# ---------------------------------------------------------------------------
+# pending_card_text — the Telegram card body mirrors the web card (spec §6)
+# ---------------------------------------------------------------------------
+
+# Telegram's hard cap on a single message. The body must never approach it.
+_TELEGRAM_MAX = 4096
+
+
+def test_card_shows_server_tool_chip_and_each_param() -> None:
+    req = _req(
+        action={"tool_name": "charge", "params": {"amount": 500, "currency": "usd"}},
+    )
+    body = pending_card_text(req)
+    assert "stripe.charge" in body            # server.tool chip
+    assert "amount: 500" in body              # one line per param...
+    assert "currency: usd" in body            # ...all of them
+    # The original prompt copy survives.
+    assert body.startswith("⏳ Approval required for")
+    assert "Approve or reject this tool call." in body
+
+
+def test_card_includes_rationale_line_when_present() -> None:
+    req = _req(rationale="refunding a duplicate order")
+    body = pending_card_text(req)
+    assert "Why: refunding a duplicate order" in body
+
+
+def test_card_omits_why_line_when_rationale_null() -> None:
+    body = pending_card_text(_req(rationale=None))
+    assert "Why:" not in body
+
+
+def test_card_omits_why_line_when_rationale_blank() -> None:
+    # Whitespace-only rationale is semantically empty — must not emit "Why:  ".
+    body = pending_card_text(_req(rationale="   \n  "))
+    assert "Why:" not in body
+
+
+def test_card_handles_empty_params_gracefully() -> None:
+    req = _req(action={"tool_name": "ping", "params": {}})
+    body = pending_card_text(req)
+    # Chip + prompt still render; no orphan key/value noise, no crash.
+    assert "stripe.ping" in body
+    assert "Approve or reject this tool call." in body
+
+
+def test_card_handles_missing_params_key() -> None:
+    # A row whose action JSON has no "params" at all must not blow up.
+    body = pending_card_text(_req(action={"tool_name": "ping"}))
+    assert "stripe.ping" in body
+
+
+def test_card_handles_non_dict_params() -> None:
+    # Malformed-but-valid JSON (params is a list, not an object) — degrade, don't raise.
+    body = pending_card_text(_req(action={"tool_name": "ping", "params": ["a", "b"]}))
+    assert "stripe.ping" in body
+    assert "Approve or reject this tool call." in body
+
+
+def test_card_handles_missing_tool_name() -> None:
+    # No tool_name → chip falls back to the server name alone, no "stripe.None".
+    body = pending_card_text(_req(action={"params": {"x": 1}}))
+    assert "None" not in body
+    assert "stripe" in body
+
+
+def test_card_clips_an_overlong_value() -> None:
+    long_value = "x" * 5000
+    req = _req(action={"tool_name": "charge", "params": {"note": long_value}})
+    body = pending_card_text(req)
+    # The raw 5000-char value must not survive verbatim; the line is clipped.
+    assert long_value not in body
+    assert "…" in body
+    assert len(body) <= _TELEGRAM_MAX
+
+
+def test_card_truncates_when_params_are_too_many() -> None:
+    # Hundreds of params, each non-trivial — the block is dropped past budget
+    # and the cut is flagged, with the whole body staying under the cap.
+    params = {f"field_{i}": f"value-{i}-" + "y" * 40 for i in range(500)}
+    req = _req(action={"tool_name": "charge", "params": params})
+    body = pending_card_text(req)
+    assert len(body) <= _TELEGRAM_MAX
+    assert len(body) <= 2000          # budgeted well under Telegram's limit
+    assert "…" in body               # truncation is visible, not silent
+    # The prompt must still be intact even after truncation.
+    assert "Approve or reject this tool call." in body
+    # Not every param could fit.
+    rendered = sum(1 for k in params if k in body)
+    assert rendered < len(params)
+
+
+def test_card_is_plain_text_not_markdown() -> None:
+    # Param values with Markdown metacharacters are emitted raw (plain text),
+    # NOT backslash-escaped — the card is sent without parse_mode.
+    req = _req(
+        action={"tool_name": "post", "params": {"msg": "_bold_ *x* [a](b) `c`"}},
+    )
+    body = pending_card_text(req)
+    assert "_bold_ *x* [a](b) `c`" in body
+    assert "\\_" not in body and "\\*" not in body

--- a/tests/orchestration/test_approval_notify.py
+++ b/tests/orchestration/test_approval_notify.py
@@ -23,6 +23,7 @@ def _req(
     coworker_id: str = "cw1",
     conversation_id: str | None = "conv1",
     action_summary: str | None = "stripe.charge(amount)",
+    rationale: str | None = None,
 ) -> ApprovalRequest:
     now = datetime.now(tz=UTC)
     return ApprovalRequest(
@@ -36,6 +37,7 @@ def _req(
         mcp_server_name="stripe",
         action={"tool_name": "charge", "params": {"amount": 500}},
         action_summary=action_summary,
+        rationale=rationale,
         status="pending",
         decided_by=None,
         note=None,
@@ -214,6 +216,40 @@ async def test_web_card_emits_requested_then_resolved() -> None:
     }
     # No Telegram traffic for a web conversation.
     assert h.tg_sends == [] and h.tg_edits == []
+
+
+async def test_web_requested_payload_carries_decision_fields() -> None:
+    # §1.1: the web card must be informative from the push alone. The notifier
+    # projects the row's {tool_name, params} snapshot + identity + rationale.
+    h = _Harness(
+        conversations={"conv1": _conv()}, bindings={"bind1": _binding("web")}
+    )
+    n = h.notifier()
+    await n.notify_status(_req(rationale="refunding duplicate order"))
+    payload = h.web_events[0][2]
+    assert payload["mcp_server_name"] == "stripe"
+    assert payload["tool_name"] == "charge"
+    assert payload["params"] == {"amount": 500}
+    assert payload["coworker_id"] == "cw1"
+    assert payload["conversation_id"] == "conv1"
+    assert payload["rationale"] == "refunding duplicate order"
+    assert payload["requested_at"]  # ISO timestamp present
+
+
+async def test_web_card_emits_cancelled_resolution() -> None:
+    # §1.5: a container-side cancel flips the web card to ``cancelled``.
+    h = _Harness(
+        conversations={"conv1": _conv()}, bindings={"bind1": _binding("web")}
+    )
+    n = h.notifier()
+    req = _req()
+    await n.notify_status(req)
+    await n.notify_hard(req, "cancelled")
+    assert h.web_events[1][2] == {
+        "type": "approval.resolved",
+        "request_id": "req1",
+        "outcome": "cancelled",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webui/test_v1_approval_policies.py
+++ b/tests/webui/test_v1_approval_policies.py
@@ -285,7 +285,7 @@ async def test_garbage_uuid_collapses_to_same_404() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _seed_pending_request(actor: AuthenticatedUser) -> str:
+async def _seed_pending_request(actor: AuthenticatedUser) -> tuple[str, str]:
     cw = await create_coworker(
         tenant_id=actor.tenant_id,
         name=f"cw-{uuid.uuid4().hex[:6]}",
@@ -298,27 +298,33 @@ async def _seed_pending_request(actor: AuthenticatedUser) -> str:
         mcp_server_name="stripe",
         action={"tool_name": "charge", "params": {"amount": 500}},
         action_summary="charge $500",
+        rationale="refunding the duplicate order",
         expires_at=datetime.now(UTC) + timedelta(minutes=5),
     )
-    return req.id
+    return req.id, cw.id
 
 
 async def test_pending_requests_returns_own_tenant_only() -> None:
     a = await _make_actor("a")
     b = await _make_actor("b")
-    a_req = await _seed_pending_request(a)
-    b_req = await _seed_pending_request(b)
+    a_req, a_cw = await _seed_pending_request(a)
+    b_req, _ = await _seed_pending_request(b)
     async with _client(_build_app(a)) as ac:
         resp = await ac.get("/api/v1/approval-requests", headers=_AUTH)
     assert resp.status_code == 200
     ids = {r["request_id"] for r in resp.json()}
     assert a_req in ids
     assert b_req not in ids
-    # Projection never leaks the raw params, only the tool name + summary.
+    # §1.2: the projection now carries the decision-relevant payload — the raw
+    # params (the decision input), the requesting coworker, and the rationale —
+    # flattened out of the internal ``action`` wrapper.
     row = next(r for r in resp.json() if r["request_id"] == a_req)
     assert row["tool_name"] == "charge"
     assert row["action_summary"] == "charge $500"
-    assert "params" not in row
+    assert row["params"] == {"amount": 500}
+    assert row["coworker_id"] == a_cw
+    assert row["rationale"] == "refunding the duplicate order"
+    # The internal {tool_name, params} wrapper itself is never exposed verbatim.
     assert "action" not in row
 
 

--- a/tests/webui/test_v1_conversations.py
+++ b/tests/webui/test_v1_conversations.py
@@ -26,7 +26,7 @@ Bug-bait focus:
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -34,9 +34,11 @@ from fastapi import FastAPI
 
 from rolemesh.auth.provider import AuthenticatedUser
 from rolemesh.db import (
+    create_approval_request,
     create_coworker,
     create_tenant,
     create_user,
+    resolve_approval_request,
     store_message,
 )
 from webui.api_v1 import router as api_v1_router
@@ -323,5 +325,150 @@ async def test_get_conversation_with_invalid_uuid_returns_404_not_500() -> None:
     app = _build_app(_authed(tid, uid))
     async with _client(app) as c:
         r = await c.get("/api/v1/conversations/not-a-uuid")
+    assert r.status_code == 404
+    assert r.json()["code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Conversation approval record — GET /conversations/{id}/approval-requests
+#
+# This sub-resource is the chat surface's source of truth for re-rendering the
+# full approval history inline (pending + resolved), so a reload doesn't drop
+# the resolved ✅/❌ cards. Bug-bait: it must (a) include resolved rows, not
+# just pending; (b) order by requested_at (where the card belongs) not
+# decided_at; (c) scope to the one conversation; (d) hold the tenant edge.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_request(
+    *, tenant_id: str, coworker_id: str, conversation_id: str, summary: str
+) -> str:
+    req = await create_approval_request(
+        tenant_id=tenant_id,
+        coworker_id=coworker_id,
+        conversation_id=conversation_id,
+        job_id="job-x",
+        mcp_server_name="stripe",
+        action={"tool_name": "charge", "params": {"amount": 500}},
+        action_summary=summary,
+        rationale="why",
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+    )
+    return req.id
+
+
+@pytest.mark.asyncio
+async def test_conversation_approvals_include_resolved_oldest_first() -> None:
+    """Pending AND resolved rows come back, oldest-first by requested_at.
+
+    The pending-only inbox read would drop the resolved card on reload — the
+    whole reason this endpoint exists. We seed two requests, resolve the
+    *first*, and assert both surface with their real status in request order.
+    """
+    tid, uid, cw_id = await _make_tenant_user_coworker()
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        r = await c.post(f"/api/v1/coworkers/{cw_id}/conversations", json={})
+        conv_id = r.json()["id"]
+
+    first = await _seed_request(
+        tenant_id=tid, coworker_id=cw_id, conversation_id=conv_id, summary="first"
+    )
+    second = await _seed_request(
+        tenant_id=tid, coworker_id=cw_id, conversation_id=conv_id, summary="second"
+    )
+    resolved = await resolve_approval_request(
+        first, tenant_id=tid, status="approved", decided_by=uid
+    )
+    assert resolved is not None, "seed precondition: first request must resolve"
+
+    async with _client(app) as c:
+        r = await c.get(f"/api/v1/conversations/{conv_id}/approval-requests")
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    assert [x["request_id"] for x in rows] == [first, second], "oldest-first"
+    assert rows[0]["status"] == "approved"
+    assert rows[0]["decided_at"] is not None
+    assert rows[1]["status"] == "pending"
+    assert rows[1]["decided_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_conversation_approvals_ordered_by_request_not_decision_time() -> None:
+    """A request raised first but decided last still sorts first.
+
+    The card belongs where the agent raised it (right after the user turn),
+    not where the human happened to click — so ordering keys on requested_at.
+    Resolving the *older* request last (so decided_at order is the reverse of
+    requested_at order) would expose an accidental ORDER BY decided_at.
+    """
+    tid, uid, cw_id = await _make_tenant_user_coworker()
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        r = await c.post(f"/api/v1/coworkers/{cw_id}/conversations", json={})
+        conv_id = r.json()["id"]
+
+    older = await _seed_request(
+        tenant_id=tid, coworker_id=cw_id, conversation_id=conv_id, summary="older"
+    )
+    newer = await _seed_request(
+        tenant_id=tid, coworker_id=cw_id, conversation_id=conv_id, summary="newer"
+    )
+    # Decide the NEWER one first, the OLDER one second — decided_at order is
+    # now the opposite of requested_at order.
+    await resolve_approval_request(newer, tenant_id=tid, status="approved")
+    await resolve_approval_request(older, tenant_id=tid, status="rejected")
+
+    async with _client(app) as c:
+        r = await c.get(f"/api/v1/conversations/{conv_id}/approval-requests")
+    assert r.status_code == 200, r.text
+    assert [x["request_id"] for x in r.json()] == [older, newer]
+
+
+@pytest.mark.asyncio
+async def test_conversation_approvals_scoped_to_the_one_conversation() -> None:
+    """A request on a *sibling* conversation (same tenant) is not returned."""
+    tid, uid, cw_id = await _make_tenant_user_coworker()
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        a = await c.post(f"/api/v1/coworkers/{cw_id}/conversations", json={})
+        conv_a = a.json()["id"]
+        b = await c.post(f"/api/v1/coworkers/{cw_id}/conversations", json={})
+        conv_b = b.json()["id"]
+
+    mine = await _seed_request(
+        tenant_id=tid, coworker_id=cw_id, conversation_id=conv_a, summary="mine"
+    )
+    await _seed_request(
+        tenant_id=tid, coworker_id=cw_id, conversation_id=conv_b, summary="sibling"
+    )
+
+    async with _client(app) as c:
+        r = await c.get(f"/api/v1/conversations/{conv_a}/approval-requests")
+    assert r.status_code == 200, r.text
+    assert [x["request_id"] for x in r.json()] == [mine]
+
+
+@pytest.mark.asyncio
+async def test_conversation_approvals_cross_tenant_is_404() -> None:
+    """Tenant A asking for tenant B's conversation gets a flat 404.
+
+    Same isolation contract as the conversation GET: a guessed/leaked UUID
+    from another tenant must collapse to the same 404 a non-existent id gets
+    — no read of B's approvals, no existence oracle.
+    """
+    a_tid, a_uid, _ = await _make_tenant_user_coworker("convapr-a")
+    b_tid, _b_uid, b_cw = await _make_tenant_user_coworker("convapr-b")
+    b_app = _build_app(_authed(b_tid, _b_uid))
+    async with _client(b_app) as c:
+        r = await c.post(f"/api/v1/coworkers/{b_cw}/conversations", json={})
+        b_conv = r.json()["id"]
+    await _seed_request(
+        tenant_id=b_tid, coworker_id=b_cw, conversation_id=b_conv, summary="victim"
+    )
+
+    a_app = _build_app(_authed(a_tid, a_uid))
+    async with _client(a_app) as c:
+        r = await c.get(f"/api/v1/conversations/{b_conv}/approval-requests")
     assert r.status_code == 404
     assert r.json()["code"] == "NOT_FOUND"

--- a/tests/webui/test_ws_approval.py
+++ b/tests/webui/test_ws_approval.py
@@ -105,6 +105,84 @@ def test_build_requested_frame_whitelists_fields() -> None:
     assert "secret_internal_key" not in frame
 
 
+def test_build_requested_frame_carries_decision_fields() -> None:
+    # §1.1: the card must be informative from the push alone. params is the
+    # decision input; rationale + conversation_id are nullable and pass through.
+    frame = _build_approval_frame_or_none(
+        {
+            "type": "approval.requested",
+            "request_id": "r1",
+            "mcp_server_name": "stripe",
+            "tool_name": "charge",
+            "params": {"amount": 500, "currency": "usd"},
+            "coworker_id": "cw1",
+            "conversation_id": None,
+            "requested_at": "2026-05-31T00:00:00Z",
+            "rationale": "refunding the duplicate order",
+            "action_summary": "stripe.charge",
+            "expires_at": "2026-05-31T00:05:00Z",
+            "secret_internal_key": "must-not-leak",
+        }
+    )
+    assert frame is not None
+    assert frame["params"] == {"amount": 500, "currency": "usd"}
+    assert frame["rationale"] == "refunding the duplicate order"
+    assert frame["mcp_server_name"] == "stripe"
+    assert frame["tool_name"] == "charge"
+    assert frame["coworker_id"] == "cw1"
+    assert frame["conversation_id"] is None
+    assert frame["requested_at"] == "2026-05-31T00:00:00Z"
+    assert "secret_internal_key" not in frame
+    # The full frame must validate against the wire schema (no extra=forbid trip).
+    WsServerEventApprovalRequested.model_validate(frame)
+
+
+def test_build_requested_frame_drops_non_dict_params() -> None:
+    # A malformed params (not an object) must never reach the browser as one —
+    # the schema types it as object|null, and the SPA reads keys off it.
+    frame = _build_approval_frame_or_none(
+        {
+            "type": "approval.requested",
+            "request_id": "r1",
+            "params": "amount=500",  # malformed
+        }
+    )
+    assert frame is not None
+    assert "params" not in frame
+
+
+def test_build_requested_frame_omits_absent_optional_fields() -> None:
+    # When the carrier has only the legacy minimal set, no new keys appear —
+    # so an old orchestrator payload still projects a valid, lean frame.
+    frame = _build_approval_frame_or_none(
+        {
+            "type": "approval.requested",
+            "request_id": "r1",
+            "action_summary": "stripe.charge",
+            "expires_at": "2026-05-31T00:00:00Z",
+        }
+    )
+    assert frame == {
+        "type": "event.approval.requested",
+        "request_id": "r1",
+        "action_summary": "stripe.charge",
+        "expires_at": "2026-05-31T00:00:00Z",
+    }
+
+
+def test_build_resolved_frame_accepts_cancelled() -> None:
+    # §1.5: a container-side cancel must flip the card, not strand it pending.
+    frame = _build_approval_frame_or_none(
+        {"type": "approval.resolved", "request_id": "r1", "outcome": "cancelled"}
+    )
+    assert frame == {
+        "type": "event.approval.resolved",
+        "request_id": "r1",
+        "outcome": "cancelled",
+    }
+    WsServerEventApprovalResolved.model_validate(frame)
+
+
 def test_build_resolved_frame() -> None:
     frame = _build_approval_frame_or_none(
         {"type": "approval.resolved", "request_id": "r1", "outcome": "approved"}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -73,8 +73,8 @@ export type ApprovalPolicyCreate =
   components['schemas']['ApprovalPolicyCreate'];
 export type ApprovalPolicyUpdate =
   components['schemas']['ApprovalPolicyUpdate'];
-export type PendingApprovalRequest =
-  components['schemas']['PendingApprovalRequest'];
+export type ApprovalRequest =
+  components['schemas']['ApprovalRequest'];
 export type ConditionExpr = components['schemas']['ConditionExpr'];
 
 export type ErrorResponseBody =
@@ -464,7 +464,7 @@ export class ApiClient {
    *  own cards. Tenant scoping is enforced server-side. */
   async listPendingApprovals(
     conversationId?: string,
-  ): Promise<PendingApprovalRequest[]> {
+  ): Promise<ApprovalRequest[]> {
     const qs = conversationId
       ? `?conversation_id=${encodeURIComponent(conversationId)}`
       : '';
@@ -473,7 +473,24 @@ export class ApiClient {
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as PendingApprovalRequest[];
+    return (await resp.json()) as ApprovalRequest[];
+  }
+
+  /** A conversation's full HITL approval record — pending AND resolved,
+   *  oldest first. The chat surface fetches this on load so resolved
+   *  ✅/❌ cards re-render inline in chronological position (not just
+   *  in-flight ones). Tenant scoping is enforced server-side. */
+  async listConversationApprovals(
+    conversationId: string,
+  ): Promise<ApprovalRequest[]> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/conversations/${encodeURIComponent(
+        conversationId,
+      )}/approval-requests`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as ApprovalRequest[];
   }
 
   /** Returns `{ ok: true }` on 202, `{ ok: false, alreadyTerminal: true }`

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1367,6 +1367,8 @@ export interface components {
             /** @description Higher wins on multiple matches; ties break to newest. */
             priority: number;
             /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
             updated_at: string;
         };
         ApprovalPolicyCreate: {
@@ -1404,6 +1406,20 @@ export interface components {
             requested_at: string;
             /** Format: date-time */
             expires_at: string;
+            /**
+             * @description Raw {tool_name→params} arguments snapshot — the decision input
+             *     (§1.2). Tenant-scoped endpoint, so never crosses a tenant edge.
+             */
+            params?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Format: uuid
+             * @description The coworker whose call is gated.
+             */
+            coworker_id?: string | null;
+            /** @description The agent's free-text "why I'm calling this tool" (nullable). */
+            rationale?: string | null;
         };
         SkillFile: {
             path: string;
@@ -1925,6 +1941,35 @@ export interface components {
              *     run at all.
              */
             request_id: string;
+            /** @description The gated MCP server identity (§1.1). */
+            mcp_server_name?: string | null;
+            /** @description The gated tool name (§1.1). */
+            tool_name?: string | null;
+            /**
+             * @description Raw tool input arguments — the decision input (§1.1). Without
+             *     it the card cannot be informative.
+             */
+            params?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Format: uuid
+             * @description The coworker whose call is gated (§1.1).
+             */
+            coworker_id?: string | null;
+            /**
+             * Format: uuid
+             * @description Originating conversation; null for scheduled-task approvals
+             *     that have no live conversation (§1.1).
+             */
+            conversation_id?: string | null;
+            /** @description When the approval became pending (ISO-8601, §1.1). */
+            requested_at?: string | null;
+            /**
+             * @description The agent's "why I'm calling this tool" (§1.1). Nullable; the
+             *     card omits the section when null.
+             */
+            rationale?: string | null;
             /** @description One-line human summary of the gated tool call. */
             action_summary?: string | null;
             /** @description When the pending approval auto-expires (ISO-8601). */
@@ -1940,10 +1985,12 @@ export interface components {
             request_id: string;
             /**
              * @description The orchestrator's deterministic terminal state (no LLM in
-             *     the loop). The SPA edits the card in place.
+             *     the loop). The SPA edits the card in place. `cancelled` =
+             *     the coworker's container withdrew the call (Stop / hook
+             *     exception), distinct from `expired` (no decision in time).
              * @enum {string}
              */
-            outcome: "approved" | "rejected" | "expired";
+            outcome: "approved" | "rejected" | "expired" | "cancelled";
         };
         WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"] | components["schemas"]["WsServerEventRunProgress"] | components["schemas"]["WsServerEventMessageAppended"] | components["schemas"]["WsServerEventApprovalRequested"] | components["schemas"]["WsServerEventApprovalResolved"];
         WsClientFrameRequestRun: {

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -256,6 +256,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/conversations/{id}/approval-requests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        /**
+         * List a conversation's approval requests (all states, for chat history)
+         * @description The conversation's full HITL approval record — pending AND resolved
+         *     (approved / rejected / expired / cancelled) — oldest first, so the SPA
+         *     re-renders approval cards inline in the message stream on reload, not
+         *     just the pending ones. Tenant-scoped via the conversation row: a
+         *     conversation outside the caller's tenant returns 404.
+         */
+        get: operations["listConversationApprovalRequests"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/models": {
         parameters: {
             query?: never;
@@ -1391,7 +1417,7 @@ export interface components {
             enabled?: boolean;
             priority?: number;
         };
-        PendingApprovalRequest: {
+        ApprovalRequest: {
             /**
              * Format: uuid
              * @description Echo back in a `request.approval_decision` WS frame.
@@ -1420,6 +1446,21 @@ export interface components {
             coworker_id?: string | null;
             /** @description The agent's free-text "why I'm calling this tool" (nullable). */
             rationale?: string | null;
+            /**
+             * @description Lifecycle status. Always `pending` on the tenant-wide inbox read
+             *     (`GET /approval-requests`); the conversation sub-resource
+             *     (`GET /conversations/{id}/approval-requests`) returns every state so
+             *     resolved cards re-render inline in chat history.
+             * @enum {string}
+             */
+            status: "pending" | "approved" | "rejected" | "expired" | "cancelled";
+            /**
+             * Format: date-time
+             * @description When the request was resolved; null while pending.
+             */
+            decided_at?: string | null;
+            /** @description The approver's note on a reject; null otherwise. */
+            note?: string | null;
         };
         SkillFile: {
             path: string;
@@ -2538,6 +2579,30 @@ export interface operations {
             404: components["responses"]["NotFound"];
         };
     };
+    listConversationApprovalRequests: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApprovalRequest"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
     listModels: {
         parameters: {
             query?: {
@@ -3394,7 +3459,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PendingApprovalRequest"][];
+                    "application/json": components["schemas"]["ApprovalRequest"][];
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -24,6 +24,22 @@
   --color-d-ink-2: #94a3b8;
   --color-d-ink-3: #64748b;
   --color-d-ink-4: #334155;
+
+  /* v2 terracotta tokens — bridge of the --rm-* design tokens
+     (src/styles/tokens.css) into Tailwind's @theme. Without these, utilities
+     like `border-accent` / `bg-accent/5` / `border-border-2` and the bare
+     `bg-surface` referenced colors @theme never registered, so Tailwind
+     dropped them at build and the approval card lost its accent line, panel
+     background and borders. Values mirror --rm-* light; the `-d-` variants
+     mirror the tokens.css dark @media block. */
+  --color-accent: #c2613f;
+  --color-d-accent: #d6764f;
+  --color-surface: #ffffff;
+  --color-d-surface: #27231c;
+  --color-border: rgba(42, 38, 32, 0.10);
+  --color-d-border: rgba(236, 231, 220, 0.10);
+  --color-border-2: rgba(42, 38, 32, 0.17);
+  --color-d-border-2: rgba(236, 231, 220, 0.17);
 }
 
 /* ─── Base ─── */

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -11,6 +11,9 @@ import './styles/tokens.css';
 // Skills / Models / Credentials). Lives next to tokens.css so all
 // v2 stylesheets load before any component mounts.
 import './styles/settings-pages.css';
+// Card-scoped warm-palette override for the HITL approval card (re-points the
+// @theme tokens to --rm-* inside rm-approval-card only).
+import './styles/approval-card.css';
 
 import './components/chat-panel.js';
 import './components/message-list.js';

--- a/web/src/components/approval-card.test.ts
+++ b/web/src/components/approval-card.test.ts
@@ -39,20 +39,13 @@ describe('<rm-approval-card>', () => {
     vi.useRealTimers();
   });
 
-  it('renders the action summary and both action buttons when pending', async () => {
-    el = await mount({ actionSummary: 'charge $500 on stripe' });
-    expect($(el, '[data-testid="approval-summary"]')?.textContent).toContain(
-      'charge $500 on stripe',
+  it('renders the tool chip and both action buttons when pending', async () => {
+    el = await mount({ mcpServerName: 'stripe', toolName: 'charge' });
+    expect($(el, '[data-testid="approval-tool"]')?.textContent).toContain(
+      'charge',
     );
     expect($(el, '[data-testid="approval-approve"]')).not.toBeNull();
     expect($(el, '[data-testid="approval-reject"]')).not.toBeNull();
-  });
-
-  it('falls back to a generic summary when none is given', async () => {
-    el = await mount({ actionSummary: null });
-    expect($(el, '[data-testid="approval-summary"]')?.textContent).toContain(
-      'needs your approval',
-    );
   });
 
   // --- new field rendering ---------------------------------------------------

--- a/web/src/components/approval-card.test.ts
+++ b/web/src/components/approval-card.test.ts
@@ -17,6 +17,18 @@ function $<T extends Element>(el: Element, sel: string): T | null {
   return el.querySelector<T>(sel);
 }
 
+function $$(el: Element, sel: string): Element[] {
+  return Array.from(el.querySelectorAll(sel));
+}
+
+function decisions(el: ApprovalCard): ReturnType<typeof vi.fn> {
+  const fn = vi.fn();
+  el.addEventListener('approval-decision', (e) =>
+    fn((e as CustomEvent<ApprovalDecisionDetail>).detail),
+  );
+  return fn;
+}
+
 describe('<rm-approval-card>', () => {
   let el: ApprovalCard | null = null;
   beforeEach(() => {
@@ -24,9 +36,10 @@ describe('<rm-approval-card>', () => {
   });
   afterEach(() => {
     el?.remove();
+    vi.useRealTimers();
   });
 
-  it('renders the action summary and both buttons when pending', async () => {
+  it('renders the action summary and both action buttons when pending', async () => {
     el = await mount({ actionSummary: 'charge $500 on stripe' });
     expect($(el, '[data-testid="approval-summary"]')?.textContent).toContain(
       'charge $500 on stripe',
@@ -42,12 +55,112 @@ describe('<rm-approval-card>', () => {
     );
   });
 
-  it('emits approval-decision with the request id + approve verb', async () => {
-    el = await mount({ requestId: 'abc', actionSummary: 's' });
-    const onDecision = vi.fn();
-    el.addEventListener('approval-decision', (e) =>
-      onDecision((e as CustomEvent<ApprovalDecisionDetail>).detail),
+  // --- new field rendering ---------------------------------------------------
+
+  it('renders the tool chip from server + tool name', async () => {
+    el = await mount({ mcpServerName: 'amazon-ads-api', toolName: 'campaign.pause' });
+    expect($(el, '[data-testid="approval-tool"]')?.textContent).toContain(
+      'amazon-ads-api · campaign.pause',
     );
+  });
+
+  it('renders one params row per entry, with strings quoted and numbers bare', async () => {
+    el = await mount({
+      params: { campaign_id: 'SP-Auto', amount: 3210, dry_run: false },
+    });
+    const rows = $$(el, '[data-testid="approval-param-row"]');
+    expect(rows).toHaveLength(3);
+    const values = $$(el, '[data-testid="approval-param-value"]').map(
+      (v) => v.textContent?.trim(),
+    );
+    expect(values).toContain('"SP-Auto"');
+    expect(values).toContain('3210');
+    expect(values).toContain('false');
+  });
+
+  it('omits the params block entirely when params is empty', async () => {
+    el = await mount({ params: {} });
+    expect($(el, '[data-testid="approval-params"]')).toBeNull();
+  });
+
+  it('collapses params behind a disclosure when over the threshold', async () => {
+    const params = Object.fromEntries(
+      Array.from({ length: 10 }, (_, i) => [`k${i}`, i]),
+    );
+    el = await mount({ params });
+    // Only the first 6 shown initially, plus a toggle.
+    expect($$(el, '[data-testid="approval-param-row"]')).toHaveLength(6);
+    const toggle = $<HTMLButtonElement>(el, '[data-testid="approval-params-toggle"]');
+    expect(toggle?.textContent).toContain('Show all 10');
+    toggle!.click();
+    await el.updateComplete;
+    expect($$(el, '[data-testid="approval-param-row"]')).toHaveLength(10);
+  });
+
+  it('renders the rationale block when present', async () => {
+    el = await mount({ rationale: 'Lowest ROAS campaign; frees $3,210/mo.' });
+    expect($(el, '[data-testid="approval-rationale"]')?.textContent).toContain(
+      'Lowest ROAS campaign',
+    );
+  });
+
+  it('omits the rationale block when null (absence is meaningful, §3.4)', async () => {
+    el = await mount({ rationale: null });
+    expect($(el, '[data-testid="approval-rationale"]')).toBeNull();
+  });
+
+  it('omits the rationale block when blank whitespace', async () => {
+    el = await mount({ rationale: '   ' });
+    expect($(el, '[data-testid="approval-rationale"]')).toBeNull();
+  });
+
+  // --- countdown (§3.2) ------------------------------------------------------
+
+  it('shows minutes-left and is NOT urgent above 5 minutes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T12:00:00Z'));
+    const expiresAt = new Date(Date.now() + 6 * 60_000).toISOString();
+    el = await mount({ expiresAt });
+    const cd = $(el, '[data-testid="approval-countdown"]');
+    expect(cd?.textContent).toContain('6m left');
+    expect(cd?.getAttribute('data-urgent')).toBe('false');
+  });
+
+  it('marks the countdown urgent under the 5-minute threshold', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T12:00:00Z'));
+    const expiresAt = new Date(Date.now() + 4 * 60_000 + 59_000).toISOString();
+    el = await mount({ expiresAt });
+    const cd = $(el, '[data-testid="approval-countdown"]');
+    expect(cd?.textContent).toContain('4m left');
+    expect(cd?.getAttribute('data-urgent')).toBe('true');
+  });
+
+  it('renders seconds + urgent under one minute, and "expired" past zero', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T12:00:00Z'));
+    el = await mount({
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    });
+    let cd = $(el, '[data-testid="approval-countdown"]');
+    expect(cd?.textContent).toContain('30s left');
+    expect(cd?.getAttribute('data-urgent')).toBe('true');
+
+    // Advance past expiry; the 1Hz tick should flip it to "expired" — and the
+    // buttons must stay live (the SPA never self-resolves, §3.2).
+    vi.setSystemTime(new Date('2026-05-31T12:01:00Z'));
+    await vi.advanceTimersByTimeAsync(1000);
+    await el.updateComplete;
+    cd = $(el, '[data-testid="approval-countdown"]');
+    expect(cd?.textContent).toContain('expired');
+    expect($(el, '[data-testid="approval-approve"]')).not.toBeNull();
+  });
+
+  // --- approve path ----------------------------------------------------------
+
+  it('emits approve immediately with no note on the approve button', async () => {
+    el = await mount({ requestId: 'abc' });
+    const onDecision = decisions(el);
     $<HTMLButtonElement>(el, '[data-testid="approval-approve"]')!.click();
     expect(onDecision).toHaveBeenCalledTimes(1);
     expect(onDecision).toHaveBeenCalledWith({
@@ -56,44 +169,122 @@ describe('<rm-approval-card>', () => {
     });
   });
 
-  it('emits the reject verb from the ❌ button', async () => {
+  // --- reject-with-note path (§3.5) -----------------------------------------
+
+  it('a single Reject click opens the note form and does NOT emit', async () => {
     el = await mount({ requestId: 'abc' });
-    const onDecision = vi.fn();
-    el.addEventListener('approval-decision', (e) =>
-      onDecision((e as CustomEvent<ApprovalDecisionDetail>).detail),
-    );
+    const onDecision = decisions(el);
     $<HTMLButtonElement>(el, '[data-testid="approval-reject"]')!.click();
+    await el.updateComplete;
+    expect($(el, '[data-testid="approval-reject-form"]')).not.toBeNull();
+    expect($(el, '[data-testid="approval-note"]')).not.toBeNull();
+    expect(onDecision).not.toHaveBeenCalled();
+  });
+
+  it('the form Reject submits the trimmed note', async () => {
+    el = await mount({ requestId: 'abc' });
+    const onDecision = decisions(el);
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject"]')!.click();
+    await el.updateComplete;
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="approval-note"]')!;
+    ta.value = '  amount too high — needs signoff  ';
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject-confirm"]')!.click();
+    expect(onDecision).toHaveBeenCalledWith({
+      requestId: 'abc',
+      decision: 'reject',
+      note: 'amount too high — needs signoff',
+    });
+  });
+
+  it('an empty note submits a reject with no note field (nullable, §3.5)', async () => {
+    el = await mount({ requestId: 'abc' });
+    const onDecision = decisions(el);
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject"]')!.click();
+    await el.updateComplete;
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject-confirm"]')!.click();
     expect(onDecision).toHaveBeenCalledWith({
       requestId: 'abc',
       decision: 'reject',
     });
   });
 
-  it('does not emit while busy (double-tap guard)', async () => {
+  it('Cancel collapses the form without emitting', async () => {
+    el = await mount({ requestId: 'abc' });
+    const onDecision = decisions(el);
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject"]')!.click();
+    await el.updateComplete;
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject-cancel"]')!.click();
+    await el.updateComplete;
+    expect($(el, '[data-testid="approval-reject-form"]')).toBeNull();
+    expect($(el, '[data-testid="approval-reject"]')).not.toBeNull();
+    expect(onDecision).not.toHaveBeenCalled();
+  });
+
+  // --- busy guard ------------------------------------------------------------
+
+  it('does not open the reject form while busy', async () => {
     el = await mount({ busy: true });
-    const onDecision = vi.fn();
-    el.addEventListener('approval-decision', onDecision);
-    // The button is disabled; calling click() on a disabled button is a no-op,
-    // and the handler also early-returns on busy — belt and braces.
+    $<HTMLButtonElement>(el, '[data-testid="approval-reject"]')?.click();
+    await el.updateComplete;
+    expect($(el, '[data-testid="approval-reject-form"]')).toBeNull();
+  });
+
+  it('does not emit approve while busy (double-tap guard)', async () => {
+    el = await mount({ busy: true });
+    const onDecision = decisions(el);
     $<HTMLButtonElement>(el, '[data-testid="approval-approve"]')?.click();
     expect(onDecision).not.toHaveBeenCalled();
   });
 
-  it('shows a terminal status pill and hides the buttons once resolved', async () => {
-    el = await mount({ status: 'approved' });
+  // --- resolved states (§3.6) ------------------------------------------------
+
+  it.each([
+    ['approved', 'Approved'],
+    ['rejected', 'Rejected'],
+    ['expired', 'Timed out'],
+    ['cancelled', 'Cancelled'],
+  ] as const)('shows the %s pill and hides the buttons', async (status, label) => {
+    el = await mount({ status });
     expect($(el, '[data-testid="approval-approve"]')).toBeNull();
     expect($(el, '[data-testid="approval-reject"]')).toBeNull();
-    expect($(el, '[data-testid="approval-status"]')?.textContent).toContain(
-      'Approved',
+    expect($(el, '[data-testid="approval-status"]')?.textContent).toContain(label);
+  });
+
+  it('shows the resolution timestamp from resolvedAt', async () => {
+    const resolvedAt = Date.parse('2026-05-31T14:34:00Z');
+    el = await mount({ status: 'approved', resolvedAt });
+    const ts = $(el, '[data-testid="approval-resolved-time"]');
+    expect(ts?.textContent).toContain('at');
+    // The exact wall-clock string depends on TZ; assert it carries the rendered
+    // local time of resolvedAt rather than hardcoding a zone.
+    expect(ts?.textContent).toContain(
+      new Date(resolvedAt).toLocaleTimeString([], {
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
     );
   });
 
-  it('does not emit after it has resolved even if emit is forced', async () => {
+  it('echoes the rejection note back as "Your reason" on a rejected card', async () => {
+    el = await mount({ status: 'rejected', note: 'over budget' });
+    const block = $(el, '[data-testid="approval-resolved-note"]');
+    expect(block?.textContent).toContain('Your reason');
+    expect(block?.textContent).toContain('over budget');
+  });
+
+  it('shows no resolved-note when a rejection carried no note', async () => {
+    el = await mount({ status: 'rejected', note: null });
+    expect($(el, '[data-testid="approval-resolved-note"]')).toBeNull();
+  });
+
+  it('shows no resolved-note on a non-reject outcome even if a note exists', async () => {
+    el = await mount({ status: 'approved', note: 'stray' });
+    expect($(el, '[data-testid="approval-resolved-note"]')).toBeNull();
+  });
+
+  it('does not render decision buttons once resolved (no late tap)', async () => {
     el = await mount({ status: 'rejected' });
-    const onDecision = vi.fn();
-    el.addEventListener('approval-decision', onDecision);
-    // No buttons exist; nothing to click. Assert the resolved render really
-    // dropped them (a regression that left them would let a late tap fire).
+    const onDecision = decisions(el);
     expect($(el, '[data-testid="approval-approve"]')).toBeNull();
     expect(onDecision).not.toHaveBeenCalled();
   });

--- a/web/src/components/approval-card.ts
+++ b/web/src/components/approval-card.ts
@@ -468,10 +468,6 @@ export class ApprovalCard extends LitElement {
 
   override render(): TemplateResult {
     const resolved = this.status !== 'pending';
-    const summary =
-      this.actionSummary && this.actionSummary.trim()
-        ? this.actionSummary
-        : 'A tool call needs your approval.';
     return html`
       <div
         class="my-2 max-w-[560px] rounded-xl border border-border-2 dark:border-d-border-2 bg-surface dark:bg-d-surface overflow-hidden ${resolved
@@ -483,12 +479,6 @@ export class ApprovalCard extends LitElement {
         ${this.renderHeader()}
         <div class="px-3.5 py-3">
           ${this.renderMeta()}${this.renderToolChip()}
-          <div
-            class="text-[13px] text-ink-1 dark:text-d-ink-1 break-words mb-2.5"
-            data-testid="approval-summary"
-          >
-            ${summary}
-          </div>
           <div class=${resolved ? 'opacity-75' : ''}>
             ${this.renderParams()}
           </div>

--- a/web/src/components/approval-card.ts
+++ b/web/src/components/approval-card.ts
@@ -1,31 +1,65 @@
-// HITL approval card (docs/21-hitl-approval-plan.md §10 S5). Renders one pending
-// tool-approval request inside the chat stream: the human-readable action
-// summary plus ✅ / ❌ buttons. On click it dispatches an `approval-decision`
-// CustomEvent; chat-panel relays it to the orchestrator via the v1 WS frame
-// (`V1WsClient.sendApprovalDecision`). The card never sends the approver
+// HITL approval card (.hitl-ui/spec.md §3; docs/21-hitl-approval-plan.md §10 S5).
+// Renders one tool-approval request inside the chat stream as a rich decision
+// surface: tool identity, the raw params the decision turns on, the agent's
+// optional rationale, a live countdown, and a Reject-with-note / Approve action
+// pair. After resolution the card stays in place showing its terminal state —
+// it is the user's scrollable record of the decision (§3.6).
+//
+// On Approve the card dispatches an `approval-decision` CustomEvent immediately.
+// On Reject it first expands an inline note form (§3.5); only the form's Reject
+// button dispatches. chat-panel relays the event to the orchestrator via the v1
+// WS frame (`V1WsClient.sendApprovalDecision`). The card never sends the approver
 // identity — that is stamped server-side from the verified WS ticket (IDOR
-// guard), so this component only knows the request id + verb.
+// guard), so this component only knows the request id + verb + optional note.
 //
 // Light DOM (createRenderRoot → this) so the chat surface's Tailwind utility
 // classes apply, matching chat-panel / message-list.
 
-import { LitElement, html, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 
 import type { ApprovalStatus } from './approval-store.js';
 
-/** Fired when the user taps ✅ or ❌. Bubbles + composed so chat-panel
- *  (the light-DOM host) catches it. */
+/** Fired when the user confirms a decision. Bubbles + composed so chat-panel
+ *  (the light-DOM host) catches it. `note` is present only on a Reject that
+ *  went through the inline form with non-empty text (§3.5). */
 export interface ApprovalDecisionDetail {
   requestId: string;
   decision: 'approve' | 'reject';
+  note?: string;
 }
 
-const STATUS_LABEL: Record<Exclude<ApprovalStatus, 'pending'>, string> = {
-  approved: '✅ Approved',
-  rejected: '❌ Rejected',
-  expired: '⏰ Expired',
+/** Terminal-state header presentation (§3.6). */
+const RESOLVED_PRESENTATION: Record<
+  Exclude<ApprovalStatus, 'pending'>,
+  { label: string; classes: string }
+> = {
+  approved: {
+    label: '✓ Approved',
+    classes:
+      'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300',
+  },
+  rejected: {
+    label: '✕ Rejected',
+    classes: 'bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-300',
+  },
+  expired: {
+    label: '⏰ Timed out',
+    classes: 'bg-surface-2 dark:bg-d-surface-2 text-ink-2 dark:text-d-ink-2',
+  },
+  cancelled: {
+    label: '⊘ Cancelled',
+    classes: 'bg-surface-2 dark:bg-d-surface-2 text-ink-2 dark:text-d-ink-2',
+  },
 };
+
+/** How many params to show before collapsing behind a "Show all" (§3.3). */
+const PARAMS_COLLAPSE_THRESHOLD = 8;
+const PARAMS_COLLAPSED_COUNT = 6;
+/** Soft truncation for the rationale (§3.4). */
+const RATIONALE_TRUNCATE = 400;
+/** Countdown turns red under this many ms remaining (§3.2). */
+const URGENT_MS = 5 * 60 * 1000;
 
 @customElement('rm-approval-card')
 export class ApprovalCard extends LitElement {
@@ -36,80 +70,431 @@ export class ApprovalCard extends LitElement {
    *  between the click and the `event.approval.resolved` echo). */
   @property({ type: Boolean }) busy = false;
 
+  // --- Rich-card fields (§3 / spec Appendix C.5) ---
+  @property() mcpServerName: string | null = null;
+  @property() toolName: string | null = null;
+  @property({ attribute: false }) params: Record<string, unknown> = {};
+  @property() rationale: string | null = null;
+  /** ISO-8601; drives the "2m ago" meta line. */
+  @property() requestedAt: string | null = null;
+  /** ISO-8601; drives the live countdown. */
+  @property() expiresAt: string | null = null;
+  /** Resolved display name of the requesting coworker (null ⇒ omit). */
+  @property() coworkerName: string | null = null;
+  /** Epoch ms of the terminal flip; null while pending. */
+  @property({ type: Number }) resolvedAt: number | null = null;
+  /** The user's rejection note, echoed back as "YOUR REASON" on a resolved
+   *  rejected card (§3.6). May arrive via prop (store) or be remembered from
+   *  the form the user just submitted. */
+  @property() note: string | null = null;
+
+  /** Inline reject-note form open? */
+  @state() private rejecting = false;
+  /** Params disclosure expanded (when over the collapse threshold)? */
+  @state() private paramsExpanded = false;
+  /** Rationale "▸ more" expanded? */
+  @state() private rationaleExpanded = false;
+  /** Wall clock, re-read at 1Hz so the countdown ticks (§3.2). */
+  @state() private now = Date.now();
+  /** Locally-remembered note from the form submit, so the resolved card can
+   *  show it even when the host doesn't plumb `note` back through the store. */
+  private submittedNote: string | null = null;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
   protected override createRenderRoot() {
     return this;
   }
 
-  private emit(decision: 'approve' | 'reject'): void {
-    if (this.busy || this.status !== 'pending') return;
+  override connectedCallback(): void {
+    super.connectedCallback();
+    if (this.status === 'pending') this.startTicking();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.stopTicking();
+  }
+
+  protected override willUpdate(changed: Map<string, unknown>): void {
+    if (changed.has('status')) {
+      if (this.status === 'pending') this.startTicking();
+      else this.stopTicking();
+    }
+  }
+
+  private startTicking(): void {
+    if (this.timer != null) return;
+    this.timer = setInterval(() => {
+      this.now = Date.now();
+    }, 1000);
+  }
+
+  private stopTicking(): void {
+    if (this.timer != null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  // --- Decision dispatch -----------------------------------------------------
+
+  private canAct(): boolean {
+    return !this.busy && this.status === 'pending';
+  }
+
+  private approve(): void {
+    if (!this.canAct()) return;
     this.dispatchEvent(
       new CustomEvent<ApprovalDecisionDetail>('approval-decision', {
-        detail: { requestId: this.requestId, decision },
+        detail: { requestId: this.requestId, decision: 'approve' },
         bubbles: true,
         composed: true,
       }),
     );
   }
 
-  private renderActions(): TemplateResult {
+  /** First Reject click: open the note form. Does NOT submit (§3.5). */
+  private openRejectForm(): void {
+    if (!this.canAct()) return;
+    this.rejecting = true;
+  }
+
+  private cancelReject(): void {
+    this.rejecting = false;
+  }
+
+  private confirmReject(): void {
+    if (!this.canAct()) return;
+    const ta = this.querySelector<HTMLTextAreaElement>(
+      '[data-testid="approval-note"]',
+    );
+    const note = ta?.value.trim() ?? '';
+    this.submittedNote = note || null;
+    this.dispatchEvent(
+      new CustomEvent<ApprovalDecisionDetail>('approval-decision', {
+        detail: {
+          requestId: this.requestId,
+          decision: 'reject',
+          // Empty submit is fine — the field is nullable; omit it then (§3.5).
+          ...(note ? { note } : {}),
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  // --- Value / time formatting ----------------------------------------------
+
+  private paramDisplay(v: unknown): string {
+    if (v === null || v === undefined) return 'null';
+    if (typeof v === 'boolean' || typeof v === 'number') return String(v);
+    if (typeof v === 'string') return `"${v}"`;
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  }
+
+  private relativeTime(iso: string): string | null {
+    const t = Date.parse(iso);
+    if (Number.isNaN(t)) return null;
+    const diff = this.now - t;
+    if (diff < 0) return 'just now';
+    if (diff < 60_000) return 'just now';
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+    return 'yesterday';
+  }
+
+  private absoluteTime(ms: number): string {
+    return new Date(ms).toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  /** Countdown text + urgency from `expiresAt` and the ticking clock (§3.2). */
+  private countdown(): { text: string; urgent: boolean } | null {
+    if (!this.expiresAt) return null;
+    const exp = Date.parse(this.expiresAt);
+    if (Number.isNaN(exp)) return null;
+    const ms = exp - this.now;
+    if (ms <= 0) return { text: 'expired', urgent: true };
+    const totalSec = Math.floor(ms / 1000);
+    if (totalSec < 60) return { text: `${totalSec}s left`, urgent: true };
+    return { text: `${Math.floor(totalSec / 60)}m left`, urgent: ms < URGENT_MS };
+  }
+
+  // --- Subrenders ------------------------------------------------------------
+
+  private renderHeader(): TemplateResult {
     if (this.status !== 'pending') {
+      const pres = RESOLVED_PRESENTATION[this.status];
+      const ts =
+        this.resolvedAt != null
+          ? html`<span
+              class="ml-1 font-normal opacity-70 text-[11px]"
+              data-testid="approval-resolved-time"
+              >at ${this.absoluteTime(this.resolvedAt)}</span
+            >`
+          : nothing;
       return html`
-        <span
-          class="text-[12px] font-medium text-ink-2 dark:text-d-ink-2"
-          data-testid="approval-status"
-          >${STATUS_LABEL[this.status]}</span
+        <div
+          class="flex items-center gap-2 px-3.5 py-2 text-[12px] font-semibold border-b border-black/5 dark:border-white/10 ${pres.classes}"
+          data-testid="approval-header"
         >
+          <span data-testid="approval-status">${pres.label}</span>${ts}
+        </div>
+      `;
+    }
+    const cd = this.countdown();
+    return html`
+      <div
+        class="flex items-center gap-2 px-3.5 py-2 text-[12px] font-semibold border-b border-amber-200/60 dark:border-amber-700/40 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400"
+        data-testid="approval-header"
+      >
+        <span class="uppercase tracking-wide text-[11px]">⚠ Approval needed</span>
+        ${cd
+          ? html`<span
+              class="ml-auto font-medium text-[11px] tabular-nums ${cd.urgent
+                ? 'text-red-600 dark:text-red-400'
+                : 'opacity-80'}"
+              data-testid="approval-countdown"
+              data-urgent=${cd.urgent ? 'true' : 'false'}
+              >${cd.text}</span
+            >`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderMeta(): TemplateResult | typeof nothing {
+    const parts: string[] = [];
+    if (this.coworkerName) parts.push(`${this.coworkerName} coworker`);
+    if (this.requestedAt) {
+      const rel = this.relativeTime(this.requestedAt);
+      if (rel) parts.push(rel);
+    }
+    if (parts.length === 0) return nothing;
+    return html`
+      <div
+        class="text-[11px] text-ink-3 dark:text-d-ink-3 mb-2"
+        data-testid="approval-meta"
+      >
+        ${parts.join(' · ')}
+      </div>
+    `;
+  }
+
+  private renderToolChip(): TemplateResult | typeof nothing {
+    if (!this.mcpServerName && !this.toolName) return nothing;
+    const label = [this.mcpServerName, this.toolName]
+      .filter(Boolean)
+      .join(' · ');
+    return html`
+      <div
+        class="inline-block font-mono text-[13px] text-ink-1 dark:text-d-ink-1 bg-black/5 dark:bg-white/10 px-2.5 py-1 rounded-md mb-2.5"
+        data-testid="approval-tool"
+      >
+        ${label}
+      </div>
+    `;
+  }
+
+  private renderParams(): TemplateResult | typeof nothing {
+    const entries = Object.entries(this.params ?? {});
+    if (entries.length === 0) return nothing;
+    const over = entries.length > PARAMS_COLLAPSE_THRESHOLD;
+    const shown =
+      over && !this.paramsExpanded
+        ? entries.slice(0, PARAMS_COLLAPSED_COUNT)
+        : entries;
+    return html`
+      <div
+        class="border border-border-2 dark:border-d-border-2 rounded-lg bg-surface-2 dark:bg-d-surface-2 mb-2.5 overflow-hidden"
+        data-testid="approval-params"
+      >
+        ${shown.map(
+          ([k, v]) => html`
+            <div
+              class="grid grid-cols-[130px_1fr] gap-3 px-3 py-1.5 text-[12.5px] border-b border-border-2 dark:border-d-border-2 last:border-b-0 items-start"
+              data-testid="approval-param-row"
+            >
+              <span
+                class="font-mono text-[11.5px] text-ink-3 dark:text-d-ink-3 break-words"
+                data-testid="approval-param-key"
+                >${k}</span
+              >
+              <span
+                class="font-mono text-[12px] text-ink-1 dark:text-d-ink-1 break-words whitespace-pre-wrap leading-relaxed"
+                data-testid="approval-param-value"
+                >${this.paramDisplay(v)}</span
+              >
+            </div>
+          `,
+        )}
+        ${over
+          ? html`<button
+              type="button"
+              class="w-full text-left px-3 py-1.5 text-[11.5px] text-ink-3 dark:text-d-ink-3 hover:bg-black/5 dark:hover:bg-white/5 cursor-pointer"
+              data-testid="approval-params-toggle"
+              @click=${() => (this.paramsExpanded = !this.paramsExpanded)}
+            >
+              ${this.paramsExpanded
+                ? '▾ Show fewer'
+                : `▸ Show all ${entries.length}`}
+            </button>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderRationale(): TemplateResult | typeof nothing {
+    const text = this.rationale?.trim();
+    if (!text) return nothing;
+    const long = text.length > RATIONALE_TRUNCATE;
+    const body =
+      long && !this.rationaleExpanded
+        ? `${text.slice(0, RATIONALE_TRUNCATE)}…`
+        : text;
+    return html`
+      <div
+        class="text-[12.5px] text-ink-2 dark:text-d-ink-2 leading-relaxed border-l-[3px] border-accent dark:border-d-accent bg-accent/5 dark:bg-d-accent/10 px-3 py-2 rounded-r-lg mb-2.5"
+        data-testid="approval-rationale"
+      >
+        <span
+          class="text-[10px] tracking-wide uppercase font-semibold text-accent dark:text-d-accent mr-1.5 align-top"
+          >Why</span
+        >${body}${long
+          ? html`<button
+              type="button"
+              class="ml-1 text-[11px] text-accent dark:text-d-accent cursor-pointer underline"
+              data-testid="approval-rationale-toggle"
+              @click=${() => (this.rationaleExpanded = !this.rationaleExpanded)}
+            >
+              ${this.rationaleExpanded ? 'less' : 'more'}
+            </button>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderResolvedNote(): TemplateResult | typeof nothing {
+    if (this.status !== 'rejected') return nothing;
+    const note = this.note ?? this.submittedNote;
+    if (!note) return nothing;
+    return html`
+      <div
+        class="text-[12.5px] text-ink-2 dark:text-d-ink-2 mt-2.5 px-3 py-2 bg-surface-2 dark:bg-d-surface-2 rounded-md leading-relaxed"
+        data-testid="approval-resolved-note"
+      >
+        <span
+          class="block text-[10px] tracking-wide uppercase font-medium text-ink-3 dark:text-d-ink-3 mb-1"
+          >Your reason</span
+        >${note}
+      </div>
+    `;
+  }
+
+  private renderActions(): TemplateResult | typeof nothing {
+    if (this.status !== 'pending') return nothing;
+    if (this.rejecting) {
+      return html`
+        <div
+          class="mt-3 border-t border-border dark:border-d-border pt-3"
+          data-testid="approval-reject-form"
+        >
+          <label
+            class="block text-[11.5px] text-ink-3 dark:text-d-ink-3 mb-1.5 leading-relaxed"
+          >
+            Tell the coworker why (optional). This text becomes the tool-call
+            rejection reason — they'll read it and adjust.
+          </label>
+          <textarea
+            data-testid="approval-note"
+            class="w-full min-h-[56px] px-2.5 py-2 border border-border-2 dark:border-d-border-2 rounded-md text-[12.5px] resize-y bg-surface dark:bg-d-surface focus:outline-none focus:border-accent"
+            placeholder="e.g. amount is too high — needs senior signoff above $5k"
+            ?disabled=${this.busy}
+          ></textarea>
+          <div class="flex items-center justify-end gap-2 mt-2">
+            <button
+              type="button"
+              data-testid="approval-reject-cancel"
+              class="text-[12px] px-3 py-1 rounded-md border border-border-2 dark:border-d-border-2 text-ink-2 dark:text-d-ink-2 hover:bg-surface-2 dark:hover:bg-d-surface-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              ?disabled=${this.busy}
+              @click=${() => this.cancelReject()}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              data-testid="approval-reject-confirm"
+              class="text-[12px] px-3 py-1 rounded-md bg-red-600 text-white hover:bg-red-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              ?disabled=${this.busy}
+              @click=${() => this.confirmReject()}
+            >
+              Reject
+            </button>
+          </div>
+        </div>
       `;
     }
     return html`
-      <div class="flex items-center gap-2">
-        <button
-          type="button"
-          data-testid="approval-approve"
-          class="text-[12px] px-3 py-1 rounded-md border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          ?disabled=${this.busy}
-          @click=${() => this.emit('approve')}
-        >
-          ✅ Approve
-        </button>
+      <div class="flex items-center justify-end gap-2 mt-3">
         <button
           type="button"
           data-testid="approval-reject"
           class="text-[12px] px-3 py-1 rounded-md border border-red-300 dark:border-red-700 text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           ?disabled=${this.busy}
-          @click=${() => this.emit('reject')}
+          @click=${() => this.openRejectForm()}
         >
           ❌ Reject
+        </button>
+        <button
+          type="button"
+          data-testid="approval-approve"
+          class="text-[12px] px-3 py-1 rounded-md border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          ?disabled=${this.busy}
+          @click=${() => this.approve()}
+        >
+          ✅ Approve
         </button>
       </div>
     `;
   }
 
   override render(): TemplateResult {
+    const resolved = this.status !== 'pending';
     const summary =
       this.actionSummary && this.actionSummary.trim()
         ? this.actionSummary
         : 'A tool call needs your approval.';
     return html`
       <div
-        class="my-2 rounded-xl border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/15 px-4 py-3"
+        class="my-2 max-w-[560px] rounded-xl border border-border-2 dark:border-d-border-2 bg-surface dark:bg-d-surface overflow-hidden ${resolved
+          ? 'opacity-95'
+          : ''}"
         data-testid="approval-card"
       >
-        <div class="flex items-start justify-between gap-3">
-          <div class="min-w-0">
-            <div
-              class="text-[11px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400"
-            >
-              Approval needed
-            </div>
-            <div
-              class="mt-0.5 text-[13px] text-ink-1 dark:text-d-ink-1 break-words"
-              data-testid="approval-summary"
-            >
-              ${summary}
-            </div>
+        ${this.renderHeader()}
+        <div class="px-3.5 py-3">
+          ${this.renderMeta()}${this.renderToolChip()}
+          <div
+            class="text-[13px] text-ink-1 dark:text-d-ink-1 break-words mb-2.5"
+            data-testid="approval-summary"
+          >
+            ${summary}
           </div>
-          <div class="shrink-0">${this.renderActions()}</div>
+          <div class=${resolved ? 'opacity-75' : ''}>
+            ${this.renderParams()}
+          </div>
+          <div class=${resolved ? 'opacity-55' : ''}>
+            ${this.renderRationale()}
+          </div>
+          ${this.renderResolvedNote()}${this.renderActions()}
         </div>
       </div>
     `;

--- a/web/src/components/approval-card.ts
+++ b/web/src/components/approval-card.ts
@@ -478,6 +478,7 @@ export class ApprovalCard extends LitElement {
           ? 'opacity-95'
           : ''}"
         data-testid="approval-card"
+        data-appr-id=${this.requestId}
       >
         ${this.renderHeader()}
         <div class="px-3.5 py-3">

--- a/web/src/components/approval-card.ts
+++ b/web/src/components/approval-card.ts
@@ -423,7 +423,7 @@ export class ApprovalCard extends LitElement {
             <button
               type="button"
               data-testid="approval-reject-cancel"
-              class="text-[12px] px-3 py-1 rounded-md border border-border-2 dark:border-d-border-2 text-ink-2 dark:text-d-ink-2 hover:bg-surface-2 dark:hover:bg-d-surface-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="text-[13px] font-medium px-3.5 py-1.5 rounded-lg border border-border-2 dark:border-d-border-2 text-ink-2 dark:text-d-ink-2 bg-surface dark:bg-d-surface hover:bg-surface-2 dark:hover:bg-d-surface-2 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               ?disabled=${this.busy}
               @click=${() => this.cancelReject()}
             >
@@ -432,7 +432,7 @@ export class ApprovalCard extends LitElement {
             <button
               type="button"
               data-testid="approval-reject-confirm"
-              class="text-[12px] px-3 py-1 rounded-md bg-red-600 text-white hover:bg-red-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="text-[13px] font-medium px-3.5 py-1.5 rounded-lg bg-[var(--rm-bad)] text-white hover:brightness-90 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               ?disabled=${this.busy}
               @click=${() => this.confirmReject()}
             >
@@ -447,20 +447,20 @@ export class ApprovalCard extends LitElement {
         <button
           type="button"
           data-testid="approval-reject"
-          class="text-[12px] px-3 py-1 rounded-md border border-red-300 dark:border-red-700 text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="text-[13px] font-medium px-3.5 py-1.5 rounded-lg border border-border-2 dark:border-d-border-2 text-ink-2 dark:text-d-ink-2 bg-surface dark:bg-d-surface hover:bg-surface-2 dark:hover:bg-d-surface-2 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           ?disabled=${this.busy}
           @click=${() => this.openRejectForm()}
         >
-          ❌ Reject
+          Reject
         </button>
         <button
           type="button"
           data-testid="approval-approve"
-          class="text-[12px] px-3 py-1 rounded-md border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          class="text-[13px] font-medium px-3.5 py-1.5 rounded-lg bg-accent text-[var(--rm-accent-ink)] hover:bg-[var(--rm-accent-2)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           ?disabled=${this.busy}
           @click=${() => this.approve()}
         >
-          ✅ Approve
+          Approve
         </button>
       </div>
     `;

--- a/web/src/components/approval-policies-page.test.ts
+++ b/web/src/components/approval-policies-page.test.ts
@@ -31,19 +31,26 @@ vi.mock('../api/client.js', async () => {
 
 import './approval-policies-page.js';
 import './approval-policy-dialog.js';
-import { summarizeCondition } from './approval-policies-page.js';
+import {
+  priorityBadgeClass,
+  sortPolicies,
+} from './approval-policies-page.js';
 import type { ApprovalPoliciesPage } from './approval-policies-page.js';
 import type { ApprovalPolicyDialog } from './approval-policy-dialog.js';
+import { conditionSentence, formatValue } from './condition-form.js';
 
+let _idSeq = 0;
 function policy(overrides: Partial<ApprovalPolicy> = {}): ApprovalPolicy {
+  _idSeq += 1;
   return {
-    id: 'p1',
+    id: `p${_idSeq}`,
     tenant_id: 't1',
     mcp_server_name: 'stripe',
     tool_name: 'charge',
     condition_expr: { field: 'amount', op: '>', value: 100 },
     enabled: true,
     priority: 0,
+    created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
     ...overrides,
   };
@@ -55,25 +62,87 @@ async function flush(el: HTMLElement & { updateComplete: Promise<unknown> }) {
   await el.updateComplete;
 }
 
-describe('summarizeCondition', () => {
-  it('renders always / never', () => {
-    expect(summarizeCondition({ always: true })).toBe('always');
-    expect(summarizeCondition({ always: false })).toBe('never');
+// ── pure renderers (single source of truth shared with the list + preview) ──
+
+describe('conditionSentence', () => {
+  it('renders every time / never', () => {
+    expect(conditionSentence({ always: true })).toBe('every time');
+    expect(conditionSentence(null)).toBe('every time');
+    expect(conditionSentence(undefined)).toBe('every time');
+    expect(conditionSentence({ always: false })).toBe('never');
   });
-  it('renders a leaf', () => {
-    expect(summarizeCondition({ field: 'amount', op: '>', value: 100 })).toBe(
-      'amount > 100',
+
+  it('renders a single leaf, HTML-escaping the operator', () => {
+    // `>` must be escaped or it would inject markup into the unsafeHTML sink.
+    expect(conditionSentence({ field: 'amount', op: '>', value: 100 })).toBe(
+      'when <b>amount &gt; 100</b>',
     );
   });
-  it('renders a connective', () => {
+
+  it('quotes string values so "5000" is distinguishable from 5000', () => {
+    // Quotes are HTML-escaped for the unsafeHTML sink; they render as `"`.
     expect(
-      summarizeCondition({ or: [
-        { field: 'a', op: '==', value: 1 },
-        { field: 'b', op: '==', value: 2 },
-      ] }),
-    ).toBe('a == 1 or b == 2');
+      conditionSentence({ field: 'currency', op: '==', value: 'USD' }),
+    ).toBe('when <b>currency == &quot;USD&quot;</b>');
+  });
+
+  it('joins flat AND / OR with natural-language words', () => {
+    expect(
+      conditionSentence({
+        and: [
+          { field: 'a', op: '==', value: 1 },
+          { field: 'b', op: '==', value: 2 },
+        ],
+      }),
+    ).toBe('when <b>a == 1 AND b == 2</b>');
+    expect(
+      conditionSentence({
+        or: [
+          { field: 'a', op: '==', value: 1 },
+          { field: 'b', op: '==', value: 2 },
+        ],
+      }),
+    ).toBe('when <b>a == 1 OR b == 2</b>');
+  });
+
+  it('falls back to (advanced condition) for shapes the builder cannot express', () => {
+    const nested = { and: [{ or: [{ field: 'a', op: '==', value: 1 }] }] };
+    expect(conditionSentence(nested)).toBe('when <i>(advanced condition)</i>');
   });
 });
+
+describe('formatValue', () => {
+  it('keeps numbers / booleans / null bare and quotes strings', () => {
+    expect(formatValue(5000)).toBe('5000');
+    expect(formatValue(true)).toBe('true');
+    expect(formatValue(null)).toBe('null');
+    expect(formatValue('USD')).toBe('"USD"');
+    expect(formatValue(['a', 'b'])).toBe('["a","b"]');
+  });
+});
+
+describe('priorityBadgeClass', () => {
+  it('is amber for high, muted for zero, neutral otherwise', () => {
+    expect(priorityBadgeClass(20)).toBe('rm-pol-pri--hi');
+    expect(priorityBadgeClass(10)).toBe('rm-pol-pri--hi');
+    expect(priorityBadgeClass(0)).toBe('rm-pol-pri--zero');
+    expect(priorityBadgeClass(5)).toBe('');
+    expect(priorityBadgeClass(-3)).toBe('');
+  });
+});
+
+describe('sortPolicies', () => {
+  it('orders by priority desc, then created_at desc (matches server eval)', () => {
+    const a = policy({ id: 'a', priority: 5, created_at: '2026-01-01T00:00:00Z' });
+    const b = policy({ id: 'b', priority: 20, created_at: '2026-01-01T00:00:00Z' });
+    const cOld = policy({ id: 'c', priority: 5, created_at: '2026-01-01T00:00:00Z' });
+    const cNew = policy({ id: 'd', priority: 5, created_at: '2026-05-01T00:00:00Z' });
+    const out = sortPolicies([a, b, cOld, cNew]);
+    expect(out.map((p) => p.id)).toEqual(['b', 'd', 'a', 'c']);
+  });
+});
+
+// ── list page ──
 
 describe('<rm-approval-policies-page>', () => {
   let el: ApprovalPoliciesPage | null = null;
@@ -88,27 +157,147 @@ describe('<rm-approval-policies-page>', () => {
     el = null;
   });
 
-  it('lists policies from the API with a condition summary', async () => {
-    listSpy.mockResolvedValue([policy({ priority: 7 })]);
-    el = document.createElement('rm-approval-policies-page') as ApprovalPoliciesPage;
-    document.body.appendChild(el);
-    await flush(el);
-    expect(listSpy).toHaveBeenCalledTimes(1);
-    const row = el.querySelector('[data-testid="policy-row"]');
-    expect(row?.textContent).toContain('stripe · charge');
-    expect(row?.textContent).toContain('amount > 100');
-    expect(row?.textContent).toContain('priority 7');
+  async function mount(rows: ApprovalPolicy[]): Promise<ApprovalPoliciesPage> {
+    listSpy.mockResolvedValue(rows);
+    const node = document.createElement(
+      'rm-approval-policies-page',
+    ) as ApprovalPoliciesPage;
+    document.body.appendChild(node);
+    await flush(node);
+    return node;
+  }
+
+  it('renders a priority badge, condition sentence, and (all tools) for *', async () => {
+    el = await mount([policy({ priority: 7, tool_name: '*' })]);
+    const row = el.querySelector('[data-testid="policy-row"]')!;
+    expect(
+      row.querySelector('[data-testid="policy-priority"]')?.textContent,
+    ).toContain('priority 7');
+    expect(row.textContent).toContain('stripe · *');
+    expect(row.textContent).toContain('(all tools)');
+    expect(
+      row.querySelector('[data-testid="policy-sentence"]')?.textContent,
+    ).toContain('amount > 100');
   });
 
-  it('shows the empty state when there are no policies', async () => {
-    el = document.createElement('rm-approval-policies-page') as ApprovalPoliciesPage;
-    document.body.appendChild(el);
+  it('renders cards in evaluation order (priority desc, newest tie first)', async () => {
+    el = await mount([
+      policy({ id: 'lo', priority: 0 }),
+      policy({ id: 'hi', priority: 20 }),
+      policy({ id: 'mid', priority: 5 }),
+    ]);
+    const ids = [...el.querySelectorAll('[data-policy-id]')].map((n) =>
+      n.getAttribute('data-policy-id'),
+    );
+    expect(ids).toEqual(['hi', 'mid', 'lo']);
+  });
+
+  it('shows the empty state with a create CTA and hides the eval-order hint', async () => {
+    el = await mount([]);
+    expect(el.querySelector('[data-testid="policy-empty"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="policy-hint"]')).toBeNull();
+  });
+
+  it('shows the eval-order hint only when policies exist', async () => {
+    el = await mount([policy()]);
+    expect(el.querySelector('[data-testid="policy-hint"]')).not.toBeNull();
+  });
+
+  it('opens the create dialog from the empty-state CTA', async () => {
+    el = await mount([]);
+    el
+      .querySelector<HTMLButtonElement>('[data-testid="policy-empty"] button')!
+      .click();
     await flush(el);
-    expect(el.querySelector('.rm-empty')).not.toBeNull();
+    const dialog = el.querySelector('rm-approval-policy-dialog') as ApprovalPolicyDialog;
+    expect(dialog.open).toBe(true);
+    expect(dialog.editing).toBeNull();
+    expect(dialog.duplicating).toBeNull();
+  });
+
+  // ── enable/disable toggle (§5.3) ──
+
+  it('optimistically flips the toggle and PATCHes enabled', async () => {
+    el = await mount([policy({ id: 'p1', enabled: true })]);
+    el.querySelector<HTMLButtonElement>('[data-testid="policy-toggle"]')!.click();
+    await flush(el);
+    expect(updateSpy).toHaveBeenCalledWith('p1', { enabled: false });
+    expect(
+      el.querySelector('[data-testid="policy-toggle"]')?.textContent,
+    ).toContain('Disabled');
+  });
+
+  it('reverts the toggle and shows a toast when the PATCH fails', async () => {
+    updateSpy.mockRejectedValue(new Error('boom'));
+    el = await mount([policy({ id: 'p1', enabled: true })]);
+    el.querySelector<HTMLButtonElement>('[data-testid="policy-toggle"]')!.click();
+    await flush(el);
+    // Reverted to the original state.
+    expect(
+      el.querySelector('[data-testid="policy-toggle"]')?.textContent,
+    ).toContain('Enabled');
+    expect(el.querySelector('[data-testid="policy-toast"]')?.textContent).toContain(
+      'try again',
+    );
+  });
+
+  // ── duplicate (§5.9) ──
+
+  it('opens the dialog in duplicate (create) mode pre-filled from the source', async () => {
+    el = await mount([
+      policy({ id: 'src', mcp_server_name: 'erp', tool_name: 'refund', enabled: false }),
+    ]);
+    el.querySelector<HTMLButtonElement>('[data-testid="policy-duplicate"]')!.click();
+    await flush(el);
+    const dialog = el.querySelector('rm-approval-policy-dialog') as ApprovalPolicyDialog;
+    expect(dialog.open).toBe(true);
+    expect(dialog.editing).toBeNull();
+    expect(dialog.duplicating?.id).toBe('src');
+    // Saving a duplicate POSTs a new policy (never PATCHes the source).
+    dialog.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
+    await flush(el);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(createSpy.mock.calls[0][0].mcp_server_name).toBe('erp');
+    expect(createSpy.mock.calls[0][0].enabled).toBe(false);
+  });
+
+  // ── delete confirm (§5.10) ──
+
+  it('restates the policy in the delete confirmation and deletes on confirm', async () => {
+    el = await mount([
+      policy({ id: 'del', mcp_server_name: 'erp', tool_name: 'refund' }),
+    ]);
+    el.querySelector<HTMLButtonElement>('[data-testid="policy-delete"]')!.click();
+    await flush(el);
+    const desc = el.querySelector('[data-testid="delete-desc"]');
+    expect(desc?.textContent).toContain('erp · refund');
+    expect(desc?.textContent).toContain('amount > 100');
+
+    el
+      .querySelector<HTMLElement>('[data-testid="confirm-delete-dialog"]')!
+      .dispatchEvent(new CustomEvent('confirm', { bubbles: true, composed: true }));
+    await flush(el);
+    expect(deleteSpy).toHaveBeenCalledWith('del');
+    expect(el.querySelectorAll('[data-testid="policy-row"]').length).toBe(0);
+  });
+
+  it('does not delete when the confirmation is cancelled', async () => {
+    el = await mount([policy({ id: 'del' })]);
+    el.querySelector<HTMLButtonElement>('[data-testid="policy-delete"]')!.click();
+    await flush(el);
+    el
+      .querySelector<HTMLElement>('[data-testid="confirm-delete-dialog"]')!
+      .dispatchEvent(new CustomEvent('cancel', { bubbles: true, composed: true }));
+    await flush(el);
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(el.querySelectorAll('[data-testid="policy-row"]').length).toBe(1);
   });
 });
 
-describe('<rm-approval-policy-dialog> create flow', () => {
+// ── dialog (§5.11-5.14) ──
+
+describe('<rm-approval-policy-dialog>', () => {
   let el: ApprovalPolicyDialog | null = null;
   beforeEach(() => {
     createSpy.mockReset().mockResolvedValue(policy());
@@ -131,13 +320,21 @@ describe('<rm-approval-policy-dialog> create flow', () => {
     return d;
   }
 
+  function setInput(d: ApprovalPolicyDialog, testid: string, value: string) {
+    const input = d.querySelector<HTMLInputElement>(`[data-testid="${testid}"]`)!;
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+  }
+
+  it('exposes Priority and Enabled at the top level (no disclosure)', async () => {
+    el = await mountOpen();
+    expect(el.querySelector('[data-testid="priority"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="enabled"]')).not.toBeNull();
+  });
+
   it('creates an always-require policy by default', async () => {
     el = await mountOpen();
-    el.querySelector<HTMLInputElement>('[data-testid="mcp-server-name"]')!.value =
-      'stripe';
-    el
-      .querySelector<HTMLInputElement>('[data-testid="mcp-server-name"]')!
-      .dispatchEvent(new Event('input'));
+    setInput(el, 'mcp-server-name', 'stripe');
     el.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
     await flush(el);
     expect(createSpy).toHaveBeenCalledTimes(1);
@@ -147,48 +344,88 @@ describe('<rm-approval-policy-dialog> create flow', () => {
     expect(body.condition_expr).toEqual({ always: true });
   });
 
-  it('builds a match-condition from the leaf rows', async () => {
+  it('builds a flat AND of leaves and labels the combiner naturally', async () => {
     el = await mountOpen();
-    // server name
-    const name = el.querySelector<HTMLInputElement>(
-      '[data-testid="mcp-server-name"]',
-    )!;
-    name.value = 'stripe';
-    name.dispatchEvent(new Event('input'));
-    // switch to match mode
-    el.querySelector<HTMLInputElement>('[data-testid="mode-match"]')!.click();
+    setInput(el, 'mcp-server-name', 'stripe');
+    el.querySelector<HTMLButtonElement>('[data-testid="mode-match"]')!.click();
     await flush(el);
-    // fill the single leaf row
-    const field = el.querySelector<HTMLInputElement>('[data-testid="leaf-field"]')!;
-    field.value = 'amount';
-    field.dispatchEvent(new Event('input'));
-    const value = el.querySelector<HTMLInputElement>('[data-testid="leaf-value"]')!;
-    value.value = '100';
-    value.dispatchEvent(new Event('input'));
-    const op = el.querySelector<HTMLSelectElement>('[data-testid="leaf-op"]')!;
-    op.value = '>';
-    op.dispatchEvent(new Event('change'));
+    setInput(el, 'leaf-field', 'amount');
+    setInput(el, 'leaf-value', '100');
+    el.querySelector<HTMLButtonElement>('[data-testid="add-row"]')!.click();
+    await flush(el);
+    // The combiner segmented control surfaces only with ≥2 rows.
+    expect(el.querySelector('[data-testid="connective-and"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="connective-or"]')?.textContent).toContain(
+      'Any (OR)',
+    );
+    const fields = el.querySelectorAll<HTMLInputElement>('[data-testid="leaf-field"]');
+    fields[1].value = 'currency';
+    fields[1].dispatchEvent(new Event('input'));
+    const values = el.querySelectorAll<HTMLInputElement>('[data-testid="leaf-value"]');
+    values[1].value = '"USD"';
+    values[1].dispatchEvent(new Event('input'));
     await flush(el);
 
     el.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
     await flush(el);
-    expect(createSpy).toHaveBeenCalledTimes(1);
     expect(createSpy.mock.calls[0][0].condition_expr).toEqual({
-      field: 'amount',
-      op: '>',
-      value: 100,
+      and: [
+        { field: 'amount', op: '==', value: 100 },
+        { field: 'currency', op: '==', value: 'USD' },
+      ],
     });
+  });
+
+  it('fails closed to {always:true} when match mode has no usable rows', async () => {
+    el = await mountOpen();
+    setInput(el, 'mcp-server-name', 'stripe');
+    el.querySelector<HTMLButtonElement>('[data-testid="mode-match"]')!.click();
+    await flush(el);
+    // Leave the single leaf row empty.
+    el.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
+    await flush(el);
+    expect(createSpy.mock.calls[0][0].condition_expr).toEqual({ always: true });
   });
 
   it('requires server + tool names before submitting', async () => {
     el = await mountOpen();
-    // tool_name defaults to "*", but server name is blank → blocked.
+    setInput(el, 'tool-name', ''); // blank the default *
     el.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
     await flush(el);
     expect(createSpy).not.toHaveBeenCalled();
+    expect(el.querySelector('[data-testid="form-error"]')?.textContent).toContain(
+      'required',
+    );
+  });
+
+  it('live-previews the rule and appends a disabled note when off', async () => {
+    el = await mountOpen();
+    setInput(el, 'mcp-server-name', 'erp');
+    setInput(el, 'tool-name', 'refund');
+    setInput(el, 'priority', '5');
+    await flush(el);
+    const preview = el.querySelector('[data-testid="policy-preview"]')!;
+    expect(preview.textContent).toContain('erp · refund');
+    expect(preview.textContent).toContain('Priority 5');
+    expect(preview.textContent).not.toContain('disabled');
+
+    el.querySelector<HTMLButtonElement>('[data-testid="enabled"]')!.click();
+    await flush(el);
     expect(
-      el.querySelector('[data-testid="form-error"]')?.textContent,
-    ).toContain('required');
+      el.querySelector('[data-testid="policy-preview"]')?.textContent,
+    ).toContain('disabled');
+  });
+
+  it('labels title + save button per flow', async () => {
+    el = await mountOpen();
+    expect(el.querySelector('[data-testid="submit"]')?.textContent).toContain(
+      'Create policy',
+    );
+    el.remove();
+    el = await mountOpen({ editing: policy({ id: 'e' }) });
+    expect(el.querySelector('[data-testid="submit"]')?.textContent).toContain(
+      'Save changes',
+    );
   });
 
   it('opens a complex stored condition read-only and leaves it untouched on save', async () => {
@@ -196,12 +433,25 @@ describe('<rm-approval-policy-dialog> create flow', () => {
     el = await mountOpen({
       editing: policy({ id: 'pX', condition_expr: complex }),
     });
-    // The flat builder can't represent the nested condition.
     expect(el.querySelector('[data-testid="condition-readonly"]')).not.toBeNull();
     el.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
     await flush(el);
     expect(updateSpy).toHaveBeenCalledTimes(1);
     // condition_expr is NOT in the patch body — the stored complex expr stays.
     expect(updateSpy.mock.calls[0][1].condition_expr).toBeUndefined();
+  });
+
+  it('emits approval-policy-saved with the returned policy', async () => {
+    const returned = policy({ id: 'new-1' });
+    createSpy.mockResolvedValue(returned);
+    el = await mountOpen();
+    setInput(el, 'mcp-server-name', 'stripe');
+    const saved = vi.fn();
+    el.addEventListener('approval-policy-saved', saved as EventListener);
+    el.querySelector<HTMLButtonElement>('[data-testid="submit"]')!.click();
+    await flush(el);
+    expect(saved).toHaveBeenCalledTimes(1);
+    const detail = (saved.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.policy.id).toBe('new-1');
   });
 });

--- a/web/src/components/approval-policies-page.ts
+++ b/web/src/components/approval-policies-page.ts
@@ -1,33 +1,38 @@
 // Approval policies page (#/manage/approval-policies).
 //
-// HITL tool-approval policy CRUD (docs/21-hitl-approval-plan.md §10 S5). List +
-// create/edit dialog (with the §7 condition builder) + delete confirm. Mirrors
-// the <rm-mcp-servers-page> structure so the governance pages read alike.
+// HITL tool-approval policy CRUD (spec §5). The list ranks rules in the same
+// order the server evaluates them (priority desc, then created_at desc), shows
+// a priority badge + always-visible enable/disable switch per row, and reveals
+// Edit / Duplicate / Delete on hover. Create/edit/duplicate share one dialog;
+// delete goes through a confirmation modal that restates the rule.
 
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import { ApiError, getApiClient } from '../api/client.js';
 import type { ApprovalPolicy } from '../api/client.js';
 import './approval-policy-dialog.js';
 import './confirm-dialog.js';
-import { iconPencil, iconTrash } from './icons.js';
+import { conditionSentence } from './condition-form.js';
+import { iconCopy, iconPencil, iconTrash } from './icons.js';
 
-/** One-line human summary of a condition_expr for the list row. */
-export function summarizeCondition(expr: unknown): string {
-  if (typeof expr !== 'object' || expr === null) return 'custom';
-  const obj = expr as Record<string, unknown>;
-  if ('always' in obj) return obj.always === true ? 'always' : 'never';
-  if ('field' in obj && 'op' in obj) {
-    return `${String(obj.field)} ${String(obj.op)} ${JSON.stringify(obj.value)}`;
-  }
-  for (const c of ['and', 'or'] as const) {
-    if (c in obj && Array.isArray(obj[c])) {
-      const subs = obj[c] as unknown[];
-      return subs.map(summarizeCondition).join(` ${c} `);
-    }
-  }
-  return 'custom';
+/** Badge tint class for a priority value (Appendix C.3): amber when ≥10,
+ *  muted when exactly 0, neutral otherwise. */
+export function priorityBadgeClass(priority: number): string {
+  if (priority >= 10) return 'rm-pol-pri--hi';
+  if (priority === 0) return 'rm-pol-pri--zero';
+  return '';
+}
+
+/** List order = server evaluation order (spec §5.5): priority desc, then the
+ *  newest rule first on ties. created_at is an ISO-8601 string from the API. */
+export function sortPolicies(rows: ApprovalPolicy[]): ApprovalPolicy[] {
+  return [...rows].sort(
+    (a, b) =>
+      b.priority - a.priority ||
+      Date.parse(b.created_at) - Date.parse(a.created_at),
+  );
 }
 
 @customElement('rm-approval-policies-page')
@@ -35,12 +40,21 @@ export class ApprovalPoliciesPage extends LitElement {
   @state() private rows: ApprovalPolicy[] = [];
   @state() private loading = true;
   @state() private listError: string | null = null;
-  @state() private deleteError: Record<string, string> = {};
   @state() private dialogOpen = false;
   @state() private editTarget: ApprovalPolicy | null = null;
+  @state() private duplicateSource: ApprovalPolicy | null = null;
   @state() private deleteTarget: ApprovalPolicy | null = null;
   @state() private deleteInFlight = false;
+  /** Ids currently mid-PATCH on their toggle — disables the control so a
+   *  double-click can't queue two conflicting writes. */
+  @state() private togglingIds: Set<string> = new Set();
+  @state() private toast: string | null = null;
+  /** Id to pulse after a create/duplicate save (spec §5.7). */
+  @state() private highlightId: string | null = null;
+
   private readonly api = getApiClient();
+  private toastTimer: number | null = null;
+  private highlightTimer: number | null = null;
 
   protected override createRenderRoot() {
     return this;
@@ -49,6 +63,12 @@ export class ApprovalPoliciesPage extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     void this.refresh();
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    if (this.highlightTimer) clearTimeout(this.highlightTimer);
   }
 
   private async refresh(): Promise<void> {
@@ -69,14 +89,60 @@ export class ApprovalPoliciesPage extends LitElement {
     return (err as Error).message;
   }
 
+  private showToast(msg: string): void {
+    this.toast = msg;
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    this.toastTimer = window.setTimeout(() => {
+      this.toast = null;
+    }, 3200);
+  }
+
   private openCreate = (): void => {
     this.editTarget = null;
+    this.duplicateSource = null;
     this.dialogOpen = true;
   };
 
   private openEdit(row: ApprovalPolicy): void {
     this.editTarget = row;
+    this.duplicateSource = null;
     this.dialogOpen = true;
+  }
+
+  private openDuplicate(row: ApprovalPolicy): void {
+    this.editTarget = null;
+    this.duplicateSource = row;
+    this.dialogOpen = true;
+  }
+
+  private closeDialog = (): void => {
+    this.dialogOpen = false;
+    this.editTarget = null;
+    this.duplicateSource = null;
+  };
+
+  /** Optimistic enable/disable (spec §5.3): flip immediately, PATCH in the
+   *  background, revert + toast on failure. No confirm — fully reversible. */
+  private async toggleEnabled(row: ApprovalPolicy): Promise<void> {
+    if (this.togglingIds.has(row.id)) return;
+    const next = !row.enabled;
+    this.rows = this.rows.map((r) =>
+      r.id === row.id ? { ...r, enabled: next } : r,
+    );
+    this.togglingIds = new Set(this.togglingIds).add(row.id);
+    try {
+      await this.api.updateApprovalPolicy(row.id, { enabled: next });
+    } catch {
+      // Revert to the value we flipped away from.
+      this.rows = this.rows.map((r) =>
+        r.id === row.id ? { ...r, enabled: row.enabled } : r,
+      );
+      this.showToast('Couldn’t update — try again');
+    } finally {
+      const ids = new Set(this.togglingIds);
+      ids.delete(row.id);
+      this.togglingIds = ids;
+    }
   }
 
   private askDelete(row: ApprovalPolicy): void {
@@ -92,20 +158,42 @@ export class ApprovalPoliciesPage extends LitElement {
     const row = this.deleteTarget;
     if (!row || this.deleteInFlight) return;
     this.deleteInFlight = true;
-    this.deleteError = { ...this.deleteError, [row.id]: '' };
     try {
       await this.api.deleteApprovalPolicy(row.id);
+      this.rows = this.rows.filter((r) => r.id !== row.id);
       this.deleteTarget = null;
-      await this.refresh();
     } catch (err) {
-      this.deleteError = { ...this.deleteError, [row.id]: this.errMessage(err) };
       this.deleteTarget = null;
+      this.showToast(this.errMessage(err));
     } finally {
       this.deleteInFlight = false;
     }
   }
 
+  /** Splice the saved policy into the local list (no full re-fetch) so we can
+   *  pulse the exact card. Create/duplicate append; edit replaces in place. */
+  private onSaved(policy: ApprovalPolicy): void {
+    const existing = this.rows.some((r) => r.id === policy.id);
+    this.rows = existing
+      ? this.rows.map((r) => (r.id === policy.id ? policy : r))
+      : [...this.rows, policy];
+    this.pulse(policy.id);
+  }
+
+  private pulse(id: string): void {
+    this.highlightId = id;
+    if (this.highlightTimer) clearTimeout(this.highlightTimer);
+    void this.updateComplete.then(() => {
+      const card = this.querySelector(`[data-policy-id="${id}"]`);
+      card?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    });
+    this.highlightTimer = window.setTimeout(() => {
+      this.highlightId = null;
+    }, 1800);
+  }
+
   override render() {
+    const sorted = sortPolicies(this.rows);
     return html`
       <div class="rm-spane">
         <div class="rm-ch">
@@ -119,96 +207,178 @@ export class ApprovalPoliciesPage extends LitElement {
           </button>
         </div>
         <p class="rm-sub">
-          Tenant-scoped gates: a matching MCP tool call blocks and waits for a
-          human ✅/❌ before it runs.
+          Which actions your coworkers should pause and confirm with you before
+          running. Confirmations appear in the chat; for scheduled tasks they go
+          to whoever set up the task.
         </p>
 
         ${this.loading
           ? html`<div class="rm-banner-loading">Loading…</div>`
           : this.listError
             ? html`<div class="rm-banner-err">${this.listError}</div>`
-            : this.rows.length === 0
+            : sorted.length === 0
               ? this.renderEmpty()
-              : this.rows.map((r) => this.renderRow(r))}
+              : html`
+                  ${sorted.map((r) => this.renderRow(r))}
+                  ${this.renderHint()}
+                `}
 
         <rm-approval-policy-dialog
           ?open=${this.dialogOpen}
           .editing=${this.editTarget}
-          @close=${() => {
-            this.dialogOpen = false;
-            this.editTarget = null;
+          .duplicating=${this.duplicateSource}
+          @close=${this.closeDialog}
+          @approval-policy-saved=${(e: CustomEvent<{ policy: ApprovalPolicy }>) => {
+            this.onSaved(e.detail.policy);
           }}
-          @approval-policy-created=${() => { void this.refresh(); }}
-          @approval-policy-updated=${() => { void this.refresh(); }}
         ></rm-approval-policy-dialog>
         ${this.renderDeleteDialog()}
+        ${this.toast
+          ? html`<div class="rm-toast" role="status" data-testid="policy-toast">
+              ${this.toast}
+            </div>`
+          : nothing}
       </div>
     `;
   }
 
-  private renderEmpty() {
+  private renderHint(): TemplateResult {
+    // Timeout copy is 5 minutes (APPROVAL_TIMEOUT = 300_000ms); the spec's
+    // "20-minute" text is stale.
     return html`
-      <div class="rm-empty">
-        <span class="rm-empty-title">No approval policies yet</span>
-        Click <b>+ New policy</b> above to gate an MCP tool behind a human ✅/❌.
+      <p class="rm-pol-hint" data-testid="policy-hint">
+        Anything not matching above runs without asking. When multiple rules
+        match the same call, the highest priority wins; ties go to the newest.
+        Approvals time out after 5 minutes and auto-reject — the coworker can
+        re-request next turn.
+      </p>
+    `;
+  }
+
+  private renderEmpty(): TemplateResult {
+    return html`
+      <div class="rm-pol-empty" data-testid="policy-empty">
+        <div class="rm-pol-empty-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+            <path d="M9 12l2 2 4-4"/>
+            <path d="M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"/>
+          </svg>
+        </div>
+        <p>No approval policies yet.</p>
+        <p class="rm-pol-empty-sub">
+          Every tool call runs without asking. Create your first policy to gate
+          consequential actions.
+        </p>
+        <button type="button" class="rm-add" @click=${this.openCreate}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+            <path d="M12 5v14M5 12h14"/>
+          </svg>
+          Create your first policy
+        </button>
       </div>
     `;
   }
 
-  private renderRow(r: ApprovalPolicy) {
-    const delErr = this.deleteError[r.id] || '';
-    const tool = r.tool_name === '*' ? 'every tool' : r.tool_name;
+  private renderRow(r: ApprovalPolicy): TemplateResult {
+    const toolDisp =
+      r.tool_name === '*'
+        ? html`* <span class="rm-pol-alltools">(all tools)</span>`
+        : r.tool_name;
+    const dim = r.enabled ? '' : ' rm-card--dim';
+    const hi = this.highlightId === r.id ? ' rm-card--highlight' : '';
+    const toggling = this.togglingIds.has(r.id);
     return html`
-      <div class="rm-card" data-policy-id=${r.id} data-testid="policy-row">
-        <span class="rm-ic">${(r.mcp_server_name?.[0] ?? '?').toUpperCase()}</span>
+      <div class="rm-card${dim}${hi}" data-policy-id=${r.id} data-testid="policy-row">
+        <span
+          class="rm-pol-pri ${priorityBadgeClass(r.priority)}"
+          data-testid="policy-priority"
+        >priority ${r.priority}</span>
         <span class="rm-mn">
-          <b>${r.mcp_server_name} · ${tool}</b>
-          <span>when ${summarizeCondition(r.condition_expr)} · priority ${r.priority}</span>
+          <b>${r.mcp_server_name} · ${toolDisp}</b>
+          <span class="rm-pol-sent" data-testid="policy-sentence"
+            >${unsafeHTML(conditionSentence(r.condition_expr))} → pause to
+            confirm</span
+          >
         </span>
-        <span class="rm-pill ${r.enabled ? 'rm-pill-on' : 'rm-pill-off'}">
-          ${r.enabled ? 'enabled' : 'disabled'}
-        </span>
+        <button
+          type="button"
+          class="rm-pol-toggle ${r.enabled ? 'rm-pol-toggle--on' : ''}"
+          title=${r.enabled ? 'Click to disable' : 'Click to enable'}
+          data-testid="policy-toggle"
+          ?disabled=${toggling}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            void this.toggleEnabled(r);
+          }}
+        >
+          <span>${r.enabled ? 'Enabled' : 'Disabled'}</span>
+          <span class="rm-switch"></span>
+        </button>
         <span class="rm-row-acts">
           <button
             type="button"
             class="rm-iconbtn"
             title="Edit policy"
             data-testid="policy-edit"
-            @click=${() => this.openEdit(r)}
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              this.openEdit(r);
+            }}
           >${iconPencil(15)}</button>
+          <button
+            type="button"
+            class="rm-iconbtn"
+            title="Duplicate policy"
+            data-testid="policy-duplicate"
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              this.openDuplicate(r);
+            }}
+          >${iconCopy(15)}</button>
           <button
             type="button"
             class="rm-iconbtn rm-iconbtn--danger"
             title="Delete policy"
             data-testid="policy-delete"
-            @click=${() => this.askDelete(r)}
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              this.askDelete(r);
+            }}
           >${iconTrash(15)}</button>
         </span>
-        ${delErr ? html`<div class="rm-row-error">${delErr}</div>` : nothing}
       </div>
     `;
   }
 
-  private renderDeleteDialog() {
+  private renderDeleteDialog(): TemplateResult {
     const target = this.deleteTarget;
+    const toolDisp = target?.tool_name === '*' ? 'any tool' : target?.tool_name;
     return html`
       <rm-confirm-dialog
-        title=${target
-          ? `Delete policy for "${target.mcp_server_name}"?`
-          : 'Delete policy?'}
+        title="Delete approval policy?"
         ?open=${target !== null}
         tone="danger"
-        confirm-label="Delete"
+        confirm-label="Delete policy"
         busy-label="Deleting…"
         ?busy=${this.deleteInFlight}
         data-testid="confirm-delete-dialog"
         @cancel=${this.cancelDelete}
         @confirm=${() => void this.performDelete()}
       >
-        <p style="margin: 0;">
-          The gate stops applying immediately. In-flight requests are
-          unaffected. This cannot be undone.
-        </p>
+        ${target
+          ? html`<p style="margin: 0 0 10px;" data-testid="delete-desc">
+                You’re about to delete the policy that pauses for
+                <code>${target.mcp_server_name} · ${toolDisp}</code>
+                ${unsafeHTML(conditionSentence(target.condition_expr))}.
+              </p>
+              <p style="margin: 0; font-size: 12.5px; color: var(--rm-ink-3); line-height: 1.55;">
+                After deletion, matching calls will run without asking. Pending
+                approvals already raised under this policy stay live until
+                decided or expired; only future calls change.
+              </p>`
+          : nothing}
       </rm-confirm-dialog>
     `;
   }

--- a/web/src/components/approval-policy-dialog.test.ts
+++ b/web/src/components/approval-policy-dialog.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { MCPServer } from '../api/client.js';
+
+// The dialog fetches the tenant's MCP servers on open to seed the server / tool
+// combobox suggestions. Mock the client so the fetch is deterministic; the
+// policy CRUD methods are stubs (these tests never submit).
+const { listServersSpy } = vi.hoisted(() => ({ listServersSpy: vi.fn() }));
+
+vi.mock('../api/client.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../api/client.js')>('../api/client.js');
+  return {
+    ...actual,
+    getApiClient: () => ({
+      listMCPServers: listServersSpy,
+      createApprovalPolicy: vi.fn(),
+      updateApprovalPolicy: vi.fn(),
+    }),
+  };
+});
+
+import './approval-policy-dialog.js';
+import type { ApprovalPolicyDialog } from './approval-policy-dialog.js';
+import type { Combobox } from './combobox.js';
+
+function server(name: string, tools: Record<string, boolean>): MCPServer {
+  return {
+    id: `id-${name}`,
+    tenant_id: 't1',
+    name,
+    type: 'http',
+    url: `https://${name}.example`,
+    auth_mode: 'service',
+    tool_reversibility: tools,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as MCPServer;
+}
+
+/** Mount the dialog, open it, wait for the async server-load + re-render. */
+async function mountOpen(): Promise<ApprovalPolicyDialog> {
+  const el = document.createElement(
+    'rm-approval-policy-dialog',
+  ) as ApprovalPolicyDialog;
+  document.body.appendChild(el);
+  el.open = true;
+  await el.updateComplete;
+  await new Promise<void>((r) => setTimeout(r, 0)); // loadServers resolves
+  await el.updateComplete;
+  return el;
+}
+
+function combos(el: HTMLElement): Combobox[] {
+  return Array.from(el.querySelectorAll('rm-combobox')) as Combobox[];
+}
+
+/** Drive a combobox as if the user typed `value` into it. */
+function typeInto(combo: Combobox, value: string): void {
+  const input = combo.querySelector('input')!;
+  input.value = value;
+  input.dispatchEvent(new Event('input'));
+}
+
+describe('approval-policy-dialog — server/tool comboboxes', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    listServersSpy.mockReset();
+  });
+
+  it('seeds the server combobox with the configured MCP servers', async () => {
+    listServersSpy.mockResolvedValue([server('stripe', {}), server('mock-fs', {})]);
+    const el = await mountOpen();
+    const [serverCombo] = combos(el);
+    expect([...serverCombo.options].sort()).toEqual(['mock-fs', 'stripe']);
+  });
+
+  it('tool suggestions follow the selected server (no cross-server leak)', async () => {
+    listServersSpy.mockResolvedValue([
+      server('stripe', { charge: false, refund: false }),
+      server('mock-fs', { write_file: false, read_file: true }),
+    ]);
+    const el = await mountOpen();
+    const [serverCombo, toolCombo] = combos(el);
+
+    typeInto(serverCombo, 'stripe');
+    await el.updateComplete;
+    expect([...toolCombo.options].sort()).toEqual(['*', 'charge', 'refund']);
+    expect(toolCombo.options).not.toContain('write_file');
+
+    typeInto(serverCombo, 'mock-fs');
+    await el.updateComplete;
+    expect([...toolCombo.options].sort()).toEqual(['*', 'read_file', 'write_file']);
+  });
+
+  it('an unknown server offers only * and never blocks free-text entry', async () => {
+    // The whole point: gate a server/tool that has never connected.
+    listServersSpy.mockResolvedValue([server('stripe', { charge: false })]);
+    const el = await mountOpen();
+    const [serverCombo, toolCombo] = combos(el);
+
+    typeInto(serverCombo, 'totally-new-server');
+    await el.updateComplete;
+    expect(toolCombo.options).toEqual(['*']);
+
+    typeInto(toolCombo, 'some_uncatalogued_tool');
+    await el.updateComplete;
+    expect(toolCombo.value).toBe('some_uncatalogued_tool');
+  });
+
+  it('degrades gracefully when the server fetch fails', async () => {
+    listServersSpy.mockRejectedValue(new Error('network'));
+    const el = await mountOpen();
+    const [serverCombo, toolCombo] = combos(el);
+    expect(serverCombo.options).toEqual([]);
+    expect(toolCombo.options).toEqual(['*']); // wildcard always available
+  });
+});

--- a/web/src/components/approval-policy-dialog.ts
+++ b/web/src/components/approval-policy-dialog.ts
@@ -21,11 +21,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import './dialog.js';
+import './combobox.js';
 import { ApiError, getApiClient } from '../api/client.js';
 import type {
   ApprovalPolicy,
   ApprovalPolicyCreate,
   ApprovalPolicyUpdate,
+  MCPServer,
 } from '../api/client.js';
 import {
   CONDITION_OPS,
@@ -61,6 +63,10 @@ export class ApprovalPolicyDialog extends LitElement {
   @state() private conditionEditable = true;
   @state() private busy = false;
   @state() private err: string | null = null;
+  /** Tenant's configured MCP servers, fetched on open to seed the server /
+   *  tool suggestion lists. Best-effort: empty on fetch failure (the fields
+   *  stay free-text regardless). */
+  @state() private servers: MCPServer[] = [];
 
   private readonly api = getApiClient();
 
@@ -73,7 +79,31 @@ export class ApprovalPolicyDialog extends LitElement {
       this.seedForm();
       this.err = null;
       this.busy = false;
+      void this.loadServers();
     }
+  }
+
+  /** Load the tenant's MCP servers to seed the suggestion lists. Best-effort —
+   *  a failure just means no suggestions; the fields are still usable. */
+  private async loadServers(): Promise<void> {
+    try {
+      this.servers = await this.api.listMCPServers();
+    } catch {
+      this.servers = [];
+    }
+  }
+
+  /** Tool-name suggestions for the currently-typed server: the `*` wildcard
+   *  plus the keys of that server's `tool_reversibility` map (the tool names
+   *  the operator declared). There is no live tool list — tools are only known
+   *  inside a connected container — so these declared names are the best
+   *  always-available source, and they work even before the server connects.
+   *  Returns just `*` when the typed server isn't a configured one; the field
+   *  stays free-text either way. */
+  private suggestedTools(): string[] {
+    const match = this.servers.find((s) => s.name === this.mcpServerName);
+    const declared = match ? Object.keys(match.tool_reversibility ?? {}) : [];
+    return ['*', ...declared.filter((t) => t && t !== '*')];
   }
 
   /** The policy the form should seed from: the edit target, else the
@@ -359,34 +389,38 @@ export class ApprovalPolicyDialog extends LitElement {
           Require a human to sign off before a coworker runs a specific tool
           call. Approvals time out after 5 minutes and auto-reject.
         </p>
-        <div class="mb-3">
-          <label class="block text-[12.5px] font-medium mb-1">MCP server name</label>
-          <input
-            type="text"
-            class=${INPUT_CLASS}
-            placeholder="e.g. stripe"
-            data-testid="mcp-server-name"
-            .value=${this.mcpServerName}
-            @input=${(e: Event) => {
-              this.mcpServerName = (e.target as HTMLInputElement).value;
-            }}
-            ?disabled=${this.busy}
-          />
+        <div class="mb-1 flex gap-3">
+          <div class="flex-1 min-w-0">
+            <label class="block text-[12.5px] font-medium mb-1">MCP server name</label>
+            <rm-combobox
+              .value=${this.mcpServerName}
+              .options=${this.servers.map((s) => s.name)}
+              placeholder="e.g. stripe"
+              testid="mcp-server-name"
+              ?disabled=${this.busy}
+              @change=${(e: CustomEvent<{ value: string }>) => {
+                this.mcpServerName = e.detail.value;
+              }}
+            ></rm-combobox>
+          </div>
+          <div class="flex-1 min-w-0">
+            <label class="block text-[12.5px] font-medium mb-1">Tool name</label>
+            <rm-combobox
+              mono
+              .value=${this.toolName}
+              .options=${this.suggestedTools()}
+              placeholder="exact tool, or *"
+              testid="tool-name"
+              ?disabled=${this.busy}
+              @change=${(e: CustomEvent<{ value: string }>) => {
+                this.toolName = e.detail.value;
+              }}
+            ></rm-combobox>
+          </div>
         </div>
-        <div class="mb-3">
-          <label class="block text-[12.5px] font-medium mb-1">Tool name</label>
-          <input
-            type="text"
-            class="${INPUT_CLASS} font-mono"
-            placeholder="exact tool name, or * for every tool"
-            data-testid="tool-name"
-            .value=${this.toolName}
-            @input=${(e: Event) => {
-              this.toolName = (e.target as HTMLInputElement).value;
-            }}
-            ?disabled=${this.busy}
-          />
-        </div>
+        <p class="mb-3 text-[11px] text-ink-3 dark:text-d-ink-3">
+          Pick a configured server/tool, or type one that isn't connected yet.
+        </p>
         <div class="mb-3">
           <label class="block text-[12.5px] font-medium mb-1">Require approval</label>
           ${this.renderConditionBuilder()}

--- a/web/src/components/approval-policy-dialog.ts
+++ b/web/src/components/approval-policy-dialog.ts
@@ -1,7 +1,14 @@
-// <rm-approval-policy-dialog> — create / edit an HITL approval policy
-// (docs/21-hitl-approval-plan.md §10 S5), including the structured condition
-// builder (§7 grammar). One dialog backs both flows: `editing` null = create
-// (POST), non-null = edit (PATCH).
+// <rm-approval-policy-dialog> — create / edit / duplicate an HITL approval
+// policy (spec §5.7-5.14), including the structured condition builder (§7
+// grammar). One dialog backs all three flows:
+//   - `editing` non-null  → edit  (PATCH; title "Edit approval policy")
+//   - `duplicating` non-null → create, pre-filled (POST; "Duplicate …")
+//   - both null            → create, defaults (POST; "New approval policy")
+//
+// Every field is visible at top level — no "More options" disclosure (§5.11);
+// Priority and Enabled are core fields used on most policy creations. A live
+// preview (§5.13) regenerates on every change using the same `conditionSentence`
+// renderer as the list cards, so what the user previews is what the card shows.
 //
 // The condition builder exposes the shallow subset of the §7 grammar
 // (`{always}` or a flat and/or of `{field,op,value}` leaves) — see
@@ -11,6 +18,7 @@
 
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 import './dialog.js';
 import { ApiError, getApiClient } from '../api/client.js';
@@ -25,6 +33,7 @@ import {
   type ConditionMode,
   type LeafRow,
   buildConditionExpr,
+  conditionSentence,
   emptyRow,
   exprToForm,
 } from './condition-form.js';
@@ -38,6 +47,8 @@ const INPUT_CLASS =
 export class ApprovalPolicyDialog extends LitElement {
   @property({ type: Boolean }) open = false;
   @property({ attribute: false }) editing: ApprovalPolicy | null = null;
+  /** Source policy when opening in duplicate mode — create flow, pre-filled. */
+  @property({ attribute: false }) duplicating: ApprovalPolicy | null = null;
 
   @state() private mcpServerName = '';
   @state() private toolName = '*';
@@ -65,13 +76,20 @@ export class ApprovalPolicyDialog extends LitElement {
     }
   }
 
+  /** The policy the form should seed from: the edit target, else the
+   *  duplicate source, else nothing (defaults). */
+  private seedSource(): ApprovalPolicy | null {
+    return this.editing ?? this.duplicating;
+  }
+
   private seedForm(): void {
-    if (this.editing) {
-      this.mcpServerName = this.editing.mcp_server_name;
-      this.toolName = this.editing.tool_name;
-      this.priority = this.editing.priority;
-      this.enabled = this.editing.enabled;
-      const form: ConditionForm = exprToForm(this.editing.condition_expr);
+    const src = this.seedSource();
+    if (src) {
+      this.mcpServerName = src.mcp_server_name;
+      this.toolName = src.tool_name;
+      this.priority = src.priority;
+      this.enabled = src.enabled;
+      const form: ConditionForm = exprToForm(src.condition_expr);
       this.mode = form.mode;
       this.connective = form.connective;
       this.rows = form.rows.length ? form.rows : [emptyRow()];
@@ -102,6 +120,7 @@ export class ApprovalPolicyDialog extends LitElement {
     this.busy = true;
     this.err = null;
     try {
+      let saved: ApprovalPolicy;
       if (this.editing) {
         const body: ApprovalPolicyUpdate = {
           mcp_server_name: this.mcpServerName.trim(),
@@ -112,33 +131,28 @@ export class ApprovalPolicyDialog extends LitElement {
         // Only resend the condition if it's still editable here — otherwise
         // leave the (complex) stored expression untouched.
         if (this.conditionEditable) {
-          body.condition_expr = buildConditionExpr({
-            mode: this.mode,
-            connective: this.connective,
-            rows: this.rows,
-          });
+          body.condition_expr = this.currentExpr();
         }
-        await this.api.updateApprovalPolicy(this.editing.id, body);
-        this.dispatchEvent(
-          new CustomEvent('approval-policy-updated', { bubbles: true, composed: true }),
-        );
+        saved = await this.api.updateApprovalPolicy(this.editing.id, body);
       } else {
+        // Create — covers both the New and Duplicate flows (duplicate just
+        // seeds the form; the POST is identical, server assigns a new id).
         const body: ApprovalPolicyCreate = {
           mcp_server_name: this.mcpServerName.trim(),
           tool_name: this.toolName.trim(),
           priority: this.priority,
           enabled: this.enabled,
-          condition_expr: buildConditionExpr({
-            mode: this.mode,
-            connective: this.connective,
-            rows: this.rows,
-          }),
+          condition_expr: this.currentExpr(),
         };
-        await this.api.createApprovalPolicy(body);
-        this.dispatchEvent(
-          new CustomEvent('approval-policy-created', { bubbles: true, composed: true }),
-        );
+        saved = await this.api.createApprovalPolicy(body);
       }
+      this.dispatchEvent(
+        new CustomEvent('approval-policy-saved', {
+          detail: { policy: saved },
+          bubbles: true,
+          composed: true,
+        }),
+      );
       this.close();
     } catch (err) {
       this.err =
@@ -148,6 +162,15 @@ export class ApprovalPolicyDialog extends LitElement {
     } finally {
       this.busy = false;
     }
+  }
+
+  /** condition_expr from the current form state (fail-closed per §5.14). */
+  private currentExpr() {
+    return buildConditionExpr({
+      mode: this.mode,
+      connective: this.connective,
+      rows: this.rows,
+    });
   }
 
   private updateRow(i: number, patch: Partial<LeafRow>): void {
@@ -173,7 +196,7 @@ export class ApprovalPolicyDialog extends LitElement {
           This policy uses an advanced condition that the form can't edit.
           The other fields are still editable; the condition is left as-is.
           <pre class="mt-1 text-[11.5px] overflow-x-auto">${JSON.stringify(
-            this.editing?.condition_expr ?? {},
+            this.seedSource()?.condition_expr ?? {},
             null,
             2,
           )}</pre>
@@ -182,28 +205,27 @@ export class ApprovalPolicyDialog extends LitElement {
     }
     return html`
       <div class="flex flex-col gap-2">
-        <label class="flex items-center gap-2 text-[12.5px]">
-          <input
-            type="radio"
-            name="cond-mode"
+        <div class="rm-seg" role="radiogroup" aria-label="When to require approval">
+          <button
+            type="button"
+            class="${this.mode === 'always' ? 'rm-seg--on' : ''}"
             data-testid="mode-always"
-            ?checked=${this.mode === 'always'}
-            @change=${() => { this.mode = 'always'; }}
+            aria-pressed=${this.mode === 'always'}
+            @click=${() => { this.mode = 'always'; }}
             ?disabled=${this.busy}
-          />
-          Always require approval for this tool
-        </label>
-        <label class="flex items-center gap-2 text-[12.5px]">
-          <input
-            type="radio"
-            name="cond-mode"
+          >Every time</button>
+          <button
+            type="button"
+            class="${this.mode === 'match' ? 'rm-seg--on' : ''}"
             data-testid="mode-match"
-            ?checked=${this.mode === 'match'}
-            @change=${() => { this.mode = 'match'; }}
+            aria-pressed=${this.mode === 'match'}
+            @click=${() => {
+              this.mode = 'match';
+              if (this.rows.length === 0) this.rows = [emptyRow()];
+            }}
             ?disabled=${this.busy}
-          />
-          Only when a condition matches
-        </label>
+          >Only when…</button>
+        </div>
         ${this.mode === 'match' ? this.renderLeaves() : nothing}
       </div>
     `;
@@ -211,25 +233,26 @@ export class ApprovalPolicyDialog extends LitElement {
 
   private renderLeaves(): TemplateResult {
     return html`
-      <div class="pl-6 flex flex-col gap-2" data-testid="leaf-rows">
+      <div class="pl-1 flex flex-col gap-2" data-testid="leaf-rows">
         ${this.rows.length > 1
-          ? html`<div class="text-[12px]">
-              Match
-              <select
-                class="text-[12px] px-1 py-0.5 rounded border border-surface-3 dark:border-d-surface-3 bg-surface-1 dark:bg-d-surface-1"
-                .value=${this.connective}
-                data-testid="connective"
-                @change=${(e: Event) => {
-                  this.connective = (e.target as HTMLSelectElement).value as
-                    | 'and'
-                    | 'or';
-                }}
-                ?disabled=${this.busy}
-              >
-                <option value="and">all</option>
-                <option value="or">any</option>
-              </select>
-              of:
+          ? html`<div class="flex items-center gap-2 text-[12px]">
+              <span class="text-ink-2 dark:text-d-ink-2">Combine with</span>
+              <div class="rm-seg">
+                <button
+                  type="button"
+                  class="${this.connective === 'and' ? 'rm-seg--on' : ''}"
+                  data-testid="connective-and"
+                  @click=${() => { this.connective = 'and'; }}
+                  ?disabled=${this.busy}
+                >All (AND)</button>
+                <button
+                  type="button"
+                  class="${this.connective === 'or' ? 'rm-seg--on' : ''}"
+                  data-testid="connective-or"
+                  @click=${() => { this.connective = 'or'; }}
+                  ?disabled=${this.busy}
+                >Any (OR)</button>
+              </div>
             </div>`
           : nothing}
         ${this.rows.map((r, i) => this.renderLeaf(r, i))}
@@ -291,17 +314,51 @@ export class ApprovalPolicyDialog extends LitElement {
     `;
   }
 
+  /** Live preview sentence (§5.13) — single source of truth shared with the
+   *  list cards via `conditionSentence`. */
+  private renderPreview(): TemplateResult {
+    const server = this.mcpServerName.trim() || 'a server';
+    const toolDisp = this.toolName.trim() === '*' ? 'any tool' : this.toolName.trim() || 'a tool';
+    const expr =
+      this.editing && !this.conditionEditable
+        ? this.editing.condition_expr
+        : this.currentExpr();
+    const sentence = conditionSentence(expr);
+    return html`
+      <div class="rm-pol-preview" data-testid="policy-preview">
+        When a coworker calls <code>${server} · ${toolDisp}</code>
+        ${unsafeHTML(sentence)}, pause and ask the requester to confirm before
+        running. Priority <b>${this.priority}</b>.${this.enabled
+          ? nothing
+          : html` <i>(disabled — won’t match until re-enabled)</i>`}
+      </div>
+    `;
+  }
+
+  private dialogTitle(): string {
+    if (this.editing) return 'Edit approval policy';
+    if (this.duplicating) return 'Duplicate approval policy';
+    return 'New approval policy';
+  }
+
+  private saveLabel(): string {
+    return this.editing ? 'Save changes' : 'Create policy';
+  }
+
   override render(): TemplateResult {
-    const title = this.editing ? 'Edit approval policy' : 'New approval policy';
     return html`
       <rm-dialog
-        title=${title}
+        title=${this.dialogTitle()}
         ?open=${this.open}
         ?close-on-backdrop=${!this.busy}
         ?close-on-esc=${!this.busy}
         width="560px"
         @close=${this.close}
       >
+        <p class="text-[12.5px] text-ink-2 dark:text-d-ink-2 mb-3">
+          Require a human to sign off before a coworker runs a specific tool
+          call. Approvals time out after 5 minutes and auto-reject.
+        </p>
         <div class="mb-3">
           <label class="block text-[12.5px] font-medium mb-1">MCP server name</label>
           <input
@@ -330,37 +387,42 @@ export class ApprovalPolicyDialog extends LitElement {
             ?disabled=${this.busy}
           />
         </div>
-        <div class="mb-3 flex items-center gap-4">
+        <div class="mb-3">
+          <label class="block text-[12.5px] font-medium mb-1">Require approval</label>
+          ${this.renderConditionBuilder()}
+        </div>
+        <div class="mb-2 flex items-end gap-4">
           <label class="text-[12.5px] font-medium">
             Priority
+            <span class="text-ink-3 dark:text-d-ink-3 font-normal">higher wins on ties</span>
             <input
               type="number"
-              class="${INPUT_CLASS} w-20 ml-2 inline-block"
+              class="${INPUT_CLASS} w-24 mt-1 block"
               data-testid="priority"
               .value=${String(this.priority)}
               @input=${(e: Event) => {
-                this.priority = Number((e.target as HTMLInputElement).value) || 0;
+                this.priority = parseInt((e.target as HTMLInputElement).value, 10) || 0;
               }}
               ?disabled=${this.busy}
             />
           </label>
-          <label class="flex items-center gap-2 text-[12.5px] font-medium">
-            <input
-              type="checkbox"
+          <div class="text-[12.5px] font-medium">
+            Status
+            <button
+              type="button"
+              class="rm-pol-toggle ${this.enabled ? 'rm-pol-toggle--on' : ''} mt-1"
               data-testid="enabled"
-              ?checked=${this.enabled}
-              @change=${(e: Event) => {
-                this.enabled = (e.target as HTMLInputElement).checked;
-              }}
+              aria-pressed=${this.enabled}
+              @click=${() => { this.enabled = !this.enabled; }}
               ?disabled=${this.busy}
-            />
-            Enabled
-          </label>
+            >
+              <span>${this.enabled ? 'Enabled' : 'Disabled'}</span>
+              <span class="rm-switch"></span>
+            </button>
+          </div>
         </div>
-        <div class="mb-2">
-          <label class="block text-[12.5px] font-medium mb-1">Condition</label>
-          ${this.renderConditionBuilder()}
-        </div>
+
+        ${this.renderPreview()}
 
         ${this.err
           ? html`<div
@@ -383,7 +445,7 @@ export class ApprovalPolicyDialog extends LitElement {
             data-testid="submit"
             ?disabled=${this.busy}
             @click=${() => void this.submit()}
-          >${this.busy ? 'Saving…' : this.editing ? 'Save' : 'Create'}</button>
+          >${this.busy ? 'Saving…' : this.saveLabel()}</button>
         </div>
       </rm-dialog>
     `;

--- a/web/src/components/approval-store.test.ts
+++ b/web/src/components/approval-store.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   type ApprovalCard,
   applyResolved,
+  cardsFromConversation,
   mergePending,
   upsertRequested,
 } from './approval-store.js';
@@ -12,7 +13,7 @@ import type {
 } from '../ws/v1_client.js';
 import type { components } from '../api/generated/types.js';
 
-type PendingRow = components['schemas']['PendingApprovalRequest'];
+type PendingRow = components['schemas']['ApprovalRequest'];
 
 function requested(
   id: string,
@@ -43,6 +44,9 @@ function row(id: string, extra: Partial<PendingRow> = {}): PendingRow {
     action_summary: 's',
     requested_at: '2026-01-01T00:00:00Z',
     expires_at: '2026-01-01T00:05:00Z',
+    status: 'pending',
+    decided_at: null,
+    note: null,
     ...extra,
   };
 }
@@ -62,6 +66,7 @@ function seed(id: string, status: ApprovalCard['status']): ApprovalCard {
     status,
     resolvedAt: null,
     note: null,
+    orderTs: 0,
   };
 }
 
@@ -235,5 +240,53 @@ describe('mergePending', () => {
     const out = mergePending([seed('a', 'approved')], [row('a')]);
     expect(out).toHaveLength(1);
     expect(out[0].status).toBe('approved');
+  });
+});
+
+describe('cardsFromConversation', () => {
+  it('preserves a resolved row status verbatim (not forced to pending)', () => {
+    // This is the whole point of the full-conversation read vs mergePending:
+    // a row that the server records as rejected must re-render as a rejected
+    // card on reload, with no live action buttons.
+    const out = cardsFromConversation([
+      row('a', { status: 'rejected', decided_at: '2026-01-01T00:02:00Z' }),
+    ]);
+    expect(out[0].status).toBe('rejected');
+  });
+
+  it('parses decided_at into resolvedAt for a terminal row', () => {
+    const out = cardsFromConversation([
+      row('a', { status: 'approved', decided_at: '2026-01-01T00:02:00Z' }),
+    ]);
+    expect(out[0].resolvedAt).toBe(Date.parse('2026-01-01T00:02:00Z'));
+  });
+
+  it('leaves resolvedAt null for a still-pending row even if decided_at leaks in', () => {
+    // Defensive: a pending row should never carry a decided_at, but if the API
+    // ever sends one we must not paint a pending card as already-decided.
+    const out = cardsFromConversation([
+      row('a', { status: 'pending', decided_at: '2026-01-01T00:02:00Z' }),
+    ]);
+    expect(out[0].resolvedAt).toBeNull();
+  });
+
+  it('orders the card by requested_at, not decided_at', () => {
+    // The card belongs where the request was raised (right after the user's
+    // message), not where it was decided — decided_at can be much later.
+    const out = cardsFromConversation([
+      row('a', {
+        status: 'approved',
+        requested_at: '2026-01-01T00:00:00Z',
+        decided_at: '2026-01-01T09:00:00Z',
+      }),
+    ]);
+    expect(out[0].orderTs).toBe(Date.parse('2026-01-01T00:00:00Z'));
+  });
+
+  it('defaults status to pending when the row omits it', () => {
+    const r = row('a');
+    delete (r as { status?: string }).status;
+    const out = cardsFromConversation([r]);
+    expect(out[0].status).toBe('pending');
   });
 });

--- a/web/src/components/approval-store.test.ts
+++ b/web/src/components/approval-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   type ApprovalCard,
@@ -16,44 +16,102 @@ type PendingRow = components['schemas']['PendingApprovalRequest'];
 
 function requested(
   id: string,
-  summary: string | null = 'do thing',
+  extra: Partial<ApprovalRequestedEvent> = {},
 ): ApprovalRequestedEvent {
   return {
     type: 'event.approval.requested',
     request_id: id,
-    action_summary: summary,
+    action_summary: 'do thing',
     expires_at: '2026-01-01T00:00:00Z',
+    ...extra,
   };
 }
 
 function resolved(
   id: string,
-  outcome: 'approved' | 'rejected' | 'expired',
+  outcome: 'approved' | 'rejected' | 'expired' | 'cancelled',
 ): ApprovalResolvedEvent {
   return { type: 'event.approval.resolved', request_id: id, outcome };
 }
 
-function row(id: string, summary: string | null = 's'): PendingRow {
+function row(id: string, extra: Partial<PendingRow> = {}): PendingRow {
   return {
     request_id: id,
     conversation_id: null,
     mcp_server_name: 'stripe',
     tool_name: 'charge',
-    action_summary: summary,
+    action_summary: 's',
     requested_at: '2026-01-01T00:00:00Z',
     expires_at: '2026-01-01T00:05:00Z',
+    ...extra,
+  };
+}
+
+/** A resolved card seed with all required fields populated. */
+function seed(id: string, status: ApprovalCard['status']): ApprovalCard {
+  return {
+    requestId: id,
+    mcpServerName: 'stripe',
+    toolName: 'charge',
+    params: {},
+    coworkerId: null,
+    rationale: null,
+    requestedAt: null,
+    expiresAt: null,
+    actionSummary: 's',
+    status,
+    resolvedAt: null,
+    note: null,
   };
 }
 
 describe('upsertRequested', () => {
   it('adds a pending card for a new request', () => {
-    const out = upsertRequested([], requested('a', 'charge $500'));
+    const out = upsertRequested([], requested('a', { action_summary: 'charge $500' }));
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({
       requestId: 'a',
       actionSummary: 'charge $500',
       status: 'pending',
     });
+  });
+
+  it('maps the new decision-relevant fields off the requested event', () => {
+    const out = upsertRequested(
+      [],
+      requested('a', {
+        mcp_server_name: 'amazon-ads-api',
+        tool_name: 'campaign.pause',
+        params: { campaign_id: 'SP-1', amount: 3210 },
+        coworker_id: 'cw-7',
+        rationale: 'ROAS below floor',
+        requested_at: '2026-05-31T10:00:00Z',
+      }),
+    );
+    expect(out[0]).toMatchObject({
+      mcpServerName: 'amazon-ads-api',
+      toolName: 'campaign.pause',
+      params: { campaign_id: 'SP-1', amount: 3210 },
+      coworkerId: 'cw-7',
+      rationale: 'ROAS below floor',
+      requestedAt: '2026-05-31T10:00:00Z',
+      resolvedAt: null,
+      note: null,
+    });
+  });
+
+  it('defaults params to {} when the field is missing', () => {
+    const out = upsertRequested([], requested('a'));
+    expect(out[0].params).toEqual({});
+  });
+
+  it('coerces a non-object params (array) to {} rather than passing it through', () => {
+    // The server drops non-dict params upstream; the store must not surface an
+    // array to the card, which would render Object.entries garbage.
+    const ev = requested('a', {
+      params: [1, 2, 3] as unknown as Record<string, unknown>,
+    });
+    expect(upsertRequested([], ev)[0].params).toEqual({});
   });
 
   it('is idempotent — a redelivered requested event does not duplicate', () => {
@@ -66,10 +124,7 @@ describe('upsertRequested', () => {
     // The WS can replay event.approval.requested on reconnect. If that
     // re-pended an already-decided card, the user would see live buttons on a
     // request the server has already closed — a real double-decision risk.
-    const seeded: ApprovalCard[] = [
-      { requestId: 'a', actionSummary: 's', expiresAt: null, status: 'approved' },
-    ];
-    const out = upsertRequested(seeded, requested('a'));
+    const out = upsertRequested([seed('a', 'approved')], requested('a'));
     expect(out).toHaveLength(1);
     expect(out[0].status).toBe('approved');
   });
@@ -77,15 +132,34 @@ describe('upsertRequested', () => {
   it('coerces a missing action_summary to null', () => {
     const ev = { type: 'event.approval.requested', request_id: 'a' } as
       ApprovalRequestedEvent;
-    expect(upsertRequested([], ev)[0].actionSummary).toBeNull();
+    const out = upsertRequested([], ev);
+    expect(out[0].actionSummary).toBeNull();
+    expect(out[0].rationale).toBeNull();
+    expect(out[0].params).toEqual({});
   });
 });
 
 describe('applyResolved', () => {
+  afterEach(() => vi.useRealTimers());
+
   it('flips a pending card to its outcome', () => {
     const seeded = upsertRequested([], requested('a'));
     const out = applyResolved(seeded, resolved('a', 'rejected'));
     expect(out[0].status).toBe('rejected');
+  });
+
+  it('flips on the cancelled outcome (container withdrew the call)', () => {
+    const seeded = upsertRequested([], requested('a'));
+    const out = applyResolved(seeded, resolved('a', 'cancelled'));
+    expect(out[0].status).toBe('cancelled');
+  });
+
+  it('stamps resolvedAt from the wall clock on the flip', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-31T12:00:00Z'));
+    const seeded = upsertRequested([], requested('a'));
+    const out = applyResolved(seeded, resolved('a', 'approved'));
+    expect(out[0].resolvedAt).toBe(Date.parse('2026-05-31T12:00:00Z'));
   });
 
   it('ignores a resolution for an unknown id (no phantom card)', () => {
@@ -94,10 +168,7 @@ describe('applyResolved', () => {
   });
 
   it('is first-wins — does not re-resolve an already-terminal card', () => {
-    const seeded: ApprovalCard[] = [
-      { requestId: 'a', actionSummary: 's', expiresAt: null, status: 'approved' },
-    ];
-    const out = applyResolved(seeded, resolved('a', 'expired'));
+    const out = applyResolved([seed('a', 'approved')], resolved('a', 'expired'));
     expect(out[0].status).toBe('approved');
   });
 
@@ -120,6 +191,26 @@ describe('mergePending', () => {
     expect(out[0].status).toBe('pending');
   });
 
+  it('maps the new fields off the REST pending row', () => {
+    const out = mergePending(
+      [],
+      [
+        row('a', {
+          params: { order_id: 'ord_1' },
+          coworker_id: 'cw-2',
+          rationale: 'why',
+        }),
+      ],
+    );
+    expect(out[0]).toMatchObject({
+      params: { order_id: 'ord_1' },
+      coworkerId: 'cw-2',
+      rationale: 'why',
+      mcpServerName: 'stripe',
+      toolName: 'charge',
+    });
+  });
+
   it('drops a pending card decided while disconnected (absent from rows)', () => {
     // Card 'a' was pending; it was decided server-side while the socket was
     // down, so it is absent from the reconnect read. Leaving it would show a
@@ -130,19 +221,18 @@ describe('mergePending', () => {
   });
 
   it('keeps already-resolved cards (the user record of the decision)', () => {
-    const seeded: ApprovalCard[] = [
-      { requestId: 'done', actionSummary: 's', expiresAt: null, status: 'rejected' },
-    ];
-    const out = mergePending(seeded, [row('new')]);
+    const out = mergePending([seed('done', 'rejected')], [row('new')]);
     expect(out.find((c) => c.requestId === 'done')?.status).toBe('rejected');
     expect(out.find((c) => c.requestId === 'new')?.status).toBe('pending');
   });
 
+  it('keeps a cancelled card across reconnect', () => {
+    const out = mergePending([seed('c', 'cancelled')], [row('new')]);
+    expect(out.find((c) => c.requestId === 'c')?.status).toBe('cancelled');
+  });
+
   it('does not re-pend a row whose id already has a resolved card', () => {
-    const seeded: ApprovalCard[] = [
-      { requestId: 'a', actionSummary: 's', expiresAt: null, status: 'approved' },
-    ];
-    const out = mergePending(seeded, [row('a')]);
+    const out = mergePending([seed('a', 'approved')], [row('a')]);
     expect(out).toHaveLength(1);
     expect(out[0].status).toBe('approved');
   });

--- a/web/src/components/approval-store.ts
+++ b/web/src/components/approval-store.ts
@@ -1,6 +1,7 @@
 // Pure state helpers for the HITL approval cards (docs/21-hitl-approval-plan.md
-// §10 S5). Kept out of `chat-panel.ts` so the event→state transitions are unit-
-// testable in isolation, without mounting the whole chat surface.
+// §10 S5; rich-card contract in .hitl-ui/spec.md §3 + Appendix C.5). Kept out of
+// `chat-panel.ts` so the event→state transitions are unit-testable in isolation,
+// without mounting the whole chat surface.
 //
 // The card list is the SPA's view of in-flight approvals for the *current*
 // conversation. Three inputs feed it:
@@ -9,7 +10,10 @@
 //   - `GET /api/v1/approval-requests` (reconnect) → the authoritative pending set
 //
 // Every function is pure and returns a fresh array (Lit `@state` change
-// detection is reference-based), never mutating the input.
+// detection is reference-based), never mutating the input. The one exception to
+// "pure" is `applyResolved` stamping a client-side `resolvedAt`: the wire's
+// resolved event carries no timestamp (§3.6 says fall back to client time), so
+// we read the wall clock at flip time. That is a deliberate, documented seam.
 
 import type { components } from '../api/generated/types.js';
 import type {
@@ -17,16 +21,55 @@ import type {
   ApprovalResolvedEvent,
 } from '../ws/v1_client.js';
 
-export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'expired';
+export type ApprovalStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'expired'
+  | 'cancelled';
 
 export interface ApprovalCard {
   requestId: string;
-  actionSummary: string | null;
+  /** The gated MCP server (`event.approval.requested.mcp_server_name`). */
+  mcpServerName: string | null;
+  /** The gated tool (`tool_name`). */
+  toolName: string | null;
+  /** Raw tool arguments — the decision input (§3.3). Defaults to `{}` when the
+   *  wire omits it or sends a non-object (the server drops non-dicts upstream,
+   *  but we still normalise defensively). */
+  params: Record<string, unknown>;
+  /** The coworker whose call is gated; used by the card meta line. */
+  coworkerId: string | null;
+  /** The agent's free-text "why" (§3.4). Null ⇒ the card omits the block. */
+  rationale: string | null;
+  /** When the approval became pending (ISO-8601), for the "2m ago" meta. */
+  requestedAt: string | null;
+  /** When the pending approval auto-expires (ISO-8601), drives the countdown. */
   expiresAt: string | null;
+  /** Server's one-line hint; kept for narrow surfaces and as a card subtitle. */
+  actionSummary: string | null;
   status: ApprovalStatus;
+  /** Client-stamped wall-clock (epoch ms) of the terminal flip; null while
+   *  pending. The wire's resolved event has no timestamp, so this is our own
+   *  record of "decided at" for the resolved header (§3.6). */
+  resolvedAt: number | null;
+  /** The approver's own rejection note (§3.5), held locally so the resolved
+   *  card can echo it back ("YOUR REASON"). Never comes off the wire — it is
+   *  what the user typed — and is lost on reconnect, which is acceptable. */
+  note: string | null;
 }
 
 type PendingRow = components['schemas']['PendingApprovalRequest'];
+
+/** Normalise a wire `params` value to a plain object. A non-object (array,
+ *  string, null, undefined) collapses to `{}` so the card never has to special-
+ *  case it — matching the server, which discards non-dict params upstream. */
+function coerceParams(p: unknown): Record<string, unknown> {
+  if (p && typeof p === 'object' && !Array.isArray(p)) {
+    return p as Record<string, unknown>;
+  }
+  return {};
+}
 
 /** Add a pending card for a freshly-requested approval.
  *
@@ -44,9 +87,17 @@ export function upsertRequested(
     ...cards,
     {
       requestId: ev.request_id,
-      actionSummary: ev.action_summary ?? null,
+      mcpServerName: ev.mcp_server_name ?? null,
+      toolName: ev.tool_name ?? null,
+      params: coerceParams(ev.params),
+      coworkerId: ev.coworker_id ?? null,
+      rationale: ev.rationale ?? null,
+      requestedAt: ev.requested_at ?? null,
       expiresAt: ev.expires_at ?? null,
+      actionSummary: ev.action_summary ?? null,
       status: 'pending',
+      resolvedAt: null,
+      note: null,
     },
   ];
 }
@@ -55,7 +106,8 @@ export function upsertRequested(
  *
  *  A resolution for an id we never showed is ignored (no phantom card with a
  *  status but no context). A card that already resolved is left untouched
- *  (first-wins, mirroring the server-side row transition). */
+ *  (first-wins, mirroring the server-side row transition). The flip stamps
+ *  `resolvedAt` from the wall clock since the wire carries no timestamp. */
 export function applyResolved(
   cards: readonly ApprovalCard[],
   ev: ApprovalResolvedEvent,
@@ -64,7 +116,7 @@ export function applyResolved(
   const next = cards.map((c) => {
     if (c.requestId !== ev.request_id || c.status !== 'pending') return c;
     changed = true;
-    return { ...c, status: ev.outcome };
+    return { ...c, status: ev.outcome, resolvedAt: Date.now() };
   });
   return changed ? next : [...cards];
 }
@@ -85,9 +137,17 @@ export function mergePending(
   const resolved = cards.filter((c) => c.status !== 'pending');
   const fromRows: ApprovalCard[] = rows.map((r) => ({
     requestId: r.request_id,
+    mcpServerName: r.mcp_server_name ?? null,
+    toolName: r.tool_name ?? null,
+    params: coerceParams(r.params),
+    coworkerId: r.coworker_id ?? null,
+    rationale: r.rationale ?? null,
+    requestedAt: r.requested_at ?? null,
+    expiresAt: r.expires_at ?? null,
     actionSummary: r.action_summary ?? null,
-    expiresAt: r.expires_at,
     status: 'pending',
+    resolvedAt: null,
+    note: null,
   }));
   // De-dup defensively: a row whose id already has a resolved card (decided in
   // the same instant the read raced) stays resolved, not re-pended.

--- a/web/src/components/approval-store.ts
+++ b/web/src/components/approval-store.ts
@@ -57,9 +57,17 @@ export interface ApprovalCard {
    *  card can echo it back ("YOUR REASON"). Never comes off the wire — it is
    *  what the user typed — and is lost on reconnect, which is acceptable. */
   note: string | null;
+  /** Ordering key (epoch ms) used to interleave the card with chat messages in
+   *  chronological position instead of pinning it to the conversation tail. It
+   *  is stamped client-side at the instant the card enters the timeline for a
+   *  *live* push (so it follows arrival order regardless of client↔server clock
+   *  skew), and parsed from the server `requested_at` on reload (so it matches
+   *  the server's ordering of the persisted messages around it). Both sources
+   *  are monotonic within their own world, which is all the interleave needs. */
+  orderTs: number;
 }
 
-type PendingRow = components['schemas']['PendingApprovalRequest'];
+type PendingRow = components['schemas']['ApprovalRequest'];
 
 /** Normalise a wire `params` value to a plain object. A non-object (array,
  *  string, null, undefined) collapses to `{}` so the card never has to special-
@@ -98,6 +106,10 @@ export function upsertRequested(
       status: 'pending',
       resolvedAt: null,
       note: null,
+      // Live push: stamp arrival time so the card sorts after the user message
+      // that triggered it and before the (later) confirmation, even if the
+      // server's requested_at clock differs from the browser's.
+      orderTs: Date.now(),
     },
   ];
 }
@@ -148,9 +160,46 @@ export function mergePending(
     status: 'pending',
     resolvedAt: null,
     note: null,
+    orderTs: r.requested_at ? Date.parse(r.requested_at) : Date.now(),
   }));
   // De-dup defensively: a row whose id already has a resolved card (decided in
   // the same instant the read raced) stays resolved, not re-pended.
   const resolvedIds = new Set(resolved.map((c) => c.requestId));
   return [...resolved, ...fromRows.filter((c) => !resolvedIds.has(c.requestId))];
+}
+
+/** Build the full card list from a conversation's authoritative approval record
+ *  (`GET /api/v1/conversations/{id}/approval-requests`).
+ *
+ *  Unlike {@link mergePending} (pending-only, for the inbox / reconnect), this
+ *  read carries *every* status plus `decided_at`, so the chat surface can
+ *  re-render resolved ✅/❌ cards inline on reload — not just in-flight ones.
+ *  `status` is taken verbatim from the row (the server is the source of truth),
+ *  `resolvedAt` is parsed from `decided_at` for terminal rows, and `orderTs` is
+ *  parsed from `requested_at` so the card lands in chronological position among
+ *  the persisted messages. `note` (the approver's typed reason) is client-only
+ *  and not persisted, so it is always null here. */
+export function cardsFromConversation(
+  rows: readonly PendingRow[],
+): ApprovalCard[] {
+  return rows.map((r) => {
+    const status = (r.status as ApprovalStatus) ?? 'pending';
+    const decidedAt = r.decided_at ?? null;
+    return {
+      requestId: r.request_id,
+      mcpServerName: r.mcp_server_name ?? null,
+      toolName: r.tool_name ?? null,
+      params: coerceParams(r.params),
+      coworkerId: r.coworker_id ?? null,
+      rationale: r.rationale ?? null,
+      requestedAt: r.requested_at ?? null,
+      expiresAt: r.expires_at ?? null,
+      actionSummary: r.action_summary ?? null,
+      status,
+      resolvedAt:
+        status !== 'pending' && decidedAt ? Date.parse(decidedAt) : null,
+      note: r.note ?? null,
+      orderTs: r.requested_at ? Date.parse(r.requested_at) : 0,
+    };
+  });
 }

--- a/web/src/components/approvals-inbox.test.ts
+++ b/web/src/components/approvals-inbox.test.ts
@@ -1,0 +1,494 @@
+// @vitest-environment happy-dom
+//
+// <rm-approvals-inbox> — adversarial coverage of the triage popover
+// (.hitl-ui/spec.md §4). The store lives IN the component (it self-fetches
+// the tenant-wide pending set); the chat card is the only decision surface,
+// so the inbox must never expose approve/reject nor emit a decision frame.
+//
+// Anti-mirror stance: we drive real DOM (clicks, property flips, document
+// events) and assert externally observable effects — fetch calls, emitted
+// events, scroll/highlight side effects — never the component's private
+// state. The pure helpers (paramsInline / formatCountdown / isUrgent) are
+// tested against the spec's stated truncation + threshold rules, including
+// the boundary cases the row rendering turns on.
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const listPendingSpy = vi.fn();
+
+vi.mock('../api/client.js', async () => {
+  const actual = await vi.importActual<typeof import('../api/client.js')>(
+    '../api/client.js',
+  );
+  return {
+    ...actual,
+    getApiClient: () => ({
+      listPendingApprovals: listPendingSpy,
+    }),
+  };
+});
+
+import {
+  ApprovalsInbox,
+  paramsInline,
+  formatCountdown,
+  isUrgent,
+} from './approvals-inbox.js';
+import type {
+  Conversation,
+  Coworker,
+  PendingApprovalRequest,
+} from '../api/client.js';
+
+// --- fixtures ---------------------------------------------------------------
+
+const COWORKER_OPS: Coworker = {
+  id: 'cw-ops',
+  tenant_id: 't1',
+  name: 'Ops',
+  folder: 'ops',
+  agent_backend: 'claude',
+} as unknown as Coworker;
+
+const COWORKER_LOG: Coworker = {
+  ...COWORKER_OPS,
+  id: 'cw-log',
+  name: 'Logistics',
+};
+
+const CONV_OPS: Conversation = {
+  id: 'conv-ops',
+  tenant_id: 't1',
+  coworker_id: 'cw-ops',
+  channel_binding_id: 'ch-1',
+  channel_chat_id: 'web:conv-ops',
+  name: 'Q2 ad spend review',
+  requires_trigger: true,
+  created_at: '2026-05-30T00:00:00Z',
+} as unknown as Conversation;
+
+/** Minutes-from-now as an ISO `expires_at`. A few seconds of slack keep
+ *  the floor-based countdown (`Xm left`) from rounding down under render
+ *  latency — e.g. exactly 18min would otherwise display "17m left". */
+function expiresInMin(mins: number): string {
+  return new Date(Date.now() + mins * 60_000 + 5_000).toISOString();
+}
+
+function req(
+  over: Partial<PendingApprovalRequest> & { request_id: string },
+): PendingApprovalRequest {
+  return {
+    conversation_id: 'conv-ops',
+    coworker_id: 'cw-ops',
+    mcp_server_name: 'amazon-ads-api',
+    tool_name: 'campaign.pause',
+    action_summary: null,
+    requested_at: new Date(Date.now() - 30_000).toISOString(),
+    expires_at: expiresInMin(18),
+    params: { campaign_id: 'SP-Auto-Hydration', account_id: 'ACME-PRIME' },
+    rationale: null,
+    ...over,
+  } as PendingApprovalRequest;
+}
+
+async function settle(el: ApprovalsInbox): Promise<void> {
+  for (let i = 0; i < 25; i += 1) {
+    await Promise.resolve();
+    await el.updateComplete;
+  }
+}
+
+interface MountOpts {
+  rows?: PendingApprovalRequest[];
+  open?: boolean;
+  coworkers?: Coworker[];
+  conversations?: Conversation[];
+  activeConversationId?: string | null;
+  jumpHandler?: ApprovalsInbox['jumpHandler'];
+  onCount?: (detail: { total: number; urgent: number }) => void;
+}
+
+async function mount(opts: MountOpts = {}): Promise<ApprovalsInbox> {
+  listPendingSpy.mockResolvedValue(opts.rows ?? []);
+  const el = document.createElement('rm-approvals-inbox') as ApprovalsInbox;
+  if (opts.onCount) {
+    el.addEventListener('approvals-count', (e) =>
+      opts.onCount!((e as CustomEvent).detail),
+    );
+  }
+  el.open = opts.open ?? false;
+  el.coworkers = opts.coworkers ?? [COWORKER_OPS, COWORKER_LOG];
+  el.conversations = opts.conversations ?? [CONV_OPS];
+  if (opts.activeConversationId !== undefined) {
+    el.activeConversationId = opts.activeConversationId;
+  }
+  if (opts.jumpHandler) el.jumpHandler = opts.jumpHandler;
+  document.body.appendChild(el);
+  await settle(el);
+  return el;
+}
+
+describe('paramsInline', () => {
+  it('joins up to the first 4 entries as k: v · …', () => {
+    const out = paramsInline({ a: 1, b: 'two', c: true, d: 'four', e: 'five' });
+    // Only the first four keys appear.
+    expect(out).toBe('a: 1 · b: two · c: true · d: four');
+    expect(out).not.toContain('e:');
+  });
+
+  it('truncates a long value at 30 chars + ellipsis (never silently drops it)', () => {
+    const long = 'x'.repeat(50);
+    const out = paramsInline({ text: long });
+    expect(out).toBe('text: ' + 'x'.repeat(30) + '…');
+  });
+
+  it('returns empty string for empty object, non-object, array, and null', () => {
+    expect(paramsInline({})).toBe('');
+    expect(paramsInline(null)).toBe('');
+    expect(paramsInline(undefined)).toBe('');
+    expect(paramsInline('nope')).toBe('');
+    expect(paramsInline([1, 2, 3])).toBe('');
+  });
+});
+
+describe('formatCountdown', () => {
+  const now = Date.parse('2026-06-01T12:00:00Z');
+  it('renders minutes when > 60s remain', () => {
+    expect(formatCountdown('2026-06-01T12:18:00Z', now)).toBe('18m left');
+  });
+  it('renders seconds under a minute', () => {
+    expect(formatCountdown('2026-06-01T12:00:42Z', now)).toBe('42s left');
+  });
+  it('renders "expired" at or past the deadline', () => {
+    expect(formatCountdown('2026-06-01T12:00:00Z', now)).toBe('expired');
+    expect(formatCountdown('2026-06-01T11:59:00Z', now)).toBe('expired');
+  });
+  it('drops a missing or unparseable timestamp', () => {
+    expect(formatCountdown(null, now)).toBe('');
+    expect(formatCountdown('not-a-date', now)).toBe('');
+  });
+});
+
+describe('isUrgent (badge / row threshold)', () => {
+  const now = Date.parse('2026-06-01T12:00:00Z');
+  it('is false at exactly 5 minutes out (boundary is strict <)', () => {
+    expect(isUrgent('2026-06-01T12:05:00Z', now)).toBe(false);
+  });
+  it('is true just inside 5 minutes', () => {
+    expect(isUrgent('2026-06-01T12:04:59Z', now)).toBe(true);
+  });
+  it('is true for an already-expired item', () => {
+    expect(isUrgent('2026-06-01T11:50:00Z', now)).toBe(true);
+  });
+  it('is false with no expiry', () => {
+    expect(isUrgent(null, now)).toBe(false);
+  });
+});
+
+describe('<rm-approvals-inbox> rendering', () => {
+  afterEach(() => {
+    document.querySelectorAll('rm-approvals-inbox').forEach((el) => el.remove());
+    listPendingSpy.mockReset();
+    vi.useRealTimers();
+  });
+
+  it('renders nothing in the DOM while closed', async () => {
+    const el = await mount({ open: false, rows: [req({ request_id: 'r1' })] });
+    expect(el.querySelector('[data-testid="approvals-panel"]')).toBeNull();
+  });
+
+  it('renders a row with coworker name, tool chip, conv title, countdown and params', async () => {
+    const el = await mount({
+      open: true,
+      rows: [req({ request_id: 'r1', expires_at: expiresInMin(18) })],
+    });
+    const row = el.querySelector('[data-testid="approvals-row"]')!;
+    expect(row).not.toBeNull();
+    expect(row.querySelector('.h')?.textContent).toContain('Ops coworker');
+    expect(
+      row.querySelector('[data-testid="approvals-row-tool"]')?.textContent,
+    ).toBe('amazon-ads-api.campaign.pause');
+    expect(row.querySelector('.m')?.textContent).toContain('Q2 ad spend review');
+    expect(
+      row.querySelector('[data-testid="approvals-row-countdown"]')?.textContent,
+    ).toBe('18m left');
+    expect(
+      row.querySelector('[data-testid="approvals-row-params"]')?.textContent,
+    ).toContain('campaign_id: SP-Auto-Hydration');
+    expect(
+      el.querySelector('[data-testid="approvals-row-open"]')?.textContent,
+    ).toContain('Open in chat');
+  });
+
+  it('omits the params-inline line when params is empty', async () => {
+    const el = await mount({
+      open: true,
+      rows: [req({ request_id: 'r1', params: {} })],
+    });
+    expect(el.querySelector('[data-testid="approvals-row-params"]')).toBeNull();
+  });
+
+  it('sorts rows by expires_at ascending (most urgent first), regardless of input order', async () => {
+    const el = await mount({
+      open: true,
+      rows: [
+        req({ request_id: 'mid', expires_at: expiresInMin(10) }),
+        req({ request_id: 'soon', expires_at: expiresInMin(3) }),
+        req({ request_id: 'far', expires_at: expiresInMin(18) }),
+      ],
+    });
+    const ids = Array.from(
+      el.querySelectorAll('[data-testid="approvals-row"]'),
+    ).map((r) => r.getAttribute('data-appr-row-id'));
+    expect(ids).toEqual(['soon', 'mid', 'far']);
+  });
+
+  it('marks a row urgent (data-urgent=true) when under 5 minutes', async () => {
+    const el = await mount({
+      open: true,
+      rows: [
+        req({ request_id: 'soon', expires_at: expiresInMin(3) }),
+        req({ request_id: 'calm', expires_at: expiresInMin(18) }),
+      ],
+    });
+    const byId = (id: string) =>
+      el
+        .querySelector(`[data-appr-row-id="${id}"]`)!
+        .querySelector('[data-testid="approvals-row-countdown"]')!
+        .getAttribute('data-urgent');
+    expect(byId('soon')).toBe('true');
+    expect(byId('calm')).toBe('false');
+  });
+
+  it('renders the empty state with the Activity pointer when nothing is pending', async () => {
+    const el = await mount({ open: true, rows: [] });
+    const empty = el.querySelector('[data-testid="approvals-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('Nothing waiting for you');
+    expect(empty?.textContent).toContain('Activity');
+    // No rows at all in the empty state.
+    expect(el.querySelector('[data-testid="approvals-row"]')).toBeNull();
+  });
+
+  it('shows the "N expiring soon" sub-heading only when something is urgent', async () => {
+    const calm = await mount({
+      open: true,
+      rows: [req({ request_id: 'r1', expires_at: expiresInMin(18) })],
+    });
+    expect(
+      calm.querySelector('[data-testid="approvals-urgent-note"]'),
+    ).toBeNull();
+    calm.remove();
+
+    const hot = await mount({
+      open: true,
+      rows: [
+        req({ request_id: 'r1', expires_at: expiresInMin(2) }),
+        req({ request_id: 'r2', expires_at: expiresInMin(18) }),
+      ],
+    });
+    expect(
+      hot.querySelector('[data-testid="approvals-urgent-note"]')?.textContent,
+    ).toContain('1 expiring soon');
+  });
+
+  it('falls back to a generic coworker label when the id is unknown', async () => {
+    const el = await mount({
+      open: true,
+      coworkers: [], // nothing to resolve against
+      rows: [req({ request_id: 'r1' })],
+    });
+    expect(el.querySelector('.h')?.textContent?.trim()).toMatch(/^Coworker/);
+  });
+});
+
+describe('<rm-approvals-inbox> badge count event', () => {
+  afterEach(() => {
+    document.querySelectorAll('rm-approvals-inbox').forEach((el) => el.remove());
+    listPendingSpy.mockReset();
+  });
+
+  it('emits {total, urgent} for the shell badge after a fetch', async () => {
+    const counts: Array<{ total: number; urgent: number }> = [];
+    await mount({
+      open: false,
+      rows: [
+        req({ request_id: 'r1', expires_at: expiresInMin(2) }), // urgent
+        req({ request_id: 'r2', expires_at: expiresInMin(18) }), // calm
+      ],
+      onCount: (d) => counts.push(d),
+    });
+    const last = counts.at(-1);
+    expect(last).toEqual({ total: 2, urgent: 1 });
+  });
+
+  it('emits a zero count when nothing is pending (clears a stale badge)', async () => {
+    const counts: Array<{ total: number; urgent: number }> = [];
+    await mount({ open: false, rows: [], onCount: (d) => counts.push(d) });
+    expect(counts.at(-1)).toEqual({ total: 0, urgent: 0 });
+  });
+});
+
+describe('<rm-approvals-inbox> re-fetch triggers (§4.8)', () => {
+  afterEach(() => {
+    document.querySelectorAll('rm-approvals-inbox').forEach((el) => el.remove());
+    listPendingSpy.mockReset();
+    vi.useRealTimers();
+  });
+
+  it('① opening the popover re-fetches', async () => {
+    const el = await mount({ open: false, rows: [] });
+    listPendingSpy.mockClear();
+    el.open = true;
+    await settle(el);
+    expect(listPendingSpy).toHaveBeenCalled();
+  });
+
+  it('② switching the active conversation re-fetches', async () => {
+    const el = await mount({ open: false, rows: [], activeConversationId: 'c1' });
+    listPendingSpy.mockClear();
+    el.activeConversationId = 'c2';
+    await settle(el);
+    expect(listPendingSpy).toHaveBeenCalled();
+  });
+
+  it('② does NOT re-fetch redundantly on the initial conversation assignment', async () => {
+    // The connectedCallback seed is the only fetch; the first
+    // activeConversationId set (undefined→value) must not double up.
+    listPendingSpy.mockResolvedValue([]);
+    const el = document.createElement('rm-approvals-inbox') as ApprovalsInbox;
+    el.activeConversationId = 'c1';
+    document.body.appendChild(el);
+    await settle(el);
+    expect(listPendingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('③ tab becoming visible re-fetches', async () => {
+    const el = await mount({ open: false, rows: [] });
+    listPendingSpy.mockClear();
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await settle(el);
+    expect(listPendingSpy).toHaveBeenCalled();
+  });
+
+  it('④ refresh() (the approval-activity surrogate) re-fetches', async () => {
+    const el = await mount({ open: false, rows: [] });
+    listPendingSpy.mockClear();
+    await el.refresh();
+    expect(listPendingSpy).toHaveBeenCalled();
+  });
+
+  it('does not stand up a high-frequency timer while CLOSED', async () => {
+    // Backstop: a closed inbox must not poll. We seed once on mount, then
+    // assert no further fetch lands across a generous window.
+    vi.useFakeTimers({ toFake: ['setInterval'] });
+    listPendingSpy.mockResolvedValue([]);
+    const el = document.createElement('rm-approvals-inbox') as ApprovalsInbox;
+    document.body.appendChild(el);
+    // Flush the connectedCallback seed.
+    await Promise.resolve();
+    const seedCalls = listPendingSpy.mock.calls.length;
+    vi.advanceTimersByTime(120_000); // 2 minutes of wall-clock
+    expect(listPendingSpy.mock.calls.length).toBe(seedCalls);
+    el.remove();
+  });
+});
+
+describe('<rm-approvals-inbox> jumpToConv (§4.7)', () => {
+  afterEach(() => {
+    document.querySelectorAll('rm-approvals-inbox').forEach((el) => el.remove());
+    document.querySelectorAll('[data-appr-id]').forEach((el) => el.remove());
+    listPendingSpy.mockReset();
+  });
+
+  it('asks the shell to switch coworker+conversation, then scrolls + highlights the card', async () => {
+    const jumpSpy = vi.fn(async (_convId: string | null, _cwId: string | null) => {
+      // The fake shell "switches" by materialising the target card in the
+      // document, exactly as the slotted chat-panel would after navigating.
+      const card = document.createElement('div');
+      card.setAttribute('data-appr-id', 'r1');
+      (card as unknown as { scrollIntoView: () => void }).scrollIntoView =
+        vi.fn();
+      document.body.appendChild(card);
+    });
+    const el = await mount({
+      open: true,
+      jumpHandler: jumpSpy,
+      rows: [
+        req({
+          request_id: 'r1',
+          conversation_id: 'conv-x',
+          coworker_id: 'cw-log',
+        }),
+      ],
+    });
+    const closes = vi.fn();
+    el.addEventListener('inbox-close', closes);
+
+    el.querySelector<HTMLElement>('[data-testid="approvals-row"]')!.click();
+    await settle(el);
+
+    expect(jumpSpy).toHaveBeenCalledWith('conv-x', 'cw-log');
+    expect(closes).toHaveBeenCalled();
+    const card = document.querySelector('[data-appr-id="r1"]')!;
+    expect(
+      (card as unknown as { scrollIntoView: ReturnType<typeof vi.fn> })
+        .scrollIntoView,
+    ).toHaveBeenCalled();
+    expect(card.classList.contains('rm-appr-highlight')).toBe(true);
+  });
+
+  it('the redundant "Open in chat" button jumps too (without double-bubbling the row click)', async () => {
+    const jumpSpy = vi.fn(async () => {});
+    const el = await mount({
+      open: true,
+      jumpHandler: jumpSpy,
+      rows: [req({ request_id: 'r1', conversation_id: 'conv-x' })],
+    });
+    el.querySelector<HTMLElement>('[data-testid="approvals-row-open"]')!.click();
+    await settle(el);
+    // Exactly one jump despite the button living inside the clickable row.
+    expect(jumpSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('<rm-approvals-inbox> is triage-only (never decides)', () => {
+  afterEach(() => {
+    document.querySelectorAll('rm-approvals-inbox').forEach((el) => el.remove());
+    listPendingSpy.mockReset();
+  });
+
+  it('renders no approve/reject controls', async () => {
+    const el = await mount({ open: true, rows: [req({ request_id: 'r1' })] });
+    expect(el.querySelector('[data-testid="approval-approve"]')).toBeNull();
+    expect(el.querySelector('[data-testid="approval-reject"]')).toBeNull();
+    // No <textarea> reject-note form leaks into the triage surface.
+    expect(el.querySelector('textarea')).toBeNull();
+  });
+
+  it('never emits an approval-decision frame when a row is actioned', async () => {
+    const el = await mount({
+      open: true,
+      jumpHandler: vi.fn(async () => {}),
+      rows: [req({ request_id: 'r1' })],
+    });
+    const decision = vi.fn();
+    el.addEventListener('approval-decision', decision);
+    // Both affordances: the row and the inner button.
+    el.querySelector<HTMLElement>('[data-testid="approvals-row"]')!.click();
+    el.querySelector<HTMLElement>('[data-testid="approvals-row-open"]')!.click();
+    await settle(el);
+    expect(decision).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/approvals-inbox.test.ts
+++ b/web/src/components/approvals-inbox.test.ts
@@ -44,7 +44,7 @@ import {
 import type {
   Conversation,
   Coworker,
-  PendingApprovalRequest,
+  ApprovalRequest,
 } from '../api/client.js';
 
 // --- fixtures ---------------------------------------------------------------
@@ -82,8 +82,8 @@ function expiresInMin(mins: number): string {
 }
 
 function req(
-  over: Partial<PendingApprovalRequest> & { request_id: string },
-): PendingApprovalRequest {
+  over: Partial<ApprovalRequest> & { request_id: string },
+): ApprovalRequest {
   return {
     conversation_id: 'conv-ops',
     coworker_id: 'cw-ops',
@@ -95,7 +95,7 @@ function req(
     params: { campaign_id: 'SP-Auto-Hydration', account_id: 'ACME-PRIME' },
     rationale: null,
     ...over,
-  } as PendingApprovalRequest;
+  } as ApprovalRequest;
 }
 
 async function settle(el: ApprovalsInbox): Promise<void> {
@@ -106,7 +106,7 @@ async function settle(el: ApprovalsInbox): Promise<void> {
 }
 
 interface MountOpts {
-  rows?: PendingApprovalRequest[];
+  rows?: ApprovalRequest[];
   open?: boolean;
   coworkers?: Coworker[];
   conversations?: Conversation[];

--- a/web/src/components/approvals-inbox.ts
+++ b/web/src/components/approvals-inbox.ts
@@ -5,7 +5,7 @@
 // it dispatches no `approval-decision` frame and renders no approve /
 // reject controls.
 //
-// State scope: the component self-holds its own `PendingApprovalRequest[]`
+// State scope: the component self-holds its own `ApprovalRequest[]`
 // fetched from `GET /api/v1/approval-requests` WITHOUT a conversation_id
 // filter (tenant-wide; RLS scopes to the user's tenant server-side). The
 // approval-store is deliberately NOT lifted to the shell — the inbox and
@@ -32,7 +32,7 @@ import {
   getApiClient,
   type Conversation,
   type Coworker,
-  type PendingApprovalRequest,
+  type ApprovalRequest,
 } from '../api/client.js';
 import { iconInbox } from './icons.js';
 
@@ -118,7 +118,7 @@ export class ApprovalsInbox extends LitElement {
 
   /** Tenant-wide pending set — the inbox's own store (NOT the chat
    *  panel's). */
-  @state() private requests: PendingApprovalRequest[] = [];
+  @state() private requests: ApprovalRequest[] = [];
   /** Re-read at 1Hz while open so the countdowns tick. */
   @state() private now = Date.now();
 
@@ -267,7 +267,7 @@ export class ApprovalsInbox extends LitElement {
    *  §4.7) scroll the matching card into view and pulse it. Cross-coworker
    *  jumps reload the page in the shell, so the scroll is best-effort there
    *  and authoritative for an already-loaded conversation. */
-  private async jumpToConv(req: PendingApprovalRequest): Promise<void> {
+  private async jumpToConv(req: ApprovalRequest): Promise<void> {
     // Tell the shell to close the popover (it owns `open`).
     this.dispatchEvent(
       new CustomEvent('inbox-close', { bubbles: true, composed: true }),
@@ -299,7 +299,7 @@ export class ApprovalsInbox extends LitElement {
 
   /** Ascending by `expires_at` — most urgent first (§4.5). A missing
    *  timestamp sorts last (it has no deadline pressure). */
-  private sorted(): PendingApprovalRequest[] {
+  private sorted(): ApprovalRequest[] {
     return [...this.requests].sort((a, b) => {
       const ta = a.expires_at ? Date.parse(a.expires_at) : Infinity;
       const tb = b.expires_at ? Date.parse(b.expires_at) : Infinity;
@@ -516,7 +516,7 @@ export class ApprovalsInbox extends LitElement {
     `;
   }
 
-  private renderRow(r: PendingApprovalRequest): TemplateResult {
+  private renderRow(r: ApprovalRequest): TemplateResult {
     const name = this.coworkerName(r.coworker_id);
     const tool = [r.mcp_server_name, r.tool_name].filter(Boolean).join('.');
     const title = this.conversationTitle(r.conversation_id);

--- a/web/src/components/approvals-inbox.ts
+++ b/web/src/components/approvals-inbox.ts
@@ -1,0 +1,587 @@
+// <rm-approvals-inbox> — top-bar popover surfacing every pending tool
+// approval across the current tenant the user is the approver for
+// (.hitl-ui/spec.md §4; Appendix C.2). Triage-only: a row navigates to
+// the chat where the decision card lives — the inbox NEVER decides, so
+// it dispatches no `approval-decision` frame and renders no approve /
+// reject controls.
+//
+// State scope: the component self-holds its own `PendingApprovalRequest[]`
+// fetched from `GET /api/v1/approval-requests` WITHOUT a conversation_id
+// filter (tenant-wide; RLS scopes to the user's tenant server-side). The
+// approval-store is deliberately NOT lifted to the shell — the inbox and
+// the chat panel each keep their own view; the inbox is fed by explicit
+// re-fetch triggers (§4.8 "Option A" minus the shared singleton):
+//
+//   1. popover open                  (willUpdate on `open` false→true)
+//   2. active conversation switch    (willUpdate on `activeConversationId`)
+//   3. tab becomes visible           (document `visibilitychange`)
+//   4. an `approval-activity` event  (the shell calls `refresh()`)
+//   + a ~30s slow poll WHILE OPEN only (cleared on close) as a backstop.
+//
+// There is no high-frequency standing timer — the badge is event-driven,
+// not polled.
+//
+// Light DOM (createRenderRoot → this) so the shell's design-token CSS and
+// the global highlight keyframe (defined in chat-shell) apply, matching
+// the other v2 surfaces.
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import {
+  getApiClient,
+  type Conversation,
+  type Coworker,
+  type PendingApprovalRequest,
+} from '../api/client.js';
+import { iconInbox } from './icons.js';
+
+/** Countdown turns urgent (deep red) under this many ms remaining (§4.1
+ *  / §4.3). Matches the chat card's 5-minute threshold. */
+const URGENT_MS = 5 * 60 * 1000;
+/** Slow backstop poll cadence while the popover is open (§4.8). */
+const POLL_MS = 30_000;
+/** Highlight pulse duration on the jumped-to card (§4.7). */
+const HIGHLIGHT_MS = 1800;
+
+/** Join up to the first 4 param entries as `k: v · k: v · …`, each value
+ *  stringified and truncated to 30 chars (§4.4 / Appendix C.2). A missing
+ *  or non-object `params` (or an empty object) collapses to '' so the row
+ *  omits the line. Exported for unit testing. */
+export function paramsInline(params: unknown): string {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) return '';
+  const entries = Object.entries(params as Record<string, unknown>);
+  if (entries.length === 0) return '';
+  return entries
+    .slice(0, 4)
+    .map(([k, v]) => {
+      let val = typeof v === 'string' ? v : JSON.stringify(v) ?? String(v);
+      if (val.length > 30) val = val.slice(0, 30) + '…';
+      return `${k}: ${val}`;
+    })
+    .join(' · ');
+}
+
+/** Countdown text from an ISO `expires_at` against `now` (epoch ms):
+ *  `Xm left` / `Xs left` / `expired` (Appendix C.2 `formatCountdown`).
+ *  An unparseable / missing timestamp yields '' so the row drops it.
+ *  Exported for unit testing. */
+export function formatCountdown(expiresAt: string | null, now: number): string {
+  if (!expiresAt) return '';
+  const exp = Date.parse(expiresAt);
+  if (Number.isNaN(exp)) return '';
+  const ms = exp - now;
+  if (ms <= 0) return 'expired';
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s left`;
+  return `${Math.floor(totalSec / 60)}m left`;
+}
+
+/** Is this request within the urgent window (or already past expiry)?
+ *  Exported for unit testing the badge threshold. */
+export function isUrgent(expiresAt: string | null, now: number): boolean {
+  if (!expiresAt) return false;
+  const exp = Date.parse(expiresAt);
+  if (Number.isNaN(exp)) return false;
+  return exp - now < URGENT_MS;
+}
+
+/** {total, urgent-count} emitted on the `approvals-count` event so the
+ *  shell can paint its badge without owning the store. */
+export interface ApprovalsCountDetail {
+  total: number;
+  urgent: number;
+}
+
+@customElement('rm-approvals-inbox')
+export class ApprovalsInbox extends LitElement {
+  /** Whether the popover panel is visible. Driven by the shell's top-bar
+   *  toggle (the shell owns which popover is open). */
+  @property({ type: Boolean }) open = false;
+  /** The chat panel's active conversation — a change is a re-fetch
+   *  trigger (§4.8). */
+  @property() activeConversationId: string | null = null;
+  /** Tenant coworkers, for `coworker_id → name` resolution (§8.3). */
+  @property({ attribute: false }) coworkers: Coworker[] = [];
+  /** Conversations known to the shell (active coworker's), for best-effort
+   *  `conversation_id → title` resolution on the row meta line. */
+  @property({ attribute: false }) conversations: Conversation[] = [];
+  /** Wired by the shell: switch sidebar coworker + open the conversation
+   *  the gated card lives in. Awaited before the inbox attempts to scroll
+   *  to and highlight the card (§4.7). */
+  @property({ attribute: false }) jumpHandler:
+    | ((
+        conversationId: string | null,
+        coworkerId: string | null,
+      ) => void | Promise<void>)
+    | null = null;
+
+  /** Tenant-wide pending set — the inbox's own store (NOT the chat
+   *  panel's). */
+  @state() private requests: PendingApprovalRequest[] = [];
+  /** Re-read at 1Hz while open so the countdowns tick. */
+  @state() private now = Date.now();
+
+  private readonly api = getApiClient();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private tickTimer: ReturnType<typeof setInterval> | null = null;
+  private highlightTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Last {total,urgent} dispatched, so we only emit on change. */
+  private lastCount: ApprovalsCountDetail | null = null;
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('visibilitychange', this.onVisibility);
+    // Seed the badge once on mount: the count must be visible before the
+    // user ever opens the popover.
+    void this.refresh();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('visibilitychange', this.onVisibility);
+    this.stopPoll();
+    this.stopTick();
+    if (this.highlightTimer != null) {
+      clearTimeout(this.highlightTimer);
+      this.highlightTimer = null;
+    }
+  }
+
+  protected override willUpdate(changed: Map<string, unknown>): void {
+    if (changed.has('open')) {
+      if (this.open) {
+        void this.refresh();
+        this.startPoll();
+        this.startTick();
+      } else {
+        this.stopPoll();
+        this.stopTick();
+      }
+    }
+    // Conversation switch — re-fetch, but skip the initial undefined→value
+    // assignment the shell makes on first paint (the connectedCallback
+    // seed already covers that, and double-fetching is wasteful).
+    if (
+      changed.has('activeConversationId') &&
+      changed.get('activeConversationId') !== undefined
+    ) {
+      void this.refresh();
+    }
+  }
+
+  // --- Triggers --------------------------------------------------------------
+
+  private onVisibility = (): void => {
+    if (document.visibilityState === 'visible') void this.refresh();
+  };
+
+  /** Re-fetch the tenant-wide pending set. Public so the shell can call it
+   *  on an `approval-activity` bubble from the chat panel. Failures are
+   *  swallowed (logged) — a stale list is better than a thrown render. */
+  async refresh(): Promise<void> {
+    try {
+      const rows = await this.api.listPendingApprovals();
+      this.requests = rows;
+      this.now = Date.now();
+      this.emitCount();
+    } catch (err) {
+      console.warn('approvals-inbox: listPendingApprovals failed', err);
+    }
+  }
+
+  private startPoll(): void {
+    if (this.pollTimer != null) return;
+    this.pollTimer = setInterval(() => void this.refresh(), POLL_MS);
+  }
+
+  private stopPoll(): void {
+    if (this.pollTimer != null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  private startTick(): void {
+    if (this.tickTimer != null) return;
+    this.tickTimer = setInterval(() => {
+      this.now = Date.now();
+      this.emitCount();
+    }, 1000);
+  }
+
+  private stopTick(): void {
+    if (this.tickTimer != null) {
+      clearInterval(this.tickTimer);
+      this.tickTimer = null;
+    }
+  }
+
+  /** Dispatch {total, urgent} to the shell badge, but only when it changes
+   *  — keeps the badge from re-rendering every 1Hz tick when nothing
+   *  crossed the urgency line. */
+  private emitCount(): void {
+    const total = this.requests.length;
+    const urgent = this.requests.filter((r) =>
+      isUrgent(r.expires_at ?? null, this.now),
+    ).length;
+    if (
+      this.lastCount &&
+      this.lastCount.total === total &&
+      this.lastCount.urgent === urgent
+    ) {
+      return;
+    }
+    this.lastCount = { total, urgent };
+    this.dispatchEvent(
+      new CustomEvent<ApprovalsCountDetail>('approvals-count', {
+        detail: { total, urgent },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  // --- Lookups ---------------------------------------------------------------
+
+  private coworkerName(id: string | null | undefined): string | null {
+    if (!id) return null;
+    return this.coworkers.find((c) => c.id === id)?.name ?? null;
+  }
+
+  private conversationTitle(id: string | null | undefined): string | null {
+    if (!id) return null;
+    const conv = this.conversations.find((c) => c.id === id);
+    const name = conv?.name?.trim();
+    return name ? name : null;
+  }
+
+  // --- Navigation (§4.7) -----------------------------------------------------
+
+  /** Triage tap: close the popover, ask the shell to switch coworker +
+   *  conversation, then (after our own update settles — NO setTimeout, per
+   *  §4.7) scroll the matching card into view and pulse it. Cross-coworker
+   *  jumps reload the page in the shell, so the scroll is best-effort there
+   *  and authoritative for an already-loaded conversation. */
+  private async jumpToConv(req: PendingApprovalRequest): Promise<void> {
+    // Tell the shell to close the popover (it owns `open`).
+    this.dispatchEvent(
+      new CustomEvent('inbox-close', { bubbles: true, composed: true }),
+    );
+    this.open = false;
+    if (this.jumpHandler) {
+      await this.jumpHandler(
+        req.conversation_id ?? null,
+        req.coworker_id ?? null,
+      );
+    }
+    await this.updateComplete;
+    const card = document.querySelector<HTMLElement>(
+      `[data-appr-id="${req.request_id}"]`,
+    );
+    if (!card) return;
+    if (typeof card.scrollIntoView === 'function') {
+      card.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+    card.classList.add('rm-appr-highlight');
+    if (this.highlightTimer != null) clearTimeout(this.highlightTimer);
+    this.highlightTimer = setTimeout(() => {
+      card.classList.remove('rm-appr-highlight');
+      this.highlightTimer = null;
+    }, HIGHLIGHT_MS);
+  }
+
+  // --- Render ----------------------------------------------------------------
+
+  /** Ascending by `expires_at` — most urgent first (§4.5). A missing
+   *  timestamp sorts last (it has no deadline pressure). */
+  private sorted(): PendingApprovalRequest[] {
+    return [...this.requests].sort((a, b) => {
+      const ta = a.expires_at ? Date.parse(a.expires_at) : Infinity;
+      const tb = b.expires_at ? Date.parse(b.expires_at) : Infinity;
+      return ta - tb;
+    });
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.open) return nothing;
+    const items = this.sorted();
+    const total = items.length;
+    const urgent = items.filter((r) =>
+      isUrgent(r.expires_at ?? null, this.now),
+    ).length;
+    let sub = 'all clear';
+    if (total > 0) {
+      sub = `${total} to review`;
+    }
+    return html`
+      <style>
+        rm-approvals-inbox .appr-panel {
+          position: absolute;
+          z-index: 50;
+          top: calc(100% + 8px);
+          right: 0;
+          width: 380px;
+          max-height: 70vh;
+          overflow-y: auto;
+          background: var(--rm-surface);
+          border: 1px solid var(--rm-border-2);
+          border-radius: var(--rm-r);
+          box-shadow: var(--rm-shadow-md);
+          animation: rm-pop 0.12s ease both;
+        }
+        rm-approvals-inbox .appr-hd {
+          padding: 13px 15px;
+          border-bottom: 1px solid var(--rm-border);
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--rm-ink);
+        }
+        rm-approvals-inbox .appr-hd small {
+          font-weight: 400;
+          color: var(--rm-ink-3);
+          margin-left: 6px;
+        }
+        rm-approvals-inbox .appr-hd .hd-urgent {
+          color: var(--rm-bad);
+          font-weight: 500;
+        }
+        rm-approvals-inbox .appr-item {
+          padding: 12px 15px;
+          border-bottom: 1px solid var(--rm-border);
+          cursor: pointer;
+          transition: background 0.1s;
+          width: 100%;
+          text-align: left;
+          background: none;
+          border-left: none;
+          border-right: none;
+          border-top: none;
+          color: inherit;
+          font-family: inherit;
+          display: block;
+        }
+        rm-approvals-inbox .appr-item:hover {
+          background: var(--rm-surface-2);
+        }
+        rm-approvals-inbox .appr-item:last-of-type {
+          border-bottom: none;
+        }
+        rm-approvals-inbox .appr-item .h {
+          font-size: 13.5px;
+          font-weight: 500;
+          color: var(--rm-ink);
+          margin: 0 0 3px;
+          line-height: 1.4;
+          display: flex;
+          align-items: center;
+          flex-wrap: wrap;
+          gap: 2px;
+        }
+        rm-approvals-inbox .appr-item .toolname {
+          font-family: var(--rm-font-mono, monospace);
+          font-size: 11px;
+          color: var(--rm-ink-2);
+          background: rgba(0, 0, 0, 0.05);
+          padding: 1px 6px;
+          border-radius: 4px;
+          margin-left: 6px;
+          font-weight: 400;
+        }
+        rm-approvals-inbox .appr-item .m {
+          font-size: 11.5px;
+          color: var(--rm-ink-3);
+          margin: 0 0 8px;
+          line-height: 1.5;
+        }
+        rm-approvals-inbox .appr-item .exp {
+          font-variant-numeric: tabular-nums;
+        }
+        rm-approvals-inbox .appr-item .exp.urgent {
+          color: var(--rm-bad);
+          font-weight: 600;
+        }
+        rm-approvals-inbox .appr-item .params-inline {
+          font-size: 11.5px;
+          color: var(--rm-ink-3);
+          font-family: var(--rm-font-mono, monospace);
+          line-height: 1.45;
+          margin: 0 0 9px;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+          word-break: break-word;
+        }
+        rm-approvals-inbox .appr-item .a {
+          display: flex;
+        }
+        rm-approvals-inbox .appr-item .a .btn-review {
+          flex: 1;
+          padding: 5px 12px;
+          border-radius: 7px;
+          font-size: 12.5px;
+          font-weight: 500;
+          border: 1px solid var(--rm-border-2);
+          background: var(--rm-surface-2);
+          color: var(--rm-ink-2);
+          cursor: pointer;
+          font-family: inherit;
+          text-align: center;
+          transition: 0.13s;
+        }
+        rm-approvals-inbox .appr-item .a .btn-review:hover {
+          border-color: var(--rm-accent);
+          color: var(--rm-ink);
+        }
+        rm-approvals-inbox .appr-empty {
+          padding: 36px 24px 32px;
+          text-align: center;
+        }
+        rm-approvals-inbox .appr-empty .empty-check {
+          width: 42px;
+          height: 42px;
+          border-radius: 50%;
+          background: var(--rm-good-subtle, rgba(47, 125, 91, 0.12));
+          color: var(--rm-good);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 0 auto 12px;
+        }
+        rm-approvals-inbox .appr-empty p {
+          font-size: 13.5px;
+          color: var(--rm-ink-2);
+          margin: 0 0 4px;
+          line-height: 1.5;
+        }
+        rm-approvals-inbox .appr-empty .empty-sub {
+          font-size: 12px;
+          color: var(--rm-ink-3);
+        }
+        rm-approvals-inbox .appr-foot {
+          padding: 9px 14px 11px;
+          border-top: 1px solid var(--rm-border-2);
+          font-size: 11.5px;
+          color: var(--rm-ink-3);
+          text-align: center;
+        }
+      </style>
+      <div class="appr-panel" data-menu="approvals" role="dialog" aria-label="Approvals inbox" data-testid="approvals-panel">
+        <div class="appr-hd" data-testid="approvals-heading">
+          Approvals
+          <small>
+            ${total === 0
+              ? sub
+              : html`${total} to review${urgent > 0
+                  ? html` ·
+                      <span class="hd-urgent" data-testid="approvals-urgent-note"
+                        >${urgent} expiring soon</span
+                      >`
+                  : nothing}`}
+          </small>
+        </div>
+        ${total === 0
+          ? this.renderEmpty()
+          : items.map((r) => this.renderRow(r))}
+        <div class="appr-foot">Updates live as coworkers request approvals.</div>
+      </div>
+    `;
+  }
+
+  private renderEmpty(): TemplateResult {
+    return html`
+      <div class="appr-empty" data-testid="approvals-empty">
+        <div class="empty-check">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            aria-hidden="true"
+          >
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </div>
+        <p>Nothing waiting for you.</p>
+        <p class="empty-sub">Decisions you've made show up in Activity.</p>
+      </div>
+    `;
+  }
+
+  private renderRow(r: PendingApprovalRequest): TemplateResult {
+    const name = this.coworkerName(r.coworker_id);
+    const tool = [r.mcp_server_name, r.tool_name].filter(Boolean).join('.');
+    const title = this.conversationTitle(r.conversation_id);
+    const cd = formatCountdown(r.expires_at ?? null, this.now);
+    const urgent = isUrgent(r.expires_at ?? null, this.now);
+    const inline = paramsInline(r.params);
+    return html`
+      <div
+        class="appr-item"
+        role="button"
+        tabindex="0"
+        data-testid="approvals-row"
+        data-appr-row-id=${r.request_id}
+        @click=${() => void this.jumpToConv(r)}
+        @keydown=${(e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            void this.jumpToConv(r);
+          }
+        }}
+      >
+        <div class="h">
+          ${name ? `${name} coworker` : 'Coworker'}
+          ${tool
+            ? html`<span class="toolname" data-testid="approvals-row-tool"
+                >${tool}</span
+              >`
+            : nothing}
+        </div>
+        <div class="m">
+          ${title ? html`"${title}" · ` : nothing}
+          ${cd
+            ? html`<span
+                class="exp ${urgent ? 'urgent' : ''}"
+                data-testid="approvals-row-countdown"
+                data-urgent=${urgent ? 'true' : 'false'}
+                >${cd}</span
+              >`
+            : nothing}
+        </div>
+        ${inline
+          ? html`<div class="params-inline" data-testid="approvals-row-params">
+              ${inline}
+            </div>`
+          : nothing}
+        <div class="a">
+          <button
+            type="button"
+            class="btn-review"
+            data-testid="approvals-row-open"
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              void this.jumpToConv(r);
+            }}
+          >
+            Open in chat →
+          </button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rm-approvals-inbox': ApprovalsInbox;
+  }
+}

--- a/web/src/components/chat-panel.test.ts
+++ b/web/src/components/chat-panel.test.ts
@@ -159,6 +159,8 @@ describe('ChatPanel — side-channel events (PR #38)', () => {
     expect(i.messages[1]).toEqual({
       role: 'assistant',
       content: '⏰ 2 minutes up!',
+      // Ordering key parsed from the event's own server timestamp.
+      timestamp: Date.parse('2026-05-31T12:00:00+00:00'),
     });
     // Side-channel push must NOT touch run state — there's no
     // user-initiated run associated with a scheduled-task reminder.

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -282,6 +282,16 @@ export class ChatPanel extends LitElement {
     this.v1.sendApprovalDecision(detail.requestId, detail.decision, detail.note);
   }
 
+  /** Bubble a tenant-scope "something changed in approvals" signal so the
+   *  top-bar inbox (which keeps its own cross-conversation store) can
+   *  re-pull. `composed` lets it cross the shadow boundary if a future
+   *  host shadow-roots the panel; today both live in light DOM. */
+  private emitApprovalActivity(): void {
+    this.dispatchEvent(
+      new CustomEvent('approval-activity', { bubbles: true, composed: true }),
+    );
+  }
+
   private handleV1Event(e: ServerEvent): void {
     if (this.runState === 'running') this.resetRunningWatchdog();
     switch (e.type) {
@@ -381,12 +391,15 @@ export class ChatPanel extends LitElement {
           this.approvals,
           e as ApprovalRequestedEvent,
         );
+        // Nudge the cross-conversation inbox to re-pull (§4.8 trigger C).
+        this.emitApprovalActivity();
         break;
       }
       case 'event.approval.resolved': {
         const ev = e as ApprovalResolvedEvent;
         this.approvals = applyResolved(this.approvals, ev);
         this.approvalInflight.delete(ev.request_id);
+        this.emitApprovalActivity();
         break;
       }
       case 'event.run.error': {

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -771,8 +771,14 @@ export class ChatPanel extends LitElement {
           <div class="flex-1 overflow-y-auto" id="scroll-area">
             <div class="max-w-[720px] mx-auto w-full">
               ${this.messages.length === 0 ? this.renderEmpty() : ''}
-              <rm-message-list .messages=${this.messages}></rm-message-list>
-              ${this.renderApprovals()}
+              <rm-message-list
+                .messages=${this.messages}
+                .approvals=${this.approvals}
+                .approvalBusy=${this.approvalInflight}
+                .coworkerName=${this.activeCoworkerName}
+                @approval-decision=${(e: CustomEvent<ApprovalDecisionDetail>) =>
+                  this.handleApprovalDecision(e.detail)}
+              ></rm-message-list>
               ${this.messages.length > 0 || this.approvals.length > 0
                 ? html`<div class="h-8"></div>`
                 : ''}
@@ -804,40 +810,6 @@ export class ChatPanel extends LitElement {
             </div>
           </div>
         </div>
-      </div>
-    `;
-  }
-
-  /** Render the in-flight HITL approval cards (if any). Each card emits an
-   *  `approval-decision` CustomEvent that we relay to the WS frame. */
-  private renderApprovals() {
-    if (this.approvals.length === 0) return '';
-    return html`
-      <div
-        class="px-4"
-        data-testid="approval-region"
-        @approval-decision=${(e: CustomEvent<ApprovalDecisionDetail>) =>
-          this.handleApprovalDecision(e.detail)}
-      >
-        ${this.approvals.map(
-          (c) => html`
-            <rm-approval-card
-              .requestId=${c.requestId}
-              .actionSummary=${c.actionSummary}
-              .status=${c.status}
-              .mcpServerName=${c.mcpServerName}
-              .toolName=${c.toolName}
-              .params=${c.params}
-              .rationale=${c.rationale}
-              .requestedAt=${c.requestedAt}
-              .expiresAt=${c.expiresAt}
-              .coworkerName=${this.activeCoworkerName}
-              .resolvedAt=${c.resolvedAt}
-              .note=${c.note}
-              .busy=${this.approvalInflight.has(c.requestId)}
-            ></rm-approval-card>
-          `,
-        )}
       </div>
     `;
   }

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -34,7 +34,7 @@ import type { ApprovalDecisionDetail } from './approval-card.js';
 import {
   type ApprovalCard,
   applyResolved,
-  mergePending,
+  cardsFromConversation,
   upsertRequested,
 } from './approval-store.js';
 
@@ -53,6 +53,14 @@ export interface ChatMessage {
   streaming?: boolean;
   safetyStage?: string;
   safetyRuleId?: string;
+  /** Ordering key (epoch ms) for chronological interleave with approval cards.
+   *  Stamped with the wall clock when the bubble first gets *content* (live), or
+   *  parsed from the server `timestamp` on reload. An empty streaming
+   *  placeholder is stamped at creation and re-stamped on its first token, so a
+   *  post-approval confirmation sorts after the approval card that gated it
+   *  rather than before (the placeholder is born before the card, but its
+   *  content arrives after). Mirrors `ApprovalCard.orderTs`. */
+  timestamp: number;
 }
 
 type RunState = 'idle' | 'running' | 'stopping' | 'cancelling';
@@ -198,6 +206,11 @@ export class ChatPanel extends LitElement {
         .map((m) => ({
           role: m.role === 'assistant' ? 'assistant' : 'user',
           content: m.content,
+          // Server timestamp is the ordering key on reload so persisted
+          // messages interleave correctly with the conversation's resolved
+          // approval cards (both server-clock). Falls back to 0 for the rare
+          // row with no timestamp, which keeps it at the very top.
+          timestamp: m.timestamp ? Date.parse(m.timestamp) : 0,
         }));
     } catch (err) {
       console.warn('listMessages failed', err);
@@ -228,6 +241,10 @@ export class ChatPanel extends LitElement {
     void this.v1.connect();
 
     await this.loadMessages(conversationId);
+    // Re-render the conversation's full approval record (pending + resolved)
+    // inline. Without this, a reload showed messages only — resolved ✅/❌
+    // cards vanished — and a fresh load had no cards until the first live push.
+    await this.refreshApprovals(conversationId);
   }
 
   private teardownV1(): void {
@@ -240,25 +257,37 @@ export class ChatPanel extends LitElement {
   private handleV1Status(s: ConnectionStatus): void {
     const wasConnected = this.connected;
     this.connected = s === 'open';
-    // On (re)connect, re-render in-flight approval cards from the
-    // authoritative DB rows — the live `event.approval.requested` push is
-    // fire-and-forget, so a card that arrived while the socket was down (or
-    // before a reload) is only recoverable via this read (§10 S5).
+    // On (re)connect, re-render approval cards from the authoritative DB rows —
+    // the live `event.approval.requested`/`resolved` pushes are fire-and-forget,
+    // so a card raised (or decided) while the socket was down is only
+    // recoverable via this read (§10 S5).
     if (this.connected && !wasConnected) {
-      void this.refreshPendingApprovals();
+      void this.refreshApprovals(this.activeConversationId);
     }
   }
 
-  private async refreshPendingApprovals(): Promise<void> {
-    const conversationId = this.activeConversationId;
+  /** Rebuild the card list from the conversation's full approval record
+   *  (pending + resolved, oldest-first). The server is the source of truth for
+   *  status / timestamps; we preserve only the client-side rejection `note`
+   *  (never persisted) by carrying it over from the matching in-memory card. */
+  private async refreshApprovals(conversationId: string | null): Promise<void> {
     if (!conversationId) return;
     try {
-      const rows = await this.api.listPendingApprovals(conversationId);
+      const rows = await this.api.listConversationApprovals(conversationId);
       // Guard against a conversation switch mid-flight.
       if (this.activeConversationId !== conversationId) return;
-      this.approvals = mergePending(this.approvals, rows);
+      const localNotes = new Map(
+        this.approvals
+          .filter((c) => c.note)
+          .map((c) => [c.requestId, c.note] as const),
+      );
+      this.approvals = cardsFromConversation(rows).map((c) =>
+        localNotes.has(c.requestId)
+          ? { ...c, note: localNotes.get(c.requestId) ?? null }
+          : c,
+      );
     } catch (err) {
-      console.warn('listPendingApprovals failed', err);
+      console.warn('listConversationApprovals failed', err);
     }
   }
 
@@ -307,7 +336,9 @@ export class ChatPanel extends LitElement {
         if (!hasPlaceholder) {
           this.messages = [
             ...this.messages,
-            { role: 'assistant', content: '', streaming: true },
+            // Provisional stamp; re-stamped when the first token lands so a
+            // post-approval confirmation sorts after its gating card.
+            { role: 'assistant', content: '', streaming: true, timestamp: Date.now() },
           ];
         }
         this.agentStatus = { label: 'Thinking…' };
@@ -324,12 +355,18 @@ export class ChatPanel extends LitElement {
         if (last?.role === 'assistant' && last.streaming) {
           this.messages = [
             ...this.messages.slice(0, -1),
-            { ...last, content: last.content + delta },
+            {
+              ...last,
+              content: last.content + delta,
+              // First token into an empty placeholder: re-stamp to now so a
+              // confirmation gated by an approval sorts after that card.
+              timestamp: last.content ? last.timestamp : Date.now(),
+            },
           ];
         } else {
           this.messages = [
             ...this.messages,
-            { role: 'assistant', content: delta, streaming: true },
+            { role: 'assistant', content: delta, streaming: true, timestamp: Date.now() },
           ];
         }
         break;
@@ -376,10 +413,19 @@ export class ChatPanel extends LitElement {
           typeof (e as { content?: unknown }).content === 'string'
             ? (e as { content: string }).content
             : '';
+        // The side-channel push carries its own server timestamp; honour it so
+        // an out-of-band reminder lands in chronological position rather than
+        // always at "now" (matters on reload, where it sits among server-
+        // stamped history).
+        const appendedAt = (e as { timestamp?: unknown }).timestamp;
+        const ts =
+          typeof appendedAt === 'string' && appendedAt
+            ? Date.parse(appendedAt)
+            : Date.now();
         if (content) {
           this.messages = [
             ...this.messages,
-            { role: 'assistant', content },
+            { role: 'assistant', content, timestamp: ts },
           ];
         }
         break;
@@ -423,6 +469,7 @@ export class ChatPanel extends LitElement {
               typeof details.stage === 'string' ? details.stage : 'unknown',
             safetyRuleId:
               typeof details.rule_id === 'string' ? details.rule_id : undefined,
+            timestamp: Date.now(),
           };
           if (last?.role === 'assistant' && last.streaming && !last.content) {
             this.messages = [...this.messages.slice(0, -1), safetyMsg];
@@ -433,12 +480,17 @@ export class ChatPanel extends LitElement {
           if (last?.role === 'assistant' && last.streaming && !last.content) {
             this.messages = [
               ...this.messages.slice(0, -1),
-              { ...last, content: `**Error:** ${message}`, streaming: false },
+              {
+                ...last,
+                content: `**Error:** ${message}`,
+                streaming: false,
+                timestamp: Date.now(),
+              },
             ];
           } else {
             this.messages = [
               ...this.messages,
-              { role: 'assistant', content: `**Error:** ${message}` },
+              { role: 'assistant', content: `**Error:** ${message}`, timestamp: Date.now() },
             ];
           }
         }
@@ -591,7 +643,11 @@ export class ChatPanel extends LitElement {
       if (err instanceof ApiError) {
         this.messages = [
           ...this.messages,
-          { role: 'assistant', content: `**Error:** cancel failed (${err.message})` },
+          {
+            role: 'assistant',
+            content: `**Error:** cancel failed (${err.message})`,
+            timestamp: Date.now(),
+          },
         ];
       }
       this.runState = 'running';
@@ -619,7 +675,11 @@ export class ChatPanel extends LitElement {
         console.warn('createCoworkerConversation failed', err);
         this.messages = [
           ...this.messages,
-          { role: 'assistant', content: '**Error:** could not create conversation' },
+          {
+            role: 'assistant',
+            content: '**Error:** could not create conversation',
+            timestamp: Date.now(),
+          },
         ];
         return;
       }
@@ -640,7 +700,7 @@ export class ChatPanel extends LitElement {
       }
     }
 
-    this.messages = [...this.messages, { role: 'user', content: text }];
+    this.messages = [...this.messages, { role: 'user', content: text, timestamp: Date.now() }];
     // Reset terminal flag so Stop/Cancel re-enable for the new run.
     this.runTerminal = false;
     this.runState = 'running';

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -270,8 +270,16 @@ export class ChatPanel extends LitElement {
     if (!this.v1) return;
     if (this.approvalInflight.has(detail.requestId)) return;
     this.approvalInflight.add(detail.requestId);
+    // Stash the rejection note locally so the resolved card can echo it back
+    // ("YOUR REASON", §3.6) — the note never returns on the resolved event.
+    if (detail.decision === 'reject' && detail.note) {
+      const note = detail.note;
+      this.approvals = this.approvals.map((c) =>
+        c.requestId === detail.requestId ? { ...c, note } : c,
+      );
+    }
     this.requestUpdate();
-    this.v1.sendApprovalDecision(detail.requestId, detail.decision);
+    this.v1.sendApprovalDecision(detail.requestId, detail.decision, detail.note);
   }
 
   private handleV1Event(e: ServerEvent): void {
@@ -804,6 +812,15 @@ export class ChatPanel extends LitElement {
               .requestId=${c.requestId}
               .actionSummary=${c.actionSummary}
               .status=${c.status}
+              .mcpServerName=${c.mcpServerName}
+              .toolName=${c.toolName}
+              .params=${c.params}
+              .rationale=${c.rationale}
+              .requestedAt=${c.requestedAt}
+              .expiresAt=${c.expiresAt}
+              .coworkerName=${this.activeCoworkerName}
+              .resolvedAt=${c.resolvedAt}
+              .note=${c.note}
               .busy=${this.approvalInflight.has(c.requestId)}
             ></rm-approval-card>
           `,

--- a/web/src/components/chat-shell.test.ts
+++ b/web/src/components/chat-shell.test.ts
@@ -33,6 +33,7 @@ const listConvsSpy = vi.fn();
 const listMessagesSpy = vi.fn();
 const createConvSpy = vi.fn();
 const listModelsSpy = vi.fn();
+const listPendingApprovalsSpy = vi.fn();
 
 vi.mock('../api/client.js', async () => {
   const actual = await vi.importActual<typeof import('../api/client.js')>(
@@ -47,6 +48,8 @@ vi.mock('../api/client.js', async () => {
       listMessages: listMessagesSpy,
       createCoworkerConversation: createConvSpy,
       listModels: listModelsSpy,
+      // The slotted <rm-approvals-inbox> self-fetches on mount.
+      listPendingApprovals: listPendingApprovalsSpy,
       setToken: vi.fn(),
     }),
   };
@@ -252,7 +255,9 @@ describe('<rm-chat-shell>', () => {
       listMessagesSpy,
       createConvSpy,
       listModelsSpy,
+      listPendingApprovalsSpy,
     ].forEach((s) => s.mockReset());
+    listPendingApprovalsSpy.mockResolvedValue([]);
     listCoworkersSpy.mockResolvedValue([COWORKER_A, COWORKER_B]);
     getMeSpy.mockResolvedValue(ME);
     listConvsSpy.mockResolvedValue([
@@ -505,6 +510,93 @@ describe('<rm-chat-shell>', () => {
       '[data-testid="topbar-settings"]',
     )!.click();
     expect(loc.hashAssignments).toEqual(['#/manage/coworkers']);
+  });
+
+  describe('approvals inbox integration', () => {
+    it('renders an approvals trigger in the top-bar icon strip', async () => {
+      const el = await mountShell();
+      expect(
+        el.querySelector('[data-testid="topbar-approvals"]'),
+      ).not.toBeNull();
+      // It is NOT a hash-route button — it toggles a popover, so it must
+      // not navigate.
+      el.querySelector<HTMLButtonElement>(
+        '[data-testid="topbar-approvals"]',
+      )!.click();
+      expect(loc.hashAssignments).toEqual([]);
+    });
+
+    it('clicking the trigger opens the inbox panel; clicking again closes it', async () => {
+      const el = await mountShell();
+      // Closed by default — the inbox renders nothing.
+      expect(el.querySelector('[data-testid="approvals-panel"]')).toBeNull();
+      const btn = el.querySelector<HTMLButtonElement>(
+        '[data-testid="topbar-approvals"]',
+      )!;
+      btn.click();
+      await settle(el);
+      expect(
+        el.querySelector('[data-testid="approvals-panel"]'),
+      ).not.toBeNull();
+      btn.click();
+      await settle(el);
+      expect(el.querySelector('[data-testid="approvals-panel"]')).toBeNull();
+    });
+
+    it('no badge when the inbox reports zero pending', async () => {
+      const el = await mountShell();
+      expect(el.querySelector('[data-testid="approvals-badge"]')).toBeNull();
+    });
+
+    it('paints a badge with the pending count from the inbox count event', async () => {
+      const el = await mountShell();
+      const inbox = el.querySelector('rm-approvals-inbox')!;
+      inbox.dispatchEvent(
+        new CustomEvent('approvals-count', {
+          detail: { total: 3, urgent: 0 },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      await settle(el);
+      const badge = el.querySelector('[data-testid="approvals-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent?.trim()).toBe('3');
+      expect(badge?.getAttribute('data-urgent')).toBe('false');
+    });
+
+    it('deepens the badge (data-urgent) when at least one item is expiring soon', async () => {
+      const el = await mountShell();
+      const inbox = el.querySelector('rm-approvals-inbox')!;
+      inbox.dispatchEvent(
+        new CustomEvent('approvals-count', {
+          detail: { total: 2, urgent: 1 },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      await settle(el);
+      expect(
+        el
+          .querySelector('[data-testid="approvals-badge"]')
+          ?.getAttribute('data-urgent'),
+      ).toBe('true');
+    });
+
+    it('re-pulls the inbox when the chat-panel bubbles approval-activity', async () => {
+      const el = await mountShell();
+      // The inbox already seeded once on mount; isolate the trigger.
+      listPendingApprovalsSpy.mockClear();
+      // chat-panel dispatches this bubbling+composed on requested/resolved.
+      el.querySelector('rm-chat-panel')!.dispatchEvent(
+        new CustomEvent('approval-activity', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      await settle(el);
+      expect(listPendingApprovalsSpy).toHaveBeenCalled();
+    });
   });
 
   it('clicking a conversation row navigates with a new ?chat_id', async () => {

--- a/web/src/components/chat-shell.ts
+++ b/web/src/components/chat-shell.ts
@@ -49,11 +49,17 @@ import {
 import { connectionState } from '../ws/connection-state.js';
 import { clearToken } from '../services/oidc-auth.js';
 import './chat-panel.js';
+import './approvals-inbox.js';
+import type {
+  ApprovalsCountDetail,
+  ApprovalsInbox,
+} from './approvals-inbox.js';
 import './reauth-banner.js';
 import {
   iconActivity,
   iconChevronDown,
   iconClose,
+  iconInbox,
   iconLogout,
   iconPlus,
   iconSearch,
@@ -183,7 +189,12 @@ export class RmChatShell extends LitElement {
   @state() private bootstrapped = false;
   /** Which popover, if any, is open. Only one at a time to keep
    *  keyboard handling simple. */
-  @state() private openMenu: '' | 'coworker' | 'user' = '';
+  @state() private openMenu: '' | 'coworker' | 'user' | 'approvals' = '';
+  /** Pending-approval count for the top-bar badge, fed by the inbox's
+   *  `approvals-count` event (the inbox owns the store — §4.8). `urgent`
+   *  flags ≥1 item under the 5-minute expiry line so the badge deepens. */
+  @state() private approvalTotal = 0;
+  @state() private approvalUrgent = false;
   /** Sidebar conversation-list search. Toggled by the "Search
    *  conversations" button; clearing or closing restores the full
    *  list. Filtering is purely client-side over the already-fetched
@@ -228,6 +239,13 @@ export class RmChatShell extends LitElement {
     void this.bootstrap();
     document.addEventListener('click', this.onDocumentClick, true);
     this.addEventListener('agent-connection', this.onAgentConnection);
+    // Approvals inbox plumbing (§4): the inbox owns its own store and
+    // bubbles {total,urgent} for the badge; it asks us to close the
+    // popover on a row jump; and the chat-panel bubbles `approval-activity`
+    // whenever a card is requested/resolved so we re-pull the inbox.
+    this.addEventListener('approvals-count', this.onApprovalsCount as EventListener);
+    this.addEventListener('inbox-close', this.onInboxClose);
+    this.addEventListener('approval-activity', this.onApprovalActivity);
     // Subscribe to the aggregate ConnectionState so any WS client
     // flipping open/closed directly drives the top-bar dot — even if
     // the message-editor's agent-connection relay misses an edge.
@@ -241,6 +259,9 @@ export class RmChatShell extends LitElement {
     super.disconnectedCallback();
     document.removeEventListener('click', this.onDocumentClick, true);
     this.removeEventListener('agent-connection', this.onAgentConnection);
+    this.removeEventListener('approvals-count', this.onApprovalsCount as EventListener);
+    this.removeEventListener('inbox-close', this.onInboxClose);
+    this.removeEventListener('approval-activity', this.onApprovalActivity);
     this.connStateUnsub?.();
     this.connStateUnsub = null;
   }
@@ -249,6 +270,44 @@ export class RmChatShell extends LitElement {
     const detail = (e as CustomEvent<{ connected: boolean }>).detail;
     if (detail && typeof detail.connected === 'boolean') {
       this.agentConnected = detail.connected;
+    }
+  };
+
+  private onApprovalsCount = (e: CustomEvent<ApprovalsCountDetail>): void => {
+    this.approvalTotal = e.detail.total;
+    this.approvalUrgent = e.detail.urgent > 0;
+  };
+
+  private onInboxClose = (): void => {
+    if (this.openMenu === 'approvals') this.openMenu = '';
+  };
+
+  /** A chat-panel approval card was requested/resolved — re-pull the
+   *  inbox so the badge + list reflect the change without waiting for the
+   *  next open or poll. */
+  private onApprovalActivity = (): void => {
+    void this.querySelector<ApprovalsInbox>('rm-approvals-inbox')?.refresh();
+  };
+
+  private toggleApprovals = (): void => {
+    this.openMenu = this.openMenu === 'approvals' ? '' : 'approvals';
+  };
+
+  /** Wired into the inbox: switch sidebar coworker + open the gated
+   *  conversation. Cross-coworker / cross-conversation jumps full-reload
+   *  via the existing navigation (chat-panel reads URL params in its
+   *  constructor); a jump to the already-active conversation is a no-op
+   *  here and the inbox just scrolls to the card in place (§4.7). */
+  private jumpToConversation = async (
+    conversationId: string | null,
+    coworkerId: string | null,
+  ): Promise<void> => {
+    if (coworkerId && coworkerId !== this.activeCoworkerId) {
+      location.href = this.buildHref(coworkerId, conversationId);
+      return;
+    }
+    if (conversationId && conversationId !== this.activeConversationId) {
+      this.navigateConversation(conversationId);
     }
   };
 
@@ -915,6 +974,36 @@ export class RmChatShell extends LitElement {
           display: grid;
           place-items: center;
         }
+        /* Deeper red when any pending approval is < 5 minutes from expiry
+         * (spec §4.1) — the dot draws the eye before the deadline lapses. */
+        rm-chat-shell .cs-iconbtn .bdg.urgent {
+          background: var(--rm-bad);
+        }
+        /* The approvals popover anchors to this relatively-positioned
+         * wrapper so the inbox's absolutely-positioned panel hangs under
+         * the trigger button. */
+        rm-chat-shell .appr-anchor {
+          position: relative;
+          display: inline-flex;
+        }
+        /* Amber halo pulse on the card the inbox jumps to (§4.7). Lives
+         * here (not in the inbox component) so it is present in the global
+         * stylesheet even when the popover has already closed; the target
+         * card lives in the slotted chat-panel. */
+        rm-chat-shell .rm-appr-highlight {
+          animation: rm-appr-highlight 1.8s ease-out;
+        }
+        @keyframes rm-appr-highlight {
+          0% {
+            box-shadow: 0 0 0 0 var(--rm-accent);
+          }
+          25% {
+            box-shadow: 0 0 0 4px var(--rm-accent-subtle, rgba(194, 97, 63, 0.3));
+          }
+          100% {
+            box-shadow: 0 0 0 0 rgba(194, 97, 63, 0);
+          }
+        }
         rm-chat-shell .cs-tenant {
           display: flex;
           align-items: center;
@@ -1177,6 +1266,36 @@ export class RmChatShell extends LitElement {
               `
             : nothing}
           <span class="spacer"></span>
+          <span class="appr-anchor">
+            <button
+              class="cs-iconbtn"
+              data-testid="topbar-approvals"
+              data-menu-trigger="approvals"
+              aria-label="Approvals"
+              aria-haspopup="dialog"
+              aria-expanded=${this.openMenu === 'approvals'}
+              title="Approvals"
+              @click=${this.toggleApprovals}
+            >
+              ${iconInbox(19)}
+              ${this.approvalTotal > 0
+                ? html`<span
+                    class=${`bdg ${this.approvalUrgent ? 'urgent' : ''}`}
+                    data-testid="approvals-badge"
+                    data-urgent=${this.approvalUrgent ? 'true' : 'false'}
+                    >${this.approvalTotal}</span
+                  >`
+                : nothing}
+            </button>
+            <rm-approvals-inbox
+              data-testid="approvals-inbox"
+              .open=${this.openMenu === 'approvals'}
+              .activeConversationId=${this.activeConversationId}
+              .coworkers=${this.coworkers}
+              .conversations=${this.conversations}
+              .jumpHandler=${this.jumpToConversation}
+            ></rm-approvals-inbox>
+          </span>
           <button
             class="cs-iconbtn"
             data-testid="topbar-activity"

--- a/web/src/components/combobox.test.ts
+++ b/web/src/components/combobox.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+
+import './combobox.js';
+import type { Combobox } from './combobox.js';
+
+async function mount(options: string[], value = ''): Promise<Combobox> {
+  const el = document.createElement('rm-combobox') as Combobox;
+  el.options = options;
+  el.value = value;
+  el.testid = 'cb';
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+const input = (el: Combobox) => el.querySelector('input')!;
+const menu = (el: Combobox): string[] =>
+  Array.from(el.querySelectorAll('[data-combobox-option]')).map(
+    (n) => n.getAttribute('data-combobox-option') ?? '',
+  );
+
+function type(el: Combobox, value: string): void {
+  const i = input(el);
+  i.value = value;
+  i.dispatchEvent(new Event('input'));
+}
+
+describe('rm-combobox', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('opens on focus and lists all options', async () => {
+    const el = await mount(['stripe', 'mock-fs']);
+    input(el).dispatchEvent(new Event('focus'));
+    await el.updateComplete;
+    expect(menu(el).sort()).toEqual(['mock-fs', 'stripe']);
+  });
+
+  it('filters by case-insensitive substring as you type', async () => {
+    const el = await mount(['stripe', 'mock-fs', 'amazon']);
+    type(el, 'M'); // matches mock-fs and amazon (both contain 'm')
+    await el.updateComplete;
+    expect(menu(el)).toEqual(['mock-fs', 'amazon']);
+  });
+
+  it('typing emits change and never constrains the value (free text)', async () => {
+    const el = await mount(['stripe']);
+    let last = '';
+    el.addEventListener('change', (e) => {
+      last = (e as CustomEvent<{ value: string }>).detail.value;
+    });
+    type(el, 'server-not-in-the-list');
+    await el.updateComplete;
+    expect(last).toBe('server-not-in-the-list');
+    expect(el.value).toBe('server-not-in-the-list');
+  });
+
+  it('picking a suggestion sets the value, emits change, and closes', async () => {
+    const el = await mount(['stripe', 'mock-fs']);
+    input(el).dispatchEvent(new Event('focus'));
+    await el.updateComplete;
+    let last = '';
+    el.addEventListener('change', (e) => {
+      last = (e as CustomEvent<{ value: string }>).detail.value;
+    });
+    const opt = el.querySelector<HTMLElement>('[data-combobox-option="mock-fs"]')!;
+    // mousedown (not click) so it fires before input blur — the real flow.
+    opt.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    await el.updateComplete;
+    expect(last).toBe('mock-fs');
+    expect(el.value).toBe('mock-fs');
+    expect(menu(el)).toEqual([]); // closed after pick
+  });
+
+  it('Escape closes the menu', async () => {
+    const el = await mount(['stripe']);
+    input(el).dispatchEvent(new Event('focus'));
+    await el.updateComplete;
+    expect(menu(el).length).toBe(1);
+    input(el).dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await el.updateComplete;
+    expect(menu(el)).toEqual([]);
+  });
+});

--- a/web/src/components/combobox.ts
+++ b/web/src/components/combobox.ts
@@ -1,0 +1,211 @@
+// <rm-combobox> — a text input with a styled suggestion dropdown that still
+// accepts free text. Mirrors the prototype's policy server/tool pickers
+// (.hitl-ui/prototype.html §830): a bordered box with a chevron and a clean
+// popup panel — NOT a native <select> (which would force a choice) nor a
+// <datalist> (whose OS-native popup looks out of place). Typing filters the
+// suggestions; picking one fills the field; but any value can be typed, so a
+// server/tool that isn't connected yet can still be entered.
+//
+// Light DOM (createRenderRoot → this) so the host dialog's Tailwind utilities
+// apply, matching the surrounding form fields' palette.
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+/** Fired on every value change (typing or picking a suggestion). */
+export interface ComboboxChangeDetail {
+  value: string;
+}
+
+@customElement('rm-combobox')
+export class Combobox extends LitElement {
+  @property() value = '';
+  /** Suggestion list. Suggestions only — never a constraint on the value. */
+  @property({ attribute: false }) options: string[] = [];
+  @property() placeholder = '';
+  @property({ type: Boolean }) disabled = false;
+  /** Monospace the field + options (used for the tool-name picker). */
+  @property({ type: Boolean }) mono = false;
+  /** Applied as the inner <input>'s data-testid so tests/automation target it. */
+  @property() testid = '';
+
+  @state() private open = false;
+  @state() private highlight = -1;
+  /** Set while we programmatically refocus the input after a pick, so the
+   *  focus handler doesn't immediately reopen the menu we just closed. */
+  private suppressFocusOpen = false;
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('pointerdown', this.onDocPointerDown, true);
+  }
+
+  /** Close when a pointer goes down outside this element. */
+  private readonly onDocPointerDown = (e: PointerEvent): void => {
+    if (!this.contains(e.target as Node)) this.closeMenu();
+  };
+
+  private emit(value: string): void {
+    this.value = value;
+    this.dispatchEvent(
+      new CustomEvent<ComboboxChangeDetail>('change', {
+        detail: { value },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /** Visible suggestions: de-duped, case-insensitive substring match on the
+   *  current value. An empty value shows everything. */
+  private filtered(): string[] {
+    const seen = new Set<string>();
+    const uniq = this.options.filter((o) => {
+      if (!o || seen.has(o)) return false;
+      seen.add(o);
+      return true;
+    });
+    const q = this.value.trim().toLowerCase();
+    if (!q) return uniq;
+    return uniq.filter((o) => o.toLowerCase().includes(q));
+  }
+
+  private openMenu(): void {
+    if (this.disabled || this.open) return;
+    this.open = true;
+    document.addEventListener('pointerdown', this.onDocPointerDown, true);
+  }
+
+  private closeMenu(): void {
+    this.open = false;
+    this.highlight = -1;
+    document.removeEventListener('pointerdown', this.onDocPointerDown, true);
+  }
+
+  private input(): HTMLInputElement | null {
+    return this.querySelector('input');
+  }
+
+  private onInput(e: Event): void {
+    this.emit((e.target as HTMLInputElement).value);
+    this.highlight = -1;
+    this.openMenu();
+  }
+
+  private pick(opt: string): void {
+    this.emit(opt);
+    this.closeMenu();
+    // Keep focus for continued keyboard use, but don't let the focus handler
+    // reopen the menu we just closed.
+    this.suppressFocusOpen = true;
+    this.input()?.focus();
+    this.suppressFocusOpen = false;
+  }
+
+  private onFocus(): void {
+    if (this.suppressFocusOpen) return;
+    this.openMenu();
+  }
+
+  private onKeydown(e: KeyboardEvent): void {
+    const opts = this.filtered();
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      this.openMenu();
+      this.highlight = Math.min(this.highlight + 1, opts.length - 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      this.highlight = Math.max(this.highlight - 1, 0);
+    } else if (e.key === 'Enter') {
+      if (this.open && this.highlight >= 0 && opts[this.highlight]) {
+        e.preventDefault();
+        this.pick(opts[this.highlight]);
+      }
+    } else if (e.key === 'Escape') {
+      if (this.open) {
+        e.preventDefault();
+        this.closeMenu();
+      }
+    }
+  }
+
+  override render(): TemplateResult {
+    const opts = this.open ? this.filtered() : [];
+    return html`
+      <div class="relative">
+        <input
+          type="text"
+          class="w-full text-[13.5px] pl-3 pr-8 py-2 rounded-md border
+            border-surface-3 dark:border-d-surface-3 bg-surface-1 dark:bg-d-surface-1
+            text-ink-0 dark:text-d-ink-0 focus:outline-none focus:ring-2
+            focus:ring-brand ${this.mono ? 'font-mono' : ''}"
+          placeholder=${this.placeholder}
+          autocomplete="off"
+          .value=${this.value}
+          ?disabled=${this.disabled}
+          data-testid=${this.testid || nothing}
+          @input=${this.onInput}
+          @focus=${this.onFocus}
+          @keydown=${this.onKeydown}
+        />
+        <button
+          type="button"
+          tabindex="-1"
+          class="absolute right-2 top-1/2 -translate-y-1/2 text-ink-3
+            dark:text-d-ink-3 cursor-pointer disabled:cursor-not-allowed"
+          aria-label="Toggle suggestions"
+          ?disabled=${this.disabled}
+          @click=${() => {
+            if (this.open) this.closeMenu();
+            else {
+              this.openMenu();
+              this.input()?.focus();
+            }
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round"
+            stroke-linejoin="round"><path d="M6 9l6 6 6-6" /></svg>
+        </button>
+        ${this.open && opts.length
+          ? html`<div
+              class="absolute z-50 left-0 right-0 mt-1 max-h-56 overflow-auto
+                rounded-md border border-surface-3 dark:border-d-surface-3
+                bg-surface-1 dark:bg-d-surface-1 shadow-lg py-1"
+              role="listbox"
+              data-testid=${this.testid ? `${this.testid}-menu` : nothing}
+            >
+              ${opts.map(
+                (o, i) => html`<div
+                  class="px-3 py-1.5 text-[13px] cursor-pointer text-ink-1
+                    dark:text-d-ink-1 ${this.mono ? 'font-mono' : ''} ${i ===
+                  this.highlight
+                    ? 'bg-surface-2 dark:bg-d-surface-2'
+                    : 'hover:bg-surface-2 dark:hover:bg-d-surface-2'}"
+                  role="option"
+                  data-combobox-option=${o}
+                  @mousedown=${(e: Event) => {
+                    // mousedown (not click) so it fires before the input blur.
+                    e.preventDefault();
+                    this.pick(o);
+                  }}
+                >
+                  ${o}
+                </div>`,
+              )}
+            </div>`
+          : nothing}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rm-combobox': Combobox;
+  }
+}

--- a/web/src/components/condition-form.ts
+++ b/web/src/components/condition-form.ts
@@ -89,6 +89,69 @@ export function buildConditionExpr(form: {
   return { [form.connective]: leaves } as unknown as ConditionExpr;
 }
 
+/** Reverse of {@link parseValue} for display in a sentence (§5.12).
+ *
+ *  Numbers / booleans render bare, `null` as `null`, strings quoted (so the
+ *  reader can tell `"5000"` the string from `5000` the number), arrays/objects
+ *  as JSON. This is the *display* form — distinct from {@link leafToRow}'s
+ *  edit form, which strips the quotes off a string so the input is editable. */
+export function formatValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Escape a string for safe interpolation into the `conditionSentence` HTML. */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function leafSentence(leaf: Leaf): string {
+  return esc(`${leaf.field ?? '?'} ${leaf.op ?? '?'} ${formatValue(leaf.value)}`);
+}
+
+/** Human-readable, HTML-safe rendering of a `condition_expr` (Appendix C.3).
+ *
+ *  The single source of truth for both the list-card subtitle and the dialog's
+ *  live preview — the same sentence appears in both places so what the user
+ *  previews is exactly what the card will show. The condition body is wrapped
+ *  in `<b>…</b>`; callers must render the result with `unsafeHTML` (the leaf
+ *  text is escaped, so this is safe). Anything the flat builder can't express
+ *  (deep nesting, mixed forms) collapses to an `(advanced condition)` note
+ *  rather than lying about the shape.
+ *
+ *  Returns the *clause* only ("every time" / "when <b>…</b>"); callers add the
+ *  surrounding "→ pause to confirm" / full-sentence framing. */
+export function conditionSentence(expr: unknown): string {
+  if (typeof expr !== 'object' || expr === null) return 'every time';
+  const obj = expr as Record<string, unknown>;
+  if ('always' in obj) {
+    return obj.always === false ? 'never' : 'every time';
+  }
+  if (isLeaf(obj)) {
+    return `when <b>${leafSentence(obj)}</b>`;
+  }
+  for (const [connective, word] of [
+    ['and', 'AND'],
+    ['or', 'OR'],
+  ] as const) {
+    const subs = obj[connective];
+    if (Array.isArray(subs) && subs.length > 0 && subs.every(isLeaf)) {
+      return `when <b>${(subs as Leaf[]).map(leafSentence).join(` ${word} `)}</b>`;
+    }
+  }
+  return 'when <i>(advanced condition)</i>';
+}
+
 interface Leaf {
   field: string;
   op: string;

--- a/web/src/components/icons.ts
+++ b/web/src/components/icons.ts
@@ -29,6 +29,27 @@ export function iconActivity(size = 19): SVGTemplateResult {
   `;
 }
 
+/** Inbox — tray with incoming chevron. v2 topbar approvals trigger
+ *  (spec §4.1). Matches the activity/settings stroke convention. */
+export function iconInbox(size = 19): SVGTemplateResult {
+  return svg`
+    <svg
+      width=${size}
+      height=${size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M22 12h-6l-2 3h-4l-2-3H2"/>
+      <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>
+    </svg>
+  `;
+}
+
 /** Settings — gear. v2 topbar + settings shell sidebar entry. */
 export function iconSettings(size = 19): SVGTemplateResult {
   return svg`

--- a/web/src/components/icons.ts
+++ b/web/src/components/icons.ts
@@ -167,6 +167,27 @@ export function iconTrash(size = 15): SVGTemplateResult {
   `;
 }
 
+/** Copy / Duplicate — overlapping sheets. Used by the policy row's
+ *  Duplicate hover action (spec §5.4). */
+export function iconCopy(size = 15): SVGTemplateResult {
+  return svg`
+    <svg
+      width=${size}
+      height=${size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2"/>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+    </svg>
+  `;
+}
+
 /** Settings-nav icons (per docs/webui-ui-redesign-v2-prototype.html
  *  lines 489-502). Sized 16×16 to fit the .ni rail; stroke-width 1.8
  *  matches the prototype's quiet line weight. */

--- a/web/src/components/message-editor.ts
+++ b/web/src/components/message-editor.ts
@@ -54,7 +54,7 @@ function colourForCoworker(c: Coworker | null): string {
 @customElement('rm-message-editor')
 export class MessageEditor extends LitElement {
   // Three-state UI:
-  //  idle     — brand-colored Send button (↑), enabled when text present
+  //  idle     — accent (terracotta) Send button (↑), enabled when text present
   //  running  — dark Stop button (■), always enabled; clicking emits 'stop'
   //  stopping — dimmed Stop button with spinner ring, disabled
   @property({ type: String }) agentState: AgentState = 'idle';
@@ -253,7 +253,10 @@ export class MessageEditor extends LitElement {
     const base = 'flex items-center justify-center w-8 h-8 rounded-lg transition-all duration-150 relative';
     if (this.agentState === 'idle') {
       return this.canSend
-        ? `${base} bg-brand text-white hover:bg-brand-dark active:scale-95 shadow-sm`
+        // Terracotta accent to match the prototype's `.send` (var(--accent) /
+        // accent-ink, hover accent-2). Uses --rm-* directly so it flips for
+        // dark mode like the rest of the v2 palette.
+        ? `${base} bg-[var(--rm-accent)] text-[var(--rm-accent-ink)] hover:bg-[var(--rm-accent-2)] active:scale-95 shadow-sm`
         : `${base} bg-surface-2 dark:bg-d-surface-2 text-ink-4 dark:text-d-ink-4 cursor-default`;
     }
     if (this.agentState === 'running') {

--- a/web/src/components/message-list.ts
+++ b/web/src/components/message-list.ts
@@ -7,10 +7,10 @@ import './approval-card.js';
 @customElement('rm-message-list')
 export class MessageList extends LitElement {
   @property({ attribute: false }) messages: ChatMessage[] = [];
-  // In-flight + resolved HITL approval cards, rendered inline at the tail of the
-  // conversation stream so they scroll with it (not as a detached footer block).
-  // An approval is raised by the latest agent turn and the container blocks until
-  // it resolves, so the tail is its correct chronological position.
+  // In-flight + resolved HITL approval cards, interleaved into the message
+  // stream by timestamp (see `render`) so each card sits in its true
+  // chronological position — right after the user turn that triggered it and
+  // before the confirmation — instead of being pinned to the conversation tail.
   @property({ attribute: false }) approvals: ApprovalCard[] = [];
   @property({ attribute: false }) approvalBusy: Set<string> = new Set();
   @property() coworkerName = '';
@@ -46,27 +46,53 @@ export class MessageList extends LitElement {
     }
   }
 
+  /** Merge messages and approval cards into one chronological stream.
+   *
+   *  Both carry an epoch-ms ordering key (`ChatMessage.timestamp` /
+   *  `ApprovalCard.orderTs`) that is consistent within its source — server
+   *  clock on reload, browser clock on live push. The sort is stable, so when
+   *  two items share a key (e.g. coarse server-second granularity) their
+   *  original relative order is kept, with messages before cards on a tie. */
+  private timeline(): Array<
+    { kind: 'message'; ts: number; msg: ChatMessage }
+    | { kind: 'approval'; ts: number; card: ApprovalCard }
+  > {
+    const items: Array<
+      { kind: 'message'; ts: number; msg: ChatMessage }
+      | { kind: 'approval'; ts: number; card: ApprovalCard }
+    > = [
+      ...this.messages.map(
+        (msg) => ({ kind: 'message' as const, ts: msg.timestamp, msg }),
+      ),
+      ...this.approvals.map(
+        (card) => ({ kind: 'approval' as const, ts: card.orderTs, card }),
+      ),
+    ];
+    return items.sort((a, b) => a.ts - b.ts);
+  }
+
   override render() {
     if (this.messages.length === 0 && this.approvals.length === 0) return html``;
     return html`
       <div class="flex flex-col px-4 pt-6">
-        ${this.messages.map((msg) => html`<rm-message-item .message=${msg}></rm-message-item>`)}
-        ${this.approvals.map(
-          (c) => html`<rm-approval-card
-            .requestId=${c.requestId}
-            .actionSummary=${c.actionSummary}
-            .status=${c.status}
-            .mcpServerName=${c.mcpServerName}
-            .toolName=${c.toolName}
-            .params=${c.params}
-            .rationale=${c.rationale}
-            .requestedAt=${c.requestedAt}
-            .expiresAt=${c.expiresAt}
-            .coworkerName=${this.coworkerName}
-            .resolvedAt=${c.resolvedAt}
-            .note=${c.note}
-            .busy=${this.approvalBusy.has(c.requestId)}
-          ></rm-approval-card>`,
+        ${this.timeline().map((item) =>
+          item.kind === 'message'
+            ? html`<rm-message-item .message=${item.msg}></rm-message-item>`
+            : html`<rm-approval-card
+                .requestId=${item.card.requestId}
+                .actionSummary=${item.card.actionSummary}
+                .status=${item.card.status}
+                .mcpServerName=${item.card.mcpServerName}
+                .toolName=${item.card.toolName}
+                .params=${item.card.params}
+                .rationale=${item.card.rationale}
+                .requestedAt=${item.card.requestedAt}
+                .expiresAt=${item.card.expiresAt}
+                .coworkerName=${this.coworkerName}
+                .resolvedAt=${item.card.resolvedAt}
+                .note=${item.card.note}
+                .busy=${this.approvalBusy.has(item.card.requestId)}
+              ></rm-approval-card>`,
         )}
       </div>
     `;

--- a/web/src/components/message-list.ts
+++ b/web/src/components/message-list.ts
@@ -17,9 +17,31 @@ export class MessageList extends LitElement {
 
   protected override createRenderRoot() { return this; }
 
+  // "Stick to bottom" only while the user is already near the bottom. Without
+  // this guard the unconditional scroll-to-bottom below yanked the view down on
+  // EVERY re-render — and re-renders are frequent (connection-state changes / WS
+  // reconnect churn) — so a user who scrolled up to read an approval card or
+  // earlier messages was snapped back to the bottom and could not scroll.
+  private stickToBottom = true;
+  private scrollEl: HTMLElement | null = null;
+  private readonly onScroll = () => {
+    const c = this.scrollEl;
+    if (c) this.stickToBottom = c.scrollHeight - c.scrollTop - c.clientHeight < 80;
+  };
+
+  override firstUpdated() {
+    this.scrollEl = document.getElementById('scroll-area');
+    this.scrollEl?.addEventListener('scroll', this.onScroll, { passive: true });
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.scrollEl?.removeEventListener('scroll', this.onScroll);
+  }
+
   override updated() {
-    const container = document.getElementById('scroll-area');
-    if (container) {
+    const container = this.scrollEl ?? document.getElementById('scroll-area');
+    if (container && this.stickToBottom) {
       requestAnimationFrame(() => { container.scrollTop = container.scrollHeight; });
     }
   }

--- a/web/src/components/message-list.ts
+++ b/web/src/components/message-list.ts
@@ -78,7 +78,8 @@ export class MessageList extends LitElement {
         ${this.timeline().map((item) =>
           item.kind === 'message'
             ? html`<rm-message-item .message=${item.msg}></rm-message-item>`
-            : html`<rm-approval-card
+            : html`<div class="pl-10">
+              <rm-approval-card
                 .requestId=${item.card.requestId}
                 .actionSummary=${item.card.actionSummary}
                 .status=${item.card.status}
@@ -92,7 +93,8 @@ export class MessageList extends LitElement {
                 .resolvedAt=${item.card.resolvedAt}
                 .note=${item.card.note}
                 .busy=${this.approvalBusy.has(item.card.requestId)}
-              ></rm-approval-card>`,
+              ></rm-approval-card>
+            </div>`,
         )}
       </div>
     `;

--- a/web/src/components/message-list.ts
+++ b/web/src/components/message-list.ts
@@ -1,10 +1,19 @@
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import type { ChatMessage } from './chat-panel.js';
+import type { ApprovalCard } from './approval-store.js';
+import './approval-card.js';
 
 @customElement('rm-message-list')
 export class MessageList extends LitElement {
   @property({ attribute: false }) messages: ChatMessage[] = [];
+  // In-flight + resolved HITL approval cards, rendered inline at the tail of the
+  // conversation stream so they scroll with it (not as a detached footer block).
+  // An approval is raised by the latest agent turn and the container blocks until
+  // it resolves, so the tail is its correct chronological position.
+  @property({ attribute: false }) approvals: ApprovalCard[] = [];
+  @property({ attribute: false }) approvalBusy: Set<string> = new Set();
+  @property() coworkerName = '';
 
   protected override createRenderRoot() { return this; }
 
@@ -16,10 +25,27 @@ export class MessageList extends LitElement {
   }
 
   override render() {
-    if (this.messages.length === 0) return html``;
+    if (this.messages.length === 0 && this.approvals.length === 0) return html``;
     return html`
       <div class="flex flex-col px-4 pt-6">
         ${this.messages.map((msg) => html`<rm-message-item .message=${msg}></rm-message-item>`)}
+        ${this.approvals.map(
+          (c) => html`<rm-approval-card
+            .requestId=${c.requestId}
+            .actionSummary=${c.actionSummary}
+            .status=${c.status}
+            .mcpServerName=${c.mcpServerName}
+            .toolName=${c.toolName}
+            .params=${c.params}
+            .rationale=${c.rationale}
+            .requestedAt=${c.requestedAt}
+            .expiresAt=${c.expiresAt}
+            .coworkerName=${this.coworkerName}
+            .resolvedAt=${c.resolvedAt}
+            .note=${c.note}
+            .busy=${this.approvalBusy.has(c.requestId)}
+          ></rm-approval-card>`,
+        )}
       </div>
     `;
   }

--- a/web/src/components/settings-shell.ts
+++ b/web/src/components/settings-shell.ts
@@ -133,17 +133,17 @@ const NAV_GROUPS: NavGroup[] = [
     heading: 'Governance',
     entries: [
       {
-        slug: 'safety',
-        label: 'Safety rules',
-        icon: () => iconShield(16),
-        render: () => html`<rm-safety-rules-page></rm-safety-rules-page>`,
-      },
-      {
         slug: 'approval-policies',
         label: 'Approval policies',
         icon: () => iconShield(16),
         render: () =>
           html`<rm-approval-policies-page></rm-approval-policies-page>`,
+      },
+      {
+        slug: 'safety',
+        label: 'Safety rules',
+        icon: () => iconShield(16),
+        render: () => html`<rm-safety-rules-page></rm-safety-rules-page>`,
       },
     ],
   },

--- a/web/src/styles/approval-card.css
+++ b/web/src/styles/approval-card.css
@@ -1,0 +1,41 @@
+/* Approval card — opt the card subtree into the v2 warm palette.
+ *
+ * The card is built from the chat's Tailwind utilities (`bg-surface-2`,
+ * `text-ink-2`, `border-border-2`, `font-mono`, …). The app's default @theme
+ * maps those to a cool slate palette, but the v2 design (.hitl-ui/prototype)
+ * wants warm terracotta + Hanken/JetBrains type. Rather than rewrite every
+ * utility on the component, we re-point the @theme custom properties to the
+ * --rm-* design tokens for THIS element's subtree only — so the utilities
+ * resolve warm inside the card and stay slate everywhere else.
+ *
+ * The --rm-* tokens already flip for dark mode (tokens.css @media), so pointing
+ * both the light (`--color-x`) and dark (`--color-d-x`) @theme vars at the same
+ * --rm-* token gives correct light/dark automatically. The @theme tokens must
+ * still be *declared* in app.css for Tailwind to generate the utilities at
+ * build time; this file only overrides their values within the card. */
+rm-approval-card {
+  font-family: var(--rm-font-body);
+  --font-mono: var(--rm-font-mono);
+
+  --color-surface: var(--rm-surface);
+  --color-surface-2: var(--rm-surface-2);
+  --color-surface-3: var(--rm-surface-3);
+  --color-ink-0: var(--rm-ink);
+  --color-ink-1: var(--rm-ink);
+  --color-ink-2: var(--rm-ink-2);
+  --color-ink-3: var(--rm-ink-3);
+  --color-border: var(--rm-border);
+  --color-border-2: var(--rm-border-2);
+  --color-accent: var(--rm-accent);
+
+  --color-d-surface: var(--rm-surface);
+  --color-d-surface-2: var(--rm-surface-2);
+  --color-d-surface-3: var(--rm-surface-3);
+  --color-d-ink-0: var(--rm-ink);
+  --color-d-ink-1: var(--rm-ink);
+  --color-d-ink-2: var(--rm-ink-2);
+  --color-d-ink-3: var(--rm-ink-3);
+  --color-d-border: var(--rm-border);
+  --color-d-border-2: var(--rm-border-2);
+  --color-d-accent: var(--rm-accent);
+}

--- a/web/src/styles/settings-pages.css
+++ b/web/src/styles/settings-pages.css
@@ -342,6 +342,213 @@
   font-size: var(--rm-text-sm);
 }
 
+/* ── Approval-policies page (spec §5) ─────────────────────────────
+ * Policy rows reuse .rm-card but swap the avatar for a priority badge
+ * and the status pill for an always-visible enable/disable switch.
+ * Prototype lines 379-411. */
+
+/* Priority badge — fixed-width left chip. ≥10 amber, 0 muted gray,
+ * else neutral surface. Tabular numerals so badges line up. */
+.rm-pol-pri {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--rm-ink-3);
+  background: var(--rm-surface-2);
+  padding: 5px 8px;
+  border-radius: 5px;
+  flex-shrink: 0;
+  min-width: 64px;
+  text-align: center;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+.rm-pol-pri.rm-pol-pri--hi { background: var(--rm-warn-subtle); color: var(--rm-warn); }
+.rm-pol-pri.rm-pol-pri--zero { background: var(--rm-surface-3); color: var(--rm-ink-3); }
+.rm-card.rm-card--dim .rm-pol-pri { background: var(--rm-surface-3); color: var(--rm-ink-3); }
+
+/* "(all tools)" qualifier after a `*` tool name. */
+.rm-pol-alltools { font-size: 11px; color: var(--rm-ink-3); font-weight: 400; }
+
+/* The condition sentence on the row subtitle keeps the muted subtitle
+ * colour but bolds the condition body so it reads as a clause. */
+.rm-mn .rm-pol-sent b { color: var(--rm-ink-2); font-weight: 600; }
+.rm-mn .rm-pol-sent i { font-style: italic; }
+
+/* Enable/disable switch — always visible (not hover-gated), so a
+ * policy can be silenced in one click (spec §5.3). Bright even when
+ * the card body is dimmed. */
+.rm-pol-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 11.5px;
+  color: var(--rm-ink-3);
+  font-weight: 500;
+  padding: 4px 7px;
+  border-radius: 7px;
+  transition: var(--rm-transition);
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  font-family: inherit;
+}
+.rm-pol-toggle:hover { background: var(--rm-surface-3); }
+.rm-pol-toggle .rm-switch {
+  width: 30px;
+  height: 18px;
+  border-radius: 9px;
+  background: var(--rm-surface-3);
+  position: relative;
+  transition: var(--rm-transition);
+  border: 1px solid var(--rm-border-2);
+  flex-shrink: 0;
+}
+.rm-pol-toggle .rm-switch::after {
+  content: '';
+  position: absolute;
+  top: 1.5px;
+  left: 1.5px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #fff;
+  transition: var(--rm-transition);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+.rm-pol-toggle.rm-pol-toggle--on { color: var(--rm-accent); }
+.rm-pol-toggle.rm-pol-toggle--on .rm-switch {
+  background: var(--rm-accent);
+  border-color: var(--rm-accent);
+}
+.rm-pol-toggle.rm-pol-toggle--on .rm-switch::after { left: 14.5px; }
+.rm-pol-toggle:disabled { opacity: 0.6; cursor: progress; }
+
+/* The dim only applies to the card body, never the toggle — the user
+ * keeps a bright control to re-enable. .rm-card--dim already sets the
+ * card opacity; pull the toggle back to full. */
+.rm-card.rm-card--dim .rm-pol-toggle { opacity: 1; }
+
+/* Newly-created / just-edited card pulse (spec §5.7 — same intent as
+ * the inbox→chat highlight). */
+@keyframes rm-pol-highlight {
+  0% { box-shadow: 0 0 0 0 rgba(194, 97, 63, 0); }
+  30% { box-shadow: 0 0 0 5px var(--rm-accent-subtle); }
+  100% { box-shadow: 0 0 0 0 rgba(194, 97, 63, 0); }
+}
+.rm-card.rm-card--highlight { animation: rm-pol-highlight 1.8s ease-out; }
+
+/* Rich empty state (spec §5.6) — check-circle + create CTA. */
+.rm-pol-empty {
+  text-align: center;
+  padding: 42px 24px 36px;
+  background: var(--rm-surface-2);
+  border: 1px dashed var(--rm-border-2);
+  border-radius: var(--rm-r);
+}
+.rm-pol-empty .rm-pol-empty-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: var(--rm-surface);
+  border: 1px solid var(--rm-border-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 14px;
+  color: var(--rm-good);
+}
+.rm-pol-empty p { margin: 0 0 5px; color: var(--rm-ink-2); font-size: 14px; line-height: 1.5; }
+.rm-pol-empty .rm-pol-empty-sub { color: var(--rm-ink-3); font-size: 12.5px; margin-bottom: 16px; }
+.rm-pol-empty button {
+  background: var(--rm-accent);
+  color: var(--rm-accent-ink);
+  padding: 9px 18px;
+  border-radius: 8px;
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: inherit;
+  transition: var(--rm-transition);
+}
+.rm-pol-empty button:hover { background: var(--rm-accent-2); }
+
+/* Bottom evaluation-order hint (spec §5.1) — hidden when the list is
+ * empty (no rules ⇒ order is meaningless). */
+.rm-pol-hint {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--rm-border);
+  font-size: 12.5px;
+  color: var(--rm-ink-3);
+  line-height: 1.6;
+}
+
+/* Dialog live preview (spec §5.13). */
+.rm-pol-preview {
+  background: var(--rm-accent-subtle);
+  border-radius: var(--rm-radius-sm);
+  padding: 11px 13px;
+  font-size: 12.5px;
+  color: var(--rm-ink-2);
+  line-height: 1.55;
+  margin-top: 14px;
+}
+.rm-pol-preview code {
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  background: var(--rm-surface);
+  padding: 1px 5px;
+  border-radius: 5px;
+}
+.rm-pol-preview b { color: var(--rm-ink); font-weight: 600; }
+.rm-pol-preview i { color: var(--rm-ink-3); }
+
+/* Segmented control (Every time / Only when… and All/Any) in the dialog. */
+.rm-seg {
+  display: inline-flex;
+  gap: 4px;
+  background: var(--rm-surface-2);
+  padding: 3px;
+  border-radius: 8px;
+}
+.rm-seg button {
+  padding: 5px 12px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: var(--rm-ink-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+.rm-seg button.rm-seg--on { background: var(--rm-surface); color: var(--rm-ink); font-weight: 500; }
+.rm-seg button:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* Transient toast (spec §5.3 — optimistic-toggle failure). Anchored to
+ * the page wrapper; auto-dismisses. */
+.rm-toast {
+  position: fixed;
+  bottom: 22px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--rm-ink);
+  color: var(--rm-bg);
+  font-size: 12.5px;
+  padding: 9px 16px;
+  border-radius: 8px;
+  box-shadow: var(--rm-shadow-md);
+  z-index: 60;
+  animation: rm-fade 0.18s ease both;
+}
+
 /* Hide the native <details> marker for any <summary> that uses
  * .list-none (Tailwind's marker-removal utility doesn't reach the
  * browser-specific pseudo-elements). The coworker wizard's review


### PR DESCRIPTION
## Summary

The HITL tool-approval **UI**, built on the merged backend (#41) + its startup fix
(#42), and rebased onto `main` (so it carries the #44 schema-wipe fix). Makes
approvals fully usable in the web app and faithful to the v2 prototype:

- the **chat approval card** shows the real tool-call params, rationale, a live
  countdown and reject-with-note, renders in **chronological position** in the
  message stream, and matches the prototype's warm styling;
- the **policies page + dialog** get full management affordances and a server/tool
  **combobox** that suggests configured MCP servers/tools while staying free-text;
- the **cross-conversation inbox** and the **Telegram** card are included;
- a misconfigured policy that fail-closes now **explains why** instead of silently
  gating everything.

## What's included

**Wire contract & core card (U1–U3)**
- `2780983` U1 — decision-relevant fields on WS/REST; `rationale` plumbed nullable
  end-to-end; `cancelled` resolved outcome; openapi + regenerated `types.ts`.
- `d9f408d` U2 — rich chat card: params table, rationale, 1 Hz countdown, inline
  reject-with-note, all four resolved states.
- `88ae220` U3 — policies page: priority badge, in-row toggle, duplicate,
  delete-confirm, sort, live-preview dialog with AND/OR builder.
- `00f200d` ship `rolemesh/core/config.py` to the agent image (import fix).

**Inbox & Telegram (U4–U5)**
- `56cf1f9` order Approval policies above Safety rules in Settings → Governance.
- `617851a` U4 — approvals inbox: top-bar cross-conversation triage popover.
- `6265e9b` U5 — Telegram approval card mirrors the web card.

**In-stream placement & prototype-fidelity polish**
- `8464564` render approval cards inline in the message stream.
- `bb35200` only auto-scroll to bottom when already near bottom.
- `776c099` drop the redundant summary line.
- `ed58cb2` interleave approval cards into the message stream **by timestamp**
  (resolved cards survive reload via a new conversation sub-resource:
  `GET /api/v1/conversations/{id}/approval-requests`).
- `01de0ba` make the card match the v2 prototype — bridge the terracotta `--rm-*`
  tokens into `@theme` (the card's accent/border/surface utilities were being
  dropped at build), warm-palette + Hanken/JetBrains fonts scoped to the card,
  prototype buttons, and indent the card to align with the message text.

**Policy dialog comboboxes**
- `e6bd8ac` suggest the tenant's MCP servers, and a selected server's tools (from
  `tool_reversibility`), via a styled free-text `rm-combobox` — so a server/tool
  that isn't connected yet can still be entered.

**Fail-closed visibility & composer**
- `740dd30` when a policy condition can't be evaluated (e.g. a typo'd field name),
  the gate now **explains itself** in the card/Telegram/log
  (`evaluate_condition_explained` → reason carried as the rationale), instead of a
  silent gate-everything. Stays fail-closed (a safety gate must err toward asking).
- `8fe328c` composer Send button uses the prototype's terracotta accent (was indigo).

## Testing

- Web: **435** vitest pass (33 files); production `vite build` green;
  `lint:tokens-only / no-admin-chat / flat-route` clean.
- Agent/backend: approval policy + hook + REST/WS/contract suites green
  (`tests/agent` 110 pass; conversation sub-resource + openapi contract/codegen
  green). Cross-tenant isolation holds; new behaviours mutation-checked.

## Notes

- The agent-supplied rationale ("why the agent made this call") is still NOT wired
  (always null on a genuine match — the card omits the WHY then). The rationale
  field currently carries only the system's fail-closed explanation.
- The fail-closed-WHY runs inside the agent container, so it takes effect after the
  `rolemesh-agent` image is rebuilt + a fresh container spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
