### PR TITLE
fix(ipc): keep NATS reconnecting instead of going silently deaf

### DIFF
--- a/src/rolemesh/ipc/nats_transport.py
+++ b/src/rolemesh/ipc/nats_transport.py
@@ -6,6 +6,7 @@ between the Orchestrator and container Agents.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import nats
@@ -25,6 +26,11 @@ _STREAM_MAX_AGE_S = 3600.0
 # KV TTL: 1 hour in seconds
 _KV_TTL_SECONDS = 3600.0
 
+# Bound the INITIAL connect so a missing NATS fails boot fast with a helpful
+# error, instead of blocking forever under max_reconnect_attempts=-1. Steady-
+# state reconnects (after a connection has been established) stay unbounded.
+_CONNECT_TIMEOUT_S = 10.0
+
 
 class NatsTransport:
     """NATS transport for Orchestrator-side IPC.
@@ -43,17 +49,42 @@ class NatsTransport:
         Raises ConnectionError if NATS is unreachable.
         """
 
-        async def _quiet_error(exc: Exception) -> None:
-            logger.debug("NATS connection attempt failed", error=str(exc))
+        async def _on_error(exc: Exception) -> None:
+            # Per-attempt errors stay at DEBUG: with infinite reconnect this
+            # fires on every retry during an outage, so a higher level would
+            # spam. The once-per-event callbacks below carry the visible signal.
+            logger.debug("NATS connection error", error=str(exc))
+
+        async def _on_disconnected() -> None:
+            logger.warning("NATS disconnected — reconnecting", url=self._url)
+
+        async def _on_reconnected() -> None:
+            # Durable consumers persist server-side across a NATS restart, so
+            # push subscriptions resume on reconnect with no resubscribe needed.
+            logger.info("NATS reconnected", url=self._url)
 
         try:
-            self._nc = await nats.connect(
-                self._url,
-                max_reconnect_attempts=3,
-                reconnect_time_wait=1,
-                error_cb=_quiet_error,
+            # Retry reconnects forever. The previous 3-attempt budget (~3s)
+            # meant any NATS outage longer than that exhausted the attempts and
+            # nats-py permanently closed the connection — the orchestrator kept
+            # running but was silently deaf to NATS until restarted.
+            #
+            # max_reconnect_attempts governs the INITIAL connect too, so under
+            # -1 a missing NATS would block boot forever. Bound only the first
+            # connect with wait_for to keep the fail-fast ConnectionError below;
+            # once connected, reconnects are unbounded.
+            self._nc = await asyncio.wait_for(
+                nats.connect(
+                    self._url,
+                    max_reconnect_attempts=-1,
+                    reconnect_time_wait=2,
+                    error_cb=_on_error,
+                    disconnected_cb=_on_disconnected,
+                    reconnected_cb=_on_reconnected,
+                ),
+                timeout=_CONNECT_TIMEOUT_S,
             )
-        except Exception as exc:
+        except Exception as exc:  # includes asyncio.TimeoutError (initial connect)
             raise ConnectionError(
                 f"Cannot connect to NATS at {self._url}. "
                 f"Start NATS with: docker compose -f docker-compose.dev.yml up -d"


### PR DESCRIPTION
## Problem

The orchestrator connected to NATS with `max_reconnect_attempts=3` /
`reconnect_time_wait=1` — only **~3 seconds** of reconnect budget. Any NATS
outage longer than that (a server restart, JetStream recovery, host load, a
network blip) exhausted the attempts, after which nats-py **permanently closes
the connection**. The orchestrator process kept running but was **deaf to NATS
forever**: follow-up publishes silently failed and the scheduler wedged (phantom
active slots), recoverable only by a full orchestrator restart.

It was hard to diagnose because the sole callback (`error_cb`) logged at `DEBUG`,
so the failure was invisible in normal logs.

### Reproduced deterministically

Stop NATS for >3s, then start it. Before this fix the orchestrator gave up
mid-outage and never reconnected — a follow-up NATS restart produced **zero** log
lines, confirming the client was closed and dead.

## Fix

- `max_reconnect_attempts=-1`: retry reconnects forever, so the connection
  survives any outage and resumes when NATS returns. The orchestrator's IPC
  subscriptions are **durable** consumers, which persist server-side across a
  NATS restart, so delivery resumes on reconnect with no resubscribe needed.
- Add `disconnected_cb` (WARNING) / `reconnected_cb` (INFO) so the
  disconnect/recover transitions are visible. `error_cb` stays at DEBUG: under
  infinite reconnect it fires on every retry, so a higher level would spam.
- `max_reconnect_attempts` also governs the **initial** connect, so under `-1` a
  missing NATS would block boot forever. Bound only the first connect with
  `wait_for(_CONNECT_TIMEOUT_S=10s)` to preserve the fail-fast `ConnectionError`
  that boot relies on (`main.py`, `evaluation/cli.py`).

## Verification

- Isolated throwaway NATS: connect → stop 6s → start → auto-reconnects, pub/sub
  roundtrip works again.
- Live orchestrator: 6s NATS outage → kept retrying past the old ~3s budget →
  `NATS reconnected` → stayed functional. The same scenario previously left it
  permanently wedged.
- Fail-fast boot preserved: connecting to a dead NATS raises `ConnectionError`
  after the bounded timeout instead of hanging.

## Scope / not included

- Container side (`agent_runner/main.py`) uses nats-py defaults (~120s budget) —
  more resilient but still finite; aligning it is a separate follow-up.
- The original warm-idle follow-up symptom (container-side delivery stall, fixed
  by killing the container) is a **distinct** issue and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)