### PR TITLE
feat(safety): platform-level safety rules (cross-tenant, default tier)

### DIFF
--- a/src/rolemesh/db/__init__.py
+++ b/src/rolemesh/db/__init__.py
@@ -19,6 +19,7 @@ from rolemesh.db.coworker_mcp import *  # noqa: F403
 from rolemesh.db.legacy import *  # noqa: F403
 from rolemesh.db.mcp_server import *  # noqa: F403
 from rolemesh.db.model import *  # noqa: F403
+from rolemesh.db.platform_safety import *  # noqa: F403
 from rolemesh.db.safety import *  # noqa: F403
 from rolemesh.db.schema import *  # noqa: F403
 from rolemesh.db.skill import *  # noqa: F403

--- a/src/rolemesh/db/platform_safety.py
+++ b/src/rolemesh/db/platform_safety.py
@@ -1,0 +1,133 @@
+"""Platform-level safety rules — cross-tenant, platform-owned reads.
+
+Rows live in ``platform_safety_rules`` (no ``tenant_id``): they apply
+across ALL tenants and are owned by the platform, not any tenant admin.
+The loader stamps the running job's ``tenant_id`` onto each snapshot so
+the Safety Pipeline — which is left untouched — treats platform and
+tenant rules identically.
+
+Two read paths, deliberately on different pools:
+
+  - :func:`fetch_platform_rule_snapshots` — **admin_conn** (B-class
+    cross-tenant maintenance per the RLS design). Used by the
+    orchestrator-side loader; returns pipeline-ready snapshot dicts for
+    every ENABLED platform rule (all tiers, floor included — floor still
+    enforces; only its *visibility* is suppressed elsewhere).
+
+  - :func:`list_visible_platform_rules` — **tenant_conn**. Used by the
+    tenant-facing v1 read API, which must stay within the business pool
+    (webui never imports ``admin_conn``). ``rolemesh_app`` holds SELECT
+    on this RLS-free catalog, so a plain ``tenant_conn`` read works; the
+    ``tenant_id`` argument only scopes the connection, not the query.
+    Floor-tier rows are filtered out here — that is where the three-tier
+    visibility contract lives.
+
+This phase exposes no write helpers: the 5 default-tier rules are seeded
+via schema seeding (:func:`rolemesh.db.schema._seed_platform_safety_rules`)
+and there is no platform-admin write REST yet.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from rolemesh.db._pool import admin_conn, tenant_conn
+
+if TYPE_CHECKING:
+    import asyncpg
+
+__all__ = [
+    "VISIBLE_TIERS",
+    "fetch_platform_rule_snapshots",
+    "list_visible_platform_rules",
+]
+
+# Tiers a tenant is allowed to SEE. ``floor`` is intentionally absent —
+# it enforces but is never surfaced to tenants.
+VISIBLE_TIERS: tuple[str, ...] = ("default", "transparent_floor")
+
+
+def _coerce_config(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, str):
+        raw = json.loads(raw) if raw else {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _row_to_snapshot(row: asyncpg.Record, *, tenant_id: str) -> dict[str, Any]:
+    """Project a platform rule row onto the pipeline snapshot shape.
+
+    Keys match ``rolemesh.safety.types.Rule.to_snapshot_dict`` exactly so
+    the pipeline cannot tell a platform snapshot from a tenant one.
+    ``tenant_id`` is the running job's tenant (stamped purely for audit
+    attribution); ``coworker_id`` is None (applies to every coworker).
+    """
+    return {
+        "id": str(row["id"]),
+        "tenant_id": tenant_id,
+        "coworker_id": None,
+        "stage": row["stage"],
+        "check_id": row["check_id"],
+        "config": _coerce_config(row["config"]),
+        "priority": int(row["priority"]),
+        "enabled": bool(row["enabled"]),
+        "description": row["description"] or "",
+    }
+
+
+def _row_to_dict(row: asyncpg.Record) -> dict[str, Any]:
+    """Full row projection (includes ``tier`` + timestamps) for read APIs."""
+    return {
+        "id": str(row["id"]),
+        "tier": row["tier"],
+        "stage": row["stage"],
+        "check_id": row["check_id"],
+        "config": _coerce_config(row["config"]),
+        "priority": int(row["priority"]),
+        "enabled": bool(row["enabled"]),
+        "description": row["description"] or "",
+        "created_at": row["created_at"].isoformat() if row["created_at"] else "",
+        "updated_at": row["updated_at"].isoformat() if row["updated_at"] else "",
+    }
+
+
+async def fetch_platform_rule_snapshots(tenant_id: str) -> list[dict[str, Any]]:
+    """Enabled platform rules as pipeline-ready snapshot dicts.
+
+    B-class (``admin_conn``): the table is tenant-agnostic. ``tenant_id``
+    is stamped onto each snapshot so the pipeline's audit attribution
+    lands on the running job's tenant — platform rules apply regardless.
+    ALL enabled tiers are returned (floor included): floor still enforces;
+    only its visibility is suppressed, and that happens in the read API,
+    not here.
+    """
+    async with admin_conn() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, stage, check_id, config, priority, enabled, description
+            FROM platform_safety_rules
+            WHERE enabled = TRUE
+            ORDER BY priority DESC, created_at
+            """
+        )
+    return [_row_to_snapshot(r, tenant_id=tenant_id) for r in rows]
+
+
+async def list_visible_platform_rules(tenant_id: str) -> list[dict[str, Any]]:
+    """Platform rules a tenant is allowed to see (default + transparent_floor).
+
+    Runs on ``tenant_conn`` so the v1 read API stays in the business pool
+    (``rolemesh_app`` has SELECT on this RLS-free catalog). ``tenant_id``
+    only scopes the connection — platform rules are global, so the query
+    has no tenant predicate. Floor-tier rows are never returned.
+    """
+    async with tenant_conn(tenant_id) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT * FROM platform_safety_rules
+            WHERE tier = ANY($1::text[])
+            ORDER BY priority DESC, created_at
+            """,
+            list(VISIBLE_TIERS),
+        )
+    return [_row_to_dict(r) for r in rows]

--- a/src/rolemesh/db/safety.py
+++ b/src/rolemesh/db/safety.py
@@ -354,19 +354,35 @@ async def insert_safety_decision(
     Called by the safety_events subscriber for every decision the
     container publishes. Never raises on per-row validation — malformed
     inputs should be filtered upstream in ``SafetyEngine.handle_safety_event``.
+
+    ``source`` ('tenant' | 'platform') is derived here — NOT in the
+    pipeline — by checking whether any triggered rule id belongs to the
+    platform-owned ``platform_safety_rules`` catalog. ``rolemesh_app``
+    holds SELECT on that RLS-free table, so this is a single cheap EXISTS
+    inside the same connection. Keeping the derivation at the write layer
+    is what lets ``pipeline_core`` stay byte-unchanged.
     """
     async with tenant_conn(tenant_id) as conn:
+        source = "tenant"
+        if triggered_rule_ids:
+            is_platform = await conn.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM platform_safety_rules "
+                "WHERE id = ANY($1::uuid[]))",
+                triggered_rule_ids,
+            )
+            if is_platform:
+                source = "platform"
         row = await conn.fetchrow(
             """
             INSERT INTO safety_decisions (
                 tenant_id, coworker_id, conversation_id, job_id,
                 stage, verdict_action, triggered_rule_ids,
-                findings, context_digest, context_summary
+                findings, context_digest, context_summary, source
             )
             VALUES (
                 $1::uuid, $2::uuid, $3, $4,
                 $5, $6, $7::uuid[],
-                $8::jsonb, $9, $10
+                $8::jsonb, $9, $10, $11
             )
             RETURNING id
             """,
@@ -380,6 +396,7 @@ async def insert_safety_decision(
             json.dumps(findings),
             context_digest,
             context_summary,
+            source,
         )
     assert row is not None
     return str(row["id"])
@@ -509,6 +526,7 @@ async def get_safety_decision(
         "findings": findings if isinstance(findings, list) else [],
         "context_digest": row["context_digest"],
         "context_summary": row["context_summary"],
+        "source": row["source"],
         "created_at": row["created_at"].isoformat() if row["created_at"] else "",
     }
 
@@ -628,6 +646,7 @@ async def list_safety_decisions(
                 "findings": findings if isinstance(findings, list) else [],
                 "context_digest": r["context_digest"],
                 "context_summary": r["context_summary"],
+                "source": r["source"],
                 "created_at": r["created_at"].isoformat() if r["created_at"] else "",
             }
         )

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -77,6 +77,88 @@ async def _seed_reference_data(
             provider, model_id, family, display,
         )
 
+    # ----- Platform safety rules seed (default tier) ----------------------
+    await _seed_platform_safety_rules(conn)
+
+
+# Default-tier platform safety rules: "industry best-practice" detections
+# the platform ships ON for every tenant. Tenants cannot loosen them (the
+# table is read-only to the business role and the pipeline is monotonic —
+# adding a tenant rule can only add restrictions); a tenant tightens by
+# adding their own stricter ``safety_rules`` rows alongside.
+#
+# Config / action posture:
+#   - secret_scanner / prompt_injection / jailbreak / toxicity ship their
+#     natural ``block`` verdict — credential leakage, injection, known
+#     jailbreak phrases and toxic output are unambiguous platform risks.
+#   - pii.regex ships a non-disruptive ``warn`` baseline scoped to high-
+#     confidence identifiers (SSN / credit card). PII appears legitimately
+#     in prompts constantly, so a cross-tenant DEFAULT only surfaces it;
+#     a tenant can tighten warn→block by adding their own rule. EMAIL /
+#     PHONE / IP are deliberately left off the baseline (too false-
+#     positive-prone for an all-tenant default).
+#
+# Stages bind to wired hooks only: INPUT_PROMPT (container-side) and
+# MODEL_OUTPUT (orchestrator-side). Slow checks reach the orchestrator
+# registry via RemoteCheck / the in-process MODEL_OUTPUT pipeline.
+#
+# Tuple shape: (check_id, stage, config, priority, description).
+_PLATFORM_DEFAULT_RULES: list[tuple[str, str, dict[str, object], int, str]] = [
+    (
+        "secret_scanner", "model_output", {}, 1000,
+        "Block credential / API-key leakage in model output.",
+    ),
+    (
+        "pii.regex", "input_prompt",
+        {
+            "patterns": {"SSN": True, "CREDIT_CARD": True},
+            "action_override": "warn",
+        },
+        1000,
+        "Surface high-confidence PII (SSN / credit card) in user prompts.",
+    ),
+    (
+        "llm_guard.prompt_injection", "input_prompt", {"threshold": 0.9}, 1000,
+        "Block prompt-injection attempts in user prompts (OWASP LLM01).",
+    ),
+    (
+        "llm_guard.jailbreak", "input_prompt", {}, 1000,
+        "Block known jailbreak phrases in user prompts.",
+    ),
+    (
+        "llm_guard.toxicity", "model_output", {"threshold": 0.7}, 1000,
+        "Block toxic model output.",
+    ),
+]
+
+
+async def _seed_platform_safety_rules(
+    conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record],
+) -> None:
+    """Idempotent seed of the 5 default-tier platform safety rules.
+
+    Keyed on the UNIQUE ``(tier, check_id, stage)`` identity so re-runs
+    and post-``TRUNCATE`` re-seeds (``_reset_test_data``) are safe. Only
+    the ``default`` tier is seeded this phase; ``floor`` /
+    ``transparent_floor`` are carried in the schema for future use.
+    """
+    import json
+
+    for check_id, stage, config, priority, description in _PLATFORM_DEFAULT_RULES:
+        await conn.execute(
+            """
+            INSERT INTO platform_safety_rules
+                (tier, stage, check_id, config, priority, description)
+            VALUES ('default', $1, $2, $3::jsonb, $4, $5)
+            ON CONFLICT (tier, check_id, stage) DO NOTHING
+            """,
+            stage,
+            check_id,
+            json.dumps(config),
+            priority,
+            description,
+        )
+
 
 async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record]) -> None:
     """Create tables and indexes.
@@ -1028,6 +1110,52 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "ON safety_rules (coworker_id) WHERE coworker_id IS NOT NULL"
     )
 
+    # --- Platform-level safety rules (cross-tenant, platform-owned) ---
+    # Platform-defined rules that apply across ALL tenants, owned by the
+    # platform rather than any tenant admin. Deliberately carries NO
+    # tenant_id / coworker_id: a platform rule is cross-tenant and all-
+    # coworker by definition. Mirrors the ``models`` catalog shape
+    # (platform-level, no RLS). The loader stamps the running job's
+    # tenant_id onto each snapshot at load time so the Safety Pipeline —
+    # which stays UNTOUCHED — treats platform and tenant rules
+    # identically. Access: the business role (rolemesh_app) may SELECT
+    # (the tenant-facing read API runs on that pool and must surface
+    # visible platform rules) but never write — see the REVOKE in the
+    # RLS section below. Writes go through admin_conn only.
+    #
+    # ``tier`` carries the three-tier model (see docs/15-safety-*):
+    #   - floor             : invisible + immutable to tenants
+    #   - transparent_floor : visible + immutable
+    #   - default           : visible; tenants cannot loosen but may add
+    #                         their own stricter tenant rules alongside
+    # This phase only seeds ``default`` rows; floor / transparent_floor
+    # are carried in the schema for future use.
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS platform_safety_rules (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            tier            TEXT NOT NULL
+                            CHECK (tier IN ('floor', 'transparent_floor', 'default')),
+            stage           TEXT NOT NULL,
+            check_id        TEXT NOT NULL,
+            config          JSONB NOT NULL DEFAULT '{}'::jsonb,
+            priority        INTEGER NOT NULL DEFAULT 1000,
+            enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+            description     TEXT NOT NULL DEFAULT '',
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    # Identity for the idempotent seed: one platform rule per
+    # (tier, check_id, stage). The seed's ON CONFLICT keys on this.
+    await conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_platform_safety_rules_identity "
+        "ON platform_safety_rules (tier, check_id, stage)"
+    )
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_platform_safety_rules_active "
+        "ON platform_safety_rules (enabled, stage)"
+    )
+
     # Per-decision audit rows. We store only a SHA-256 digest of the
     # payload + a short human summary (tool name, prompt prefix) — not
     # the original text — so the audit table cannot double as a PII
@@ -1046,6 +1174,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
             findings              JSONB NOT NULL DEFAULT '[]'::jsonb,
             context_digest        TEXT NOT NULL DEFAULT '',
             context_summary       TEXT NOT NULL DEFAULT '',
+            source                TEXT NOT NULL DEFAULT 'tenant',
             created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
         )
     """)
@@ -1053,6 +1182,14 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     # subsystem. Drop the column if an earlier deployment created it.
     await conn.execute(
         "ALTER TABLE safety_decisions DROP COLUMN IF EXISTS approval_context"
+    )
+    # ``source`` ('tenant' | 'platform') lets operators tell platform-rule
+    # hits from tenant-rule hits at a glance. Forward-migrate existing
+    # deployments. Populated at write time (see db.safety.insert_safety_
+    # decision) without touching the pipeline.
+    await conn.execute(
+        "ALTER TABLE safety_decisions "
+        "ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'tenant'"
     )
     await conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_safety_decisions_tenant_time "
@@ -1360,6 +1497,16 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     # second layer; the GRANT is the first.
     await conn.execute("REVOKE ALL ON external_tenant_map FROM rolemesh_app")
     await conn.execute("REVOKE ALL ON tenants FROM rolemesh_app")
+    # platform_safety_rules is a platform-owned catalog. Unlike tenants /
+    # external_tenant_map (full REVOKE), the business role KEEPS SELECT —
+    # the tenant-facing read API runs on rolemesh_app and must surface
+    # visible platform rules within its own pool (webui never uses
+    # admin_conn). It must never WRITE: platform rules are managed via
+    # admin_conn only. Floor-tier invisibility is enforced in the app-
+    # layer projection, not by this grant.
+    await conn.execute(
+        "REVOKE INSERT, UPDATE, DELETE ON platform_safety_rules FROM rolemesh_app"
+    )
 
     # Future tables created by migrations should inherit the same privs
     # automatically so we don't have to remember to GRANT after each DDL.

--- a/src/rolemesh/safety/loader.py
+++ b/src/rolemesh/safety/loader.py
@@ -34,6 +34,17 @@ except ModuleNotFoundError:
     # code path still works when asyncpg + pg ARE present.
     pass
 
+# Same orchestrator-only import discipline for the platform-rule reader.
+# Exposed at module scope so orchestrator tests can
+# ``monkeypatch.setattr(loader, "fetch_platform_rule_snapshots", ...)``;
+# the agent container hits the ModuleNotFoundError fallback (it never
+# calls fetch_safety_rule_snapshots — it receives the merged snapshot via
+# AgentInitData).
+try:
+    from rolemesh.db.platform_safety import fetch_platform_rule_snapshots  # noqa: F401
+except ModuleNotFoundError:
+    pass
+
 if TYPE_CHECKING:
     from agent_runner.hooks.registry import HookRegistry
     from agent_runner.tools.context import ToolContext
@@ -85,6 +96,10 @@ async def fetch_safety_rule_snapshots(
 
     ``list_safety_rules_for_coworker`` already filters ``enabled=TRUE``
     in SQL, so no application-side filter is needed here.
+
+    Platform-level rules (``platform_safety_rules``) are merged in after
+    the tenant rules — this is the single seam where cross-tenant rules
+    enter the snapshot, keeping the pipeline oblivious to their origin.
     """
     # Resolve via ``globals()`` so orchestrator tests that
     # ``monkeypatch.setattr(loader, "list_safety_rules_for_coworker",
@@ -101,7 +116,21 @@ async def fetch_safety_rule_snapshots(
             "rolemesh.db is not packaged in this environment"
         )
     rules = await fn(tenant_id, coworker_id)
-    return [r.to_snapshot_dict() for r in rules]
+    snapshots = [r.to_snapshot_dict() for r in rules]
+
+    # Merge platform-level rules (cross-tenant, platform-owned) at this
+    # single seam. They are stamped with the running job's tenant_id (for
+    # audit attribution) and coworker_id=None (all coworkers). The Safety
+    # Pipeline is UNTOUCHED — it treats these snapshots identically to
+    # tenant rules; tenant rules cannot loosen them (the pipeline is
+    # monotonic and the platform table is read-only to the business
+    # role). Resolved via ``globals()`` so tests can monkeypatch the
+    # module attribute; ``None`` only in the agent container, which never
+    # reaches this function.
+    platform_fn = globals().get("fetch_platform_rule_snapshots")
+    if platform_fn is not None:
+        snapshots.extend(await platform_fn(tenant_id))
+    return snapshots
 
 
 async def load_safety_rules_snapshot(

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -780,6 +780,14 @@ class SafetyRule(BaseModel):
     description: str
     created_at: str
     updated_at: str
+    # Platform Safety Rules: ``source`` distinguishes tenant-owned rules
+    # (editable on the admin surface) from platform-owned ones (read-only,
+    # cross-tenant). ``tier`` is set only for platform rules. ``editable``
+    # is a convenience flag the SPA uses to show/hide edit / "tighten"
+    # controls without re-deriving from source.
+    source: Literal["tenant", "platform"] = "tenant"
+    tier: Literal["floor", "transparent_floor", "default"] | None = None
+    editable: bool = True
 
 
 class SafetyCheck(BaseModel):
@@ -827,6 +835,9 @@ class SafetyDecision(BaseModel):
     findings: list[SafetyFinding] = Field(default_factory=list)
     context_digest: str
     context_summary: str
+    # 'platform' when any triggered rule is a platform-owned rule, else
+    # 'tenant'. Lets the SPA / ops filter platform-rule hits at a glance.
+    source: Literal["tenant", "platform"] = "tenant"
     created_at: str
 
 

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -17,6 +17,8 @@ enforces tenant scope at the DB level; the explicit
 
 from __future__ import annotations
 
+from typing import Any
+
 import asyncpg
 from fastapi import APIRouter, Depends, Query
 
@@ -28,6 +30,7 @@ from rolemesh.db import (
     list_safety_decisions,
     list_safety_rules,
     list_safety_rules_audit,
+    list_visible_platform_rules,
 )
 from rolemesh.safety.registry import get_orchestrator_registry
 from rolemesh.safety.types import Rule as SafetyRuleDataclass
@@ -74,6 +77,38 @@ def _rule_to_response(r: SafetyRuleDataclass) -> SafetyRule:
         description=r.description,
         created_at=r.created_at,
         updated_at=r.updated_at,
+        source="tenant",
+        tier=None,
+        editable=True,
+    )
+
+
+def _platform_rule_to_response(row: dict[str, Any]) -> SafetyRule:
+    """Project a platform rule row onto the wire shape.
+
+    Platform rules are cross-tenant and have no owning tenant, so
+    ``tenant_id`` is rendered as an empty string (the "global / platform"
+    signal) and ``coworker_id`` is None. They are read-only on every
+    tenant surface: ``editable=False`` and ``source="platform"``. ``tier``
+    carries which of the visible tiers (default / transparent_floor) this
+    rule belongs to.
+    """
+    config = row["config"]
+    return SafetyRule(
+        id=str(row["id"]),
+        tenant_id="",
+        coworker_id=None,
+        stage=row["stage"],
+        check_id=str(row["check_id"]),
+        config=config if isinstance(config, dict) else {},
+        priority=int(row["priority"]),
+        enabled=bool(row["enabled"]),
+        description=str(row["description"]),
+        created_at=str(row.get("created_at", "")),
+        updated_at=str(row.get("updated_at", "")),
+        source="platform",
+        tier=row["tier"],
+        editable=False,
     )
 
 
@@ -120,6 +155,7 @@ def _decision_row_to_response(row: dict[str, object]) -> SafetyDecision:
         findings=findings,
         context_digest=str(row.get("context_digest", "") or ""),
         context_summary=str(row.get("context_summary", "") or ""),
+        source=row.get("source", "tenant"),  # type: ignore[arg-type]
         created_at=str(row.get("created_at", "") or ""),
     )
 
@@ -187,10 +223,19 @@ async def list_rules(
 ) -> list[SafetyRule]:
     """List safety rules for the caller's tenant.
 
-    Filters mirror the admin endpoint exactly so the SPA can render
-    the same list view against either surface during the migration
-    window. Ordering (``priority DESC, updated_at DESC``) lives in
-    the helper.
+    Returns the tenant's own rules PLUS the platform-owned rules that
+    apply across all tenants. Platform rules are read-only
+    (``editable=False``, ``source="platform"``) and only the visible
+    tiers (default / transparent_floor) are surfaced — floor-tier rules
+    enforce but are never shown. They honor the ``stage`` / ``enabled``
+    filters. Like tenant-wide (``coworker_id IS NULL``) rules, platform
+    rules are excluded when the caller filters by a specific
+    ``coworker_id`` — that filter is an exact-match narrowing, and
+    platform rules are not bound to any single coworker.
+
+    Tenant-rule filters mirror the admin endpoint exactly. Ordering
+    (``priority DESC, updated_at DESC``) lives in the helper; platform
+    rules are appended after, so the list groups tenant rules first.
     """
     rows = await list_safety_rules(
         user.tenant_id,
@@ -198,7 +243,16 @@ async def list_rules(
         stage=stage,
         enabled=enabled,
     )
-    return [_rule_to_response(r) for r in rows]
+    out = [_rule_to_response(r) for r in rows]
+
+    if coworker_id is None:
+        for prow in await list_visible_platform_rules(user.tenant_id):
+            if stage is not None and prow["stage"] != stage:
+                continue
+            if enabled is not None and bool(prow["enabled"]) != enabled:
+                continue
+            out.append(_platform_rule_to_response(prow))
+    return out
 
 
 @router.get("/rules/{rule_id}", response_model=SafetyRule)
@@ -208,11 +262,29 @@ async def get_rule(
 ) -> SafetyRule:
     """Single rule, scoped to the caller's tenant.
 
-    Cross-tenant lookups return 404 (not 403) so a UUID-guess probe
-    cannot infer the row's existence in another tenant.
+    Resolves a tenant-owned rule first; falls back to a visible platform
+    rule with this id so the ids returned by ``GET /rules`` are all
+    individually fetchable. Cross-tenant lookups (and floor-tier platform
+    ids) return 404 (not 403) so a UUID-guess probe cannot infer a row's
+    existence in another tenant.
     """
-    rule = await _get_rule_or_404(rule_id, tenant_id=user.tenant_id)
-    return _rule_to_response(rule)
+    try:
+        rule = await get_safety_rule(rule_id, tenant_id=user.tenant_id)
+    except asyncpg.DataError:
+        rule = None
+    if rule is not None:
+        return _rule_to_response(rule)
+
+    for prow in await list_visible_platform_rules(user.tenant_id):
+        if str(prow["id"]) == rule_id:
+            return _platform_rule_to_response(prow)
+
+    raise_error_response(
+        "NOT_FOUND",
+        "Safety rule not found.",
+        status_code=404,
+        details={"rule_id": rule_id},
+    )
 
 
 @router.get(

--- a/tests/safety/test_loader_platform_merge.py
+++ b/tests/safety/test_loader_platform_merge.py
@@ -1,0 +1,156 @@
+"""Platform-rule merge in the loader + snapshot projection (DB-free).
+
+The loader resolves both reader functions via ``globals()`` so they can
+be monkeypatched without a live Postgres — that is the whole point of the
+module-scope import dance. The projection helpers in
+``rolemesh.db.platform_safety`` take plain dicts (``asyncpg.Record`` is
+dict-like) so they are tested directly.
+
+What these pin:
+  - tenant rules come first, platform rules are appended (single seam);
+  - a platform snapshot is byte-shaped exactly like a tenant snapshot
+    (so the UNTOUCHED pipeline cannot tell them apart);
+  - the running job's tenant_id is stamped on, coworker_id is None;
+  - platform rules alone (zero tenant rules) still produce a non-None
+    snapshot so the hook handler registers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.db import platform_safety
+from rolemesh.safety import loader
+from rolemesh.safety.types import Rule, Stage
+
+
+class _FakeTenantRule:
+    """Minimal stand-in exposing ``to_snapshot_dict`` like safety.types.Rule."""
+
+    def __init__(self, rule_id: str) -> None:
+        self._rule_id = rule_id
+
+    def to_snapshot_dict(self) -> dict[str, object]:
+        return {
+            "id": self._rule_id,
+            "tenant_id": "T",
+            "coworker_id": None,
+            "stage": "input_prompt",
+            "check_id": "pii.regex",
+            "config": {},
+            "priority": 100,
+            "enabled": True,
+            "description": "",
+        }
+
+
+def _platform_snapshot(rule_id: str, tenant_id: str) -> dict[str, object]:
+    return {
+        "id": rule_id,
+        "tenant_id": tenant_id,
+        "coworker_id": None,
+        "stage": "model_output",
+        "check_id": "llm_guard.toxicity",
+        "config": {"threshold": 0.7},
+        "priority": 1000,
+        "enabled": True,
+        "description": "tox",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_merges_platform_after_tenant(monkeypatch) -> None:
+    async def fake_tenant(tenant_id: str, coworker_id: str) -> list[_FakeTenantRule]:
+        assert (tenant_id, coworker_id) == ("T", "C")
+        return [_FakeTenantRule("tenant-rule-1")]
+
+    async def fake_platform(tenant_id: str) -> list[dict[str, object]]:
+        assert tenant_id == "T"
+        return [_platform_snapshot("plat-1", tenant_id)]
+
+    monkeypatch.setattr(loader, "list_safety_rules_for_coworker", fake_tenant)
+    monkeypatch.setattr(loader, "fetch_platform_rule_snapshots", fake_platform)
+
+    snaps = await loader.fetch_safety_rule_snapshots("T", "C")
+
+    # Tenant rules first, platform appended — single, ordered seam.
+    assert [s["id"] for s in snaps] == ["tenant-rule-1", "plat-1"]
+    plat = snaps[-1]
+    assert plat["coworker_id"] is None
+    assert plat["tenant_id"] == "T"
+
+
+@pytest.mark.asyncio
+async def test_platform_only_snapshot_is_non_none(monkeypatch) -> None:
+    """Zero tenant rules + ≥1 platform rule still registers the hook."""
+
+    async def fake_tenant(tenant_id: str, coworker_id: str) -> list[_FakeTenantRule]:
+        return []
+
+    async def fake_platform(tenant_id: str) -> list[dict[str, object]]:
+        return [_platform_snapshot("plat-1", tenant_id)]
+
+    monkeypatch.setattr(loader, "list_safety_rules_for_coworker", fake_tenant)
+    monkeypatch.setattr(loader, "fetch_platform_rule_snapshots", fake_platform)
+
+    snaps = await loader.load_safety_rules_snapshot("T", "C")
+    assert snaps is not None
+    assert [s["id"] for s in snaps] == ["plat-1"]
+
+
+@pytest.mark.asyncio
+async def test_no_rules_anywhere_is_none(monkeypatch) -> None:
+    async def fake_tenant(tenant_id: str, coworker_id: str) -> list[_FakeTenantRule]:
+        return []
+
+    async def fake_platform(tenant_id: str) -> list[dict[str, object]]:
+        return []
+
+    monkeypatch.setattr(loader, "list_safety_rules_for_coworker", fake_tenant)
+    monkeypatch.setattr(loader, "fetch_platform_rule_snapshots", fake_platform)
+
+    assert await loader.load_safety_rules_snapshot("T", "C") is None
+
+
+def test_row_to_snapshot_matches_tenant_rule_shape() -> None:
+    """A platform snapshot must be key-identical to a tenant snapshot so
+    the pipeline (untouched) cannot distinguish their origin.
+    """
+    row = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "stage": "input_prompt",
+        "check_id": "pii.regex",
+        "config": '{"patterns": {"SSN": true}}',  # JSON string from DB
+        "priority": 1000,
+        "enabled": True,
+        "description": "x",
+    }
+    snap = platform_safety._row_to_snapshot(row, tenant_id="TEN")
+
+    assert snap["tenant_id"] == "TEN"  # stamped for audit attribution
+    assert snap["coworker_id"] is None  # applies to all coworkers
+    assert snap["config"] == {"patterns": {"SSN": True}}  # str coerced to dict
+
+    reference = Rule(
+        id="i",
+        tenant_id="TEN",
+        coworker_id=None,
+        stage=Stage.INPUT_PROMPT,
+        check_id="pii.regex",
+        config={},
+    ).to_snapshot_dict()
+    assert set(snap.keys()) == set(reference.keys())
+
+
+def test_row_to_snapshot_passes_through_dict_config() -> None:
+    row = {
+        "id": "abc",
+        "stage": "model_output",
+        "check_id": "llm_guard.toxicity",
+        "config": {"threshold": 0.7},  # already a dict
+        "priority": 1000,
+        "enabled": True,
+        "description": "",
+    }
+    snap = platform_safety._row_to_snapshot(row, tenant_id="T")
+    assert snap["config"] == {"threshold": 0.7}

--- a/tests/safety/test_platform_rules_db.py
+++ b/tests/safety/test_platform_rules_db.py
@@ -1,0 +1,173 @@
+"""DB tests for Platform Safety Rules (cross-tenant, platform-owned).
+
+Hits a real Postgres testcontainer (``test_db``), so schema drift and
+grant/visibility behavior show up immediately. Exercises:
+
+  - the 5 default-tier rules are seeded idempotently;
+  - snapshots stamp the running job's tenant_id and null the coworker;
+  - the loader merges platform rules into EVERY tenant's snapshot
+    (cross-tenant), and tenants cannot edit them (separate table);
+  - tier visibility: floor rules enforce but are never surfaced to
+    tenants, default / transparent_floor are;
+  - ``safety_decisions.source`` is 'platform' when a triggered rule is a
+    platform rule, else 'tenant'.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from rolemesh.db import (
+    admin_conn,
+    create_coworker,
+    create_safety_rule,
+    create_tenant,
+    fetch_platform_rule_snapshots,
+    insert_safety_decision,
+    list_safety_decisions,
+    list_visible_platform_rules,
+)
+from rolemesh.db.platform_safety import VISIBLE_TIERS
+from rolemesh.safety import loader
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+_EXPECTED_DEFAULT_CHECKS = {
+    "secret_scanner",
+    "pii.regex",
+    "llm_guard.prompt_injection",
+    "llm_guard.jailbreak",
+    "llm_guard.toxicity",
+}
+
+
+async def _tenant_and_coworker(slug: str) -> tuple[str, str]:
+    t = await create_tenant(name=f"T-{slug}", slug=f"{slug}-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="CW", folder=f"cw-{uuid.uuid4().hex[:8]}"
+    )
+    return t.id, cw.id
+
+
+async def _insert_floor_rule() -> None:
+    """Seed one floor-tier rule directly (no write helper this phase)."""
+    async with admin_conn() as conn:
+        await conn.execute(
+            "INSERT INTO platform_safety_rules (tier, stage, check_id) "
+            "VALUES ('floor', 'input_prompt', 'pii.regex') "
+            "ON CONFLICT (tier, check_id, stage) DO NOTHING"
+        )
+
+
+class TestSeed:
+    @pytest.mark.asyncio
+    async def test_five_default_rules_seeded(self) -> None:
+        tid, _ = await _tenant_and_coworker("seed")
+        snaps = await fetch_platform_rule_snapshots(tid)
+        assert {s["check_id"] for s in snaps} == _EXPECTED_DEFAULT_CHECKS
+        assert all(s["enabled"] for s in snaps)
+
+    @pytest.mark.asyncio
+    async def test_snapshots_stamp_tenant_and_null_coworker(self) -> None:
+        tid, _ = await _tenant_and_coworker("stamp")
+        snaps = await fetch_platform_rule_snapshots(tid)
+        assert snaps
+        assert all(s["tenant_id"] == tid for s in snaps)
+        assert all(s["coworker_id"] is None for s in snaps)
+        # Snapshot shape is exactly the pipeline contract.
+        expected_keys = {
+            "id", "tenant_id", "coworker_id", "stage", "check_id",
+            "config", "priority", "enabled", "description",
+        }
+        assert all(set(s.keys()) == expected_keys for s in snaps)
+
+
+class TestVisibility:
+    @pytest.mark.asyncio
+    async def test_floor_enforces_but_is_invisible(self) -> None:
+        tid, _ = await _tenant_and_coworker("vis")
+        await _insert_floor_rule()
+
+        # Floor IS injected into the enforcement snapshot...
+        snaps = await fetch_platform_rule_snapshots(tid)
+        assert any(
+            s["stage"] == "input_prompt" and s["check_id"] == "pii.regex"
+            for s in snaps
+        )
+        # ...but is NEVER surfaced to the tenant.
+        visible = await list_visible_platform_rules(tid)
+        assert visible
+        assert all(row["tier"] in VISIBLE_TIERS for row in visible)
+        assert all(row["tier"] != "floor" for row in visible)
+
+
+class TestCrossTenant:
+    @pytest.mark.asyncio
+    async def test_platform_rules_apply_to_every_tenant(self) -> None:
+        ta, ca = await _tenant_and_coworker("xa")
+        tb, cb = await _tenant_and_coworker("xb")
+
+        snaps_a = await loader.fetch_safety_rule_snapshots(ta, ca)
+        snaps_b = await loader.fetch_safety_rule_snapshots(tb, cb)
+
+        plat_a = {s["id"] for s in snaps_a if s["coworker_id"] is None
+                  and s["check_id"] in _EXPECTED_DEFAULT_CHECKS}
+        plat_b = {s["id"] for s in snaps_b if s["coworker_id"] is None
+                  and s["check_id"] in _EXPECTED_DEFAULT_CHECKS}
+        # Same platform rule rows reach both tenants (cross-tenant).
+        assert plat_a == plat_b
+        assert len(plat_a) == len(_EXPECTED_DEFAULT_CHECKS)
+
+    @pytest.mark.asyncio
+    async def test_tenant_rules_merge_alongside_platform(self) -> None:
+        tid, cw = await _tenant_and_coworker("merge")
+        own = await create_safety_rule(
+            tenant_id=tid,
+            stage="input_prompt",
+            check_id="pii.regex",
+            config={"patterns": {"EMAIL": True}},
+        )
+        snaps = await loader.fetch_safety_rule_snapshots(tid, cw)
+        ids = {s["id"] for s in snaps}
+        # Tenant rule AND the 5 platform rules are all present.
+        assert own.id in ids
+        assert len(ids) >= len(_EXPECTED_DEFAULT_CHECKS) + 1
+
+
+class TestDecisionSource:
+    @pytest.mark.asyncio
+    async def test_source_platform_when_triggered_rule_is_platform(self) -> None:
+        tid, _ = await _tenant_and_coworker("srcp")
+        snaps = await fetch_platform_rule_snapshots(tid)
+        platform_rule_id = snaps[0]["id"]
+
+        decision_id = await insert_safety_decision(
+            tenant_id=tid,
+            stage="model_output",
+            verdict_action="block",
+            triggered_rule_ids=[platform_rule_id],
+            findings=[],
+            context_digest="d",
+            context_summary="s",
+        )
+        rows = await list_safety_decisions(tid)
+        row = next(r for r in rows if r["id"] == decision_id)
+        assert row["source"] == "platform"
+
+    @pytest.mark.asyncio
+    async def test_source_tenant_for_non_platform_rule(self) -> None:
+        tid, _ = await _tenant_and_coworker("srct")
+        decision_id = await insert_safety_decision(
+            tenant_id=tid,
+            stage="input_prompt",
+            verdict_action="block",
+            triggered_rule_ids=[str(uuid.uuid4())],
+            findings=[],
+            context_digest="d",
+            context_summary="s",
+        )
+        rows = await list_safety_decisions(tid)
+        row = next(r for r in rows if r["id"] == decision_id)
+        assert row["source"] == "tenant"

--- a/tests/webui/test_v1_safety.py
+++ b/tests/webui/test_v1_safety.py
@@ -23,11 +23,13 @@ from fastapi import FastAPI
 
 from rolemesh.auth.provider import AuthenticatedUser
 from rolemesh.db import (
+    admin_conn,
     create_coworker,
     create_safety_rule,
     create_tenant,
     create_user,
     delete_safety_rule,
+    fetch_platform_rule_snapshots,
     insert_safety_decision,
     update_safety_rule,
 )
@@ -203,10 +205,81 @@ async def test_list_rules_filters_by_stage_and_enabled() -> None:
             headers=_HDRS,
         )
     assert resp.status_code == 200
-    ids = {r["id"] for r in resp.json()}
-    assert ids == {on.id}
-    assert off.id not in ids
-    assert other_stage.id not in ids
+    rows = resp.json()
+    # Tenant-owned rows respect the exact filter.
+    tenant_ids = {r["id"] for r in rows if r["source"] == "tenant"}
+    assert tenant_ids == {on.id}
+    assert off.id not in tenant_ids
+    assert other_stage.id not in tenant_ids
+    # Platform default rules at this stage are also surfaced (read-only),
+    # honoring the same stage/enabled filter.
+    platform = [r for r in rows if r["source"] == "platform"]
+    assert platform, "expected platform input_prompt rules to be surfaced"
+    assert all(r["stage"] == "input_prompt" and r["enabled"] for r in platform)
+    assert all(r["editable"] is False and r["tier"] for r in platform)
+
+
+async def test_list_rules_surfaces_platform_rules_read_only() -> None:
+    """An unfiltered list returns the platform default rules, marked
+    read-only (source=platform, editable=False, tier set, tenant_id="").
+    Floor-tier rules enforce but must never appear.
+    """
+    user, _ = await _make_user("plat")
+    async with admin_conn() as conn:
+        await conn.execute(
+            "INSERT INTO platform_safety_rules (tier, stage, check_id) "
+            "VALUES ('floor', 'input_prompt', 'pii.regex') "
+            "ON CONFLICT (tier, check_id, stage) DO NOTHING"
+        )
+
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get("/api/v1/safety/rules", headers=_HDRS)
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    platform = [r for r in rows if r["source"] == "platform"]
+    assert len(platform) == 5  # the 5 default-tier rules
+    assert all(r["editable"] is False for r in platform)
+    assert all(r["tenant_id"] == "" for r in platform)
+    assert all(r["tier"] in ("default", "transparent_floor") for r in platform)
+    # floor never surfaces, even though it enforces
+    assert all(r["tier"] != "floor" for r in platform)
+
+
+async def test_get_platform_rule_by_id() -> None:
+    """A platform rule id from the list is individually fetchable and
+    renders the same read-only projection.
+    """
+    user, _ = await _make_user("getp")
+    snaps = await fetch_platform_rule_snapshots(user.tenant_id)
+    platform_id = snaps[0]["id"]
+
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get(f"/api/v1/safety/rules/{platform_id}", headers=_HDRS)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == platform_id
+    assert body["source"] == "platform"
+    assert body["editable"] is False
+    assert body["tier"]
+
+
+async def test_get_floor_rule_returns_404() -> None:
+    """Floor-tier platform rules are invisible — fetching one by id 404s,
+    indistinguishable from a non-existent rule.
+    """
+    user, _ = await _make_user("floor")
+    async with admin_conn() as conn:
+        floor_id = await conn.fetchval(
+            "INSERT INTO platform_safety_rules (tier, stage, check_id) "
+            "VALUES ('floor', 'model_output', 'secret_scanner') "
+            "ON CONFLICT (tier, check_id, stage) DO UPDATE SET tier = 'floor' "
+            "RETURNING id"
+        )
+
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get(f"/api/v1/safety/rules/{floor_id}", headers=_HDRS)
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "NOT_FOUND"
 
 
 async def test_get_rule_returns_full_shape() -> None:


### PR DESCRIPTION
## What

Introduces **platform-level safety rules** — platform-owned safety rules that apply across all tenants, managed by the platform rather than tenant admins — **without touching the Safety Pipeline core**.

## Design

- **New `platform_safety_rules` table**: no `tenant_id`/`coworker_id`, a `tier` enum (`floor` / `transparent_floor` / `default`), modelled on the `models` catalog (no RLS). `safety_rules` and its RLS/triggers are byte-unchanged.
- **Single merge seam**: the loader's `fetch_safety_rule_snapshots` appends platform rules to the snapshot, stamping the running job's `tenant_id` (audit attribution) and `coworker_id=None`. The pipeline treats them identically to tenant rules — `pipeline_core`/`types`/`hook_handler`/`registry` are untouched.
- **"Can't loosen" is structural**: the table is read-only to the business role and the pipeline is monotonic; a tenant tightens by adding their own stricter `safety_rules` rows.
- **Three-tier visibility**: `floor` (enforces, invisible to tenants), `transparent_floor` (enforces, visible), `default` (visible, cannot be loosened). This phase seeds only the 5 default-tier rules (`secret_scanner`, `pii.regex`/warn, `llm_guard.prompt_injection`/`jailbreak`/`toxicity`); floor/transparent_floor are carried in the schema for future use.
- **DB authorization**: `rolemesh_app` keeps SELECT but is REVOKEd write; floor-tier invisibility enforced in the app-layer projection.
- **Tenant visibility**: `GET /api/v1/safety/rules` now also returns visible platform rules tagged `source`/`tier`/`editable`; get-by-id resolves visible platform rules; floor ids 404 (indistinguishable from non-existent, to block UUID probing).
- **Audit**: `safety_decisions` gains a `source` column (`'tenant'`|`'platform'`), derived at write time via a cheap EXISTS — `pipeline_core` stays unchanged.

## Tests

36 tests, all passing locally:
- `test_loader_platform_merge.py` (DB-free): merge ordering + snapshot-shape parity with tenant rules.
- `test_platform_rules_db.py` (Postgres testcontainer): idempotent seed, cross-tenant injection, tier visibility (floor enforces but is invisible), decision-source derivation.
- `test_v1_safety.py` (+4): API surfaces platform rules read-only, floor never shown, get-by-id, floor id 404.

Manually verified end-to-end against a live Postgres: seed, floor enforce-but-invisible, cross-tenant merge, and `source` derivation all behave as specified.
