### PR TITLE
feat(admin): rolemesh-admin create-admin CLI for platform genesis + harden legacy bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,42 @@ channel with its bot tokens.
 
 ### Misc
 
-| Key                       | Purpose                                                                  |
-|---------------------------|--------------------------------------------------------------------------|
-| `ASSISTANT_NAME`          | Display name for your AI coworker.                                       |
-| `CONTAINER_NETWORK_NAME`  | Set to enable EC-2 (Internal=true) agent bridge with egress gateway.     |
-| `ADMIN_BOOTSTRAP_TOKEN`   | First-run admin token; rotate after the first sign-in.                   |
-| `ROLEMESH_AGENT_BACKEND`  | `claude` (default) or `pi`.                                              |
+| Key                          | Purpose                                                                  |
+|------------------------------|--------------------------------------------------------------------------|
+| `ASSISTANT_NAME`             | Display name for your AI coworker.                                       |
+| `CONTAINER_NETWORK_NAME`     | Set to enable EC-2 (Internal=true) agent bridge with egress gateway.     |
+| `ROLEMESH_ENV`               | `development` (default) or `production`. See note below.                 |
+| `ROLEMESH_SEED_ADMIN_EMAIL`  | If set, the WebUI seeds a `platform_admin` with this email at startup.   |
+| `ADMIN_BOOTSTRAP_TOKEN`      | DEPRECATED dev-only owner token; disabled when `ROLEMESH_ENV=production`.|
+| `ROLEMESH_AGENT_BACKEND`     | `claude` (default) or `pi`.                                              |
+
+### Seeding the first administrator
+
+On a fresh deployment nobody can log in yet, so the very first
+`platform_admin` is seeded out-of-band. Run the CLI against the same
+database (the schema is created idempotently on connect):
+
+```bash
+uv run rolemesh-admin create-admin --email you@example.com
+```
+
+This writes one privileged user row through the admin (BYPASSRLS)
+connection and is idempotent — re-running it is a no-op. The email is
+the identifier your IdP is matched against on login, **not** a
+credential; authentication still runs through the IdP. Pass
+`--external-sub` if you already know the IdP subject, otherwise the row
+is linked on the first OIDC login matching the email.
+
+For managed / IaC deploys, set `ROLEMESH_SEED_ADMIN_EMAIL` (plus optional
+`ROLEMESH_SEED_ADMIN_EXTERNAL_SUB` / `ROLEMESH_SEED_ADMIN_NAME`) and the
+WebUI seeds the same `platform_admin` at startup. Further admins and
+tenant owners are created from the platform_admin UI/API (or OIDC JIT) —
+the CLI is only for platform genesis and emergency recovery.
+
+> **Production hardening.** When `ROLEMESH_ENV=production`, the legacy
+> `ADMIN_BOOTSTRAP_TOKEN` stops authorizing (it is a permanent,
+> network-reachable owner backdoor) and a populated `BOOTSTRAP_USERS`
+> aborts startup. Both remain available in `development` for local use.
 
 See `docs/auth-architecture.md` for the full auth model.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 rolemesh = "rolemesh.main:main_sync"
 rolemesh-webui = "webui.main:main"
 rolemesh-eval = "rolemesh.evaluation.cli:main"
+rolemesh-admin = "rolemesh.admin.cli:main"
 
 [project.optional-dependencies]
 # Evaluation framework — Inspect AI based, manual / nightly only.

--- a/src/rolemesh/admin/__init__.py
+++ b/src/rolemesh/admin/__init__.py
@@ -1,0 +1,6 @@
+"""Operational admin provisioning for RoleMesh.
+
+Home of the ``rolemesh-admin`` CLI and the webui env-seed wrapper. Both
+delegate to ``rolemesh.admin.core.create_admin`` so the "seed a
+privileged user row" logic lives in exactly one place.
+"""

--- a/src/rolemesh/admin/cli.py
+++ b/src/rolemesh/admin/cli.py
@@ -1,0 +1,140 @@
+"""``rolemesh-admin`` CLI — platform genesis + emergency escape hatch.
+
+``create-admin`` seeds the first ``platform_admin`` on a fresh deploy —
+the one privileged account that nobody can create through the UI yet
+(zero users, no one to log in). This is the canonical production path
+for seeding the initial admin, replacing the static
+``ADMIN_BOOTSTRAP_TOKEN`` backdoor.
+
+Every other privileged account already has a creator and does NOT need
+this tool: further platform_admins are made by the first one in the UI;
+tenant owner/admin/member come from the platform_admin UI/API or OIDC
+JIT provisioning. ``--role`` keeps owner/admin/member available purely
+as a zero-cost escape hatch (scripts / tests / lockout recovery).
+
+Assumes infrastructure is up: PostgreSQL reachable via ``DATABASE_URL``
+(and ``ADMIN_DATABASE_URL`` for the BYPASSRLS pool). The schema is
+created idempotently on connect, so a brand-new database is fine.
+
+Exit codes:
+  0 — user created, or already present (idempotent)
+  1 — configuration error (bad role / missing --tenant) or DB failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+# Side-effect import: runs load_env() so ``.env`` lands in os.environ
+# before rolemesh.core.config captures DATABASE_URL. Mirrors the eval
+# CLI / webui entrypoints.
+import rolemesh.bootstrap  # noqa: F401
+from rolemesh.admin.core import (
+    ALLOWED_ROLES,
+    PLATFORM_ADMIN_ROLE,
+    AdminProvisionError,
+    create_admin,
+)
+from rolemesh.core.config import DATABASE_URL
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="rolemesh-admin",
+        description="RoleMesh operational admin provisioning.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    ca = sub.add_parser(
+        "create-admin",
+        help="create/confirm a privileged user (default: platform_admin)",
+    )
+    ca.add_argument(
+        "--email",
+        required=True,
+        help="login identifier the IdP is matched against (not a credential)",
+    )
+    ca.add_argument(
+        "--role",
+        default=PLATFORM_ADMIN_ROLE,
+        choices=sorted(ALLOWED_ROLES),
+        help=(
+            "default platform_admin (platform genesis); owner/admin/member "
+            "are an emergency escape hatch only"
+        ),
+    )
+    ca.add_argument(
+        "--external-sub",
+        default=None,
+        help="known IdP subject to bind now; else linked on first OIDC login",
+    )
+    ca.add_argument(
+        "--name",
+        default=None,
+        help="display name (default: the email's local part)",
+    )
+    ca.add_argument(
+        "--tenant",
+        default=None,
+        help="tenant slug — required for tenant-scoped roles only",
+    )
+    return p
+
+
+async def _cmd_create_admin(args: argparse.Namespace) -> int:
+    from rolemesh.db import close_database, init_database
+
+    await init_database(DATABASE_URL)
+    try:
+        result = await create_admin(
+            email=args.email,
+            role=args.role,
+            external_sub=args.external_sub,
+            name=args.name,
+            tenant=args.tenant,
+        )
+    finally:
+        await close_database()
+
+    verb = "Created" if result.created else "Already exists —"
+    print(
+        f"{verb} user {result.user_id} "
+        f"(role={result.role}, tenant={result.tenant_slug})"
+    )
+    if result.external_sub:
+        print(f"  external_sub bound: {result.external_sub}")
+    else:
+        print(
+            "  No external_sub bound — the row links on the first OIDC login "
+            f"whose subject matches email {result.email!r}."
+        )
+    print(f"  Login: sign in through your IdP as {result.email}.")
+    return 0
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    handlers = {"create-admin": _cmd_create_admin}
+    handler = handlers.get(args.command)
+    if handler is None:  # pragma: no cover - argparse 'required' guards this
+        parser.error(f"unknown command {args.command!r}")
+        return 1
+
+    try:
+        return asyncio.run(handler(args))
+    except AdminProvisionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/rolemesh/admin/core.py
+++ b/src/rolemesh/admin/core.py
@@ -1,0 +1,250 @@
+"""Shared admin-provisioning core for the CLI and the env-seed wrapper.
+
+Both the ``rolemesh-admin create-admin`` CLI and the webui startup seed
+(``ensure_seed_admin``) call :func:`create_admin`, so the logic that
+seeds a privileged user row exists in exactly one place.
+
+Why this is a provisioning tool and not an auth path: seeding the first
+``platform_admin`` is a provisioning problem, not an authentication one.
+The write goes through the BYPASSRLS admin pool (no request/auth
+context, and it may touch a tenant the caller holds no session for) and
+is idempotent so re-runs are safe. This replaces the static
+``ADMIN_BOOTSTRAP_TOKEN`` — a permanent, network-reachable owner
+backdoor — with an explicit, auditable operator action bound to whoever
+already holds host + DB access.
+
+Role-model dependency (task §5): the four-role / platform-vs-tenant
+*scope* model is owned by a separate "role-model redesign" task. This
+module only *references* the ``platform_admin`` role value as a string;
+it does not define a scope column or wire authorization recognition of
+``platform_admin`` — that is left to that task ("引用,不接线"). Until it
+lands, a ``platform_admin`` row is anchored to the existing ``default``
+tenant to satisfy the NOT NULL ``users.tenant_id`` constraint; the
+eventual tenant-less / scoped representation is a later migration.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from rolemesh.db import (
+    DEFAULT_TENANT,
+    admin_conn,
+    create_tenant,
+    create_user_with_external_sub,
+    get_tenant_by_slug,
+    get_user_by_email,
+    get_user_by_external_sub,
+)
+
+logger = logging.getLogger(__name__)
+
+# The platform-plane role. Referenced as a plain string; the role model
+# that gives it scope + authorization meaning is a separate task.
+PLATFORM_ADMIN_ROLE = "platform_admin"
+
+# Tenant-plane roles recognized by the existing role model. ``--role``
+# accepts these as an emergency escape hatch (scripts / tests / platform
+# lockout recovery) only; the product path for tenant roles is the
+# platform_admin UI/API or OIDC JIT provisioning — never this tool.
+_TENANT_SCOPED_ROLES = frozenset({"owner", "admin", "member"})
+
+ALLOWED_ROLES = frozenset({PLATFORM_ADMIN_ROLE}) | _TENANT_SCOPED_ROLES
+
+# Env keys for the startup seed wrapper.
+_SEED_EMAIL_ENV = "ROLEMESH_SEED_ADMIN_EMAIL"
+_SEED_EXTERNAL_SUB_ENV = "ROLEMESH_SEED_ADMIN_EXTERNAL_SUB"
+_SEED_NAME_ENV = "ROLEMESH_SEED_ADMIN_NAME"
+
+
+class AdminProvisionError(Exception):
+    """Raised for configuration errors (bad role, missing --tenant).
+
+    DB / connectivity failures are *not* wrapped — they propagate so the
+    CLI exits non-zero with a real traceback and the webui startup fails
+    loud rather than booting with a half-applied seed.
+    """
+
+
+@dataclass(frozen=True)
+class AdminProvisionResult:
+    user_id: str
+    role: str
+    tenant_id: str
+    tenant_slug: str
+    email: str
+    external_sub: str | None
+    created: bool
+
+
+async def _ensure_tenant(slug: str) -> str:
+    """Return the id of tenant ``slug``, creating it if absent."""
+    existing = await get_tenant_by_slug(slug)
+    if existing is not None:
+        return existing.id
+    created = await create_tenant(name=slug, slug=slug)
+    return created.id
+
+
+async def create_admin(
+    *,
+    email: str,
+    role: str = PLATFORM_ADMIN_ROLE,
+    external_sub: str | None = None,
+    name: str | None = None,
+    tenant: str | None = None,
+) -> AdminProvisionResult:
+    """Idempotently create/confirm a privileged user row.
+
+    Defaults to ``platform_admin`` (platform genesis — the first admin
+    no one can create through the UI yet). Tenant-scoped roles
+    (owner/admin/member) require ``tenant`` (a slug), which is created if
+    absent.
+
+    The ``email`` is the IdP login identifier, *not* a credential —
+    authentication still runs through the IdP, so even this path
+    introduces no network-reachable secret. ``external_sub`` binds a
+    known IdP subject now; left unset, the row is linked on first OIDC
+    login that matches the email.
+
+    Idempotent: an existing user (matched by ``external_sub`` when
+    given, else by ``email`` within the resolved tenant) is returned
+    unchanged with ``created=False``.
+    """
+    email = email.strip()
+    if not email:
+        raise AdminProvisionError("--email must be a non-empty string")
+    if role not in ALLOWED_ROLES:
+        raise AdminProvisionError(
+            f"--role {role!r} is not one of {sorted(ALLOWED_ROLES)}"
+        )
+    display_name = name or email.split("@", 1)[0]
+
+    # Resolve the tenant the row hangs off. platform_admin is
+    # platform-scoped and has no tenant of its own, but users.tenant_id
+    # is NOT NULL, so we anchor it to the default tenant until the
+    # role-model task introduces a scope representation. Tenant-scoped
+    # roles require an explicit --tenant.
+    if role == PLATFORM_ADMIN_ROLE:
+        if tenant is not None and tenant != DEFAULT_TENANT:
+            raise AdminProvisionError(
+                "platform_admin is platform-scoped; --tenant is only valid "
+                "for tenant-scoped roles (owner/admin/member)"
+            )
+        tenant_slug = DEFAULT_TENANT
+    else:
+        if not tenant:
+            raise AdminProvisionError(
+                f"--tenant <slug> is required for tenant-scoped role {role!r}"
+            )
+        tenant_slug = tenant
+
+    tenant_id = await _ensure_tenant(tenant_slug)
+
+    # Idempotency: prefer the unique external_sub identity, then fall
+    # back to (tenant, email). A repeat run is a no-op.
+    if external_sub:
+        by_sub = await get_user_by_external_sub(external_sub)
+        if by_sub is not None:
+            return AdminProvisionResult(
+                user_id=by_sub.id,
+                role=by_sub.role,
+                tenant_id=by_sub.tenant_id,
+                tenant_slug=tenant_slug,
+                email=by_sub.email or email,
+                external_sub=external_sub,
+                created=False,
+            )
+
+    by_email = await get_user_by_email(email, tenant_id=tenant_id)
+    if by_email is not None:
+        return AdminProvisionResult(
+            user_id=by_email.id,
+            role=by_email.role,
+            tenant_id=by_email.tenant_id,
+            tenant_slug=tenant_slug,
+            email=email,
+            external_sub=by_email.external_sub,
+            created=False,
+        )
+
+    if external_sub:
+        # Reuse the existing admin-pool writer that also populates the
+        # unique external_sub column.
+        user = await create_user_with_external_sub(
+            tenant_id=tenant_id,
+            name=display_name,
+            email=email,
+            role=role,
+            external_sub=external_sub,
+        )
+        user_id = user.id
+    else:
+        # No external_sub yet (linked on first OIDC login). create_user()
+        # writes through the RLS business pool; provisioning must not
+        # depend on an RLS/auth request context (the row may be platform
+        # scope), so we issue the insert through the BYPASSRLS admin pool
+        # directly — same pattern as ensure_bootstrap_user_row.
+        async with admin_conn() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO users (tenant_id, name, email, role)
+                VALUES ($1::uuid, $2, $3, $4)
+                RETURNING id
+                """,
+                tenant_id,
+                display_name,
+                email,
+                role,
+            )
+        assert row is not None
+        user_id = str(row["id"])
+
+    return AdminProvisionResult(
+        user_id=user_id,
+        role=role,
+        tenant_id=tenant_id,
+        tenant_slug=tenant_slug,
+        email=email,
+        external_sub=external_sub,
+        created=True,
+    )
+
+
+async def ensure_seed_admin() -> AdminProvisionResult | None:
+    """Env-seed wrapper: provision a platform_admin from env at startup.
+
+    Off (returns ``None``) unless ``ROLEMESH_SEED_ADMIN_EMAIL`` is set,
+    so it self-disables in deployments that don't opt in. When set it
+    delegates to :func:`create_admin` (always ``platform_admin`` — for
+    other roles use the CLI), reading the optional
+    ``ROLEMESH_SEED_ADMIN_EXTERNAL_SUB`` / ``ROLEMESH_SEED_ADMIN_NAME``.
+    Idempotent: an already-present admin is left untouched.
+
+    Intended for managed / IaC deploys; the CLI remains the canonical
+    interactive path.
+    """
+    email = os.environ.get(_SEED_EMAIL_ENV, "").strip()
+    if not email:
+        return None
+    external_sub = os.environ.get(_SEED_EXTERNAL_SUB_ENV) or None
+    name = os.environ.get(_SEED_NAME_ENV) or None
+    result = await create_admin(
+        email=email,
+        role=PLATFORM_ADMIN_ROLE,
+        external_sub=external_sub,
+        name=name,
+    )
+    if result.created:
+        logger.info(
+            "Seeded platform_admin %s (user_id=%s)", email, result.user_id
+        )
+    else:
+        logger.info(
+            "Seed platform_admin already present: %s (user_id=%s)",
+            email,
+            result.user_id,
+        )
+    return result

--- a/src/rolemesh/auth/bootstrap_users.py
+++ b/src/rolemesh/auth/bootstrap_users.py
@@ -138,9 +138,19 @@ _upserted: set[tuple[str, str]] = set()
 
 
 def init_bootstrap_users(
-    env_value: str | None = None, auth_mode: str | None = None
+    env_value: str | None = None,
+    auth_mode: str | None = None,
+    rolemesh_env: str | None = None,
 ) -> None:
     """Parse BOOTSTRAP_USERS once at startup.
+
+    ``rolemesh_env`` is the deployment environment (``ROLEMESH_ENV``).
+    The multi-user bootstrap map maps opaque tokens straight to
+    privileged users with no IdP, so when ``rolemesh_env`` is
+    ``production`` a populated map is a fatal misconfiguration: we raise
+    ``BootstrapUsersConfigError`` to abort startup. Seed the first admin
+    with ``rolemesh-admin create-admin`` instead. Non-production keeps
+    the historic dev/test behaviour.
 
     ``auth_mode`` is the deployed AuthProvider mode. Per §5.2.1 the
     multi-user bootstrap map is intended for dev/test only; if the
@@ -154,6 +164,18 @@ def init_bootstrap_users(
     _specs_by_token = parse_bootstrap_users_env(env_value)
     _upserted = set()
     if _specs_by_token:
+        env = (
+            rolemesh_env
+            if rolemesh_env is not None
+            else os.environ.get("ROLEMESH_ENV", "development")
+        )
+        if env == "production":
+            raise BootstrapUsersConfigError(
+                "BOOTSTRAP_USERS must not be set when ROLEMESH_ENV=production: "
+                "it maps opaque bearer tokens directly to privileged users "
+                "with no IdP. Seed the first admin with "
+                "`rolemesh-admin create-admin` instead."
+            )
         mode = auth_mode if auth_mode is not None else os.environ.get(
             "AUTH_MODE", "external"
         )

--- a/src/rolemesh/db/user.py
+++ b/src/rolemesh/db/user.py
@@ -20,6 +20,7 @@ __all__ = [
     "delete_user_oidc_tokens",
     "get_local_tenant_id",
     "get_user",
+    "get_user_by_email",
     "get_user_by_external_sub",
     "get_user_oidc_tokens",
     "get_users_for_tenant",
@@ -79,6 +80,26 @@ async def get_user_by_external_sub(external_sub: str) -> User | None:
     """Look up a user by their external OIDC subject identifier."""
     async with admin_conn() as conn:
         row = await conn.fetchrow("SELECT * FROM users WHERE external_sub = $1", external_sub)
+    if row is None:
+        return None
+    return _record_to_user(row)
+
+
+async def get_user_by_email(email: str, *, tenant_id: str) -> User | None:
+    """Look up a user by email within ``tenant_id`` (admin pool).
+
+    Cross-tenant maintenance helper (class C resolver): the
+    admin-provisioning core (``rolemesh.admin.core``) uses it to make
+    ``create-admin`` idempotent on the email identifier. ``email`` is
+    not unique on its own, so the lookup is scoped to a tenant. Not for
+    REST handlers — those go through the RLS-bound ``get_user``.
+    """
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM users WHERE tenant_id = $1::uuid AND email = $2",
+            tenant_id,
+            email,
+        )
     if row is None:
         return None
     return _record_to_user(row)

--- a/src/webui/auth.py
+++ b/src/webui/auth.py
@@ -67,7 +67,7 @@ async def authenticate_ws(token: str) -> AuthenticatedUser | None:
     """
     from rolemesh.auth.provider import AuthenticatedUser as AuthUser
     from rolemesh.db import get_tenant_by_slug
-    from webui.config import ADMIN_BOOTSTRAP_TOKEN
+    from webui.config import ADMIN_BOOTSTRAP_TOKEN, IS_PRODUCTION
 
     spec = get_spec_for_token(token)
     if spec is not None:
@@ -85,6 +85,12 @@ async def authenticate_ws(token: str) -> AuthenticatedUser | None:
         )
 
     if ADMIN_BOOTSTRAP_TOKEN and token == ADMIN_BOOTSTRAP_TOKEN:
+        if IS_PRODUCTION:
+            # Fail closed: the static bootstrap token is a permanent,
+            # network-reachable owner backdoor and is disabled in
+            # production. Seed the first admin with
+            # ``rolemesh-admin create-admin`` instead.
+            return None
         tenant = await get_tenant_by_slug("default")
         tenant_id = tenant.id if tenant else "default"
         return AuthUser(

--- a/src/webui/config.py
+++ b/src/webui/config.py
@@ -13,6 +13,22 @@ DATABASE_URL: str = os.environ.get(
 WEB_UI_PORT: int = int(os.environ.get("WEB_UI_PORT", "8080"))
 WEB_UI_HOST: str = os.environ.get("WEB_UI_HOST", "0.0.0.0")
 WEB_UI_DIST: Path = Path(os.environ.get("WEB_UI_DIST", "web/dist"))
+
+# Deployment-environment gate. "production" hardens the legacy bootstrap
+# paths; "development" (the default) keeps them for local/dev/test so
+# existing flows and the test suite are unaffected. The two hardened
+# behaviours:
+#   - ADMIN_BOOTSTRAP_TOKEN stops authorizing (see webui.auth) — it is a
+#     permanent, network-reachable owner backdoor.
+#   - BOOTSTRAP_USERS aborts startup (see rolemesh.auth.bootstrap_users).
+# Seed the first admin with ``rolemesh-admin create-admin`` (or set
+# ROLEMESH_SEED_ADMIN_EMAIL) instead.
+ROLEMESH_ENV: str = os.environ.get("ROLEMESH_ENV", "development")
+IS_PRODUCTION: bool = ROLEMESH_ENV == "production"
+
+# DEPRECATED: static single-user owner fast-path. Disabled when
+# ROLEMESH_ENV=production (fail-closed in webui.auth). Kept for
+# dev/test; full removal is tracked separately.
 ADMIN_BOOTSTRAP_TOKEN: str = os.environ.get("ADMIN_BOOTSTRAP_TOKEN", "")
 
 # Signing key for /api/v1/auth/ws-ticket. Separate from the API

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -91,8 +91,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # BOOTSTRAP_USERS multi-user fast-path (§5.2.1). Parsing happens
     # once at startup so a malformed spec fails the process boot
     # instead of intermittently failing requests. The function is a
-    # no-op when the env var is unset.
+    # no-op when the env var is unset, and aborts boot when set under
+    # ROLEMESH_ENV=production.
     init_bootstrap_users()
+
+    # Env-seed the first platform_admin (managed / IaC convenience).
+    # No-op unless ROLEMESH_SEED_ADMIN_EMAIL is set; idempotent and
+    # self-disabling. The canonical interactive path is the
+    # ``rolemesh-admin create-admin`` CLI.
+    from rolemesh.admin.core import ensure_seed_admin
+
+    await ensure_seed_admin()
 
     # Initialize TokenVault for OIDC token mirroring (mirrors orchestrator init).
     # This is per-process: orchestrator and webui each hold their own vault.

--- a/tests/admin/test_create_admin.py
+++ b/tests/admin/test_create_admin.py
@@ -1,0 +1,224 @@
+"""Tests for the admin-provisioning core (CLI + env-seed share it).
+
+Contract under test (task §6 acceptance):
+  - ``create_admin`` on an empty DB creates one platform_admin; a repeat
+    run is idempotent (no error, same user_id, created=False).
+  - ``--role owner --tenant <slug>`` creates a tenant-scoped row as the
+    escape hatch; tenant-scoped roles require a tenant.
+  - ``ensure_seed_admin`` is off unless ROLEMESH_SEED_ADMIN_EMAIL is set,
+    seeds a platform_admin when set, and skips an existing one.
+  - The write uses the BYPASSRLS admin pool — no auth context needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from rolemesh.admin.cli import _build_parser, _cmd_create_admin
+from rolemesh.admin.core import (
+    PLATFORM_ADMIN_ROLE,
+    AdminProvisionError,
+    create_admin,
+    ensure_seed_admin,
+)
+from rolemesh.db import DEFAULT_TENANT, get_tenant_by_slug
+from rolemesh.db._pool import admin_conn
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+async def _user_count_by_email(email: str) -> int:
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM users WHERE email = $1", email
+        )
+    assert row is not None
+    return int(row["n"])
+
+
+# ---------------------------------------------------------------------------
+# create_admin — platform genesis (default role)
+# ---------------------------------------------------------------------------
+
+
+async def test_creates_platform_admin_in_default_tenant() -> None:
+    result = await create_admin(email="a@b.com")
+
+    assert result.created is True
+    assert result.role == PLATFORM_ADMIN_ROLE
+    assert result.tenant_slug == DEFAULT_TENANT
+    assert result.email == "a@b.com"
+    default = await get_tenant_by_slug(DEFAULT_TENANT)
+    assert default is not None
+    assert result.tenant_id == default.id
+    assert await _user_count_by_email("a@b.com") == 1
+
+
+async def test_create_admin_is_idempotent() -> None:
+    first = await create_admin(email="a@b.com")
+    second = await create_admin(email="a@b.com")
+
+    assert first.created is True
+    assert second.created is False
+    assert second.user_id == first.user_id
+    # The duplicate run did not write a second row.
+    assert await _user_count_by_email("a@b.com") == 1
+
+
+async def test_name_defaults_to_email_local_part() -> None:
+    result = await create_admin(email="alice@example.com")
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT name FROM users WHERE id = $1::uuid", result.user_id
+        )
+    assert row is not None
+    assert row["name"] == "alice"
+
+
+async def test_explicit_name_is_used() -> None:
+    result = await create_admin(email="alice@example.com", name="Alice A")
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT name FROM users WHERE id = $1::uuid", result.user_id
+        )
+    assert row is not None
+    assert row["name"] == "Alice A"
+
+
+# ---------------------------------------------------------------------------
+# external_sub binding + idempotency by sub
+# ---------------------------------------------------------------------------
+
+
+async def test_external_sub_is_bound_and_idempotent_by_sub() -> None:
+    first = await create_admin(email="a@b.com", external_sub="idp|123")
+    assert first.created is True
+    assert first.external_sub == "idp|123"
+
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT external_sub FROM users WHERE id = $1::uuid", first.user_id
+        )
+    assert row is not None
+    assert row["external_sub"] == "idp|123"
+
+    # A different email but the same sub resolves to the same row.
+    second = await create_admin(email="other@b.com", external_sub="idp|123")
+    assert second.created is False
+    assert second.user_id == first.user_id
+
+
+# ---------------------------------------------------------------------------
+# Role validation + tenant-scoped escape hatch
+# ---------------------------------------------------------------------------
+
+
+async def test_rejects_unknown_role() -> None:
+    with pytest.raises(AdminProvisionError, match="role"):
+        await create_admin(email="a@b.com", role="godmode")
+
+
+async def test_tenant_scoped_role_requires_tenant() -> None:
+    with pytest.raises(AdminProvisionError, match="tenant"):
+        await create_admin(email="a@b.com", role="owner")
+
+
+async def test_platform_admin_rejects_foreign_tenant_flag() -> None:
+    with pytest.raises(AdminProvisionError, match="platform-scoped"):
+        await create_admin(email="a@b.com", tenant="acme")
+
+
+async def test_owner_with_tenant_creates_tenant_and_user() -> None:
+    result = await create_admin(email="boss@acme.com", role="owner", tenant="acme")
+
+    assert result.created is True
+    assert result.role == "owner"
+    assert result.tenant_slug == "acme"
+    # The tenant was auto-created.
+    acme = await get_tenant_by_slug("acme")
+    assert acme is not None
+    assert result.tenant_id == acme.id
+
+
+# ---------------------------------------------------------------------------
+# ensure_seed_admin — env wrapper
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_admin_off_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ROLEMESH_SEED_ADMIN_EMAIL", raising=False)
+    assert await ensure_seed_admin() is None
+
+
+async def test_seed_admin_seeds_platform_admin_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ROLEMESH_SEED_ADMIN_EMAIL", "seed@b.com")
+    monkeypatch.setenv("ROLEMESH_SEED_ADMIN_NAME", "Seed Admin")
+
+    result = await ensure_seed_admin()
+    assert result is not None
+    assert result.created is True
+    assert result.role == PLATFORM_ADMIN_ROLE
+
+    # Idempotent: a second startup leaves it untouched.
+    again = await ensure_seed_admin()
+    assert again is not None
+    assert again.created is False
+    assert again.user_id == result.user_id
+    assert await _user_count_by_email("seed@b.com") == 1
+
+
+async def test_seed_admin_uses_same_core_as_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The CLI create then the seed of the same email must converge on the
+    # one row — proving both go through the shared core.
+    cli = await create_admin(email="shared@b.com")
+    monkeypatch.setenv("ROLEMESH_SEED_ADMIN_EMAIL", "shared@b.com")
+    seed = await ensure_seed_admin()
+    assert seed is not None
+    assert seed.created is False
+    assert seed.user_id == cli.user_id
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_parser_defaults_to_platform_admin() -> None:
+    args = _build_parser().parse_args(["create-admin", "--email", "a@b.com"])
+    assert args.command == "create-admin"
+    assert args.email == "a@b.com"
+    assert args.role == PLATFORM_ADMIN_ROLE
+    assert args.tenant is None
+
+
+async def test_cli_command_creates_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The CLI manages its own pools via init_database/close_database; the
+    # test_db fixture already opened pools on this event loop, so stub
+    # those out and exercise the command against the live test DB.
+    import rolemesh.db as db_pkg
+
+    async def _noop(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr(db_pkg, "init_database", _noop)
+    monkeypatch.setattr(db_pkg, "close_database", _noop)
+
+    args = argparse.Namespace(
+        command="create-admin",
+        email="cli@b.com",
+        role=PLATFORM_ADMIN_ROLE,
+        external_sub=None,
+        name=None,
+        tenant=None,
+    )
+    rc = await _cmd_create_admin(args)
+    assert rc == 0
+    assert await _user_count_by_email("cli@b.com") == 1

--- a/tests/admin/test_production_tightening.py
+++ b/tests/admin/test_production_tightening.py
@@ -1,0 +1,102 @@
+"""ROLEMESH_ENV=production hardening of the legacy bootstrap paths.
+
+  - ADMIN_BOOTSTRAP_TOKEN no longer authorizes in production (fail
+    closed) but still works in development (default).
+  - BOOTSTRAP_USERS aborts startup in production but only warns / works
+    in development.
+
+The default (development) behaviour must be unchanged so the existing
+ADMIN_BOOTSTRAP_TOKEN-dependent suite is not disturbed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rolemesh.auth.bootstrap_users import (
+    BootstrapUsersConfigError,
+    _reset_for_tests,
+    init_bootstrap_users,
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> None:
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+async def _ensure_default_tenant() -> str:
+    from rolemesh.db import create_tenant, get_tenant_by_slug
+
+    existing = await get_tenant_by_slug("default")
+    if existing is not None:
+        return existing.id
+    t = await create_tenant(name="default", slug="default")
+    return t.id
+
+
+# ---------------------------------------------------------------------------
+# ADMIN_BOOTSTRAP_TOKEN
+# ---------------------------------------------------------------------------
+
+
+async def test_bootstrap_token_authorizes_in_development(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _ensure_default_tenant()
+    init_bootstrap_users("")
+    monkeypatch.setattr("webui.config.ADMIN_BOOTSTRAP_TOKEN", "legacy-tok")
+    monkeypatch.setattr("webui.config.IS_PRODUCTION", False)
+
+    from webui import auth as webui_auth
+
+    user = await webui_auth.authenticate_ws("legacy-tok")
+    assert user is not None
+    assert user.role == "owner"
+
+
+async def test_bootstrap_token_fails_closed_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _ensure_default_tenant()
+    init_bootstrap_users("")
+    monkeypatch.setattr("webui.config.ADMIN_BOOTSTRAP_TOKEN", "legacy-tok")
+    monkeypatch.setattr("webui.config.IS_PRODUCTION", True)
+
+    from webui import auth as webui_auth
+
+    # The token branch must not authorize; with no provider configured
+    # the request lands unauthenticated.
+    assert await webui_auth.authenticate_ws("legacy-tok") is None
+
+
+# ---------------------------------------------------------------------------
+# BOOTSTRAP_USERS
+# ---------------------------------------------------------------------------
+
+
+def _one_spec() -> str:
+    return json.dumps(
+        [{"token": "tok-a", "user_id": "a", "tenant": "default", "role": "owner"}]
+    )
+
+
+def test_bootstrap_users_hard_fails_in_production() -> None:
+    with pytest.raises(BootstrapUsersConfigError, match="production"):
+        init_bootstrap_users(_one_spec(), rolemesh_env="production")
+
+
+def test_bootstrap_users_ok_in_development() -> None:
+    # Does not raise; the map is parsed for the dev/test fast-path.
+    init_bootstrap_users(_one_spec(), rolemesh_env="development")
+
+
+def test_empty_bootstrap_users_ok_in_production() -> None:
+    # The feature being off is always fine, even in production.
+    init_bootstrap_users("", rolemesh_env="production")


### PR DESCRIPTION
Adds a `rolemesh-admin create-admin` CLI to seed the **first `platform_admin`** on a fresh deploy (the one privileged account nobody can create through the UI yet — zero users, no one to log in), and **hardens the legacy bootstrap backdoors in production**.

## Why
Today the first admin comes from two dev-grade backdoors: the static `ADMIN_BOOTSTRAP_TOKEN` (a permanent, network-reachable owner token) and the `BOOTSTRAP_USERS` env map (opaque tokens → privileged users, no IdP). This replaces them with an explicit, auditable operator action bound to whoever already holds host + DB access.

## What
- **`rolemesh-admin create-admin --email …`** — seeds a `platform_admin` (default), or `--role owner/admin/member --tenant <slug>` as an emergency escape hatch. The email is the IdP login identifier, **not a credential** — auth still runs through the IdP, so no network-reachable secret is introduced.
- **`rolemesh.admin.core.create_admin`** — single source of truth shared by the CLI and an optional env-seed (`ensure_seed_admin`, gated on `ROLEMESH_SEED_ADMIN_EMAIL` for managed/IaC deploys). Idempotent (matched by `external_sub`, else `(tenant, email)`); writes through the BYPASSRLS admin pool since seeding is a provisioning, not an auth, problem. Tenants are created on demand; schema is built idempotently on connect.
- **Production hardening** via new `ROLEMESH_ENV` (default `development`): when `production`, `ADMIN_BOOTSTRAP_TOKEN` stops authorizing (fail-closed in `webui.auth`) and a populated `BOOTSTRAP_USERS` aborts startup. Dev/test behaviour is unchanged.

## Scope note
`platform_admin` is referenced as a plain role string only — the scope/authorization wiring that makes it *mean* something is a separate role-model task ("引用,不接线"). Until then a `platform_admin` row is anchored to the `default` tenant to satisfy `users.tenant_id NOT NULL`.

## Tests
`tests/admin/test_create_admin.py` (happy path, idempotency, role/tenant validation) and `tests/admin/test_production_tightening.py` (the production fail-closed gates).

Manually verified against a real Postgres: create → idempotent re-run (same uuid) → tenant-scoped escape hatch → DB rows correct; both validation guards exit non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
