### PR TITLE
chore(ruff): restore vendored src/pi to pristine (missed in #48)

### DIFF
--- a/src/pi/_version.py
+++ b/src/pi/_version.py
@@ -2,19 +2,20 @@
 # don't change, don't track in version control
 
 __all__ = [
-    "__commit_id__",
     "__version__",
     "__version_tuple__",
-    "commit_id",
     "version",
     "version_tuple",
+    "__commit_id__",
+    "commit_id",
 ]
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from typing import Tuple
     from typing import Union
 
-    VERSION_TUPLE = tuple[int | str, ...]
+    VERSION_TUPLE = Tuple[Union[int, str], ...]
     COMMIT_ID = Union[str, None]
 else:
     VERSION_TUPLE = object

--- a/src/pi/agent/agent.py
+++ b/src/pi/agent/agent.py
@@ -6,7 +6,8 @@ import asyncio
 import dataclasses
 import logging
 import time
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import Any
 
 from pi.agent.agent_loop import agent_loop, agent_loop_continue
 from pi.agent.types import (
@@ -38,9 +39,6 @@ from pi.ai.types import (
     Transport,
     UserMessage,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:

--- a/src/pi/agent/agent_loop.py
+++ b/src/pi/agent/agent_loop.py
@@ -5,10 +5,12 @@ Uses async generators instead of EventStream.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import inspect
 import time
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncGenerator
+from typing import Any
 
 from pi.agent.types import (
     AgentContext,
@@ -42,10 +44,6 @@ from pi.ai.types import (
     ToolResultMessage,
 )
 from pi.ai.utils.validation import validate_tool_arguments
-
-if TYPE_CHECKING:
-    import asyncio
-    from collections.abc import AsyncGenerator
 
 
 async def _call_async(fn: Any, *args: Any) -> Any:

--- a/src/pi/agent/proxy.py
+++ b/src/pi/agent/proxy.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import dataclasses
 import json
 import time
-from typing import TYPE_CHECKING, Any
+from collections.abc import AsyncIterator
+from typing import Any
 
 import httpx
 
@@ -57,9 +58,6 @@ from pi.ai.types import (
     UserMessage,
 )
 from pi.ai.utils.json_parse import parse_streaming_json
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
 
 
 def _make_partial(model: Model) -> AssistantMessage:

--- a/src/pi/agent/types.py
+++ b/src/pi/agent/types.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pi.ai.types import (
     AssistantMessage,
@@ -20,9 +21,6 @@ from pi.ai.types import (
     ToolResultMessage,
     Usage,
 )
-
-if TYPE_CHECKING:
-    import asyncio
 
 # ThinkingLevel for agents: extends pi.ai.ThinkingLevel with "off" (no reasoning)
 ThinkingLevel = Literal["off", "minimal", "low", "medium", "high", "xhigh"]

--- a/src/pi/ai/event_stream.py
+++ b/src/pi/ai/event_stream.py
@@ -7,12 +7,9 @@ Uses asyncio.Queue for push-based async iteration.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from collections.abc import AsyncIterator
 
 from pi.ai.types import AssistantMessage, AssistantMessageEvent, DoneEvent, ErrorEvent
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
 
 
 class EventStream[T, R]:

--- a/src/pi/ai/models.py
+++ b/src/pi/ai/models.py
@@ -7,12 +7,9 @@ via register_models() or individually.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from pi.ai.types import Model, Usage, UsageCost
+from pi.ai.types import Model, Usage, UsageCost
 
 # Provider -> (ModelId -> Model)
 # Note: module-level mutable state. Safe for single-threaded asyncio use.

--- a/src/pi/ai/models_generated.py
+++ b/src/pi/ai/models_generated.py
@@ -7,13 +7,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
 
 from pi.ai.models import register_models
 from pi.ai.types import Model, ModelCost, OpenAICompletionsCompat
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 MODELS: Mapping[str, Mapping[str, Model]] = {
     "amazon-bedrock": {

--- a/src/pi/ai/oauth/anthropic_oauth.py
+++ b/src/pi/ai/oauth/anthropic_oauth.py
@@ -7,17 +7,12 @@ from __future__ import annotations
 
 import base64
 import time
-from typing import TYPE_CHECKING
 
 import httpx
 
 from pi.ai.oauth.pkce import generate_pkce
 from pi.ai.oauth.types import OAuthAuthInfo, OAuthCredentials, OAuthLoginCallbacks
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
-
-    from pi.ai.types import Model
+from pi.ai.types import Model
 
 _CLIENT_ID = base64.b64decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl").decode()
 _AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
@@ -31,6 +26,7 @@ async def login_anthropic(
     on_prompt_code: object,  # Callable[[], Awaitable[str]]
 ) -> OAuthCredentials:
     """Login with Anthropic OAuth (manual code paste flow)."""
+    from collections.abc import Callable, Coroutine
     from typing import Any
 
     _on_auth_url: Callable[[str], None] = on_auth_url  # type: ignore[assignment]

--- a/src/pi/ai/oauth/github_copilot.py
+++ b/src/pi/ai/oauth/github_copilot.py
@@ -9,17 +9,13 @@ import asyncio
 import base64
 import re
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import urlparse
 
 import httpx
 
 from pi.ai.oauth.types import OAuthAuthInfo, OAuthCredentials, OAuthLoginCallbacks
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
-
-    from pi.ai.types import Model
+from pi.ai.types import Model
 
 _CLIENT_ID = base64.b64decode("SXYxLmI1MDdhMDhjODdlY2ZlOTg=").decode()
 
@@ -195,6 +191,7 @@ async def login_github_copilot(
     signal: asyncio.Event | None = None,
 ) -> OAuthCredentials:
     """Login with GitHub Copilot OAuth (device code flow)."""
+    from collections.abc import Callable, Coroutine
 
     _on_auth: Callable[[str, str | None], None] = on_auth  # type: ignore[assignment]
     _on_prompt: Callable[[dict[str, Any]], Coroutine[Any, Any, str]] = on_prompt  # type: ignore[assignment]

--- a/src/pi/ai/oauth/openai_codex.py
+++ b/src/pi/ai/oauth/openai_codex.py
@@ -11,16 +11,14 @@ import contextlib
 import json
 import secrets
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import httpx
 
 from pi.ai.oauth.pkce import generate_pkce
 from pi.ai.oauth.types import OAuthAuthInfo, OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt
-
-if TYPE_CHECKING:
-    from pi.ai.types import Model
+from pi.ai.types import Model
 
 _CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 _AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"

--- a/src/pi/ai/oauth/types.py
+++ b/src/pi/ai/oauth/types.py
@@ -6,10 +6,9 @@ Ported from packages/ai/src/utils/oauth/types.ts.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
-if TYPE_CHECKING:
-    from pi.ai.types import Model
+from pi.ai.types import Model
 
 
 @dataclass

--- a/src/pi/ai/providers/anthropic.py
+++ b/src/pi/ai/providers/anthropic.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pi.ai.env_api_keys import get_env_api_key
 from pi.ai.models import calculate_cost
@@ -47,9 +48,6 @@ from pi.ai.types import (
 )
 from pi.ai.utils.json_parse import parse_streaming_json
 from pi.ai.utils.sanitize_unicode import sanitize_surrogates
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
 
 _log = logging.getLogger(__name__)
 

--- a/src/pi/ai/providers/azure_openai_responses.py
+++ b/src/pi/ai/providers/azure_openai_responses.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pi.ai.env_api_keys import get_env_api_key
 from pi.ai.models import supports_xhigh
@@ -27,9 +28,6 @@ from pi.ai.types import (
     StreamOptions,
     Usage,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
 
 _DEFAULT_AZURE_API_VERSION = "v1"
 _AZURE_TOOL_CALL_PROVIDERS: frozenset[str] = frozenset(["openai", "openai-codex", "opencode", "azure-openai-responses"])

--- a/src/pi/ai/providers/github_copilot_headers.py
+++ b/src/pi/ai/providers/github_copilot_headers.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-    from pi.ai.types import Message
+from pi.ai.types import Message
 
 
 def infer_copilot_initiator(messages: Sequence[Message]) -> str:

--- a/src/pi/ai/providers/openai_codex_responses.py
+++ b/src/pi/ai/providers/openai_codex_responses.py
@@ -9,8 +9,9 @@ import json
 import os
 import re
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import httpx
 
@@ -36,9 +37,6 @@ from pi.ai.types import (
     StreamOptions,
     Usage,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/src/pi/ai/providers/openai_completions.py
+++ b/src/pi/ai/providers/openai_completions.py
@@ -6,8 +6,9 @@ import contextlib
 import json
 import re
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pi.ai.env_api_keys import get_env_api_key
 from pi.ai.models import calculate_cost, supports_xhigh
@@ -48,9 +49,6 @@ from pi.ai.types import (
 )
 from pi.ai.utils.json_parse import parse_streaming_json
 from pi.ai.utils.sanitize_unicode import sanitize_surrogates
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
 
 
 @dataclass

--- a/src/pi/ai/providers/openai_responses.py
+++ b/src/pi/ai/providers/openai_responses.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pi.ai.env_api_keys import get_env_api_key
 from pi.ai.models import supports_xhigh
@@ -33,9 +34,6 @@ from pi.ai.types import (
     StreamOptions,
     Usage,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
 
 _OPENAI_TOOL_CALL_PROVIDERS: frozenset[str] = frozenset(["openai", "openai-codex", "opencode"])
 

--- a/src/pi/ai/providers/openai_responses_shared.py
+++ b/src/pi/ai/providers/openai_responses_shared.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pi.ai.models import calculate_cost
 from pi.ai.providers.transform_messages import transform_messages
@@ -32,9 +33,6 @@ from pi.ai.types import (
 )
 from pi.ai.utils.json_parse import parse_streaming_json
 from pi.ai.utils.sanitize_unicode import sanitize_surrogates
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Callable
 
 
 def _short_hash(s: str) -> str:

--- a/src/pi/ai/providers/register_builtins.py
+++ b/src/pi/ai/providers/register_builtins.py
@@ -49,64 +49,64 @@ def register_built_in_api_providers() -> None:
     register_api_provider(
         ApiProvider(
             api="anthropic-messages",
-            stream=cast("StreamFunction", stream_anthropic),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_anthropic),
+            stream=cast(StreamFunction, stream_anthropic),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_anthropic),
         )
     )
     register_api_provider(
         ApiProvider(
             api="openai-completions",
-            stream=cast("StreamFunction", stream_openai_completions),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_openai_completions),
+            stream=cast(StreamFunction, stream_openai_completions),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_openai_completions),
         )
     )
     register_api_provider(
         ApiProvider(
             api="openai-responses",
-            stream=cast("StreamFunction", stream_openai_responses),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_openai_responses),
+            stream=cast(StreamFunction, stream_openai_responses),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_openai_responses),
         )
     )
     register_api_provider(
         ApiProvider(
             api="azure-openai-responses",
-            stream=cast("StreamFunction", stream_azure_openai_responses),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_azure_openai_responses),
+            stream=cast(StreamFunction, stream_azure_openai_responses),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_azure_openai_responses),
         )
     )
     register_api_provider(
         ApiProvider(
             api="openai-codex-responses",
-            stream=cast("StreamFunction", stream_openai_codex_responses),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_openai_codex_responses),
+            stream=cast(StreamFunction, stream_openai_codex_responses),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_openai_codex_responses),
         )
     )
     register_api_provider(
         ApiProvider(
             api="google-generative-ai",
-            stream=cast("StreamFunction", stream_google),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_google),
+            stream=cast(StreamFunction, stream_google),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_google),
         )
     )
     register_api_provider(
         ApiProvider(
             api="google-gemini-cli",
-            stream=cast("StreamFunction", stream_google_gemini_cli),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_google_gemini_cli),
+            stream=cast(StreamFunction, stream_google_gemini_cli),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_google_gemini_cli),
         )
     )
     register_api_provider(
         ApiProvider(
             api="google-vertex",
-            stream=cast("StreamFunction", stream_google_vertex),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_google_vertex),
+            stream=cast(StreamFunction, stream_google_vertex),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_google_vertex),
         )
     )
     register_api_provider(
         ApiProvider(
             api="bedrock-converse-stream",
-            stream=cast("StreamFunction", stream_bedrock),
-            stream_simple=cast("StreamSimpleFunction", stream_simple_bedrock),
+            stream=cast(StreamFunction, stream_bedrock),
+            stream_simple=cast(StreamSimpleFunction, stream_simple_bedrock),
         )
     )
 

--- a/src/pi/ai/providers/transform_messages.py
+++ b/src/pi/ai/providers/transform_messages.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import replace
-from typing import TYPE_CHECKING
 
 from pi.ai.types import (
     AssistantContentBlock,
@@ -16,9 +16,6 @@ from pi.ai.types import (
     ToolCall,
     ToolResultMessage,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 def transform_messages(

--- a/src/pi/ai/stream.py
+++ b/src/pi/ai/stream.py
@@ -6,7 +6,7 @@ The result is collected by iterating the stream to completion.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import AsyncIterator
 
 from pi.ai.api_registry import ApiProvider, get_api_provider
 from pi.ai.types import (
@@ -19,9 +19,6 @@ from pi.ai.types import (
     SimpleStreamOptions,
     StreamOptions,
 )
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
 
 
 def _resolve_api_provider(api: str) -> ApiProvider:

--- a/src/pi/ai/types.py
+++ b/src/pi/ai/types.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Literal
-
-if TYPE_CHECKING:
-    import asyncio
+from typing import Any, Literal
 
 # --- API and Provider enums ---
 

--- a/src/pi/ai/utils/overflow.py
+++ b/src/pi/ai/utils/overflow.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from pi.ai.types import AssistantMessage
+from pi.ai.types import AssistantMessage
 
 OVERFLOW_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"prompt is too long", re.IGNORECASE),

--- a/src/pi/ai/utils/validation.py
+++ b/src/pi/ai/utils/validation.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from pi.ai.types import Tool, ToolCall
+from pi.ai.types import Tool, ToolCall
 
 try:
     import jsonschema

--- a/src/pi/coding_agent/core/agent_session.py
+++ b/src/pi/coding_agent/core/agent_session.py
@@ -271,7 +271,7 @@ class AgentSession:
     @property
     def state(self) -> AgentState:
         """Full agent state."""
-        return cast("AgentState", self._agent.state)
+        return cast(AgentState, self._agent.state)
 
     @property
     def model(self) -> Model | None:
@@ -291,7 +291,7 @@ class AgentSession:
     @property
     def messages(self) -> list[AgentMessage]:
         """All messages including custom types."""
-        return cast("list[AgentMessage]", self._agent.state.messages)
+        return cast(list[AgentMessage], self._agent.state.messages)
 
     @property
     def session_id(self) -> str:

--- a/src/pi/coding_agent/core/auth_storage.py
+++ b/src/pi/coding_agent/core/auth_storage.py
@@ -14,19 +14,16 @@ import contextlib
 import json
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from pathlib import Path
+from typing import Any, Literal, TypeVar
 
 import filelock
 
 from pi.ai import get_env_api_key, get_oauth_api_key, get_oauth_provider, get_oauth_providers
+from pi.ai.oauth.types import OAuthCredentials, OAuthLoginCallbacks
 from pi.coding_agent.core.config import get_agent_dir
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-    from pathlib import Path
-
-    from pi.ai.oauth.types import OAuthCredentials, OAuthLoginCallbacks
 
 T = TypeVar("T")
 

--- a/src/pi/coding_agent/core/bash_executor.py
+++ b/src/pi/coding_agent/core/bash_executor.py
@@ -9,12 +9,10 @@ import re
 import secrets
 import signal as _signal
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from typing import IO, Any, Protocol, runtime_checkable
 
 # Default max bytes before output is truncated and saved to a temp file.
 DEFAULT_MAX_BYTES = 200 * 1024  # 200 KB

--- a/src/pi/coding_agent/core/compaction/branch_summarization.py
+++ b/src/pi/coding_agent/core/compaction/branch_summarization.py
@@ -8,11 +8,14 @@ a summary of the branch being left so context isn't lost.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from pi.agent.types import AgentMessage
 from pi.ai.stream import complete_simple
+from pi.ai.types import Model
 
 from .compaction import estimate_tokens
 from .utils import (
@@ -24,12 +27,6 @@ from .utils import (
     format_file_operations,
     serialize_conversation,
 )
-
-if TYPE_CHECKING:
-    import asyncio
-
-    from pi.agent.types import AgentMessage
-    from pi.ai.types import Model
 
 # ============================================================================
 # Types

--- a/src/pi/coding_agent/core/compaction/compaction.py
+++ b/src/pi/coding_agent/core/compaction/compaction.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from pi.agent.types import AgentMessage
 from pi.ai.stream import complete_simple
+from pi.ai.types import Model, Usage
 
 from .utils import (
     SUMMARIZATION_SYSTEM_PROMPT,
@@ -24,10 +26,6 @@ from .utils import (
     format_file_operations,
     serialize_conversation,
 )
-
-if TYPE_CHECKING:
-    from pi.agent.types import AgentMessage
-    from pi.ai.types import Model, Usage
 
 # ============================================================================
 # Types

--- a/src/pi/coding_agent/core/compaction/utils.py
+++ b/src/pi/coding_agent/core/compaction/utils.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from pi.agent.types import AgentMessage
+from pi.agent.types import AgentMessage
 
 # ============================================================================
 # File Operation Tracking

--- a/src/pi/coding_agent/core/event_bus.py
+++ b/src/pi/coding_agent/core/event_bus.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Protocol
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from collections.abc import Callable
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 

--- a/src/pi/coding_agent/core/export_html/exporter.py
+++ b/src/pi/coding_agent/core/export_html/exporter.py
@@ -12,8 +12,9 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
+from pi.agent.types import AgentMessage
 from pi.ai.types import (
     AssistantMessage,
     ImageContent,
@@ -24,9 +25,6 @@ from pi.ai.types import (
     UserMessage,
     deserialize_message,
 )
-
-if TYPE_CHECKING:
-    from pi.agent.types import AgentMessage
 
 logger = logging.getLogger(__name__)
 

--- a/src/pi/coding_agent/core/extensions/runner.py
+++ b/src/pi/coding_agent/core/extensions/runner.py
@@ -9,8 +9,9 @@ import asyncio
 import contextlib
 import copy
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from pi.agent.types import AgentMessage
 from pi.coding_agent.core.extensions.types import (
     BeforeAgentStartEvent,
     ContextEvent,
@@ -38,9 +39,6 @@ from pi.coding_agent.core.extensions.types import (
     UserBashEventResult,
     is_session_before_event,
 )
-
-if TYPE_CHECKING:
-    from pi.agent.types import AgentMessage
 
 ExtensionErrorListener = Callable[[ExtensionError], None]
 

--- a/src/pi/coding_agent/core/extensions/wrapper.py
+++ b/src/pi/coding_agent/core/extensions/wrapper.py
@@ -5,15 +5,12 @@ Port of packages/coding-agent/src/core/extensions/wrapper.ts.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import asyncio
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
+from pi.coding_agent.core.extensions.runner import ExtensionRunner
 from pi.coding_agent.core.extensions.types import RegisteredTool, ToolCallEvent, ToolResultEvent
-
-if TYPE_CHECKING:
-    import asyncio
-
-    from pi.coding_agent.core.extensions.runner import ExtensionRunner
 
 
 class _WrappedRegisteredTool(AgentTool):

--- a/src/pi/coding_agent/core/footer_data_provider.py
+++ b/src/pi/coding_agent/core/footer_data_provider.py
@@ -6,10 +6,8 @@ Provides git branch and extension status data not otherwise accessible.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from collections.abc import Callable
+from typing import Protocol
 
 
 class ReadonlyFooterDataProvider(Protocol):

--- a/src/pi/coding_agent/core/model_registry.py
+++ b/src/pi/coding_agent/core/model_registry.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 from pi.ai import (
     get_models,
@@ -16,12 +17,8 @@ from pi.ai import (
     register_oauth_provider,
 )
 from pi.ai.types import Context, Model
+from pi.coding_agent.core.auth_storage import AuthStorage
 from pi.coding_agent.core.config import get_agent_dir
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from pi.coding_agent.core.auth_storage import AuthStorage
 
 # ============================================================================
 # Types

--- a/src/pi/coding_agent/core/model_resolver.py
+++ b/src/pi/coding_agent/core/model_resolver.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 import fnmatch
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from pi.agent.types import ThinkingLevel
-    from pi.ai.types import Model
-    from pi.coding_agent.core.model_registry import ModelRegistry
+from pi.agent.types import ThinkingLevel
+from pi.ai.types import Model
+from pi.coding_agent.core.model_registry import ModelRegistry
 
 # ============================================================================
 # Default models per provider

--- a/src/pi/coding_agent/core/settings_manager.py
+++ b/src/pi/coding_agent/core/settings_manager.py
@@ -10,16 +10,14 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import filelock
 
 from pi.coding_agent.core.config import CONFIG_DIR_NAME, get_agent_dir
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 # ============================================================================
 # Settings dataclasses

--- a/src/pi/coding_agent/core/tools/edit.py
+++ b/src/pi/coding_agent/core/tools/edit.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
@@ -19,10 +21,6 @@ from .edit_diff import (
     strip_bom,
 )
 from .path_utils import resolve_to_cwd
-
-if TYPE_CHECKING:
-    import asyncio
-    from collections.abc import Awaitable, Callable
 
 
 @dataclass

--- a/src/pi/coding_agent/core/tools/find.py
+++ b/src/pi/coding_agent/core/tools/find.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 import asyncio
 import glob as glob_module
 import shutil
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
 
 from .path_utils import resolve_to_cwd
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from .truncate import TruncationResult
+from .truncate import TruncationResult
 
 
 @dataclass

--- a/src/pi/coding_agent/core/tools/grep.py
+++ b/src/pi/coding_agent/core/tools/grep.py
@@ -5,18 +5,16 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
 
 from .path_utils import resolve_to_cwd
 from .truncate import TruncationResult, truncate_line
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-    from pathlib import Path
 
 
 @dataclass

--- a/src/pi/coding_agent/core/tools/ls.py
+++ b/src/pi/coding_agent/core/tools/ls.py
@@ -2,20 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
 
 from .path_utils import resolve_to_cwd
-
-if TYPE_CHECKING:
-    import asyncio
-    from collections.abc import Awaitable, Callable
-
-    from .truncate import TruncationResult
+from .truncate import TruncationResult
 
 
 @dataclass

--- a/src/pi/coding_agent/core/tools/read.py
+++ b/src/pi/coding_agent/core/tools/read.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import ImageContent, TextContent
 
 from .path_utils import resolve_read_path
 from .truncate import DEFAULT_MAX_BYTES, TruncationResult, format_size, truncate_head
-
-if TYPE_CHECKING:
-    import asyncio
-    from collections.abc import Awaitable, Callable
 
 
 @dataclass

--- a/src/pi/coding_agent/core/tools/web_fetch.py
+++ b/src/pi/coding_agent/core/tools/web_fetch.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import asyncio
+from typing import Any
 
 import httpx
 from markdownify import markdownify
@@ -11,9 +12,6 @@ from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
 
 from .truncate import truncate_tail
-
-if TYPE_CHECKING:
-    import asyncio
 
 USER_AGENT = "PPI/1.0 (compatible)"
 DEFAULT_MAX_LENGTH = 50000

--- a/src/pi/coding_agent/core/tools/web_search.py
+++ b/src/pi/coding_agent/core/tools/web_search.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import httpx
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
-
-if TYPE_CHECKING:
-    import asyncio
 
 TAVILY_API_URL = "https://api.tavily.com/search"
 DEFAULT_NUM_RESULTS = 5

--- a/src/pi/coding_agent/core/tools/write.py
+++ b/src/pi/coding_agent/core/tools/write.py
@@ -2,18 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pi.agent.types import AgentTool, AgentToolResult, AgentToolUpdateCallback
 from pi.ai.types import TextContent
 
 from .path_utils import resolve_to_cwd
-
-if TYPE_CHECKING:
-    import asyncio
-    from collections.abc import Awaitable, Callable
 
 
 @dataclass

--- a/src/pi/coding_agent/modes/rpc/rpc_client.py
+++ b/src/pi/coding_agent/modes/rpc/rpc_client.py
@@ -12,17 +12,15 @@ import logging
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from pi.agent.types import ThinkingLevel
+from pi.ai.types import ImageContent
 from pi.coding_agent.modes.rpc.rpc_types import (
     RpcResponse,
     deserialize_rpc_response,
     serialize_rpc_session_state,
 )
-
-if TYPE_CHECKING:
-    from pi.agent.types import ThinkingLevel
-    from pi.ai.types import ImageContent
 
 logger = logging.getLogger(__name__)
 

--- a/src/pi/coding_agent/modes/rpc/rpc_types.py
+++ b/src/pi/coding_agent/modes/rpc/rpc_types.py
@@ -8,12 +8,10 @@ between dataclass instances and plain JSON-serializable dicts.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
+from pi.agent.types import ThinkingLevel
 from pi.ai.types import ImageContent, Model, deserialize_model, serialize_model
-
-if TYPE_CHECKING:
-    from pi.agent.types import ThinkingLevel
 
 # ---------------------------------------------------------------------------
 # RpcCommand variants

--- a/src/pi/coding_agent/utils/image.py
+++ b/src/pi/coding_agent/utils/image.py
@@ -10,10 +10,8 @@ import base64
 import io
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from pi.ai.types import ImageContent
+from pi.ai.types import ImageContent
 
 logger = logging.getLogger(__name__)
 

--- a/src/pi/mcp/__init__.py
+++ b/src/pi/mcp/__init__.py
@@ -4,7 +4,7 @@ from pi.mcp.client import McpServerConnection
 from pi.mcp.tool_bridge import McpProxiedTool, load_mcp_tools
 
 __all__ = [
-    "McpProxiedTool",
     "McpServerConnection",
+    "McpProxiedTool",
     "load_mcp_tools",
 ]

--- a/src/pi/mcp/client.py
+++ b/src/pi/mcp/client.py
@@ -12,6 +12,7 @@ from contextlib import AsyncExitStack
 from typing import Any
 
 import httpx
+
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client


### PR DESCRIPTION
The src/pi revert was committed but not pushed before #48 merged, so the cosmetic ruff autofixes to the vendored Pi SDK (52 files) landed on main. src/pi is excluded from lint and upstream-owned, so those changes serve no purpose and would conflict on the next re-vendor. This restores src/pi to its exact pre-#48 state — ruff stays clean, behavior unchanged, full suite still 2327 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)