### PR TITLE
fix(ws): queue outbound frames across reconnects instead of dropping

### DIFF
--- a/web/src/ws/v1_client.test.ts
+++ b/web/src/ws/v1_client.test.ts
@@ -183,8 +183,16 @@ describe('V1WsClient — request.run idempotency', () => {
     expect(sent[2].idempotency_key).toBe('uuid-2');
   });
 
-  it('dispatches event.run.error when send() is called while the socket is not open', async () => {
-    const { fn: fetchFn } = makeFetch({});
+  it('buffers a send() made while not open and flushes it on connect (no drop, no error)', async () => {
+    // Regression: the old behaviour dropped the frame + dispatched WS_NOT_OPEN,
+    // so a message typed in a reconnect gap was silently lost. Now it is queued
+    // and delivered on (re)connect.
+    const { fn: fetchFn } = makeFetch({
+      '/api/v1/auth/ws-ticket': () =>
+        new Response(JSON.stringify({ ticket: 't', expires_in_s: 60 }), {
+          status: 200,
+        }),
+    });
     const WS = makeMockWebSocket();
     const client = new V1WsClient(
       { conversationId: 'conv-A', getToken: () => null },
@@ -196,10 +204,23 @@ describe('V1WsClient — request.run idempotency', () => {
     );
     const errors: ServerEvent[] = [];
     client.onEvent('event.run.error', (e) => errors.push(e));
-    // Never connected — socket is null.
+
+    // Not connected yet — the frame must be buffered, not dropped or errored.
     client.send('hi');
-    expect(errors).toHaveLength(1);
-    expect((errors[0] as { code: string }).code).toBe('WS_NOT_OPEN');
+    expect(errors).toHaveLength(0);
+
+    // Connect + open → the buffered request.run is flushed in order.
+    await client.connect();
+    const inst = openMock(WS);
+    expect(errors).toHaveLength(0);
+    const sent = inst.sent.map((s) => JSON.parse(s));
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: 'request.run',
+      input: 'hi',
+      idempotency_key: 'k',
+    });
+    client.disconnect();
   });
 });
 

--- a/web/src/ws/v1_client.ts
+++ b/web/src/ws/v1_client.ts
@@ -375,19 +375,11 @@ export class V1WsClient extends WsClientBase<ConnectionStatus> {
   }
 
   private rawSend(frame: Record<string, unknown>): void {
-    if (!this.ws || this.ws.readyState !== this.WebSocketCtor.OPEN) {
-      // request.run isn't queued — replaying after reconnect would
-      // either land in the same idempotency window (no-op) or be a
-      // duplicate the user no longer wants. Surface the dropped
-      // frame as an error event so chat-panel can warn the user.
-      this.dispatch({
-        type: 'event.run.error',
-        code: 'WS_NOT_OPEN',
-        message: 'socket not open; frame dropped',
-        details: { dropped_type: frame.type },
-      } as RunErrorEvent);
-      return;
-    }
-    this.ws.send(JSON.stringify(frame));
+    // Buffer when the socket isn't open and flush on (re)connect, instead of
+    // dropping (the old behaviour silently lost a message sent in a reconnect
+    // gap). request.run carries an idempotency_key, so a replay collapses to a
+    // single run server-side; request.stop/cancel/approval_decision are small
+    // control frames whose server handlers are first-wins/idempotent.
+    this.queueOrSend(frame);
   }
 }

--- a/web/src/ws/ws-client-base.test.ts
+++ b/web/src/ws/ws-client-base.test.ts
@@ -24,6 +24,7 @@ interface MockSocket {
   onclose: ((e: CloseEvent) => void) | null;
   onerror: ((e: Event) => void) | null;
   onmessage: ((e: MessageEvent) => void) | null;
+  sent: string[];
   close: () => void;
   send: (s: string) => void;
 }
@@ -40,7 +41,10 @@ function makeMockWebSocket() {
     this.close = () => {
       this.readyState = 3;
     };
-    this.send = () => {};
+    this.sent = [];
+    this.send = (s: string) => {
+      this.sent.push(s);
+    };
     instances.push(this);
   } as unknown as { new (url: string): MockSocket } & {
     OPEN: number;
@@ -76,6 +80,11 @@ class TestClient extends WsClientBase {
 
   stop(): void {
     this.closeAndTeardown();
+  }
+
+  /** Public passthrough so tests can exercise the buffer-or-send path. */
+  send(frame: Record<string, unknown>): void {
+    this.queueOrSend(frame);
   }
 
   protected async fetchTicket(): Promise<string> {
@@ -231,4 +240,24 @@ describe('WsClientBase lifecycle', () => {
     expect(WS.instances).toHaveLength(1);
     client.stop();
   });
+
+  it('buffers frames sent while not open and flushes them in order on open', async () => {
+    const WS = makeMockWebSocket();
+    const client = new TestClient({
+      WebSocket: WS as unknown as typeof WebSocket,
+      wsOrigin: 'ws://t',
+      reconnectDelayMs: 60_000,
+    });
+    // Queued before any socket exists — must be delivered, not dropped.
+    client.send({ type: 'a', n: 1 });
+    client.send({ type: 'a', n: 2 });
+    await client.start();
+    const inst = openSocket(WS);
+    expect(inst.sent.map((s) => JSON.parse(s))).toEqual([
+      { type: 'a', n: 1 },
+      { type: 'a', n: 2 },
+    ]);
+    client.stop();
+  });
+
 });

--- a/web/src/ws/ws-client-base.ts
+++ b/web/src/ws/ws-client-base.ts
@@ -69,6 +69,12 @@ export abstract class WsClientBase<S extends WsConnectionStatus = WsConnectionSt
   // and bail out if a teardown raced ahead.
   protected generation = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Frames buffered while the socket is not OPEN, flushed in order on (re)open
+  // so a message sent during a reconnect gap is delivered, not dropped.
+  private readonly sendQueue: string[] = [];
+
+  /** Bound on the buffered-frame queue; oldest dropped past this. */
+  private static readonly SEND_QUEUE_MAX = 50;
 
   private statusValue: S;
   private readonly statusHandlers = new Set<WsStatusHandler<S>>();
@@ -146,6 +152,7 @@ export abstract class WsClientBase<S extends WsConnectionStatus = WsConnectionSt
     ws.onopen = () => {
       if (gen !== this.generation) return;
       this.setStatus('open' as S);
+      this.flushSendQueue();
     };
     ws.onmessage = (evt: MessageEvent) => {
       if (gen !== this.generation) return;
@@ -182,6 +189,34 @@ export abstract class WsClientBase<S extends WsConnectionStatus = WsConnectionSt
     }, this.reconnectDelayMs);
   }
 
+  // --- Outbound frames (buffer across reconnects instead of dropping) ---
+
+  /** Send a frame, or buffer it (capped) when the socket isn't OPEN so it is
+   *  delivered on the next (re)connect rather than silently dropped. */
+  protected queueOrSend(frame: Record<string, unknown>): void {
+    const data = JSON.stringify(frame);
+    if (this.ws && this.ws.readyState === this.WebSocketCtor.OPEN) {
+      this.ws.send(data);
+      return;
+    }
+    this.sendQueue.push(data);
+    while (this.sendQueue.length > WsClientBase.SEND_QUEUE_MAX) {
+      this.sendQueue.shift(); // drop oldest under a sustained outage
+    }
+  }
+
+  private flushSendQueue(): void {
+    if (!this.ws || this.ws.readyState !== this.WebSocketCtor.OPEN) return;
+    const pending = this.sendQueue.splice(0);
+    for (const data of pending) {
+      try {
+        this.ws.send(data);
+      } catch {
+        // ignore — onclose will fire and the queue refills on next send
+      }
+    }
+  }
+
   /** Shared teardown — closes the socket, cancels reconnect, removes
    *  this client from `ConnectionState`. Subclasses can wrap this in
    *  their public `disconnect()` / `stop()` to retain the existing
@@ -189,6 +224,7 @@ export abstract class WsClientBase<S extends WsConnectionStatus = WsConnectionSt
   protected closeAndTeardown(): void {
     this.explicitlyClosed = true;
     this.generation += 1;
+    this.sendQueue.length = 0;
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;


### PR DESCRIPTION
## Summary

One small, targeted fix: **don't drop an outbound WebSocket frame when the
socket isn't open — buffer it and send it on (re)connect.**

`rawSend` used to **drop** a frame (and dispatch `event.run.error` /
`WS_NOT_OPEN`) whenever the socket wasn't `OPEN`. So a `request.run` typed
during a reconnect gap — e.g. right as a dev HMR reload or any blip had torn the
socket down — was **silently lost** (the reported *"`hello` never reached the
backend"*).

Frames are now **buffered (capped 50, oldest dropped) and flushed in order on
the next (re)connect**. Safe to replay: `request.run` carries an
idempotency_key (server collapses a duplicate to one run) and the other control
frames (`stop` / `cancel` / `approval_decision`) are first-wins server-side.

## Why this is the *only* change

This branch started larger (exponential backoff+jitter + an app-level
heartbeat). Both were **dropped after measuring**:

- Idle **raw** WebSockets stay open **65 s+** through **both** the vite dev
  proxy (`:5173`) **and** direct to uvicorn (`:8080`) → there is **no idle
  reaping**, so the heartbeat defended against a non-issue.
- The "reconnect every ~3 s" was a **dev-time vite HMR artifact** (full reloads
  while files were being edited), not a transport bug — and the reconnect
  backoff defended a reconnect storm that doesn't occur (and would have *slowed*
  genuine recovery). The fixed reconnect delay is left exactly as it was.

So the queue is the single change that fixes a **real, deterministically
reproducible** symptom (drop-on-send), with no behavioural change to reconnect
timing.

## Side effects (small, called out honestly)

- The `WS_NOT_OPEN` error event is **no longer dispatched** on a not-open send —
  the frame is queued silently instead. (A "queued / sending…" hint could be
  added later if desired.)
- A frame sent while disconnected is delivered **after** reconnect, so slightly
  later than typed; queued control frames replay on reconnect but are first-wins
  server-side (effectively no-ops if already resolved). The queue is per-client
  and cleared on teardown (switching conversations drops anything unsent).

## Footprint & testing

- **4 files, +98 / −20**, frontend only, no server change.
- Web **436** vitest green incl. a base-level buffer-then-flush-in-order test;
  v1's old "drops + `WS_NOT_OPEN`" test rewritten to assert **queue + flush**.
  `tsc` + `vite build` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
