### PR TITLE
ci: re-enable workflow + fix surfaced failures + parallelize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,11 @@ jobs:
       # deselects it automatically — that path is preferable to a
       # growing CI-side ignore list.
       - name: Pytest
-        run: uv run pytest tests/ --ignore=tests/attack_sim --maxfail=10 -q
+        # -n auto parallelizes across the runner's cores (pytest-xdist). The
+        # suite is test-isolated (per-worker testcontainer Postgres, per-test
+        # truncate), so workers don't share DB state. Roughly halves wall-clock
+        # on the 2-core runner and keeps us clear of the 20-minute job timeout.
+        run: uv run pytest tests/ --ignore=tests/attack_sim --maxfail=10 -q -n auto
 
   # Frontend (web/) job. Independent of the Python test job — runs in
   # parallel on its own runner so it doesn't sit through the ~50-package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=5.0",
+    "pytest-xdist>=3.6",
     "ruff>=0.8",
     "mypy>=1.13",
     "testcontainers[postgres]>=4.0",

--- a/tests/evaluation/test_scorers_final_answer.py
+++ b/tests/evaluation/test_scorers_final_answer.py
@@ -12,6 +12,14 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+
+# The eval extra (inspect-ai) is nightly-only: PR CI runs
+# `uv sync --extra dev --extra pi --extra safety-ml` without it. Skip the
+# whole module cleanly when inspect_ai is unavailable rather than failing
+# collection — mirrors the boto3 guard in
+# tests/test_agent_runner/test_amazon_bedrock_tool_limit.py.
+pytest.importorskip("inspect_ai")
+
 from inspect_ai.model import ModelName, ModelOutput
 from inspect_ai.scorer import CORRECT, INCORRECT, NOANSWER, Target
 from inspect_ai.solver import TaskState

--- a/tests/evaluation/test_scorers_tool_trace.py
+++ b/tests/evaluation/test_scorers_tool_trace.py
@@ -10,6 +10,14 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+
+# The eval extra (inspect-ai) is nightly-only: PR CI runs
+# `uv sync --extra dev --extra pi --extra safety-ml` without it. Skip the
+# whole module cleanly when inspect_ai is unavailable rather than failing
+# collection — mirrors the boto3 guard in
+# tests/test_agent_runner/test_amazon_bedrock_tool_limit.py.
+pytest.importorskip("inspect_ai")
+
 from inspect_ai.model import ModelName, ModelOutput
 from inspect_ai.scorer import CORRECT, INCORRECT, Target
 from inspect_ai.solver import TaskState

--- a/tests/webui/test_v1_ws_approval_frame.py
+++ b/tests/webui/test_v1_ws_approval_frame.py
@@ -31,6 +31,21 @@ _TEST_SECRET = "v1-ws-handshake-secret-only-for-tests"
 os.environ.setdefault("WS_TICKET_SECRET", _TEST_SECRET)
 
 
+@pytest.fixture(autouse=True)
+def _pin_ws_ticket_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the app's verifier to THIS module's signing secret per test.
+
+    ``setdefault`` is order-dependent — a sibling module collected first with
+    a different secret (``test_v1_auth_endpoints`` uses ``v1-ws-ticket-...``)
+    wins the global env, making our valid tickets verify as 4002 in a batch
+    run (WebSocketDisconnect). ``ws_ticket._get_secret`` reads the env
+    dynamically, so pinning per test makes signing and verification agree
+    regardless of collection order; monkeypatch restores the prior value
+    afterwards.
+    """
+    monkeypatch.setenv("WS_TICKET_SECRET", _TEST_SECRET)
+
+
 class _Sub:
     """A subscription whose ``messages`` async-iter yields a queued backlog
     then blocks (mirrors a live ordered consumer)."""

--- a/uv.lock
+++ b/uv.lock
@@ -833,6 +833,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "faker"
 version = "25.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2657,6 +2666,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2865,6 +2887,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "testcontainers" },
 ]
@@ -2930,6 +2953,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "python-telegram-bot", specifier = ">=22.7" },
     { name = "pyyaml", marker = "extra == 'pi'", specifier = ">=6.0" },


### PR DESCRIPTION
Makes CI actually work after it was found **manually disabled since 2026-04-25** (no CI ran on #12–#45). Re-enabling surfaced real failures that the disabled workflow had hidden; this PR fixes them and speeds the suite up so it clears the job timeout.

## Fixes (the first real CI runs caught these)
- **eval tests aborted collection**: `tests/evaluation/test_scorers_{final_answer,tool_trace}.py` import `inspect_ai` at module top, but the `eval` extra is nightly-only (PR CI syncs `dev + pi + safety-ml`). `ModuleNotFoundError` aborted the whole pytest collection. Guarded both with `pytest.importorskip("inspect_ai")`, mirroring the boto3 guard in `test_amazon_bedrock_tool_limit.py`.
- **WS ticket-secret race (2 failures)**: `test_v1_ws_approval_frame.py` (added in #43, after the test/overhaul fix) reintroduced the `os.environ.setdefault("WS_TICKET_SECRET", ...)` ordering race — `test_v1_auth_endpoints` (collected first, different secret) wins the global env, so its valid tickets verify as 4002 → WebSocketDisconnect in a full-suite run (passed in isolation). Added the same per-test autouse `_pin_ws_ticket_secret` fixture the three sibling ws modules already use.

## Speedup
- **xdist `-n auto`**: the first green run took ~19.5 min in pytest and bumped into the 20-minute job timeout (cancelled despite all tests passing). Added `pytest-xdist` and parallelized. The suite is already test-isolated (per-worker testcontainer Postgres via session-scoped `pg_url`, per-test TRUNCATE), verified locally with `-n 4`: 2327 passed in ~60s (was ~4 min serial).
- Result on the 2-core runner: **pytest 19:31 → 12:51, job ~13.3 min — green, clear of the timeout.**

## Notes
- Ruff is `continue-on-error` in CI (a pre-existing ~592-error backlog, unrelated to this PR).
- For the ~5-min ideal, a follow-up can shard tests across parallel jobs (the 2-core single-runner is the current ceiling).

Verified: latest CI run on this branch is green (2312 passed, 12 skipped, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)