### PR TITLE
fix(db): stop wiping approval_requests/policies on every startup

### DIFF
--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -980,11 +980,19 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "ON link_tokens(expires_at) WHERE used_at IS NULL"
     )
 
-    # --- Approval module REMOVED ---
-    # The human-approval subsystem was removed. Drop its tables, trigger,
-    # and function if a prior deployment created them, so upgraded
-    # databases retain no orphaned objects. ``require_approval`` remains a
-    # valid safety verdict (it now simply blocks the turn).
+    # --- Legacy v6.1 approval-audit cleanup ---
+    # The v6.1 "block-and-replay" approval subsystem was removed; the current
+    # block-and-await HITL module re-introduced ``approval_requests`` /
+    # ``approval_policies`` (created further below). Those new tables share the
+    # old names but NOT the old audit trigger/function/log, so drop only the
+    # genuinely-dead v6.1 objects to keep a v6.1-upgraded DB free of orphans.
+    #
+    # IMPORTANT: do NOT ``DROP TABLE approval_requests`` / ``approval_policies``
+    # here. ``_create_schema`` runs on every service start, so an unconditional
+    # drop wiped all approval history and policies on each restart (the tables
+    # were silently recreated empty below) — a real data-loss regression left
+    # over from the removal era. The CREATE TABLE IF NOT EXISTS + ADD COLUMN
+    # IF NOT EXISTS migrations below carry the schema forward without a drop.
     await conn.execute(
         "DROP TRIGGER IF EXISTS trg_approval_audit ON approval_requests"
     )
@@ -992,8 +1000,6 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "DROP FUNCTION IF EXISTS _approval_write_audit_from_trigger()"
     )
     await conn.execute("DROP TABLE IF EXISTS approval_audit_log CASCADE")
-    await conn.execute("DROP TABLE IF EXISTS approval_requests CASCADE")
-    await conn.execute("DROP TABLE IF EXISTS approval_policies CASCADE")
 
     # --- Safety Framework tables ---
     # Admin-managed rules that the container loads as a snapshot at job

--- a/tests/test_schema_alters.py
+++ b/tests/test_schema_alters.py
@@ -31,13 +31,15 @@ postgres is allowed for schema-level invariants.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import asyncpg
 import pytest
 
 from rolemesh.db import (
     _get_admin_pool,
+    create_approval_policy,
+    create_approval_request,
     create_channel_binding,
     create_conversation,
     create_coworker,
@@ -72,6 +74,62 @@ async def test_create_schema_is_idempotent() -> None:
         # First call is already done by the fixture; we hammer a
         # second one to assert no exception.
         await _create_schema(conn)
+
+
+async def test_create_schema_preserves_approval_data_across_restart() -> None:
+    """``_create_schema`` MUST NOT wipe approval rows on re-run.
+
+    Regression: the builder carried an unconditional ``DROP TABLE
+    approval_requests / approval_policies CASCADE`` left over from the v6.1
+    approval-module *removal*, then recreated the tables empty further down.
+    Because ``_create_schema`` runs on every ``init_database()`` — i.e. every
+    service start — this silently wiped ALL approval history and policies on
+    each restart, so resolved cards never survived a reload after a bounce.
+
+    We seed one request and one policy, simulate a restart by re-running the
+    schema builder on the live connection, and assert both survive. Before the
+    fix this asserted-count drops to 0; after it, the rows persist.
+    """
+    tenant = await create_tenant(name="T", slug=f"appr-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=tenant.id, name="cw", folder=f"f-{uuid.uuid4().hex[:8]}"
+    )
+    req = await create_approval_request(
+        tenant_id=tenant.id,
+        coworker_id=cw.id,
+        job_id="job-x",
+        mcp_server_name="mock-fs",
+        action={"tool_name": "write_file", "params": {}},
+        action_summary="s",
+        expires_at=datetime.now(UTC) + timedelta(minutes=5),
+    )
+    policy = await create_approval_policy(
+        tenant_id=tenant.id, mcp_server_name="mock-fs", tool_name="write_file"
+    )
+
+    pool = _get_admin_pool()
+    async with pool.acquire() as conn:
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM approval_requests WHERE id = $1::uuid", req.id
+            )
+            == 1
+        ), "seed precondition: request row present"
+        # Simulate a service restart: the schema builder runs again on a DB
+        # that already holds approval data.
+        await _create_schema(conn)
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM approval_requests WHERE id = $1::uuid", req.id
+            )
+            == 1
+        ), "approval request must survive a _create_schema re-run (restart)"
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM approval_policies WHERE id = $1::uuid", policy.id
+            )
+            == 1
+        ), "approval policy must survive a _create_schema re-run (restart)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`_create_schema()` carried an unconditional `DROP TABLE IF EXISTS approval_requests / approval_policies CASCADE`, left over from the era when the v6.1 *block-and-replay* approval subsystem was **removed**. The new block-and-await HITL module re-introduced those tables (`CREATE TABLE IF NOT EXISTS`, further down the same function) — but the stale drops were never deleted.

`_create_schema()` runs on **every `init_database()`** — i.e. every service start. So the execution order on each restart was:

```
DROP TABLE approval_requests   (data gone)
…
CREATE TABLE IF NOT EXISTS approval_requests   (recreated empty)
```

**Result: every webui/orchestrator restart wiped all approval history and every approval policy.** Because rows persisted fine during continuous operation, the loss only surfaced after a restart — which made it look intermittent and easy to misattribute (e.g. "the policy table is empty, someone must have deleted the policy"; resolved approval cards vanishing after a reload-following-a-bounce).

## Fix

- Remove the two `DROP TABLE` statements for the **live** tables.
- Keep the cleanup of the genuinely-removed v6.1 audit objects (trigger / function / `approval_audit_log`), which the current design does not use, and correct the misleading "Approval module REMOVED" comment.
- Forward schema evolution for the live tables is already handled by `CREATE TABLE IF NOT EXISTS` + the `ADD COLUMN IF NOT EXISTS` migrations below.

## Test

Added `test_create_schema_preserves_approval_data_across_restart`: seeds one request + one policy, re-runs `_create_schema` (simulating a restart), and asserts both survive. Mutation-verified — it asserts `0 == 1` (fails) with the drops present, passes without them.

Verified live against the dev DB: a seeded approval row survives a re-run of `_create_schema` (was 0 before, 1 after).

## Notes

- Takes effect on the **next** service restart; no current data is at risk (the table is already empty for the usual reason).
- Independent of the HITL approval-card UI work on PR #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)