### PR TITLE
feat(safety-ui): Safety rules + Safety log UI + approval safety indicators

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -2300,6 +2300,26 @@ components:
         enabled: { type: boolean }
         priority: { type: integer }
 
+    ApprovalTriggeredBy:
+      type: object
+      description: |
+        Provenance of a safety-triggered approval (§1.1, §3.10). Present on an
+        approval raised by a safety check's `require_approval` verdict; absent
+        / null on a business-policy approval. `kind` is an open tag so future
+        provenances (e.g. `scheduled_task`) extend without a break — V1 only
+        emits `safety_rule`, and the SPA degrades to no banner on unknown
+        kinds. No producer sets it yet (the safety→approval bridge is a
+        separate unbuilt effort); the field exists so the contract + typed
+        client are ready.
+      required: [kind, rule_id, check_id, stage]
+      properties:
+        kind:
+          type: string
+          enum: [safety_rule]
+        rule_id: { type: string, format: uuid }
+        check_id: { type: string }
+        stage: { $ref: '#/components/schemas/SafetyStage' }
+
     ApprovalRequest:
       type: object
       required:
@@ -2358,6 +2378,13 @@ components:
           type: string
           nullable: true
           description: The approver's note on a reject; null otherwise.
+        triggered_by:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalTriggeredBy'
+          nullable: true
+          description: |
+            Safety-rule provenance (§3.10); null for a business-policy
+            approval. Always null today — see ApprovalTriggeredBy.
 
     # -----------------------------------------------------------------
     # Skills (design §3 Phase 3 / docs/19-skills-architecture.md)
@@ -2626,6 +2653,29 @@ components:
         description: { type: string }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+        source:
+          type: string
+          enum: [tenant, platform]
+          default: tenant
+          description: |
+            Platform Safety Rules (PR #49). `tenant` rules are owned by the
+            organization and editable on the admin surface; `platform` rules
+            are cross-tenant defaults set by the platform admin — read-only
+            here. The SPA renders the two tiers in separate sections (§6.2).
+        tier:
+          type: string
+          enum: [floor, transparent_floor, default]
+          nullable: true
+          description: |
+            Platform-rule tier; null for tenant-owned rules. Set only when
+            `source == platform`.
+        editable:
+          type: boolean
+          default: true
+          description: |
+            Convenience flag the SPA uses to show/hide edit / duplicate /
+            delete affordances without re-deriving from `source`. False for
+            platform rules (audit-only).
 
     SafetyCheck:
       type: object
@@ -2710,6 +2760,13 @@ components:
           items: { $ref: '#/components/schemas/SafetyFinding' }
         context_digest: { type: string }
         context_summary: { type: string }
+        source:
+          type: string
+          enum: [tenant, platform]
+          default: tenant
+          description: |
+            `platform` when any triggered rule is platform-owned, else
+            `tenant`. Lets the log filter platform-rule hits at a glance.
         created_at: { type: string, format: date-time }
 
     SafetyDecisionPage:
@@ -3150,6 +3207,13 @@ components:
           type: string
           nullable: true
           description: When the pending approval auto-expires (ISO-8601).
+        triggered_by:
+          allOf:
+            - $ref: '#/components/schemas/ApprovalTriggeredBy'
+          nullable: true
+          description: |
+            Safety-rule provenance (§3.10); null for a business-policy
+            approval. Always null today — see ApprovalTriggeredBy.
 
     WsServerEventApprovalResolved:
       type: object

--- a/src/webui/schemas.py
+++ b/src/webui/schemas.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import get_args
+
 from pydantic import BaseModel, Field, field_validator
+
+from webui.schemas_v1 import SafetyStage
 
 # ---------------------------------------------------------------------------
 # Tenant
@@ -191,10 +195,13 @@ class AssignRequest(BaseModel):
 # V1 stages exposed through REST. Rule POST accepts any of these, but
 # the server additionally checks the stage is within the selected
 # check's ``stages`` set before writing to the DB.
-_SAFETY_STAGE_PATTERN = (
-    r"^(input_prompt|pre_tool_call|post_tool_result|"
-    r"model_output|pre_compaction)$"
-)
+# Derived from the canonical v1 ``SafetyStage`` literal (itself pinned to the
+# engine ``Stage`` enum by test_v1_safety_stage_enum_matches_safety_types_stage)
+# so this admin-write validator can never drift out of sync with the stage set.
+# PR #50 added EGRESS_REQUEST to the engine, the v1 read schema, and every
+# check's stages — but not this hardcoded regex, so editing an egress rule
+# (stage=egress_request) was rejected with a 422. Deriving it closes that gap.
+_SAFETY_STAGE_PATTERN = "^(" + "|".join(get_args(SafetyStage)) + ")$"
 
 
 class SafetyRuleResponse(BaseModel):

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -460,6 +460,34 @@ class ApprovalPolicyUpdate(BaseModel):
     )
 
 
+class ApprovalTriggeredBy(BaseModel):
+    """Provenance of an approval that did not come from a business policy.
+
+    Set by the safety pipeline when a check returns
+    ``Verdict(action="require_approval")`` (spec §1.1, §3.10). Null on a
+    normal business-policy approval. The SPA renders an amber "paused by a
+    safety rule" banner on the chat card and a small shield on the inbox
+    row when ``kind == "safety_rule"``; unknown kinds degrade to no banner.
+
+    ``kind`` is an open tag so future provenances (e.g. ``scheduled_task``)
+    extend the union without a breaking change; V1 only emits
+    ``safety_rule``. ``stage`` is a ``SafetyStage`` value (typed ``str``
+    here because this model is defined before the ``SafetyStage`` literal;
+    the OpenAPI schema ``$ref``\\s the enum so the typed client narrows it).
+
+    NOTE: no producer populates this yet — the safety→approval bridge that
+    would set it is a separate, unbuilt backend effort. The field exists so
+    the contract and SPA are ready; today it is always null end-to-end.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["safety_rule"]
+    rule_id: str
+    check_id: str
+    stage: str
+
+
 class ApprovalRequest(BaseModel):
     """Wire projection of an ``approval_requests`` row (§4.2).
 
@@ -490,6 +518,10 @@ class ApprovalRequest(BaseModel):
     status: str
     decided_at: str | None = None
     note: str | None = None
+    # §1.1/§3.10 provenance: present (kind="safety_rule") when the approval was
+    # raised by a safety check's require_approval verdict; null for business
+    # policy approvals. No producer sets it yet (see ApprovalTriggeredBy).
+    triggered_by: ApprovalTriggeredBy | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -984,6 +1016,10 @@ class WsServerEventApprovalRequested(BaseModel):
     rationale: str | None = None
     action_summary: str | None = None
     expires_at: str | None = None
+    # §1.1/§3.10 provenance for a safety-triggered approval; null for a
+    # business-policy approval. No producer sets it yet (see
+    # ApprovalTriggeredBy) — the SPA renders nothing when absent.
+    triggered_by: ApprovalTriggeredBy | None = None
 
 
 class WsServerEventApprovalResolved(BaseModel):

--- a/tests/webui/test_safety_admin_stage_pattern.py
+++ b/tests/webui/test_safety_admin_stage_pattern.py
@@ -1,0 +1,60 @@
+"""Regression: the admin safety-rule write schema must accept every engine stage.
+
+Field bug: PR #50 added ``EGRESS_REQUEST`` to the engine ``Stage`` enum, the v1
+read schema, and each check's ``stages`` — but the admin-write validator kept a
+hardcoded 5-stage regex (``_SAFETY_STAGE_PATTERN``). Editing an
+``egress.domain_rule`` rule (whose stage is ``egress_request``) was therefore
+rejected with::
+
+    HTTP 422 string_pattern_mismatch  loc=["body","stage"]  input="egress_request"
+
+The pattern is now *derived* from the canonical ``SafetyStage`` literal. These
+tests pin the specific regression and guard against the pattern drifting out of
+sync with the engine ``Stage`` set ever again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.safety.types import Stage
+from webui.schemas import (
+    _SAFETY_STAGE_PATTERN,
+    SafetyRuleCreate,
+    SafetyRuleUpdate,
+)
+
+ALL_STAGES = [s.value for s in Stage]
+
+
+@pytest.mark.parametrize("stage", ALL_STAGES)
+def test_admin_create_accepts_every_engine_stage(stage: str) -> None:
+    assert SafetyRuleCreate(stage=stage, check_id="x").stage == stage
+
+
+@pytest.mark.parametrize("stage", ALL_STAGES)
+def test_admin_update_accepts_every_engine_stage(stage: str) -> None:
+    assert SafetyRuleUpdate(stage=stage).stage == stage
+
+
+def test_egress_request_is_accepted_specifically() -> None:
+    # The exact case from the field 422 (editing an egress.domain_rule rule).
+    assert SafetyRuleUpdate(stage="egress_request").stage == "egress_request"
+    assert (
+        SafetyRuleCreate(stage="egress_request", check_id="egress.domain_rule").stage
+        == "egress_request"
+    )
+
+
+def test_unknown_stage_is_still_rejected() -> None:
+    with pytest.raises(ValueError):
+        SafetyRuleUpdate(stage="not_a_real_stage")
+
+
+def test_pattern_covers_exactly_the_engine_stage_set() -> None:
+    # Drift guard: the alternation in the regex must equal the engine's
+    # authoritative Stage values. If the engine adds a 7th stage, this fails
+    # until the (derived) pattern picks it up — closing the gap that caused
+    # the egress_request 422 in the first place.
+    inner = _SAFETY_STAGE_PATTERN.removeprefix("^(").removesuffix(")$")
+    assert set(inner.split("|")) == {s.value for s in Stage}

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1411,6 +1411,24 @@ export interface components {
             enabled?: boolean;
             priority?: number;
         };
+        /**
+         * @description Provenance of a safety-triggered approval (§1.1, §3.10). Present on an
+         *     approval raised by a safety check's `require_approval` verdict; absent
+         *     / null on a business-policy approval. `kind` is an open tag so future
+         *     provenances (e.g. `scheduled_task`) extend without a break — V1 only
+         *     emits `safety_rule`, and the SPA degrades to no banner on unknown
+         *     kinds. No producer sets it yet (the safety→approval bridge is a
+         *     separate unbuilt effort); the field exists so the contract + typed
+         *     client are ready.
+         */
+        ApprovalTriggeredBy: {
+            /** @enum {string} */
+            kind: "safety_rule";
+            /** Format: uuid */
+            rule_id: string;
+            check_id: string;
+            stage: components["schemas"]["SafetyStage"];
+        };
         ApprovalRequest: {
             /**
              * Format: uuid
@@ -1455,6 +1473,11 @@ export interface components {
             decided_at?: string | null;
             /** @description The approver's note on a reject; null otherwise. */
             note?: string | null;
+            /**
+             * @description Safety-rule provenance (§3.10); null for a business-policy
+             *     approval. Always null today — see ApprovalTriggeredBy.
+             */
+            triggered_by?: components["schemas"]["ApprovalTriggeredBy"] | null;
         };
         SkillFile: {
             path: string;
@@ -1645,6 +1668,28 @@ export interface components {
             created_at: string;
             /** Format: date-time */
             updated_at: string;
+            /**
+             * @description Platform Safety Rules (PR #49). `tenant` rules are owned by the
+             *     organization and editable on the admin surface; `platform` rules
+             *     are cross-tenant defaults set by the platform admin — read-only
+             *     here. The SPA renders the two tiers in separate sections (§6.2).
+             * @default tenant
+             * @enum {string}
+             */
+            source: "tenant" | "platform";
+            /**
+             * @description Platform-rule tier; null for tenant-owned rules. Set only when
+             *     `source == platform`.
+             * @enum {string|null}
+             */
+            tier?: "floor" | "transparent_floor" | "default" | null;
+            /**
+             * @description Convenience flag the SPA uses to show/hide edit / duplicate /
+             *     delete affordances without re-deriving from `source`. False for
+             *     platform rules (audit-only).
+             * @default true
+             */
+            editable: boolean;
         };
         SafetyCheck: {
             id: string;
@@ -1686,6 +1731,13 @@ export interface components {
             findings?: components["schemas"]["SafetyFinding"][];
             context_digest: string;
             context_summary: string;
+            /**
+             * @description `platform` when any triggered rule is platform-owned, else
+             *     `tenant`. Lets the log filter platform-rule hits at a glance.
+             * @default tenant
+             * @enum {string}
+             */
+            source: "tenant" | "platform";
             /** Format: date-time */
             created_at: string;
         };
@@ -2018,6 +2070,11 @@ export interface components {
             action_summary?: string | null;
             /** @description When the pending approval auto-expires (ISO-8601). */
             expires_at?: string | null;
+            /**
+             * @description Safety-rule provenance (§3.10); null for a business-policy
+             *     approval. Always null today — see ApprovalTriggeredBy.
+             */
+            triggered_by?: components["schemas"]["ApprovalTriggeredBy"] | null;
         };
         WsServerEventApprovalResolved: {
             /**

--- a/web/src/components/activity-shell.test.ts
+++ b/web/src/components/activity-shell.test.ts
@@ -1,13 +1,9 @@
 // @vitest-environment happy-dom
-// <rm-activity-shell> — pins the two-route layout:
-//   * `#/activity`                  → index (one card)
-//   * `#/activity/safety-decisions` → <rm-safety-decisions-page>
-//
-// We pin observable behaviour: which custom element gets slotted, which
-// hash a tab click writes, and whether the X button returns to `#/`.
-// We do NOT mock the slotted pages — their internal fetches fail
-// silently in the unit-test env, and that's fine because we're not
-// asserting on the inner page's render output, just on shell routing.
+// <rm-activity-shell> — now a thin launcher. The safety log moved to
+// Settings → Governance (spec §7), so the Activity overview's card links into
+// `#/manage/safety-log` rather than hosting the page in-shell. We pin: the
+// card exists, it navigates to the settings home, the shell never slots the
+// decisions page, and the X button returns to chat.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -91,70 +87,35 @@ describe('<rm-activity-shell>', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the index (card, no inner page) at #/activity', async () => {
+  it('renders the index launcher card and never slots the decisions page', async () => {
     loc = stubHash('#/activity');
     const el = await mount();
-    const body = el.querySelector('[data-testid="activity-body"]');
-    expect(body?.getAttribute('data-tab')).toBe('index');
     expect(
-      el.querySelector('[data-testid="activity-card-safety-decisions"]'),
+      el.querySelector('[data-testid="activity-card-safety-log"]'),
     ).not.toBeNull();
-    // Index renders no child page.
     expect(el.querySelector('rm-safety-decisions-page')).toBeNull();
   });
 
-  it('renders <rm-safety-decisions-page> at #/activity/safety-decisions', async () => {
-    loc = stubHash('#/activity/safety-decisions');
-    const el = await mount();
-    expect(el.querySelector('rm-safety-decisions-page')).not.toBeNull();
-  });
-
-  it('clicking the Safety decisions index card navigates to #/activity/safety-decisions', async () => {
+  it('clicking the Safety log card navigates to Settings → Safety log', async () => {
     loc = stubHash('#/activity');
     const el = await mount();
     const card = el.querySelector<HTMLButtonElement>(
-      '[data-testid="activity-card-safety-decisions"]',
+      '[data-testid="activity-card-safety-log"]',
     );
     card!.click();
     await settle(el);
-    expect(loc.hashAssignments).toContain('#/activity/safety-decisions');
-    expect(el.querySelector('rm-safety-decisions-page')).not.toBeNull();
-  });
-
-  it('tab bar switches via hash (URL is source of truth)', async () => {
-    loc = stubHash('#/activity');
-    const el = await mount();
-    const safetyTab = el.querySelector<HTMLButtonElement>(
-      '[data-testid="activity-tab-safety-decisions"]',
-    );
-    safetyTab!.click();
-    await settle(el);
-    expect(loc.hashAssignments).toContain('#/activity/safety-decisions');
-    expect(
-      el.querySelector('[data-testid="activity-body"]')?.getAttribute('data-tab'),
-    ).toBe('safety-decisions');
+    expect(loc.hashAssignments).toContain('#/manage/safety-log');
+    // The shell still never hosts the page itself.
+    expect(el.querySelector('rm-safety-decisions-page')).toBeNull();
   });
 
   it('X button navigates back to chat (#/)', async () => {
-    loc = stubHash('#/activity/safety-decisions');
+    loc = stubHash('#/activity');
     const el = await mount();
     const back = el.querySelector<HTMLButtonElement>(
       '[data-testid="activity-back"]',
     );
     back!.click();
     expect(loc.hashAssignments).toContain('#/');
-  });
-
-  it('reacts to external hashchange (route survives deep link / refresh)', async () => {
-    loc = stubHash('#/activity');
-    const el = await mount();
-    expect(
-      el.querySelector('[data-testid="activity-body"]')?.getAttribute('data-tab'),
-    ).toBe('index');
-    // Simulate the user pasting a URL or hitting Back. The shell
-    // must follow the URL, not its previous state.
-    location.hash = '#/activity/safety-decisions';
-    await settle(el);
-    expect(el.querySelector('rm-safety-decisions-page')).not.toBeNull();
   });
 });

--- a/web/src/components/activity-shell.ts
+++ b/web/src/components/activity-shell.ts
@@ -24,19 +24,11 @@
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-import './safety-decisions-page.js';
 import {
   iconActivity,
   iconChevronRight,
   iconClose,
 } from './icons.js';
-
-type ActivityTab = 'index' | 'safety-decisions';
-
-function tabFromHash(hash: string): ActivityTab {
-  if (hash.startsWith('#/activity/safety-decisions')) return 'safety-decisions';
-  return 'index';
-}
 
 @customElement('rm-activity-shell')
 export class RmActivityShell extends LitElement {
@@ -71,49 +63,23 @@ export class RmActivityShell extends LitElement {
     location.hash = '#/';
   };
 
-  private goTab(tab: ActivityTab): void {
-    const next =
-      tab === 'safety-decisions'
-        ? '#/activity/safety-decisions'
-        : '#/activity';
-    if (location.hash === next) return;
-    location.hash = next;
-  }
-
-  private renderTabs(active: ActivityTab): TemplateResult {
-    const items: { id: ActivityTab; label: string }[] = [
-      { id: 'index', label: 'Overview' },
-      { id: 'safety-decisions', label: 'Safety decisions' },
-    ];
-    return html`
-      <div class="as-tabs" role="tablist" aria-label="Activity sections">
-        ${items.map(
-          (t) => html`
-            <button
-              class=${`as-tab ${active === t.id ? 'active' : ''}`}
-              role="tab"
-              aria-selected=${active === t.id}
-              data-testid=${`activity-tab-${t.id}`}
-              data-tab=${t.id}
-              @click=${() => this.goTab(t.id)}
-            >${t.label}</button>
-          `,
-        )}
-      </div>
-    `;
-  }
+  // The safety log moved to Settings → Governance (spec §7); this card is now
+  // a launcher into that home rather than an in-shell tab.
+  private goSafetyLog = () => {
+    location.hash = '#/manage/safety-log';
+  };
 
   private renderIndex(): TemplateResult {
     return html`
       <div class="as-index">
         <button
           class="as-card"
-          data-testid="activity-card-safety-decisions"
-          @click=${() => this.goTab('safety-decisions')}
+          data-testid="activity-card-safety-log"
+          @click=${this.goSafetyLog}
         >
           <span class="as-card-icon">${iconActivity(22)}</span>
           <span class="as-card-body">
-            <span class="as-card-title">Safety decisions</span>
+            <span class="as-card-title">Safety log</span>
             <span class="as-card-sub">
               Live audit of allow / block / redact / warn verdicts across
               all conversations on this tenant.
@@ -126,11 +92,6 @@ export class RmActivityShell extends LitElement {
   }
 
   override render(): TemplateResult {
-    const active = tabFromHash(this.hash);
-    const body =
-      active === 'safety-decisions'
-        ? html`<rm-safety-decisions-page></rm-safety-decisions-page>`
-        : this.renderIndex();
     return html`
       <style>
         rm-activity-shell {
@@ -272,9 +233,8 @@ export class RmActivityShell extends LitElement {
           @click=${this.backToChat}
         >${iconClose(16)}</button>
       </div>
-      ${this.renderTabs(active)}
-      <div class="as-body" data-testid="activity-body" data-tab=${active}>
-        ${body}
+      <div class="as-body" data-testid="activity-body">
+        ${this.renderIndex()}
       </div>
     `;
   }

--- a/web/src/components/approval-card.test.ts
+++ b/web/src/components/approval-card.test.ts
@@ -282,3 +282,60 @@ describe('<rm-approval-card>', () => {
     expect(onDecision).not.toHaveBeenCalled();
   });
 });
+
+describe('<rm-approval-card> safety-triggered banner (§3.10)', () => {
+  let el: ApprovalCard;
+  afterEach(() => {
+    el?.remove();
+  });
+
+  it('renders an amber banner with the check label when triggered by a safety rule', async () => {
+    el = await mount({
+      mcpServerName: 'stripe',
+      toolName: 'refund.create',
+      triggeredBy: {
+        kind: 'safety_rule',
+        rule_id: 'sr-1',
+        check_id: 'presidio.pii',
+        stage: 'post_tool_result',
+      },
+    });
+    const banner = $(el, '[data-testid="approval-safety-banner"]');
+    expect(banner).not.toBeNull();
+    // Human label, never the raw id; stage intentionally omitted.
+    expect(banner?.textContent).toContain('Personal data (Presidio)');
+    expect(banner?.textContent).not.toContain('post_tool_result');
+    expect($(el, '[data-testid="approval-safety-link"]')).not.toBeNull();
+  });
+
+  it('renders no banner for a business-policy approval (triggeredBy null)', async () => {
+    el = await mount({ mcpServerName: 'stripe', toolName: 'refund.create', triggeredBy: null });
+    expect($(el, '[data-testid="approval-safety-banner"]')).toBeNull();
+  });
+
+  it('degrades to no banner on an unknown triggered_by kind (forward-compat)', async () => {
+    el = await mount({
+      mcpServerName: 'stripe',
+      toolName: 'refund.create',
+      // A future kind the SPA doesn't know about must not crash or render.
+      triggeredBy: { kind: 'scheduled_task', rule_id: 'x', check_id: 'y', stage: 'input_prompt' } as never,
+    });
+    expect($(el, '[data-testid="approval-safety-banner"]')).toBeNull();
+  });
+
+  it('jumps to the settings safety log when "view in safety log" is clicked', async () => {
+    el = await mount({
+      mcpServerName: 'stripe',
+      toolName: 'refund.create',
+      triggeredBy: {
+        kind: 'safety_rule',
+        rule_id: 'sr-1',
+        check_id: 'presidio.pii',
+        stage: 'post_tool_result',
+      },
+    });
+    location.hash = '#/';
+    ($(el, '[data-testid="approval-safety-link"]') as HTMLButtonElement).click();
+    expect(location.hash).toBe('#/manage/safety-log');
+  });
+});

--- a/web/src/components/approval-card.ts
+++ b/web/src/components/approval-card.ts
@@ -18,7 +18,9 @@
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { ApprovalStatus } from './approval-store.js';
+import type { ApprovalStatus, ApprovalTriggeredBy } from './approval-store.js';
+import { checkLabel } from './safety-catalog.js';
+import { iconShield } from './icons.js';
 
 /** Fired when the user confirms a decision. Bubbles + composed so chat-panel
  *  (the light-DOM host) catches it. `note` is present only on a Reject that
@@ -87,6 +89,10 @@ export class ApprovalCard extends LitElement {
    *  rejected card (§3.6). May arrive via prop (store) or be remembered from
    *  the form the user just submitted. */
   @property() note: string | null = null;
+  /** Safety-rule provenance (§3.10). When kind is "safety_rule" the card shows
+   *  an amber "paused by a safety rule" banner above the tool chip; null (a
+   *  business-policy approval) or an unknown kind shows nothing. */
+  @property({ attribute: false }) triggeredBy: ApprovalTriggeredBy = null;
 
   /** Inline reject-note form open? */
   @state() private rejecting = false;
@@ -289,6 +295,47 @@ export class ApprovalCard extends LitElement {
     `;
   }
 
+  // §3.10 — amber provenance banner for a safety-triggered approval. Returns
+  // nothing for a business-policy approval (triggeredBy null) OR an unknown
+  // kind (forward-compatible: a future "scheduled_task" degrades to no banner).
+  // Stage is intentionally omitted — the decision-maker cares WHICH check
+  // caught it, not WHEN in the pipeline.
+  private renderSafetyBanner(): TemplateResult | typeof nothing {
+    const tb = this.triggeredBy;
+    if (!tb || tb.kind !== 'safety_rule') return nothing;
+    return html`
+      <div
+        class="flex items-start gap-2 mb-2.5 px-2.5 py-2 rounded-md text-[12.5px]
+               bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-200
+               border-l-2 border-amber-400 dark:border-amber-600"
+        data-testid="approval-safety-banner"
+      >
+        <span class="shrink-0 mt-px text-amber-600 dark:text-amber-400"
+          >${iconShield(14)}</span
+        >
+        <span class="flex-1 min-w-0"
+          >Paused by a safety rule — <b>${checkLabel(tb.check_id)}</b></span
+        >
+        <button
+          type="button"
+          class="shrink-0 underline whitespace-nowrap hover:text-amber-900 dark:hover:text-amber-100"
+          data-testid="approval-safety-link"
+          @click=${() => this.jumpToSafetyDecision(tb.rule_id)}
+        >
+          view in safety log →
+        </button>
+      </div>
+    `;
+  }
+
+  // Navigate to Settings → Safety log (spec §3.10). The log can't yet deep-
+  // filter by rule_id (the v1 endpoint exposes no rule_id filter), so this
+  // opens the log rather than a pre-filtered, auto-opened decision. The
+  // rule_id is accepted now so the call site is stable when that lands.
+  private jumpToSafetyDecision(_ruleId: string): void {
+    location.hash = '#/manage/safety-log';
+  }
+
   private renderToolChip(): TemplateResult | typeof nothing {
     if (!this.mcpServerName && !this.toolName) return nothing;
     const label = [this.mcpServerName, this.toolName]
@@ -478,7 +525,7 @@ export class ApprovalCard extends LitElement {
       >
         ${this.renderHeader()}
         <div class="px-3.5 py-3">
-          ${this.renderMeta()}${this.renderToolChip()}
+          ${this.renderMeta()}${this.renderSafetyBanner()}${this.renderToolChip()}
           <div class=${resolved ? 'opacity-75' : ''}>
             ${this.renderParams()}
           </div>

--- a/web/src/components/approval-store.test.ts
+++ b/web/src/components/approval-store.test.ts
@@ -66,6 +66,7 @@ function seed(id: string, status: ApprovalCard['status']): ApprovalCard {
     status,
     resolvedAt: null,
     note: null,
+    triggeredBy: null,
     orderTs: 0,
   };
 }
@@ -123,6 +124,21 @@ describe('upsertRequested', () => {
     const once = upsertRequested([], requested('a'));
     const twice = upsertRequested(once, requested('a'));
     expect(twice).toHaveLength(1);
+  });
+
+  it('carries triggered_by through (safety provenance §3.10)', () => {
+    const tb = {
+      kind: 'safety_rule' as const,
+      rule_id: 'sr-1',
+      check_id: 'presidio.pii',
+      stage: 'post_tool_result' as const,
+    };
+    const out = upsertRequested([], requested('a', { triggered_by: tb }));
+    expect(out[0].triggeredBy).toEqual(tb);
+  });
+
+  it('defaults triggeredBy to null for a business-policy approval', () => {
+    expect(upsertRequested([], requested('a'))[0].triggeredBy).toBeNull();
   });
 
   it('does NOT revert a resolved card back to pending on redelivery', () => {

--- a/web/src/components/approval-store.ts
+++ b/web/src/components/approval-store.ts
@@ -28,6 +28,15 @@ export type ApprovalStatus =
   | 'expired'
   | 'cancelled';
 
+/** Provenance of a safety-triggered approval (§3.10). Present (kind
+ *  "safety_rule") when a safety check's require_approval verdict raised the
+ *  approval; null for a business-policy approval. Forward-compatible: the SPA
+ *  handles `safety_rule` explicitly and degrades to nothing on unknown kinds.
+ *  NOTE: no producer sets this yet (the safety→approval bridge is unbuilt), so
+ *  in practice it is always null today — the indicators below render nothing. */
+export type ApprovalTriggeredBy =
+  components['schemas']['ApprovalTriggeredBy'] | null;
+
 export interface ApprovalCard {
   requestId: string;
   /** The gated MCP server (`event.approval.requested.mcp_server_name`). */
@@ -57,6 +66,8 @@ export interface ApprovalCard {
    *  card can echo it back ("YOUR REASON"). Never comes off the wire — it is
    *  what the user typed — and is lost on reconnect, which is acceptable. */
   note: string | null;
+  /** Safety-rule provenance (§3.10); null for a business-policy approval. */
+  triggeredBy: ApprovalTriggeredBy;
   /** Ordering key (epoch ms) used to interleave the card with chat messages in
    *  chronological position instead of pinning it to the conversation tail. It
    *  is stamped client-side at the instant the card enters the timeline for a
@@ -106,6 +117,7 @@ export function upsertRequested(
       status: 'pending',
       resolvedAt: null,
       note: null,
+      triggeredBy: ev.triggered_by ?? null,
       // Live push: stamp arrival time so the card sorts after the user message
       // that triggered it and before the (later) confirmation, even if the
       // server's requested_at clock differs from the browser's.
@@ -160,6 +172,7 @@ export function mergePending(
     status: 'pending',
     resolvedAt: null,
     note: null,
+    triggeredBy: r.triggered_by ?? null,
     orderTs: r.requested_at ? Date.parse(r.requested_at) : Date.now(),
   }));
   // De-dup defensively: a row whose id already has a resolved card (decided in
@@ -199,6 +212,7 @@ export function cardsFromConversation(
       resolvedAt:
         status !== 'pending' && decidedAt ? Date.parse(decidedAt) : null,
       note: r.note ?? null,
+      triggeredBy: r.triggered_by ?? null,
       orderTs: r.requested_at ? Date.parse(r.requested_at) : 0,
     };
   });

--- a/web/src/components/approvals-inbox.test.ts
+++ b/web/src/components/approvals-inbox.test.ts
@@ -491,3 +491,54 @@ describe('<rm-approvals-inbox> is triage-only (never decides)', () => {
     expect(decision).not.toHaveBeenCalled();
   });
 });
+
+describe('<rm-approvals-inbox> safety-triggered shield (§4.10)', () => {
+  it('shows a shield with the check label for a safety-triggered row', async () => {
+    const el = await mount({
+      open: true,
+      rows: [
+        req({
+          request_id: 'r-saf',
+          triggered_by: {
+            kind: 'safety_rule',
+            rule_id: 'sr-1',
+            check_id: 'presidio.pii',
+            stage: 'post_tool_result',
+          },
+        }),
+      ],
+    });
+    const icon = el.querySelector('[data-testid="approvals-row-safety"]');
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute('title')).toContain('Personal data (Presidio)');
+    el.remove();
+  });
+
+  it('shows no shield for a business-policy row (triggered_by null)', async () => {
+    const el = await mount({
+      open: true,
+      rows: [req({ request_id: 'r-plain', triggered_by: null })],
+    });
+    expect(el.querySelector('[data-testid="approvals-row-safety"]')).toBeNull();
+    el.remove();
+  });
+
+  it('degrades to no shield on an unknown triggered_by kind', async () => {
+    const el = await mount({
+      open: true,
+      rows: [
+        req({
+          request_id: 'r-future',
+          triggered_by: {
+            kind: 'scheduled_task',
+            rule_id: 'x',
+            check_id: 'y',
+            stage: 'input_prompt',
+          } as never,
+        }),
+      ],
+    });
+    expect(el.querySelector('[data-testid="approvals-row-safety"]')).toBeNull();
+    el.remove();
+  });
+});

--- a/web/src/components/approvals-inbox.ts
+++ b/web/src/components/approvals-inbox.ts
@@ -34,7 +34,9 @@ import {
   type Coworker,
   type ApprovalRequest,
 } from '../api/client.js';
-import { iconInbox } from './icons.js';
+import { iconInbox, iconShield } from './icons.js';
+import { checkLabel } from './safety-catalog.js';
+import type { ApprovalTriggeredBy } from './approval-store.js';
 
 /** Countdown turns urgent (deep red) under this many ms remaining (§4.1
  *  / §4.3). Matches the chat card's 5-minute threshold. */
@@ -392,6 +394,14 @@ export class ApprovalsInbox extends LitElement {
           margin-left: 6px;
           font-weight: 400;
         }
+        /* §4.10 — third-tier safety-triggered hint, after the tool chip. */
+        rm-approvals-inbox .appr-item .inbox-saf-icon {
+          display: inline-flex;
+          align-items: center;
+          margin-left: 5px;
+          color: var(--rm-warn);
+          vertical-align: middle;
+        }
         rm-approvals-inbox .appr-item .m {
           font-size: 11.5px;
           color: var(--rm-ink-3);
@@ -516,6 +526,20 @@ export class ApprovalsInbox extends LitElement {
     `;
   }
 
+  // §4.10 — small amber shield after the tool chip when the approval was
+  // raised by a safety rule. Whole-row click still handles navigation (no
+  // separate behaviour). Renders nothing for a business-policy approval or an
+  // unknown triggered_by kind (forward-compatible).
+  private renderSafetyIcon(tb: ApprovalTriggeredBy): TemplateResult | typeof nothing {
+    if (!tb || tb.kind !== 'safety_rule') return nothing;
+    return html`<span
+      class="inbox-saf-icon"
+      data-testid="approvals-row-safety"
+      title="Triggered by safety rule: ${checkLabel(tb.check_id)}"
+      >${iconShield(11)}</span
+    >`;
+  }
+
   private renderRow(r: ApprovalRequest): TemplateResult {
     const name = this.coworkerName(r.coworker_id);
     const tool = [r.mcp_server_name, r.tool_name].filter(Boolean).join('.');
@@ -545,6 +569,7 @@ export class ApprovalsInbox extends LitElement {
                 >${tool}</span
               >`
             : nothing}
+          ${this.renderSafetyIcon(r.triggered_by ?? null)}
         </div>
         <div class="m">
           ${title ? html`"${title}" · ` : nothing}

--- a/web/src/components/icons.ts
+++ b/web/src/components/icons.ts
@@ -282,6 +282,30 @@ export function iconShield(size = 16): SVGTemplateResult {
   `;
 }
 
+/** Check-in-a-box — Settings → Governance → Approval policies (matches the
+ *  prototype nav icon; distinct from the plain shield used by Safety rules). */
+export function iconClipboardCheck(size = 16): SVGTemplateResult {
+  return svg`
+    <svg width=${size} height=${size} viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+      <path d="M9 11l3 3L22 4"/>
+      <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+    </svg>
+  `;
+}
+
+/** Document with lines — Settings → Governance → Safety log (matches the
+ *  prototype nav icon). */
+export function iconFileText(size = 16): SVGTemplateResult {
+  return svg`
+    <svg width=${size} height=${size} viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+      <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/>
+    </svg>
+  `;
+}
+
 /** General — home / house. */
 export function iconHome(size = 16): SVGTemplateResult {
   return svg`

--- a/web/src/components/message-list.ts
+++ b/web/src/components/message-list.ts
@@ -92,6 +92,7 @@ export class MessageList extends LitElement {
                 .coworkerName=${this.coworkerName}
                 .resolvedAt=${item.card.resolvedAt}
                 .note=${item.card.note}
+                .triggeredBy=${item.card.triggeredBy}
                 .busy=${this.approvalBusy.has(item.card.requestId)}
               ></rm-approval-card>
             </div>`,

--- a/web/src/components/safety-catalog.test.ts
+++ b/web/src/components/safety-catalog.test.ts
@@ -160,51 +160,56 @@ describe('effectiveAction', () => {
     expect(a).toBe('block');
   });
 
-  it('returns null for a routed check with empty routing (inert)', () => {
+  it('returns null for presidio.pii with empty block/redact lists (inert)', () => {
+    // Backend stores block_codes + redact_codes (not a routing dict).
     const a = effectiveAction(
-      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { routing: {} } },
+      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { block_codes: [], redact_codes: [] } },
       presidio,
     );
     expect(a).toBeNull();
   });
 
-  it('picks the most-severe routed action for the pill', () => {
+  it('picks redact over block for the presidio pill (most-severe wins)', () => {
     const a = effectiveAction(
       {
         check_id: 'presidio.pii',
         stage: 'post_tool_result' as SafetyStage,
-        config: { routing: { EMAIL_ADDRESS: 'redact', US_SSN: 'block' } },
+        config: { block_codes: ['US_SSN'], redact_codes: ['EMAIL_ADDRESS'] },
       },
       presidio,
     );
-    // redact outranks block in the display priority
     expect(a).toBe('redact');
   });
 });
 
 describe('safWhatPhrase', () => {
-  it('names the entities for pii.regex', () => {
-    expect(safWhatPhrase('pii.regex', { entities: ['ssn', 'credit_card'] })).toBe(
+  it('names the entities for pii.regex (backend patterns dict, uppercase keys)', () => {
+    // Backend stores { patterns: { SSN: true, CREDIT_CARD: true } }
+    expect(safWhatPhrase('pii.regex', { patterns: { SSN: true, CREDIT_CARD: true } })).toBe(
       'detect SSNs, credit cards',
     );
   });
 
-  it('avoids the word "inert" for an unconfigured routed check', () => {
-    const phrase = safWhatPhrase('presidio.pii', { routing: {} });
+  it('shows nothing-configured for pii.regex with empty patterns', () => {
+    expect(safWhatPhrase('pii.regex', { patterns: {} })).toBe(
+      'detect configured personal data',
+    );
+  });
+
+  it('avoids the word "inert" for an unconfigured presidio check', () => {
+    // Backend stores { block_codes: [], redact_codes: [] }
+    const phrase = safWhatPhrase('presidio.pii', { block_codes: [], redact_codes: [] });
     expect(phrase).not.toMatch(/inert/i);
     expect(phrase).toMatch(/running but doing nothing/i);
   });
 
-  it('summarizes presidio routing with a +N overflow', () => {
+  it('summarizes presidio block/redact codes with a +N overflow', () => {
+    // Backend stores block_codes + redact_codes
     const phrase = safWhatPhrase('presidio.pii', {
-      routing: {
-        EMAIL_ADDRESS: 'redact',
-        PHONE_NUMBER: 'redact',
-        US_SSN: 'block',
-        PERSON: 'warn',
-      },
+      block_codes: ['US_SSN', 'PERSON'],
+      redact_codes: ['EMAIL_ADDRESS', 'PHONE_NUMBER'],
     });
-    expect(phrase).toContain('emails→redact');
+    expect(phrase).toContain('SSNs→block');
     expect(phrase).toContain('+1 more');
   });
 
@@ -219,7 +224,7 @@ describe('safWhatPhrase', () => {
 describe('safSentence', () => {
   it('renders a fixed-check sentence with the effective verb and scope', () => {
     const s = safSentence(
-      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: { entities: ['ssn'] } },
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: { patterns: { SSN: true } } },
       piiRegex,
       null,
     );
@@ -240,7 +245,7 @@ describe('safSentence', () => {
 
   it('omits the verb for an inert routed check (no contradiction)', () => {
     const s = safSentence(
-      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { routing: {} } },
+      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { block_codes: [], redact_codes: [] } },
       presidio,
       null,
     );

--- a/web/src/components/safety-catalog.test.ts
+++ b/web/src/components/safety-catalog.test.ts
@@ -154,7 +154,7 @@ describe('effectiveAction', () => {
 
   it('returns block for host-list checks regardless of action_model', () => {
     const a = effectiveAction(
-      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { hosts: ['a.com'] } },
+      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { allowed_hosts: ['a.com'] } },
       domainAllowlist,
     );
     expect(a).toBe('block');
@@ -209,10 +209,10 @@ describe('safWhatPhrase', () => {
   });
 
   it('counts hosts for an allowlist', () => {
-    expect(safWhatPhrase('domain_allowlist', { hosts: ['a.com', 'b.com'] })).toBe(
+    expect(safWhatPhrase('domain_allowlist', { allowed_hosts: ['a.com', 'b.com'] })).toBe(
       'allow only 2 hosts',
     );
-    expect(safWhatPhrase('domain_allowlist', { hosts: ['a.com'] })).toBe('allow only 1 host');
+    expect(safWhatPhrase('domain_allowlist', { allowed_hosts: ['a.com'] })).toBe('allow only 1 host');
   });
 });
 
@@ -250,7 +250,7 @@ describe('safSentence', () => {
 
   it('uses the allowlist phrasing for host-list checks', () => {
     const s = safSentence(
-      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { hosts: ['a.com', 'b.com', 'c.com'] } },
+      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { allowed_hosts: ['a.com', 'b.com', 'c.com'] } },
       domainAllowlist,
       'Ops coworker',
     );

--- a/web/src/components/safety-catalog.test.ts
+++ b/web/src/components/safety-catalog.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SafetyCheck, SafetyStage } from '../api/client.js';
+import {
+  SAFETY_CHECK_CATALOG,
+  actionButtonState,
+  checkLabel,
+  effectiveAction,
+  naturalAction,
+  safSentence,
+  safWhatPhrase,
+} from './safety-catalog.js';
+
+// Minimal wire SafetyCheck factory — only the behaviour fields the helpers
+// read. Mirrors the real registry shape (verified against the live dump).
+function check(over: Partial<SafetyCheck> & Pick<SafetyCheck, 'id'>): SafetyCheck {
+  return {
+    version: '1',
+    stages: [],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: {},
+    supported_actions: {},
+    supported_codes: [],
+    config_schema: null,
+    ...over,
+  } as SafetyCheck;
+}
+
+const piiRegex = check({
+  id: 'pii.regex',
+  action_model: 'fixed',
+  stages: ['input_prompt', 'pre_tool_call', 'post_tool_result', 'model_output'],
+  natural_actions: {
+    input_prompt: 'block',
+    pre_tool_call: 'block',
+    post_tool_result: 'block',
+    model_output: 'block',
+  },
+  supported_actions: {
+    input_prompt: ['allow', 'block', 'require_approval', 'warn'],
+    pre_tool_call: ['allow', 'block', 'require_approval', 'warn'],
+    post_tool_result: ['allow', 'block', 'warn'],
+    model_output: ['allow', 'block', 'require_approval'],
+  },
+});
+
+const presidio = check({
+  id: 'presidio.pii',
+  action_model: 'config_routed',
+  stages: ['input_prompt', 'post_tool_result', 'model_output'],
+  natural_actions: { input_prompt: 'allow', post_tool_result: 'allow', model_output: 'allow' },
+  supported_actions: {
+    post_tool_result: ['allow', 'block', 'redact', 'warn'],
+  },
+});
+
+const domainAllowlist = check({
+  id: 'domain_allowlist',
+  action_model: 'fixed',
+  stages: ['pre_tool_call'],
+  natural_actions: { pre_tool_call: 'block' },
+  supported_actions: { pre_tool_call: ['allow', 'block', 'require_approval', 'warn'] },
+});
+
+describe('safety catalog coverage', () => {
+  it('labels every catalog check and never echoes the raw id', () => {
+    for (const id of Object.keys(SAFETY_CHECK_CATALOG)) {
+      expect(checkLabel(id)).toBe(SAFETY_CHECK_CATALOG[id].label);
+      expect(checkLabel(id)).not.toBe(id);
+    }
+  });
+
+  it('falls back to the id for an unknown check', () => {
+    expect(checkLabel('not.a.real.check')).toBe('not.a.real.check');
+  });
+});
+
+describe('actionButtonState — backend override whitelist {block,warn,require_approval}', () => {
+  // The natural action is the default and is always pickable.
+  it('enables the natural action even though it is not "overridable"', () => {
+    const presidioNatural = naturalAction(presidio, 'post_tool_result' as SafetyStage);
+    expect(presidioNatural).toBe('allow');
+    expect(
+      actionButtonState(presidio, 'post_tool_result' as SafetyStage, 'allow', 'allow').enabled,
+    ).toBe(true);
+  });
+
+  // allow is server-"supported" everywhere but cannot be written as an
+  // override — picking it on a block-natural check would 400. Must be
+  // disabled with a "disable the rule instead" hint, NOT the generic reason.
+  it('disables allow on a block-natural check with the disable-rule hint', () => {
+    const st = actionButtonState(
+      piiRegex,
+      'pre_tool_call' as SafetyStage,
+      'allow',
+      'block',
+    );
+    expect(st.enabled).toBe(false);
+    expect(st.reason).toMatch(/disable the rule/i);
+  });
+
+  // redact is only synthesizable by Presidio routing, never an override.
+  it('disables redact on pii.regex (cannot rewrite payload)', () => {
+    const st = actionButtonState(
+      piiRegex,
+      'pre_tool_call' as SafetyStage,
+      'redact',
+      'block',
+    );
+    expect(st.enabled).toBe(false);
+    expect(st.reason).toMatch(/redact|rewrite|presidio/i);
+  });
+
+  it('enables warn + require_approval where the stage supports them', () => {
+    expect(
+      actionButtonState(piiRegex, 'pre_tool_call' as SafetyStage, 'warn', 'block').enabled,
+    ).toBe(true);
+    expect(
+      actionButtonState(piiRegex, 'pre_tool_call' as SafetyStage, 'require_approval', 'block')
+        .enabled,
+    ).toBe(true);
+  });
+
+  // warn is excluded on model_output by the wire matrix — server-driven.
+  it('disables an action the stage does not support, with a reason', () => {
+    const st = actionButtonState(
+      piiRegex,
+      'model_output' as SafetyStage,
+      'warn',
+      'block',
+    );
+    expect(st.enabled).toBe(false);
+    expect(st.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe('effectiveAction', () => {
+  it('uses the config override when present', () => {
+    const a = effectiveAction(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: { action_override: 'warn' } },
+      piiRegex,
+    );
+    expect(a).toBe('warn');
+  });
+
+  it('falls back to the natural action with no override', () => {
+    const a = effectiveAction(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: {} },
+      piiRegex,
+    );
+    expect(a).toBe('block');
+  });
+
+  it('returns block for host-list checks regardless of action_model', () => {
+    const a = effectiveAction(
+      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { hosts: ['a.com'] } },
+      domainAllowlist,
+    );
+    expect(a).toBe('block');
+  });
+
+  it('returns null for a routed check with empty routing (inert)', () => {
+    const a = effectiveAction(
+      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { routing: {} } },
+      presidio,
+    );
+    expect(a).toBeNull();
+  });
+
+  it('picks the most-severe routed action for the pill', () => {
+    const a = effectiveAction(
+      {
+        check_id: 'presidio.pii',
+        stage: 'post_tool_result' as SafetyStage,
+        config: { routing: { EMAIL_ADDRESS: 'redact', US_SSN: 'block' } },
+      },
+      presidio,
+    );
+    // redact outranks block in the display priority
+    expect(a).toBe('redact');
+  });
+});
+
+describe('safWhatPhrase', () => {
+  it('names the entities for pii.regex', () => {
+    expect(safWhatPhrase('pii.regex', { entities: ['ssn', 'credit_card'] })).toBe(
+      'detect SSNs, credit cards',
+    );
+  });
+
+  it('avoids the word "inert" for an unconfigured routed check', () => {
+    const phrase = safWhatPhrase('presidio.pii', { routing: {} });
+    expect(phrase).not.toMatch(/inert/i);
+    expect(phrase).toMatch(/running but doing nothing/i);
+  });
+
+  it('summarizes presidio routing with a +N overflow', () => {
+    const phrase = safWhatPhrase('presidio.pii', {
+      routing: {
+        EMAIL_ADDRESS: 'redact',
+        PHONE_NUMBER: 'redact',
+        US_SSN: 'block',
+        PERSON: 'warn',
+      },
+    });
+    expect(phrase).toContain('emails→redact');
+    expect(phrase).toContain('+1 more');
+  });
+
+  it('counts hosts for an allowlist', () => {
+    expect(safWhatPhrase('domain_allowlist', { hosts: ['a.com', 'b.com'] })).toBe(
+      'allow only 2 hosts',
+    );
+    expect(safWhatPhrase('domain_allowlist', { hosts: ['a.com'] })).toBe('allow only 1 host');
+  });
+});
+
+describe('safSentence', () => {
+  it('renders a fixed-check sentence with the effective verb and scope', () => {
+    const s = safSentence(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: { entities: ['ssn'] } },
+      piiRegex,
+      null,
+    );
+    expect(s).toContain('Before tool calls');
+    expect(s).toContain('detect SSNs');
+    expect(s).toContain('<b>block the call</b>');
+    expect(s).toContain('All coworkers.');
+  });
+
+  it('shows the coworker name when scoped', () => {
+    const s = safSentence(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: {} },
+      piiRegex,
+      'Ops coworker',
+    );
+    expect(s).toContain('Ops coworker only.');
+  });
+
+  it('omits the verb for an inert routed check (no contradiction)', () => {
+    const s = safSentence(
+      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { routing: {} } },
+      presidio,
+      null,
+    );
+    expect(s).not.toContain('<b>');
+    expect(s).toContain('running but doing nothing');
+  });
+
+  it('uses the allowlist phrasing for host-list checks', () => {
+    const s = safSentence(
+      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { hosts: ['a.com', 'b.com', 'c.com'] } },
+      domainAllowlist,
+      'Ops coworker',
+    );
+    expect(s).toContain('allow only 3 hosts');
+    expect(s).toContain('<b>block the call</b>');
+    expect(s).toContain('(for anything else)');
+  });
+
+  it('escapes a coworker name with HTML metacharacters', () => {
+    const s = safSentence(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: {} },
+      piiRegex,
+      '<script>x</script>',
+    );
+    expect(s).not.toContain('<script>');
+    expect(s).toContain('&lt;script&gt;');
+  });
+});

--- a/web/src/components/safety-catalog.ts
+++ b/web/src/components/safety-catalog.ts
@@ -61,9 +61,11 @@ export const SAFETY_CHECK_CATALOG: Record<string, CheckPresentation> = {
   },
   secret_scanner: {
     label: 'Secrets & credentials',
-    desc: 'Scans for API keys, tokens, passwords, and cloud credentials. Run it on outputs to stop a coworker from leaking a secret.',
+    desc: 'Scans for API keys, tokens, passwords, and cloud credentials. Run it on outputs to stop a coworker from leaking a secret. Runs all built-in detectors automatically — no configuration needed.',
     category: 'Sensitive data',
-    cfgKind: 'secret-plugins',
+    // No cfgKind: backend SecretScannerConfig only has action_override.
+    // The dialog shows a plain info note instead of a config form.
+    cfgKind: 'secret-plugins' as const,
   },
   domain_allowlist: {
     label: 'Allowed domains only',
@@ -316,8 +318,23 @@ export function effectiveAction(
 ): SafetyVerdictAction | null {
   if (isHostList(rule.check_id)) return 'block';
   if (check?.action_model === 'config_routed') {
-    const routing = (rule.config?.['routing'] as Record<string, unknown>) ?? {};
-    return representativeRoutedAction(routing);
+    if (rule.check_id === 'presidio.pii') {
+      // Backend stores block_codes + redact_codes (not a routing dict).
+      const blockCodes = (rule.config?.['block_codes'] as string[]) ?? [];
+      const redactCodes = (rule.config?.['redact_codes'] as string[]) ?? [];
+      if (redactCodes.length > 0) return 'redact';
+      if (blockCodes.length > 0) return 'block';
+      return null; // inert
+    }
+    if (rule.check_id === 'openai_moderation') {
+      // Backend stores block_categories + warn_categories (not a routing dict).
+      const blockCats = (rule.config?.['block_categories'] as string[]) ?? [];
+      const warnCats = (rule.config?.['warn_categories'] as string[]) ?? [];
+      if (blockCats.length > 0) return 'block';
+      if (warnCats.length > 0) return 'warn';
+      return null; // inert
+    }
+    return null;
   }
   const override = rule.config?.['action_override'];
   if (typeof override === 'string') return override as SafetyVerdictAction;
@@ -333,12 +350,13 @@ function esc(s: string): string {
     .replace(/>/g, '&gt;');
 }
 
+// Keys match the backend pattern keys (uppercase, per _CONFIG_KEY_TO_CODE).
 const PII_REGEX_LABELS: Record<string, string> = {
-  ssn: 'SSNs',
-  credit_card: 'credit cards',
-  email: 'emails',
-  phone: 'phones',
-  ip: 'IPs',
+  SSN: 'SSNs',
+  CREDIT_CARD: 'credit cards',
+  EMAIL: 'emails',
+  PHONE_US: 'phones',
+  IP_ADDRESS: 'IPs',
 };
 const PRESIDIO_ENTITY_LABELS: Record<string, string> = {
   EMAIL_ADDRESS: 'emails',
@@ -359,15 +377,23 @@ export function safWhatPhrase(
 ): string {
   const pres = SAFETY_CHECK_CATALOG[checkId];
   if (checkId === 'pii.regex') {
-    const entities = (config?.['entities'] as string[]) ?? [];
-    const named = entities.map((e) => PII_REGEX_LABELS[e] ?? e);
+    // Backend: { patterns: { SSN: true, CREDIT_CARD: true, ... } }
+    const patterns = (config?.['patterns'] as Record<string, boolean> | undefined) ?? {};
+    const keys = Object.keys(patterns).filter((k) => patterns[k]);
+    const named = keys.map((k) => PII_REGEX_LABELS[k] ?? k);
     return `detect ${named.length ? named.join(', ') : 'configured personal data'}`;
   }
   if (checkId === 'presidio.pii') {
-    const routing = (config?.['routing'] as Record<string, string>) ?? {};
-    const entries = Object.entries(routing);
-    if (entries.length === 0)
+    // Backend: { block_codes: [...], redact_codes: [...] }
+    const blockCodes = (config?.['block_codes'] as string[]) ?? [];
+    const redactCodes = (config?.['redact_codes'] as string[]) ?? [];
+    const total = blockCodes.length + redactCodes.length;
+    if (total === 0)
       return 'scan for personal data (not configured yet — running but doing nothing)';
+    const entries: [string, string][] = [
+      ...blockCodes.map((c): [string, string] => [c, 'block']),
+      ...redactCodes.map((c): [string, string] => [c, 'redact']),
+    ];
     const summary = entries
       .slice(0, 3)
       .map(([k, a]) => `${PRESIDIO_ENTITY_LABELS[k] ?? k}→${a}`)
@@ -376,8 +402,8 @@ export function safWhatPhrase(
     return summary + more;
   }
   if (checkId === 'secret_scanner') {
-    const n = ((config?.['plugins'] as string[]) ?? []).length;
-    return `scan for secrets${n ? ` (${n} type${n === 1 ? '' : 's'})` : ''}`;
+    // SecretScannerConfig has no plugin selection — runs all detectors.
+    return 'scan for secrets';
   }
   if (checkId === 'domain_allowlist') {
     // domain_allowlist backend key is `allowed_hosts` (DomainAllowlistConfig).
@@ -390,13 +416,16 @@ export function safWhatPhrase(
     return p ? `allow ${p}` : 'allow listed domains';
   }
   if (checkId === 'openai_moderation') {
-    const routing = (config?.['routing'] as Record<string, string>) ?? {};
-    const n = Object.keys(routing).length;
+    // Backend: { block_categories: [...], warn_categories: [...] }
+    const blockCats = (config?.['block_categories'] as string[]) ?? [];
+    const warnCats = (config?.['warn_categories'] as string[]) ?? [];
+    const n = blockCats.length + warnCats.length;
     if (n === 0) return 'check content moderation (not configured yet)';
     return `flag ${n} categor${n === 1 ? 'y' : 'ies'}`;
   }
   if (pres?.cfgKind === 'threshold') {
-    const t = config?.['threshold'];
+    // llm_guard checks store threshold; presidio uses score_threshold on backend.
+    const t = config?.['threshold'] ?? config?.['score_threshold'];
     const label = (pres.label || checkId).toLowerCase();
     return `detect ${label}${t != null ? ` (sensitivity ${t})` : ''}`;
   }

--- a/web/src/components/safety-catalog.ts
+++ b/web/src/components/safety-catalog.ts
@@ -379,9 +379,15 @@ export function safWhatPhrase(
     const n = ((config?.['plugins'] as string[]) ?? []).length;
     return `scan for secrets${n ? ` (${n} type${n === 1 ? '' : 's'})` : ''}`;
   }
-  if (checkId === 'domain_allowlist' || checkId === 'egress.domain_rule') {
-    const n = ((config?.['hosts'] as string[]) ?? []).length;
+  if (checkId === 'domain_allowlist') {
+    // domain_allowlist backend key is `allowed_hosts` (DomainAllowlistConfig).
+    const n = ((config?.['allowed_hosts'] as string[]) ?? []).length;
     return `allow only ${n || 'listed'} host${n === 1 ? '' : 's'}`;
+  }
+  if (checkId === 'egress.domain_rule') {
+    // egress.domain_rule uses `domain_pattern` (single string per rule).
+    const p = config?.['domain_pattern'] as string | undefined;
+    return p ? `allow ${p}` : 'allow listed domains';
   }
   if (checkId === 'openai_moderation') {
     const routing = (config?.['routing'] as Record<string, string>) ?? {};

--- a/web/src/components/safety-catalog.ts
+++ b/web/src/components/safety-catalog.ts
@@ -1,0 +1,439 @@
+// Safety-check presentation catalog + sentence / action helpers (spec §6).
+//
+// WHY THIS FILE EXISTS — the wire/presentation split.
+// `GET /api/v1/safety/checks` returns `SafetyCheck[]` carrying only the
+// *behaviour* of each check: which `stages` it runs at, its `action_model`,
+// the `natural_actions` a hit produces, the `supported_actions` a rule may
+// pick, and `cost_class`. It does NOT carry the human label, description,
+// category grouping, or which config form to render — those are pure
+// presentation and live here, keyed by `check_id`. Components merge the two:
+// behaviour from the wire (never hardcoded), presentation from this catalog.
+//
+// USER-FACING LANGUAGE (spec §8.5). Nothing here leaks engineering taxonomy.
+// `action_model` ("fixed" / "config_routed" / "aggregated") drives which
+// editor experience renders but is never shown; "inert" becomes "running but
+// doing nothing"; stages get friendly phrases ("before tool calls"), with the
+// mono enum kept only for deep-inspection surfaces (the decision detail modal).
+
+import type {
+  SafetyCheck,
+  SafetyStage,
+  SafetyVerdictAction,
+} from '../api/client.js';
+
+// Which config form a check renders — a presentation hint derived from the
+// check's config_schema (spec §6.12). Not on the wire.
+export type CfgKind =
+  | 'pii-entities'
+  | 'presidio-routing'
+  | 'moderation-routing'
+  | 'threshold'
+  | 'host-list'
+  | 'secret-plugins';
+
+export interface CheckPresentation {
+  /** Human label — shown everywhere a check is named. Never the raw id. */
+  label: string;
+  /** One-line "what this check does", shown under the dialog's check select. */
+  desc: string;
+  /** Group heading in the check `<optgroup>` (Sensitive data / … / Network). */
+  category: string;
+  /** Which config form to render; absent ⇒ the check takes no config. */
+  cfgKind?: CfgKind;
+}
+
+// Presentation metadata, keyed by registered check id. Keys MUST match the
+// ids the backend registry exposes (verified by the catalog-coverage test).
+// Behaviour fields (stages/action_model/…) are intentionally absent — they
+// come from the wire SafetyCheck so the two never drift.
+export const SAFETY_CHECK_CATALOG: Record<string, CheckPresentation> = {
+  'pii.regex': {
+    label: 'Personal data (regex)',
+    desc: 'Fast pattern matchers for SSN, credit cards, email, phone, and IP addresses. Cheap enough to run before every tool call; for broader coverage use the Presidio check.',
+    category: 'Sensitive data',
+    cfgKind: 'pii-entities',
+  },
+  'presidio.pii': {
+    label: 'Personal data (Presidio)',
+    desc: 'Broader entity coverage (names, locations, emails, and more) with an adjustable confidence threshold. The only check that can rewrite a payload — required for redaction.',
+    category: 'Sensitive data',
+    cfgKind: 'presidio-routing',
+  },
+  secret_scanner: {
+    label: 'Secrets & credentials',
+    desc: 'Scans for API keys, tokens, passwords, and cloud credentials. Run it on outputs to stop a coworker from leaking a secret.',
+    category: 'Sensitive data',
+    cfgKind: 'secret-plugins',
+  },
+  domain_allowlist: {
+    label: 'Allowed domains only',
+    desc: 'Blocks any tool call whose URL reaches a host that is not on the allowlist. Complements network egress control.',
+    category: 'Network',
+    cfgKind: 'host-list',
+  },
+  'egress.domain_rule': {
+    label: 'Egress domain rule',
+    desc: 'Restricts the hosts a coworker can reach over the network. Enforced on every outbound request the coworker makes.',
+    category: 'Network',
+    cfgKind: 'host-list',
+  },
+  'llm_guard.prompt_injection': {
+    label: 'Prompt injection',
+    desc: 'Catches attempts to hijack the coworker through instructions hidden in user input or tool output.',
+    category: 'Adversarial input',
+    cfgKind: 'threshold',
+  },
+  'llm_guard.jailbreak': {
+    label: 'Jailbreak attempts',
+    desc: 'Detects attempts to talk the coworker out of its guardrails (role-play exploits and similar tricks).',
+    category: 'Adversarial input',
+    cfgKind: 'threshold',
+  },
+  'llm_guard.toxicity': {
+    label: 'Toxic content',
+    desc: 'Flags hateful, harassing, or abusive language on either side of the conversation.',
+    category: 'Content',
+    cfgKind: 'threshold',
+  },
+  openai_moderation: {
+    label: 'Content moderation',
+    desc: 'Runs text through moderation categories (sexual / hate / harassment / self-harm / violence) and lets you choose what to do for each.',
+    category: 'Content',
+    cfgKind: 'moderation-routing',
+  },
+};
+
+// Category render order for the check `<optgroup>` list — most-reached for
+// the common case first.
+export const SAFETY_CATEGORY_ORDER = [
+  'Sensitive data',
+  'Adversarial input',
+  'Content',
+  'Network',
+];
+
+// Action ladder, severity-ascending — the stable order the segmented control
+// renders regardless of which subset a (check, stage) supports.
+export const SAF_ACTION_ORDER: SafetyVerdictAction[] = [
+  'allow',
+  'warn',
+  'redact',
+  'require_approval',
+  'block',
+];
+
+// The only actions a rule may set via `config.action_override` (backend
+// whitelist — see src/webui/admin.py `_validate_safety_rule_body`). `allow`
+// is the absence of an override (a rule that "allows" everything is just the
+// natural pass-through), and `redact` cannot be synthesized by an override
+// (it needs a check that emits a modified payload — that path is the Presidio
+// routing form, not an override). The action panel uses this to decide which
+// non-natural actions are pickable, so the UI never produces a 400.
+export const OVERRIDABLE_ACTIONS: ReadonlySet<SafetyVerdictAction> = new Set([
+  'block',
+  'warn',
+  'require_approval',
+]);
+
+// Stages where a check failure fails CLOSED (the call is blocked). The other
+// two (post_tool_result, pre_compaction) fail SAFE (the call is let through).
+// Surfaced as a one-line helper in the dialog, never as "control/observational".
+export const SAF_CONTROL_STAGES: ReadonlySet<string> = new Set([
+  'input_prompt',
+  'pre_tool_call',
+  'model_output',
+  'egress_request',
+]);
+
+// Long form for the stage `<select>` — teaches the concept in plain language.
+export const SAF_STAGE_LABEL: Record<string, string> = {
+  input_prompt: 'On user input — before the coworker processes it',
+  pre_tool_call: 'Before a tool runs — check the tool arguments first',
+  post_tool_result: 'After a tool returns — before the coworker sees the result',
+  model_output: 'On the reply — before the user sees it',
+  pre_compaction: 'Before conversation compaction',
+  egress_request: 'On outbound network requests',
+};
+
+// Short friendly phrase for sentences/cards (NOT the mono enum — §8.5).
+export const SAF_STAGE_SHORT: Record<string, string> = {
+  input_prompt: 'on input',
+  pre_tool_call: 'before tool calls',
+  post_tool_result: 'on tool results',
+  model_output: 'on the reply',
+  pre_compaction: 'before compaction',
+  egress_request: 'on network requests',
+};
+
+export const SAF_ACTION_LABEL: Record<SafetyVerdictAction, string> = {
+  allow: 'Allow',
+  warn: 'Warn',
+  redact: 'Redact',
+  require_approval: 'Approve',
+  block: 'Block',
+};
+
+// Tiny sub-caption under each segmented-control button.
+export const SAF_ACTION_SUB: Record<SafetyVerdictAction, string> = {
+  allow: 'log only',
+  warn: 'flag the coworker',
+  redact: 'strip + continue',
+  require_approval: 'ask the user',
+  block: 'stop the call',
+};
+
+// Sentence verb for each action (spec §6.13).
+export const SAF_ACTION_VERB: Record<SafetyVerdictAction, string> = {
+  allow: 'let it through (audit only)',
+  warn: 'let it through but flag it for the coworker',
+  redact: 'strip the matched content and continue',
+  require_approval: 'pause and ask the person in the chat',
+  block: 'block the call',
+};
+
+// Map an action to the pill modifier class (defined in settings-pages.css).
+// allow=green, warn=gray, redact=amber, require_approval=purple, block=red.
+const SAF_ACTION_PILL: Record<SafetyVerdictAction, string> = {
+  allow: 'rm-pill-on',
+  warn: 'rm-pill-off',
+  redact: 'rm-pill-warn',
+  require_approval: 'rm-pill-appr',
+  block: 'rm-pill-bad',
+};
+
+export function safActionPillClass(action: SafetyVerdictAction): string {
+  return SAF_ACTION_PILL[action] ?? 'rm-pill-off';
+}
+
+// Why an action is unavailable for a (check, stage). The server is the source
+// of truth for WHICH (via supported_actions); these strings only explain the
+// common reasons in plain language. A reason not listed falls back to generic.
+const SAF_UNSUPPORTED_REASON: Partial<Record<SafetyVerdictAction, string>> = {
+  redact: 'Only the Presidio check can rewrite a payload, so redaction is not available here.',
+  warn: 'Nothing reads a warning at this stage.',
+  require_approval: 'There is no one to ask at this stage — the tool has already run, or there is no chat.',
+};
+
+export function unsupportedReason(action: SafetyVerdictAction): string {
+  return (
+    SAF_UNSUPPORTED_REASON[action] ??
+    'Not available for this check at this stage.'
+  );
+}
+
+// ---- behaviour lookups against the wire SafetyCheck ----
+
+export function naturalAction(
+  check: SafetyCheck | null,
+  stage: SafetyStage,
+): SafetyVerdictAction | null {
+  const na = check?.natural_actions as
+    | Partial<Record<string, SafetyVerdictAction>>
+    | undefined;
+  return na?.[stage] ?? null;
+}
+
+export function supportedActions(
+  check: SafetyCheck | null,
+  stage: SafetyStage,
+): SafetyVerdictAction[] {
+  const sa = check?.supported_actions as
+    | Partial<Record<string, SafetyVerdictAction[]>>
+    | undefined;
+  return sa?.[stage] ?? [];
+}
+
+export interface ActionButtonState {
+  enabled: boolean;
+  /** Tooltip shown when disabled; empty when enabled. */
+  reason: string;
+}
+
+// Whether a segmented-control button for `action` is pickable, and why not.
+// A button is enabled when it is the natural action (the default — selecting
+// it writes no override) OR it is both server-supported AND writable as an
+// override. `allow`/`redact` therefore stay disabled on a block-natural check
+// (you cannot downgrade to allow; redaction is configured on Presidio, not
+// overridden) — which is exactly what the backend accepts.
+export function actionButtonState(
+  check: SafetyCheck | null,
+  stage: SafetyStage,
+  action: SafetyVerdictAction,
+  natural: SafetyVerdictAction | null,
+): ActionButtonState {
+  if (action === natural) return { enabled: true, reason: '' };
+  const supported = supportedActions(check, stage).includes(action);
+  if (!supported) return { enabled: false, reason: unsupportedReason(action) };
+  if (!OVERRIDABLE_ACTIONS.has(action)) {
+    // Supported as a verdict, but not reachable as a rule override.
+    const reason =
+      action === 'allow'
+        ? 'This check always acts on a hit. To stop it, disable the rule instead.'
+        : unsupportedReason(action);
+    return { enabled: false, reason };
+  }
+  return { enabled: true, reason: '' };
+}
+
+// ---- effective action (no top-level `action` field in production) ----
+
+// The host-list checks express their whole intent as "allow these, block the
+// rest", regardless of action_model — so their effective verdict for display
+// is always block (for anything off the list).
+function isHostList(checkId: string): boolean {
+  return SAFETY_CHECK_CATALOG[checkId]?.cfgKind === 'host-list';
+}
+
+const ROUTED_VERB_PRIORITY: SafetyVerdictAction[] = [
+  'redact',
+  'block',
+  'require_approval',
+  'warn',
+  'allow',
+];
+
+function representativeRoutedAction(
+  routing: Record<string, unknown>,
+): SafetyVerdictAction | null {
+  const values = new Set(Object.values(routing).filter(Boolean) as string[]);
+  if (values.size === 0) return null;
+  for (const a of ROUTED_VERB_PRIORITY) if (values.has(a)) return a;
+  return null;
+}
+
+/** A rule (saved or in-progress draft) reduced to what the sentence needs. */
+export interface SentenceRule {
+  check_id: string;
+  stage: SafetyStage;
+  config: Record<string, unknown>;
+}
+
+// The single action a rule effectively takes, for the card pill and preview.
+// Returns null when a routed check has no routing yet (inert — no pill verb).
+export function effectiveAction(
+  rule: SentenceRule,
+  check: SafetyCheck | null,
+): SafetyVerdictAction | null {
+  if (isHostList(rule.check_id)) return 'block';
+  if (check?.action_model === 'config_routed') {
+    const routing = (rule.config?.['routing'] as Record<string, unknown>) ?? {};
+    return representativeRoutedAction(routing);
+  }
+  const override = rule.config?.['action_override'];
+  if (typeof override === 'string') return override as SafetyVerdictAction;
+  return naturalAction(check, rule.stage) ?? 'block';
+}
+
+// ---- sentence rendering (HTML string; the single source of truth) ----
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+const PII_REGEX_LABELS: Record<string, string> = {
+  ssn: 'SSNs',
+  credit_card: 'credit cards',
+  email: 'emails',
+  phone: 'phones',
+  ip: 'IPs',
+};
+const PRESIDIO_ENTITY_LABELS: Record<string, string> = {
+  EMAIL_ADDRESS: 'emails',
+  PHONE_NUMBER: 'phones',
+  US_SSN: 'SSNs',
+  CREDIT_CARD: 'credit cards',
+  PERSON: 'names',
+  LOCATION: 'locations',
+  IP_ADDRESS: 'IPs',
+  DATE_TIME: 'dates',
+};
+
+// Subject+verb phrase describing what the check looks for, varying by check
+// (spec §6.13). Returns plain text; the caller wraps it in the sentence.
+export function safWhatPhrase(
+  checkId: string,
+  config: Record<string, unknown>,
+): string {
+  const pres = SAFETY_CHECK_CATALOG[checkId];
+  if (checkId === 'pii.regex') {
+    const entities = (config?.['entities'] as string[]) ?? [];
+    const named = entities.map((e) => PII_REGEX_LABELS[e] ?? e);
+    return `detect ${named.length ? named.join(', ') : 'configured personal data'}`;
+  }
+  if (checkId === 'presidio.pii') {
+    const routing = (config?.['routing'] as Record<string, string>) ?? {};
+    const entries = Object.entries(routing);
+    if (entries.length === 0)
+      return 'scan for personal data (not configured yet — running but doing nothing)';
+    const summary = entries
+      .slice(0, 3)
+      .map(([k, a]) => `${PRESIDIO_ENTITY_LABELS[k] ?? k}→${a}`)
+      .join(', ');
+    const more = entries.length > 3 ? ` +${entries.length - 3} more` : '';
+    return summary + more;
+  }
+  if (checkId === 'secret_scanner') {
+    const n = ((config?.['plugins'] as string[]) ?? []).length;
+    return `scan for secrets${n ? ` (${n} type${n === 1 ? '' : 's'})` : ''}`;
+  }
+  if (checkId === 'domain_allowlist' || checkId === 'egress.domain_rule') {
+    const n = ((config?.['hosts'] as string[]) ?? []).length;
+    return `allow only ${n || 'listed'} host${n === 1 ? '' : 's'}`;
+  }
+  if (checkId === 'openai_moderation') {
+    const routing = (config?.['routing'] as Record<string, string>) ?? {};
+    const n = Object.keys(routing).length;
+    if (n === 0) return 'check content moderation (not configured yet)';
+    return `flag ${n} categor${n === 1 ? 'y' : 'ies'}`;
+  }
+  if (pres?.cfgKind === 'threshold') {
+    const t = config?.['threshold'];
+    const label = (pres.label || checkId).toLowerCase();
+    return `detect ${label}${t != null ? ` (sensitivity ${t})` : ''}`;
+  }
+  return (pres?.label ?? checkId).toLowerCase();
+}
+
+// Human-readable rule sentence — used on list cards, the dialog live preview,
+// and the delete-confirmation modal. Returns an HTML string (with <b>/<span>)
+// for `unsafeHTML`; all dynamic text is escaped.
+export function safSentence(
+  rule: SentenceRule,
+  check: SafetyCheck | null,
+  coworkerName: string | null,
+): string {
+  const scope = coworkerName ? `${coworkerName} only.` : 'All coworkers.';
+  const what = safWhatPhrase(rule.check_id, rule.config);
+  const stageShort = SAF_STAGE_SHORT[rule.stage] ?? rule.stage;
+  const stageCap = stageShort.charAt(0).toUpperCase() + stageShort.slice(1);
+  const scopeSpan = `<span class="rm-saf-scope-mute">${esc(scope)}</span>`;
+
+  // Inert routed checks: the "running but doing nothing" phrase already
+  // carries the meaning — appending a verb would contradict it.
+  if (check?.action_model === 'config_routed') {
+    const routing = (rule.config?.['routing'] as Record<string, unknown>) ?? {};
+    if (Object.keys(routing).length === 0) {
+      return `${esc(stageCap)}, ${esc(what)}. ${scopeSpan}`;
+    }
+  }
+
+  if (isHostList(rule.check_id)) {
+    return `${esc(stageCap)}, ${esc(what)} — <b>block the call</b> <span class="rm-saf-scope-mute">(for anything else)</span>. ${scopeSpan}`;
+  }
+
+  const action = effectiveAction(rule, check);
+  const verb = action ? SAF_ACTION_VERB[action] : null;
+  if (!verb) return `${esc(stageCap)}, ${esc(what)}. ${scopeSpan}`;
+  return `${esc(stageCap)}, ${esc(what)} — <b>${esc(verb)}</b>. ${scopeSpan}`;
+}
+
+export function checkLabel(checkId: string): string {
+  return SAFETY_CHECK_CATALOG[checkId]?.label ?? checkId;
+}
+
+export function safStageShort(stage: SafetyStage): string {
+  return SAF_STAGE_SHORT[stage] ?? stage;
+}

--- a/web/src/components/safety-catalog.ts
+++ b/web/src/components/safety-catalog.ts
@@ -29,7 +29,8 @@ export type CfgKind =
   | 'moderation-routing'
   | 'threshold'
   | 'host-list'
-  | 'secret-plugins';
+  | 'secret-plugins'
+  | 'jailbreak-phrases';
 
 export interface CheckPresentation {
   /** Human label — shown everywhere a check is named. Never the raw id. */
@@ -87,9 +88,9 @@ export const SAFETY_CHECK_CATALOG: Record<string, CheckPresentation> = {
   },
   'llm_guard.jailbreak': {
     label: 'Jailbreak attempts',
-    desc: 'Detects attempts to talk the coworker out of its guardrails (role-play exploits and similar tricks).',
+    desc: 'Detects attempts to talk the coworker out of its guardrails (role-play exploits and similar tricks). Uses a built-in phrase list by default; add custom phrases for tenant-specific patterns.',
     category: 'Adversarial input',
-    cfgKind: 'threshold',
+    cfgKind: 'jailbreak-phrases',
   },
   'llm_guard.toxicity': {
     label: 'Toxic content',
@@ -424,10 +425,15 @@ export function safWhatPhrase(
     return `flag ${n} categor${n === 1 ? 'y' : 'ies'}`;
   }
   if (pres?.cfgKind === 'threshold') {
-    // llm_guard checks store threshold; presidio uses score_threshold on backend.
-    const t = config?.['threshold'] ?? config?.['score_threshold'];
+    const t = config?.['threshold'];
     const label = (pres.label || checkId).toLowerCase();
     return `detect ${label}${t != null ? ` (sensitivity ${t})` : ''}`;
+  }
+  if (checkId === 'llm_guard.jailbreak') {
+    // Backend: { phrases: [...], case_sensitive: bool }
+    const phrases = (config?.['phrases'] as string[]) ?? [];
+    const custom = phrases.length;
+    return `detect jailbreak attempts${custom ? ` (${custom} custom phrase${custom === 1 ? '' : 's'})` : ''}`;
   }
   return (pres?.label ?? checkId).toLowerCase();
 }

--- a/web/src/components/safety-decision-detail-dialog.test.ts
+++ b/web/src/components/safety-decision-detail-dialog.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+// Safety decision detail dialog (spec §7.8–7.10) — metadata grid, findings,
+// the data-minimization privacy note, and the rule_id → label mapping.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Side-effect import registers the element (the named import is type-only).
+import './safety-decision-detail-dialog.js';
+import { severityClass } from './safety-decision-detail-dialog.js';
+import type { SafetyDecisionDetailDialog } from './safety-decision-detail-dialog.js';
+import type { SafetyDecision } from '../api/client.js';
+
+function makeDecision(over: Partial<SafetyDecision> = {}): SafetyDecision {
+  return {
+    id: 'dec-abc123',
+    tenant_id: 't1',
+    coworker_id: 'ops',
+    conversation_id: null,
+    job_id: null,
+    stage: 'pre_tool_call',
+    verdict_action: 'block',
+    triggered_rule_ids: ['sr-1'],
+    findings: [
+      { code: 'PII.SSN', severity: 'high', message: 'Detected SSN', metadata: { position: 87 } },
+    ],
+    context_digest: 'a4f3',
+    context_summary: 'erp.refund args contained SSN',
+    source: 'tenant',
+    created_at: '2026-06-03T14:23:08Z',
+    ...over,
+  } as SafetyDecision;
+}
+
+async function mount(
+  decision: SafetyDecision | null,
+  props: Partial<SafetyDecisionDetailDialog> = {},
+): Promise<SafetyDecisionDetailDialog> {
+  const el = document.createElement(
+    'rm-safety-decision-detail-dialog',
+  ) as SafetyDecisionDetailDialog;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  el.decision = decision;
+  Object.assign(el, props);
+  el.open = true;
+  await el.updateComplete;
+  await el.updateComplete;
+  return el;
+}
+
+const $ = <T extends Element>(el: Element, s: string): T | null =>
+  el.querySelector<T>(s);
+
+describe('severityClass', () => {
+  it('maps each severity to its finding-pill class', () => {
+    expect(severityClass('critical')).toBe('rm-saf-sev-critical');
+    expect(severityClass('high')).toBe('rm-saf-sev-high');
+    expect(severityClass('medium')).toBe('rm-saf-sev-medium');
+    expect(severityClass('low')).toBe('rm-saf-sev-low');
+    expect(severityClass('info')).toBe('rm-saf-sev-info');
+  });
+});
+
+describe('SafetyDecisionDetailDialog', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders metadata, the digest with a sha256 prefix, and the coworker name', async () => {
+    const el = await mount(makeDecision(), {
+      coworkerName: 'Ops coworker',
+      ruleLabels: { 'sr-1': 'Personal data (regex)' },
+    });
+    const meta = $(el, '[data-testid="saf-dec-meta"]')!;
+    expect(meta.textContent).toContain('Ops coworker');
+    expect(meta.textContent).toContain('sha256:a4f3');
+    // Stage dual-displays friendly + mono enum (deep-inspection surface).
+    expect(meta.textContent).toContain('Before tool calls');
+    expect(meta.textContent).toContain('(pre_tool_call)');
+    // Triggered rule shows the resolved label + short id.
+    expect(meta.textContent).toContain('Personal data (regex)');
+    el.remove();
+  });
+
+  it('renders findings with code, severity pill, message, and metadata', async () => {
+    const el = await mount(makeDecision());
+    const finding = $(el, '.rm-saf-finding')!;
+    expect($(finding, '.rm-saf-fcode')?.textContent?.trim()).toBe('PII.SSN');
+    expect($(finding, '.rm-saf-fsev')?.classList.contains('rm-saf-sev-high')).toBe(true);
+    expect($(finding, '.rm-saf-fmsg')?.textContent).toContain('Detected SSN');
+    expect($(finding, '.rm-saf-fmeta')?.textContent).toContain('position');
+    el.remove();
+  });
+
+  it('shows a no-findings note for an allow decision', async () => {
+    const el = await mount(makeDecision({ verdict_action: 'allow', findings: [] }));
+    expect($(el, '[data-testid="saf-dec-nofindings"]')).not.toBeNull();
+    expect($(el, '.rm-saf-finding')).toBeNull();
+    el.remove();
+  });
+
+  it('always renders the data-minimization privacy note', async () => {
+    const el = await mount(makeDecision());
+    const note = $(el, '[data-testid="saf-dec-privacy"]')!;
+    expect(note.textContent).toMatch(/raw payload is not stored/i);
+    el.remove();
+  });
+
+  it('falls back to organization-wide when no coworker name is given', async () => {
+    const el = await mount(makeDecision({ coworker_id: null }), { coworkerName: null });
+    expect($(el, '[data-testid="saf-dec-meta"]')?.textContent).toContain(
+      'organization-wide',
+    );
+    el.remove();
+  });
+});

--- a/web/src/components/safety-decision-detail-dialog.ts
+++ b/web/src/components/safety-decision-detail-dialog.ts
@@ -1,0 +1,142 @@
+// <rm-safety-decision-detail-dialog> — one safety-log decision in full
+// (spec §7.8–7.10). Metadata grid + findings list + the data-minimization
+// privacy note. Split from the page like the other v2 dialogs.
+//
+// This is a DEEP-INSPECTION surface, so it dual-displays stage (friendly +
+// mono enum) per §8.5 #3 — the mono form helps engineers root-cause without
+// forcing the taxonomy on admins elsewhere.
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import './dialog.js';
+import type {
+  SafetyDecision,
+  SafetyFinding,
+  SafetyVerdictAction,
+} from '../api/client.js';
+import {
+  SAF_STAGE_SHORT,
+  safActionPillClass,
+} from './safety-catalog.js';
+
+/** Severity → finding-pill class. */
+export function severityClass(sev: SafetyFinding['severity']): string {
+  return `rm-saf-sev-${sev}`;
+}
+
+@customElement('rm-safety-decision-detail-dialog')
+export class SafetyDecisionDetailDialog extends LitElement {
+  @property({ type: Boolean }) open = false;
+  @property({ attribute: false }) decision: SafetyDecision | null = null;
+  /** Resolved coworker display name, or null for organization-wide. */
+  @property() coworkerName: string | null = null;
+  /** rule_id → human label, resolved by the page from the loaded rules. */
+  @property({ attribute: false }) ruleLabels: Record<string, string> = {};
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  private close = () => {
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  };
+
+  private stageDual(stage: string): TemplateResult {
+    const friendly = SAF_STAGE_SHORT[stage] ?? stage;
+    const cap = friendly.charAt(0).toUpperCase() + friendly.slice(1);
+    return html`${cap} <span class="rm-saf-mono">(${stage})</span>`;
+  }
+
+  private triggeredRules(): TemplateResult {
+    const ids = this.decision?.triggered_rule_ids ?? [];
+    if (ids.length === 0) return html`—`;
+    return html`${ids.map(
+      (id, i) => html`${i > 0 ? ', ' : ''}${this.ruleLabels[id] ?? 'rule'}
+        <span class="rm-saf-mono">(${id.slice(0, 8)})</span>`,
+    )}`;
+  }
+
+  override render(): TemplateResult {
+    const d = this.decision;
+    return html`
+      <rm-dialog
+        ?open=${this.open && d !== null}
+        title=${d ? `Decision ${d.id.slice(0, 8)}` : 'Decision'}
+        width="640px"
+        @close=${this.close}
+      >
+        ${d
+          ? html`
+              <div class="rm-saf-meta" data-testid="saf-dec-meta">
+                <span class="rm-saf-mlabel">When</span>
+                <span>${new Date(d.created_at).toLocaleString()}</span>
+                <span class="rm-saf-mlabel">Verdict</span>
+                <span
+                  ><span class="rm-pill ${safActionPillClass(d.verdict_action as SafetyVerdictAction)}"
+                    >${d.verdict_action}</span
+                  ></span
+                >
+                <span class="rm-saf-mlabel">Stage</span>
+                <span>${this.stageDual(d.stage)}</span>
+                <span class="rm-saf-mlabel">Coworker</span>
+                <span>${this.coworkerName ?? 'organization-wide'}</span>
+                <span class="rm-saf-mlabel">Triggered rule</span>
+                <span>${this.triggeredRules()}</span>
+                <span class="rm-saf-mlabel">Context digest</span>
+                <span class="rm-saf-mono"
+                  >${d.context_digest ? `sha256:${d.context_digest}` : '—'}</span
+                >
+                <span class="rm-saf-mlabel">Summary</span>
+                <span>${d.context_summary || '—'}</span>
+              </div>
+
+              <div class="rm-saf-section-cap">Findings</div>
+              ${(d.findings ?? []).length === 0
+                ? html`<p
+                    class="text-[12.5px] text-ink-3 dark:text-d-ink-3"
+                    style="font-style: italic"
+                    data-testid="saf-dec-nofindings"
+                  >
+                    No findings — check ran and verdict was
+                    <b>${d.verdict_action}</b>.
+                  </p>`
+                : html`<div class="rm-saf-findings">
+                    ${(d.findings ?? []).map((f) => this.renderFinding(f))}
+                  </div>`}
+
+              <div class="rm-saf-privacy" data-testid="saf-dec-privacy">
+                <b>Data minimization</b>
+                Raw payload is not stored — only the SHA-256 digest above and
+                the short summary. To investigate further, open the conversation
+                around ${new Date(d.created_at).toLocaleTimeString()}.
+              </div>
+            `
+          : nothing}
+
+        <div slot="footer" style="display: flex; justify-content: flex-end">
+          <button type="button" class="rm-btn rm-btn--secondary" @click=${this.close}>
+            Close
+          </button>
+        </div>
+      </rm-dialog>
+    `;
+  }
+
+  private renderFinding(f: SafetyFinding): TemplateResult {
+    const meta = f.metadata ?? {};
+    const hasMeta = Object.keys(meta).length > 0;
+    return html`
+      <div class="rm-saf-finding">
+        <div class="rm-saf-fhead">
+          <span class="rm-saf-fcode">${f.code}</span>
+          <span class="rm-saf-fsev ${severityClass(f.severity)}">${f.severity}</span>
+        </div>
+        <div class="rm-saf-fmsg">${f.message}</div>
+        ${hasMeta
+          ? html`<div class="rm-saf-fmeta">${JSON.stringify(meta)}</div>`
+          : nothing}
+      </div>
+    `;
+  }
+}

--- a/web/src/components/safety-decisions-page.test.ts
+++ b/web/src/components/safety-decisions-page.test.ts
@@ -1,19 +1,23 @@
 // @vitest-environment happy-dom
-// Safety decisions page — pins the v1 read split.
+// Safety log page (spec §7) — pins the v1 read split + the revamped list.
 //
-// Reads (list + detail) must go through the typed v1 ApiClient.
-// CSV export stays on admin (CSV not on v1 per design §3 Phase 4).
+// Reads (list + detail + rules-for-labels) go through the typed v1 ApiClient;
+// CSV export stays on admin (not on v1 per design §3 Phase 4). Also pins the
+// filter set: verdict / stage / coworker — NO check dropdown (the v1 endpoint
+// has no check_id filter and we don't extend the contract).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   listDecisionsSpy,
   getDecisionSpy,
+  listRulesSpy,
   getTenantIdSpy,
   listCoworkersSpy,
 } = vi.hoisted(() => ({
   listDecisionsSpy: vi.fn(),
   getDecisionSpy: vi.fn(),
+  listRulesSpy: vi.fn(),
   getTenantIdSpy: vi.fn(),
   listCoworkersSpy: vi.fn(),
 }));
@@ -27,6 +31,7 @@ vi.mock('../api/client.js', async () => {
     getApiClient: () => ({
       listSafetyDecisions: listDecisionsSpy,
       getSafetyDecision: getDecisionSpy,
+      listSafetyRules: listRulesSpy,
     }),
   };
 });
@@ -43,6 +48,7 @@ vi.mock('../services/safety-admin-client.js', async () => {
 });
 
 import { SafetyDecisionsPage } from './safety-decisions-page.js';
+import type { SafetyDecision } from '../api/client.js';
 
 async function waitUntilLoaded(page: SafetyDecisionsPage): Promise<void> {
   for (let i = 0; i < 30; i++) {
@@ -54,73 +60,151 @@ async function waitUntilLoaded(page: SafetyDecisionsPage): Promise<void> {
   throw new Error('SafetyDecisionsPage did not finish loading');
 }
 
-function makeDecision(overrides: Record<string, unknown> = {}) {
+function makeDecision(overrides: Partial<SafetyDecision> = {}): SafetyDecision {
   return {
     id: 'd1',
     tenant_id: 't1',
     coworker_id: null,
     conversation_id: null,
     job_id: null,
-    stage: 'input_prompt' as const,
-    verdict_action: 'allow' as const,
+    stage: 'input_prompt',
+    verdict_action: 'allow',
     triggered_rule_ids: [],
     findings: [],
     context_digest: 'x'.repeat(16),
     context_summary: '',
+    source: 'tenant',
     created_at: '2026-05-21T00:00:00Z',
     ...overrides,
-  };
+  } as SafetyDecision;
 }
 
-describe('SafetyDecisionsPage routing', () => {
+async function mount(items: SafetyDecision[] = [], total?: number): Promise<SafetyDecisionsPage> {
+  listDecisionsSpy.mockResolvedValue({ total: total ?? items.length, items });
+  const page = new SafetyDecisionsPage();
+  document.body.appendChild(page);
+  await waitUntilLoaded(page);
+  await page.updateComplete;
+  return page;
+}
+
+describe('SafetyDecisionsPage', () => {
   beforeEach(() => {
     listDecisionsSpy.mockResolvedValue({ total: 0, items: [] });
     getDecisionSpy.mockResolvedValue(makeDecision());
+    listRulesSpy.mockResolvedValue([]);
     getTenantIdSpy.mockResolvedValue('t1');
-    listCoworkersSpy.mockResolvedValue([]);
+    listCoworkersSpy.mockResolvedValue([{ id: 'ops', name: 'Ops coworker' }]);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    document.body.innerHTML = '';
   });
 
-  it('list call routes to v1 ApiClient with pagination + filters', async () => {
-    const page = new SafetyDecisionsPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-
+  it('list call routes to v1 with page size 10 + offset 0', async () => {
+    const page = await mount([]);
     expect(listDecisionsSpy).toHaveBeenCalledTimes(1);
     const args = listDecisionsSpy.mock.calls[0][0];
-    expect(args.limit).toBe(25);
+    expect(args.limit).toBe(10);
     expect(args.offset).toBe(0);
-    document.body.removeChild(page);
+    page.remove();
   });
 
-  it('detail call routes to v1 ApiClient', async () => {
-    const row = makeDecision({ id: 'click-target' });
-    listDecisionsSpy.mockResolvedValue({ total: 1, items: [row] });
-    const page = new SafetyDecisionsPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-
-    // @ts-expect-error — invoking private method directly.
-    await page.openDetail(row);
-
-    expect(getDecisionSpy).toHaveBeenCalledTimes(1);
-    expect(getDecisionSpy).toHaveBeenCalledWith('click-target');
-    document.body.removeChild(page);
-  });
-
-  it('loads the page even when admin tenant lookup fails', async () => {
-    // CSV is admin-only; a transient admin failure must not block
-    // the v1 read path. The connectedCallback swallows tenant_id
-    // errors so reads keep flowing.
+  it('loads even when the admin tenant lookup fails (CSV is admin-only)', async () => {
     getTenantIdSpy.mockRejectedValue(new Error('admin offline'));
-    const page = new SafetyDecisionsPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-
+    const page = await mount([]);
     expect(listDecisionsSpy).toHaveBeenCalledTimes(1);
-    document.body.removeChild(page);
+    page.remove();
+  });
+
+  it('renders the empty state when no decisions match', async () => {
+    const page = await mount([]);
+    expect(page.querySelector('[data-testid="saf-log-empty"]')).not.toBeNull();
+    page.remove();
+  });
+
+  it('renders a row per decision with the verdict + finding codes', async () => {
+    const page = await mount([
+      makeDecision({
+        id: 'd2',
+        verdict_action: 'block',
+        stage: 'pre_tool_call',
+        context_summary: 'tool args contained SSN',
+        findings: [{ code: 'PII.SSN', severity: 'high', message: 'm' }],
+      }),
+    ]);
+    const rows = page.querySelectorAll('[data-testid="saf-log-row"]');
+    expect(rows.length).toBe(1);
+    expect(rows[0].querySelector('.rm-saf-verdict')?.textContent?.trim()).toBe('block');
+    expect(rows[0].querySelector('.rm-saf-check')?.textContent).toContain('PII.SSN');
+    expect(rows[0].querySelector('.rm-saf-summary')?.textContent).toContain(
+      'tool args contained SSN',
+    );
+    page.remove();
+  });
+
+  it('exposes verdict / stage / coworker filters but NOT a check filter', async () => {
+    const page = await mount([]);
+    expect(page.querySelector('[data-testid="saf-filter-verdict"]')).not.toBeNull();
+    expect(page.querySelector('[data-testid="saf-filter-stage"]')).not.toBeNull();
+    expect(page.querySelector('[data-testid="saf-filter-coworker"]')).not.toBeNull();
+    // The v1 endpoint has no check_id filter — the 4th dropdown is omitted.
+    expect(page.querySelector('[data-testid="saf-filter-check"]')).toBeNull();
+    page.remove();
+  });
+
+  it('changing a filter refetches with the param and resets to page 0', async () => {
+    const page = await mount([makeDecision()], 50);
+    // advance a page first so we can prove the filter resets offset
+    // @ts-expect-error private
+    page.next();
+    await page.updateComplete;
+    await Promise.resolve();
+    const verdict = page.querySelector('[data-testid="saf-filter-verdict"]') as HTMLSelectElement;
+    verdict.value = 'block';
+    verdict.dispatchEvent(new Event('change'));
+    await page.updateComplete;
+    await Promise.resolve();
+    const lastArgs = listDecisionsSpy.mock.calls.at(-1)![0];
+    expect(lastArgs.verdictAction).toBe('block');
+    expect(lastArgs.offset).toBe(0);
+    page.remove();
+  });
+
+  it('clear filters resets everything and refetches', async () => {
+    const page = await mount([makeDecision()], 5);
+    const verdict = page.querySelector('[data-testid="saf-filter-verdict"]') as HTMLSelectElement;
+    verdict.value = 'block';
+    verdict.dispatchEvent(new Event('change'));
+    await page.updateComplete;
+    (page.querySelector('[data-testid="saf-clear-filters"]') as HTMLButtonElement).click();
+    await page.updateComplete;
+    await Promise.resolve();
+    const lastArgs = listDecisionsSpy.mock.calls.at(-1)![0];
+    expect(lastArgs.verdictAction).toBeUndefined();
+    page.remove();
+  });
+
+  it('clicking a row opens the detail via the v1 ApiClient', async () => {
+    const row = makeDecision({ id: 'click-target' });
+    const page = await mount([row]);
+    (page.querySelector('[data-testid="saf-log-row"]') as HTMLButtonElement).click();
+    await page.updateComplete;
+    await Promise.resolve();
+    await page.updateComplete;
+    expect(getDecisionSpy).toHaveBeenCalledWith('click-target');
+    expect(page.querySelector('rm-safety-decision-detail-dialog')).not.toBeNull();
+    page.remove();
+  });
+
+  it('builds a rule_id → check-label map from the loaded rules', async () => {
+    listRulesSpy.mockResolvedValue([
+      { id: 'sr-1', check_id: 'pii.regex', stage: 'pre_tool_call', config: {}, priority: 100, enabled: true, tenant_id: 't', coworker_id: null, description: '', created_at: '', updated_at: '', source: 'tenant', tier: null, editable: true },
+    ]);
+    const page = await mount([]);
+    // @ts-expect-error — private state assertion
+    expect(page.ruleLabels['sr-1']).toBe('Personal data (regex)');
+    page.remove();
   });
 });

--- a/web/src/components/safety-decisions-page.ts
+++ b/web/src/components/safety-decisions-page.ts
@@ -1,9 +1,28 @@
-import { LitElement, html, nothing } from 'lit';
+// Safety log page (#/manage/safety-log) — spec §7.
+//
+// The audit-visible expression of the safety framework: every check decision
+// lands here (allows and blocks). Three workflows — tune false positives,
+// investigate a blocked workflow, audit. Moved from the Activity surface to
+// Settings → Governance (spec §7); the old paths redirect here (router.ts).
+//
+// Reads go through the typed v1 ApiClient. CSV export stays on the admin
+// surface (v1 is GET-only, no CSV — design §3 Phase 4), so this file is on
+// the lint:no-admin-chat allowlist.
+//
+// Filter bar caveat: the v1 `/safety/decisions` endpoint filters by verdict /
+// stage / coworker / time, but NOT by check — there is no `check_id` query
+// param on the contract and we don't extend it here. So the spec's 4th "check"
+// dropdown is intentionally omitted (a note in the bar says so). Finding codes
+// in each row already convey what a decision caught.
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+
 import {
   getApiClient,
   type SafetyDecision,
   type SafetyDecisionPage,
+  type SafetyRule,
   type SafetyStage,
   type SafetyVerdictAction,
 } from '../api/client.js';
@@ -13,28 +32,51 @@ import {
   listCoworkers,
   type CoworkerSummary,
 } from '../services/safety-admin-client.js';
+import './safety-decision-detail-dialog.js';
+import { checkLabel } from './safety-catalog.js';
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 10;
+
+type Filters = {
+  verdict_action?: SafetyVerdictAction;
+  coworker_id?: string;
+  stage?: SafetyStage;
+  from_ts?: string;
+  to_ts?: string;
+};
+
+const VERDICTS: SafetyVerdictAction[] = [
+  'allow',
+  'block',
+  'redact',
+  'warn',
+  'require_approval',
+];
+const STAGES: [SafetyStage, string][] = [
+  ['input_prompt', 'Input'],
+  ['pre_tool_call', 'Before tool calls'],
+  ['post_tool_result', 'After tool results'],
+  ['model_output', 'Model output'],
+  ['pre_compaction', 'Compaction'],
+  ['egress_request', 'Network egress'],
+];
 
 @customElement('rm-safety-decisions-page')
 export class SafetyDecisionsPage extends LitElement {
-  // tenantId is still cached so the legacy "Export CSV" button can
-  // hand it to the admin CSV endpoint (CSV is not on v1 per design
-  // §3 Phase 4). Decisions reads themselves derive tenant from auth.
+  // Cached so the admin CSV endpoint (not on v1) gets the tenant in its URL.
+  // Decisions reads themselves derive tenant from auth.
   @state() private tenantId: string | null = null;
-  @state() private page: SafetyDecisionPage = { total: 0, items: [] };
+  @state() private decisions: SafetyDecisionPage = { total: 0, items: [] };
   @state() private coworkers: CoworkerSummary[] = [];
+  // rule_id → check label, for the detail modal's "triggered rule" cell.
+  @state() private ruleLabels: Record<string, string> = {};
   @state() private loading = true;
   @state() private error: string | null = null;
   @state() private offset = 0;
-  @state() private filters: {
-    verdict_action?: SafetyVerdictAction;
-    coworker_id?: string;
-    stage?: SafetyStage;
-    from_ts?: string;
-    to_ts?: string;
-  } = {};
+  @state() private filters: Filters = {};
   @state() private selected: SafetyDecision | null = null;
+
+  private readonly api = getApiClient();
 
   protected override createRenderRoot() {
     return this;
@@ -42,10 +84,9 @@ export class SafetyDecisionsPage extends LitElement {
 
   override async connectedCallback(): Promise<void> {
     super.connectedCallback();
-    // Coworker list + tenant id come from the admin surface
-    // (CSV export needs the tenant in the URL). A failure here
-    // should NOT block the decisions read which goes through v1
-    // and derives tenant from auth.
+    // Admin-surface lookups (tenant id for CSV, coworker names) and the rule
+    // list (for the detail modal's rule→label map) are best-effort — a failure
+    // must not block the v1 decisions read.
     try {
       this.tenantId = await getTenantId();
     } catch {
@@ -56,6 +97,14 @@ export class SafetyDecisionsPage extends LitElement {
     } catch {
       this.coworkers = [];
     }
+    try {
+      const rules = await this.api.listSafetyRules();
+      this.ruleLabels = Object.fromEntries(
+        rules.map((r: SafetyRule) => [r.id, checkLabel(r.check_id)]),
+      );
+    } catch {
+      this.ruleLabels = {};
+    }
     await this.refresh();
   }
 
@@ -63,8 +112,7 @@ export class SafetyDecisionsPage extends LitElement {
     this.loading = true;
     this.error = null;
     try {
-      // v1 derives tenant_id from auth — no path param needed.
-      this.page = await getApiClient().listSafetyDecisions({
+      this.decisions = await this.api.listSafetyDecisions({
         verdictAction: this.filters.verdict_action,
         coworkerId: this.filters.coworker_id,
         stage: this.filters.stage,
@@ -80,29 +128,29 @@ export class SafetyDecisionsPage extends LitElement {
     }
   }
 
-  private coworkerName(id: string | null): string {
-    if (!id) return '—';
+  private coworkerName(id: string | null | undefined): string | null {
+    if (!id) return null;
     const cw = this.coworkers.find((c) => c.id === id);
     return cw ? cw.name : id.slice(0, 8);
   }
 
-  private setFilter<K extends keyof typeof this.filters>(
-    key: K,
-    value: (typeof this.filters)[K] | '',
-  ): void {
+  private setFilter<K extends keyof Filters>(key: K, value: string): void {
     const next = { ...this.filters };
-    if (value === '' || value === undefined) {
-      delete next[key];
-    } else {
-      next[key] = value;
-    }
+    if (value === '') delete next[key];
+    else next[key] = value as Filters[K];
     this.filters = next;
     this.offset = 0;
     void this.refresh();
   }
 
+  private clearFilters(): void {
+    this.filters = {};
+    this.offset = 0;
+    void this.refresh();
+  }
+
   private next(): void {
-    if (this.offset + PAGE_SIZE < this.page.total) {
+    if (this.offset + PAGE_SIZE < this.decisions.total) {
       this.offset += PAGE_SIZE;
       void this.refresh();
     }
@@ -113,6 +161,19 @@ export class SafetyDecisionsPage extends LitElement {
     void this.refresh();
   }
 
+  private async openDetail(row: SafetyDecision): Promise<void> {
+    try {
+      // Re-fetch for fields the list view may not project (full findings).
+      this.selected = await this.api.getSafetyDecision(row.id);
+    } catch {
+      this.selected = row;
+    }
+  }
+
+  private closeDetail = (): void => {
+    this.selected = null;
+  };
+
   private async exportCsv(): Promise<void> {
     if (!this.tenantId) return;
     try {
@@ -120,8 +181,7 @@ export class SafetyDecisionsPage extends LitElement {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      const today = new Date().toISOString().slice(0, 10);
-      a.download = `safety-decisions-${today}.csv`;
+      a.download = `safety-log-${new Date().toISOString().slice(0, 10)}.csv`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -131,274 +191,176 @@ export class SafetyDecisionsPage extends LitElement {
     }
   }
 
-  private async openDetail(row: SafetyDecision): Promise<void> {
-    try {
-      // Re-fetch to pick up fields the list view does not project
-      // (full ``findings`` metadata). v1 derives tenant_id from auth
-      // so the URL has no tenant segment.
-      this.selected = await getApiClient().getSafetyDecision(row.id);
-    } catch (err) {
-      this.error = err instanceof Error ? err.message : String(err);
-      this.selected = row;
-    }
-  }
-
-  private closeDetail(): void {
-    this.selected = null;
-  }
-
-  private verdictBadge(action: SafetyVerdictAction) {
-    const colors: Record<SafetyVerdictAction, string> = {
-      allow: 'bg-green-100 text-green-800',
-      block: 'bg-red-100 text-red-800',
-      redact: 'bg-yellow-100 text-yellow-800',
-      warn: 'bg-orange-100 text-orange-800',
-      require_approval: 'bg-purple-100 text-purple-800',
-    };
+  override render(): TemplateResult {
+    const items = this.decisions.items ?? [];
+    const total = this.decisions.total;
+    const start = total === 0 ? 0 : this.offset + 1;
+    const end = Math.min(this.offset + PAGE_SIZE, total);
     return html`
-      <span class="px-2 py-0.5 text-xs rounded ${colors[action] ?? ''}">
-        ${action}
-      </span>
-    `;
-  }
-
-  private renderFilters() {
-    return html`
-      <div class="flex flex-wrap gap-2 items-end mb-4">
-        <label class="text-xs flex flex-col">
-          verdict
-          <select
-            class="border rounded px-2 py-1 bg-transparent"
-            .value=${this.filters.verdict_action ?? ''}
-            @change=${(e: Event) =>
-              this.setFilter(
-                'verdict_action',
-                (e.target as HTMLSelectElement).value as SafetyVerdictAction | '',
-              )}
-          >
-            <option value="">any</option>
-            <option value="allow">allow</option>
-            <option value="block">block</option>
-            <option value="redact">redact</option>
-            <option value="warn">warn</option>
-            <option value="require_approval">require_approval</option>
-          </select>
-        </label>
-        <label class="text-xs flex flex-col">
-          stage
-          <select
-            class="border rounded px-2 py-1 bg-transparent"
-            .value=${this.filters.stage ?? ''}
-            @change=${(e: Event) =>
-              this.setFilter(
-                'stage',
-                (e.target as HTMLSelectElement).value as SafetyStage | '',
-              )}
-          >
-            <option value="">any</option>
-            <option value="input_prompt">input_prompt</option>
-            <option value="pre_tool_call">pre_tool_call</option>
-            <option value="post_tool_result">post_tool_result</option>
-            <option value="model_output">model_output</option>
-            <option value="pre_compaction">pre_compaction</option>
-          </select>
-        </label>
-        <label class="text-xs flex flex-col">
-          coworker
-          <select
-            class="border rounded px-2 py-1 bg-transparent"
-            .value=${this.filters.coworker_id ?? ''}
-            @change=${(e: Event) =>
-              this.setFilter('coworker_id', (e.target as HTMLSelectElement).value)}
-          >
-            <option value="">any</option>
-            ${this.coworkers.map(
-              (c) => html`<option value=${c.id}>${c.name}</option>`,
-            )}
-          </select>
-        </label>
-        <label class="text-xs flex flex-col">
-          from
-          <input
-            type="datetime-local"
-            class="border rounded px-2 py-1 bg-transparent"
-            .value=${this.filters.from_ts ?? ''}
-            @change=${(e: Event) =>
-              this.setFilter('from_ts', (e.target as HTMLInputElement).value)}
-          />
-        </label>
-        <label class="text-xs flex flex-col">
-          to
-          <input
-            type="datetime-local"
-            class="border rounded px-2 py-1 bg-transparent"
-            .value=${this.filters.to_ts ?? ''}
-            @change=${(e: Event) =>
-              this.setFilter('to_ts', (e.target as HTMLInputElement).value)}
-          />
-        </label>
-        <button
-          class="px-3 py-1 border rounded text-sm"
-          @click=${() => void this.refresh()}
-        >
-          Refresh
-        </button>
-        <button
-          class="px-3 py-1 border rounded text-sm"
-          @click=${() => void this.exportCsv()}
-        >
-          Export CSV
-        </button>
-      </div>
-    `;
-  }
-
-  private renderDetail() {
-    if (!this.selected) return nothing;
-    const d = this.selected;
-    return html`
-      <div
-        class="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
-        @click=${this.closeDetail}
-      >
-        <div
-          class="bg-surface-0 dark:bg-d-surface-0 border rounded-md w-[720px] max-w-[95vw] max-h-[80vh] overflow-auto p-4"
-          @click=${(e: Event) => e.stopPropagation()}
-        >
-          <div class="flex justify-between items-center mb-3">
-            <h3 class="font-semibold">Decision ${d.id.slice(0, 8)}</h3>
-            <button class="text-sm px-2" @click=${this.closeDetail}>×</button>
-          </div>
-          <dl class="grid grid-cols-3 gap-2 text-sm mb-4">
-            <dt class="text-gray-500">When</dt>
-            <dd class="col-span-2">${new Date(d.created_at).toLocaleString()}</dd>
-            <dt class="text-gray-500">Verdict</dt>
-            <dd class="col-span-2">${this.verdictBadge(d.verdict_action)}</dd>
-            <dt class="text-gray-500">Stage</dt>
-            <dd class="col-span-2">${d.stage}</dd>
-            <dt class="text-gray-500">Coworker</dt>
-            <dd class="col-span-2">${this.coworkerName(d.coworker_id ?? null)}</dd>
-            <dt class="text-gray-500">Rule ids</dt>
-            <dd class="col-span-2 font-mono text-xs">
-              ${(d.triggered_rule_ids ?? []).length === 0
-                ? '—'
-                : (d.triggered_rule_ids ?? []).join(', ')}
-            </dd>
-            <dt class="text-gray-500">Summary</dt>
-            <dd class="col-span-2 font-mono text-xs">${d.context_summary || '—'}</dd>
-            <dt class="text-gray-500">Digest</dt>
-            <dd class="col-span-2 font-mono text-xs">${d.context_digest || '—'}</dd>
-          </dl>
-          <h4 class="font-semibold text-sm mb-2">Findings</h4>
-          ${(d.findings ?? []).length === 0
-            ? html`<div class="text-sm text-gray-500">No findings.</div>`
-            : html`
-                <table class="w-full text-xs border">
-                  <thead class="bg-surface-1 dark:bg-d-surface-1">
-                    <tr class="text-left">
-                      <th class="p-1">Code</th>
-                      <th>Severity</th>
-                      <th>Message</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${(d.findings ?? []).map(
-                      (f) => html`
-                        <tr class="border-t">
-                          <td class="p-1 font-mono">${f.code}</td>
-                          <td>${f.severity}</td>
-                          <td>${f.message}</td>
-                        </tr>
-                      `,
-                    )}
-                  </tbody>
-                </table>
-              `}
-        </div>
-      </div>
-    `;
-  }
-
-  override render() {
-    const start = this.page.total === 0 ? 0 : this.offset + 1;
-    const end = Math.min(this.offset + PAGE_SIZE, this.page.total);
-    return html`
-      <div class="p-6 max-w-6xl mx-auto">
-        <a href="#" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 mb-3">
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>
-          Back to chat
-        </a>
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-xl font-semibold">Safety decisions</h2>
-          <div class="text-sm text-gray-500">
-            ${this.page.total === 0
-              ? '0 records'
-              : `${start}–${end} of ${this.page.total}`}
+      <div class="rm-spane">
+        <div class="rm-ch">
+          <h2>Safety log</h2>
+          <div style="display: flex; gap: 8px; margin-left: auto">
+            <button type="button" class="rm-btn rm-btn--secondary"
+              @click=${() => void this.refresh()} ?disabled=${this.loading}>
+              Refresh
+            </button>
+            <button type="button" class="rm-btn rm-btn--secondary"
+              data-testid="saf-export-csv"
+              @click=${() => void this.exportCsv()} ?disabled=${!this.tenantId}>
+              Export CSV
+            </button>
           </div>
         </div>
+        <p class="rm-sub">
+          Every check decision lands here — both allows and blocks. Raw payloads
+          are never stored, only a digest and a short summary. To root-cause,
+          open the conversation around the timestamp.
+        </p>
 
         ${this.renderFilters()}
+
         ${this.error
-          ? html`<div class="text-red-500 text-sm mb-2">${this.error}</div>`
-          : nothing}
-        ${this.loading
-          ? html`<div class="text-gray-500">Loading…</div>`
-          : (this.page.items ?? []).length === 0
-            ? html`<div class="text-gray-500">No decisions match these filters.</div>`
-            : html`
-                <table class="w-full text-sm border">
-                  <thead class="bg-surface-1 dark:bg-d-surface-1">
-                    <tr class="text-left">
-                      <th class="p-2">When</th>
-                      <th>Verdict</th>
-                      <th>Stage</th>
-                      <th>Coworker</th>
-                      <th>Findings</th>
-                      <th>Summary</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${(this.page.items ?? []).map(
-                      (d) => html`
-                        <tr
-                          class="border-t cursor-pointer hover:bg-surface-1 dark:hover:bg-d-surface-1"
-                          @click=${() => void this.openDetail(d)}
-                        >
-                          <td class="p-2 text-xs">
-                            ${new Date(d.created_at).toLocaleString()}
-                          </td>
-                          <td>${this.verdictBadge(d.verdict_action)}</td>
-                          <td class="text-xs">${d.stage}</td>
-                          <td class="text-xs">${this.coworkerName(d.coworker_id ?? null)}</td>
-                          <td class="text-xs font-mono">
-                            ${(d.findings ?? []).map((f) => f.code).join(', ') || '—'}
-                          </td>
-                          <td class="text-xs font-mono truncate max-w-[20ch]">
-                            ${d.context_summary || '—'}
-                          </td>
-                        </tr>
-                      `,
-                    )}
-                  </tbody>
-                </table>
-                <div class="flex justify-end gap-2 mt-3">
-                  <button
-                    class="px-3 py-1 border rounded text-sm"
-                    ?disabled=${this.offset === 0}
-                    @click=${this.prev}
-                  >
-                    ← Prev
-                  </button>
-                  <button
-                    class="px-3 py-1 border rounded text-sm"
-                    ?disabled=${this.offset + PAGE_SIZE >= this.page.total}
-                    @click=${this.next}
-                  >
-                    Next →
-                  </button>
-                </div>
-              `}
-        ${this.renderDetail()}
+          ? html`<div class="rm-banner-err">${this.error}</div>`
+          : this.loading
+            ? html`<div class="rm-banner-loading">Loading…</div>`
+            : items.length === 0
+              ? this.renderEmpty()
+              : html`
+                  <div class="rm-saf-decisions" data-testid="saf-log-list">
+                    ${items.map((d) => this.renderRow(d))}
+                  </div>
+                  <div class="rm-saf-pager">
+                    <span>Showing ${start}–${end} of ${total}</span>
+                    <div class="rm-saf-pager-btns">
+                      <button type="button" class="rm-btn rm-btn--secondary"
+                        ?disabled=${this.offset === 0} @click=${() => this.prev()}>
+                        ← Previous
+                      </button>
+                      <button type="button" class="rm-btn rm-btn--secondary"
+                        ?disabled=${this.offset + PAGE_SIZE >= total}
+                        @click=${() => this.next()}>
+                        Next →
+                      </button>
+                    </div>
+                  </div>
+                `}
+
+        <rm-safety-decision-detail-dialog
+          ?open=${this.selected !== null}
+          .decision=${this.selected}
+          .coworkerName=${this.coworkerName(this.selected?.coworker_id)}
+          .ruleLabels=${this.ruleLabels}
+          @close=${this.closeDetail}
+        ></rm-safety-decision-detail-dialog>
+      </div>
+    `;
+  }
+
+  private renderFilters(): TemplateResult {
+    return html`
+      <div class="rm-saf-filters" data-testid="saf-filters">
+        <select
+          aria-label="Filter by verdict"
+          data-testid="saf-filter-verdict"
+          @change=${(e: Event) =>
+            this.setFilter('verdict_action', (e.target as HTMLSelectElement).value)}
+        >
+          <option value="" ?selected=${!this.filters.verdict_action}>all verdicts</option>
+          ${VERDICTS.map(
+            (v) => html`<option value=${v} ?selected=${this.filters.verdict_action === v}>
+              ${v}
+            </option>`,
+          )}
+        </select>
+        <select
+          aria-label="Filter by stage"
+          data-testid="saf-filter-stage"
+          @change=${(e: Event) =>
+            this.setFilter('stage', (e.target as HTMLSelectElement).value)}
+        >
+          <option value="" ?selected=${!this.filters.stage}>all stages</option>
+          ${STAGES.map(
+            ([v, l]) => html`<option value=${v} ?selected=${this.filters.stage === v}>
+              ${l}
+            </option>`,
+          )}
+        </select>
+        <select
+          aria-label="Filter by coworker"
+          data-testid="saf-filter-coworker"
+          @change=${(e: Event) =>
+            this.setFilter('coworker_id', (e.target as HTMLSelectElement).value)}
+        >
+          <option value="" ?selected=${!this.filters.coworker_id}>all coworkers</option>
+          ${this.coworkers.map(
+            (c) => html`<option value=${c.id} ?selected=${this.filters.coworker_id === c.id}>
+              ${c.name}
+            </option>`,
+          )}
+        </select>
+        <input
+          type="datetime-local"
+          aria-label="From"
+          data-testid="saf-filter-from"
+          .value=${this.filters.from_ts ?? ''}
+          @change=${(e: Event) =>
+            this.setFilter('from_ts', (e.target as HTMLInputElement).value)}
+        />
+        <input
+          type="datetime-local"
+          aria-label="To"
+          data-testid="saf-filter-to"
+          .value=${this.filters.to_ts ?? ''}
+          @change=${(e: Event) =>
+            this.setFilter('to_ts', (e.target as HTMLInputElement).value)}
+        />
+        <button type="button" class="rm-saf-clear" data-testid="saf-clear-filters"
+          @click=${() => this.clearFilters()}>
+          Clear filters
+        </button>
+      </div>
+    `;
+  }
+
+  private renderRow(d: SafetyDecision): TemplateResult {
+    const ts = new Date(d.created_at).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    // SafetyDecision carries no check_id; the finding codes are the wire's
+    // signal of what the decision caught.
+    const findingCodes =
+      (d.findings ?? []).map((f) => f.code).join(', ') || '—';
+    const cw = this.coworkerName(d.coworker_id) ?? 'organization-wide';
+    return html`
+      <button type="button" class="rm-saf-row" data-testid="saf-log-row"
+        @click=${() => void this.openDetail(d)}>
+        <span class="rm-saf-ts">${ts}</span>
+        <span class="rm-saf-verdict rm-saf-v-${d.verdict_action}">${d.verdict_action}</span>
+        <span class="rm-saf-stage">${d.stage}</span>
+        <span class="rm-saf-check" title=${findingCodes}>${findingCodes}</span>
+        <span class="rm-saf-summary">${d.context_summary || '—'}</span>
+        <span class="rm-saf-cw">${cw}</span>
+        <span class="rm-saf-arr">›</span>
+      </button>
+    `;
+  }
+
+  private renderEmpty(): TemplateResult {
+    return html`
+      <div class="rm-pol-empty" data-testid="saf-log-empty">
+        <div class="rm-pol-empty-icon" style="color: var(--rm-good)">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.4" aria-hidden="true">
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </div>
+        <p>No decisions match your filters.</p>
+        <p class="rm-pol-empty-sub">
+          Try clearing some filters, or wait for new agent activity.
+        </p>
       </div>
     `;
   }

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -217,62 +217,64 @@ describe('SafetyRuleDialog — action_override write rule', () => {
     el.remove();
   });
 
-  it('never writes action_override for a config_routed check', async () => {
-    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result', config: { routing: { US_SSN: 'block' } } }) });
+  it('never writes action_override for a config_routed check; converts to backend format', async () => {
+    // Backend format for presidio is block_codes/redact_codes, not routing.
+    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result', config: { block_codes: ['US_SSN'], redact_codes: [] } }) });
     ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
     await el.updateComplete;
     await Promise.resolve();
     const [body] = createRuleSpy.mock.calls[0];
     expect((body.config as Record<string, unknown>).action_override).toBeUndefined();
-    expect((body.config as Record<string, unknown>).routing).toEqual({ US_SSN: 'block' });
+    expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
+    expect((body.config as Record<string, unknown>).redact_codes).toEqual([]);
     el.remove();
   });
 });
 
-describe('SafetyRuleDialog — routing form ⇄ config round-trip', () => {
-  it('loads an existing routing map into the dropdowns and back out unchanged', async () => {
+describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-trip', () => {
+  it('loads backend block_codes/redact_codes and saves back in the same format', async () => {
     updateRuleSpy.mockResolvedValue(makeRule());
+    // Server stores block_codes + redact_codes; dialog converts internally for display.
     const el = await mount({
       editing: makeRule({
         id: 'r5',
         check_id: 'presidio.pii',
         stage: 'post_tool_result',
-        config: { routing: { EMAIL_ADDRESS: 'redact', US_SSN: 'block' }, threshold: 0.6 },
+        config: { block_codes: ['US_SSN'], redact_codes: ['EMAIL_ADDRESS'], score_threshold: 0.6 },
       }),
     });
-    // The loaded routing select for EMAIL_ADDRESS exists and offers redact.
+    // The routing select for EMAIL_ADDRESS should exist (loaded from redact_codes).
     const emailSel = $<HTMLSelectElement>(
       el,
       '[data-testid="saf-routing"] select[data-routing-code="EMAIL_ADDRESS"]',
     )!;
     expect(emailSel).not.toBeNull();
-    // Save without touching anything → routing round-trips (proves the loaded
-    // config survived into buildConfig untouched).
+    // Save without touching → round-trips back to block_codes/redact_codes.
     ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
     await el.updateComplete;
     await Promise.resolve();
     const [, body] = updateRuleSpy.mock.calls[0];
-    expect((body.config as Record<string, unknown>).routing).toEqual({
-      EMAIL_ADDRESS: 'redact',
-      US_SSN: 'block',
-    });
+    expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
+    expect((body.config as Record<string, unknown>).redact_codes).toEqual(['EMAIL_ADDRESS']);
+    expect((body.config as Record<string, unknown>).score_threshold).toBeDefined();
     el.remove();
   });
 
-  it('clearing a routing dropdown drops that entity from the config', async () => {
+  it('clearing a routing dropdown removes entity from the output lists', async () => {
     updateRuleSpy.mockResolvedValue(makeRule());
     const el = await mount({
       editing: makeRule({
         id: 'r6',
         check_id: 'presidio.pii',
         stage: 'post_tool_result',
-        config: { routing: { EMAIL_ADDRESS: 'redact', US_SSN: 'block' } },
+        config: { block_codes: ['US_SSN'], redact_codes: ['EMAIL_ADDRESS'] },
       }),
     });
     const emailSel = $<HTMLSelectElement>(
       el,
       '[data-testid="saf-routing"] select[data-routing-code="EMAIL_ADDRESS"]',
     )!;
+    // Clear EMAIL_ADDRESS routing → it should vanish from redact_codes.
     emailSel.value = '';
     emailSel.dispatchEvent(new Event('change'));
     await el.updateComplete;
@@ -280,7 +282,8 @@ describe('SafetyRuleDialog — routing form ⇄ config round-trip', () => {
     await el.updateComplete;
     await Promise.resolve();
     const [, body] = updateRuleSpy.mock.calls[0];
-    expect((body.config as Record<string, unknown>).routing).toEqual({ US_SSN: 'block' });
+    expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
+    expect((body.config as Record<string, unknown>).redact_codes).toEqual([]);
     el.remove();
   });
 });

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment happy-dom
+// Safety rule dialog (spec §6.11) — the three editor experiences, the
+// scope-immutability lock, the action_override write rule, and the routing
+// form ⇄ config round-trip.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createRuleSpy, updateRuleSpy } = vi.hoisted(() => ({
+  createRuleSpy: vi.fn(),
+  updateRuleSpy: vi.fn(),
+}));
+
+vi.mock('../services/safety-admin-client.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../services/safety-admin-client.js')
+  >('../services/safety-admin-client.js');
+  return { ...actual, createRule: createRuleSpy, updateRule: updateRuleSpy };
+});
+
+// Side-effect import registers the custom element. The named import below is
+// type-only (used in `as SafetyRuleDialog`), so without this the module — and
+// its customElements.define — would be elided and the element never defined.
+import './safety-rule-dialog.js';
+import type { SafetyRuleDialog } from './safety-rule-dialog.js';
+import type { SafetyCheck, SafetyRule } from '../api/client.js';
+
+const piiRegex: SafetyCheck = {
+  id: 'pii.regex',
+  version: '1',
+  stages: ['input_prompt', 'pre_tool_call'],
+  cost_class: 'cheap',
+  action_model: 'fixed',
+  natural_actions: { input_prompt: 'block', pre_tool_call: 'block' },
+  supported_actions: {
+    input_prompt: ['allow', 'block', 'require_approval', 'warn'],
+    pre_tool_call: ['allow', 'block', 'require_approval', 'warn'],
+  },
+  supported_codes: [],
+  config_schema: null,
+} as SafetyCheck;
+
+const presidio: SafetyCheck = {
+  id: 'presidio.pii',
+  version: '1',
+  stages: ['post_tool_result'],
+  cost_class: 'slow',
+  action_model: 'config_routed',
+  natural_actions: { post_tool_result: 'allow' },
+  supported_actions: { post_tool_result: ['allow', 'block', 'redact', 'warn'] },
+  supported_codes: [],
+  config_schema: null,
+} as SafetyCheck;
+
+const domainAllowlist: SafetyCheck = {
+  id: 'domain_allowlist',
+  version: '1',
+  stages: ['pre_tool_call'],
+  cost_class: 'cheap',
+  action_model: 'fixed',
+  natural_actions: { pre_tool_call: 'block' },
+  supported_actions: { pre_tool_call: ['allow', 'block', 'require_approval', 'warn'] },
+  supported_codes: [],
+  config_schema: null,
+} as SafetyCheck;
+
+const ALL_CHECKS = [piiRegex, presidio, domainAllowlist];
+
+function makeRule(over: Partial<SafetyRule> = {}): SafetyRule {
+  return {
+    id: 'r1',
+    tenant_id: 't1',
+    coworker_id: null,
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: {},
+    priority: 100,
+    enabled: true,
+    description: '',
+    created_at: '2026-05-21T00:00:00Z',
+    updated_at: '2026-05-21T00:00:00Z',
+    source: 'tenant',
+    tier: null,
+    editable: true,
+    ...over,
+  } as SafetyRule;
+}
+
+async function mount(props: Partial<SafetyRuleDialog> = {}): Promise<SafetyRuleDialog> {
+  const el = document.createElement('rm-safety-rule-dialog') as SafetyRuleDialog;
+  // Append + await once to force the upgrade (happy-dom upgrades on connect),
+  // THEN set reactive props — props set on a pre-upgrade element shadow Lit's
+  // accessors and seedForm never sees them.
+  document.body.appendChild(el);
+  await el.updateComplete;
+  el.checks = ALL_CHECKS;
+  el.coworkers = [{ id: 'ops', name: 'Ops coworker' }];
+  Object.assign(el, props);
+  el.open = true;
+  await el.updateComplete;
+  await el.updateComplete;
+  return el;
+}
+
+const $ = <T extends Element>(el: Element, sel: string): T | null =>
+  el.querySelector<T>(sel);
+
+// Module-level hooks so EVERY test (across all describes) starts with the
+// write spies armed — a per-describe beforeEach that some blocks omitted left
+// the spies returning undefined after a prior clearAllMocks, which made submit
+// throw and skip the createRule call (a cross-test pollution bug).
+beforeEach(() => {
+  createRuleSpy.mockResolvedValue(makeRule());
+  updateRuleSpy.mockResolvedValue(makeRule());
+});
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('SafetyRuleDialog — three editor experiences (§6.11.1)', () => {
+  it('Experience 1 — fixed check shows the segmented action control', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'pii.regex' }) });
+    expect($(el, '[data-testid="saf-action-field"]')).not.toBeNull();
+    expect($(el, '[data-testid="saf-action-seg"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('Experience 1 — allow & redact are disabled; warn/approve/block usable', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'pii.regex' }) });
+    const btn = (a: string) =>
+      $<HTMLButtonElement>(el, `[data-testid="saf-action-seg"] button[data-action="${a}"]`)!;
+    expect(btn('allow').disabled).toBe(true); // cannot downgrade to allow
+    expect(btn('redact').disabled).toBe(true); // only Presidio redacts
+    expect(btn('warn').disabled).toBe(false);
+    expect(btn('require_approval').disabled).toBe(false);
+    expect(btn('block').disabled).toBe(false); // natural / default
+    // the disabled buttons carry an explanatory tooltip
+    expect(btn('redact').getAttribute('data-reason')).toBeTruthy();
+    el.remove();
+  });
+
+  it('Experience 2 — config_routed check hides the action field, shows routing', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result' }) });
+    expect($(el, '[data-testid="saf-action-field"]')).toBeNull();
+    expect($(el, '[data-testid="saf-routing"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('Experience 2 — routing dropdowns exclude allow (the blank option is allow)', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result' }) });
+    const select = $<HTMLSelectElement>(el, '[data-testid="saf-routing"] select')!;
+    const values = [...select.options].map((o) => o.value);
+    expect(values).toContain(''); // — allow these —
+    expect(values).not.toContain('allow');
+    expect(values).toContain('redact'); // presidio can redact at post_tool_result
+    el.remove();
+  });
+
+  it('Experience 3 — host-list check hides the action field, shows host textarea', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'domain_allowlist', stage: 'pre_tool_call' }) });
+    expect($(el, '[data-testid="saf-action-field"]')).toBeNull();
+    expect($(el, '[data-testid="saf-hosts"]')).not.toBeNull();
+    el.remove();
+  });
+});
+
+describe('SafetyRuleDialog — scope immutability (§6.11.3)', () => {
+  it('locks the scope select + shows the hint in edit mode', async () => {
+    const el = await mount({ editing: makeRule({ coworker_id: 'ops' }) });
+    const scope = $<HTMLSelectElement>(el, '[data-testid="saf-scope"]')!;
+    expect(scope.disabled).toBe(true);
+    expect($(el, '[data-testid="saf-scope-locked"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('leaves the scope select editable in create / duplicate mode', async () => {
+    const el = await mount({ duplicating: makeRule({ coworker_id: 'ops' }) });
+    const scope = $<HTMLSelectElement>(el, '[data-testid="saf-scope"]')!;
+    expect(scope.disabled).toBe(false);
+    expect($(el, '[data-testid="saf-scope-locked"]')).toBeNull();
+    el.remove();
+  });
+
+  it('never sends coworker_id on an edit PATCH', async () => {
+    updateRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({ editing: makeRule({ id: 'r9', coworker_id: 'ops' }) });
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    expect(updateRuleSpy).toHaveBeenCalledTimes(1);
+    const [, body] = updateRuleSpy.mock.calls[0];
+    expect(body).not.toHaveProperty('coworker_id');
+    el.remove();
+  });
+});
+
+describe('SafetyRuleDialog — action_override write rule', () => {
+  it('writes action_override only when a non-natural action is picked', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'pii.regex', stage: 'pre_tool_call' }) });
+    ($(el, '[data-testid="saf-action-seg"] button[data-action="warn"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [body] = createRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).action_override).toBe('warn');
+    el.remove();
+  });
+
+  it('omits action_override when the natural action stays selected', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'pii.regex', stage: 'pre_tool_call' }) });
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [body] = createRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).action_override).toBeUndefined();
+    el.remove();
+  });
+
+  it('never writes action_override for a config_routed check', async () => {
+    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result', config: { routing: { US_SSN: 'block' } } }) });
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [body] = createRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).action_override).toBeUndefined();
+    expect((body.config as Record<string, unknown>).routing).toEqual({ US_SSN: 'block' });
+    el.remove();
+  });
+});
+
+describe('SafetyRuleDialog — routing form ⇄ config round-trip', () => {
+  it('loads an existing routing map into the dropdowns and back out unchanged', async () => {
+    updateRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({
+      editing: makeRule({
+        id: 'r5',
+        check_id: 'presidio.pii',
+        stage: 'post_tool_result',
+        config: { routing: { EMAIL_ADDRESS: 'redact', US_SSN: 'block' }, threshold: 0.6 },
+      }),
+    });
+    // The loaded routing select for EMAIL_ADDRESS exists and offers redact.
+    const emailSel = $<HTMLSelectElement>(
+      el,
+      '[data-testid="saf-routing"] select[data-routing-code="EMAIL_ADDRESS"]',
+    )!;
+    expect(emailSel).not.toBeNull();
+    // Save without touching anything → routing round-trips (proves the loaded
+    // config survived into buildConfig untouched).
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [, body] = updateRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).routing).toEqual({
+      EMAIL_ADDRESS: 'redact',
+      US_SSN: 'block',
+    });
+    el.remove();
+  });
+
+  it('clearing a routing dropdown drops that entity from the config', async () => {
+    updateRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({
+      editing: makeRule({
+        id: 'r6',
+        check_id: 'presidio.pii',
+        stage: 'post_tool_result',
+        config: { routing: { EMAIL_ADDRESS: 'redact', US_SSN: 'block' } },
+      }),
+    });
+    const emailSel = $<HTMLSelectElement>(
+      el,
+      '[data-testid="saf-routing"] select[data-routing-code="EMAIL_ADDRESS"]',
+    )!;
+    emailSel.value = '';
+    emailSel.dispatchEvent(new Event('change'));
+    await el.updateComplete;
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [, body] = updateRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).routing).toEqual({ US_SSN: 'block' });
+    el.remove();
+  });
+});

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -595,7 +595,9 @@ export class SafetyRuleDialog extends LitElement {
   }
 
   private renderHostList(): TemplateResult {
-    const hosts = ((this.config['hosts'] as string[]) ?? []).join('\n');
+    // domain_allowlist backend config key is `allowed_hosts` (DomainAllowlistConfig),
+    // not `hosts`. This was the 400 "extra_forbidden / missing allowed_hosts" bug.
+    const hosts = ((this.config['allowed_hosts'] as string[]) ?? []).join('\n');
     return html`
       <label class="block text-[12.5px] font-medium mb-1">
         Allowed hosts
@@ -612,7 +614,7 @@ export class SafetyRuleDialog extends LitElement {
             .split(/\s+/)
             .map((s) => s.trim())
             .filter(Boolean);
-          this.config = { ...this.config, hosts: lines };
+          this.config = { ...this.config, allowed_hosts: lines };
         }}
       ></textarea>
       <p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-2 leading-snug">

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -58,12 +58,15 @@ const INPUT_CLASS =
 // Presentation lists for the per-check config forms. Human label first, the
 // technical code as a muted subtitle (§8.5: behaviour primary, code for
 // debugging). These are UI-only; the backend keys are the codes.
+
+// pii.regex: backend key is `patterns: { SSN: true, ... }` (uppercase, dict of bool).
+// Each entry: [backendKey, humanLabel]. Frontend stores as Set<backendKey>.
 const PII_REGEX_ENTITIES: [string, string][] = [
-  ['ssn', 'US Social Security numbers'],
-  ['credit_card', 'Credit card numbers'],
-  ['email', 'Email addresses'],
-  ['phone', 'Phone numbers'],
-  ['ip', 'IP addresses'],
+  ['SSN', 'US Social Security numbers'],
+  ['CREDIT_CARD', 'Credit card numbers'],
+  ['EMAIL', 'Email addresses'],
+  ['PHONE_US', 'Phone numbers'],
+  ['IP_ADDRESS', 'IP addresses'],
 ];
 const PRESIDIO_ENTITIES: [string, string][] = [
   ['EMAIL_ADDRESS', 'Email addresses'],
@@ -151,6 +154,8 @@ export class SafetyRuleDialog extends LitElement {
       this.pickedAction =
         typeof override === 'string' ? (override as SafetyVerdictAction) : null;
       delete cfg['action_override'];
+      // Convert stored backend format → internal display format per check.
+      this._normalizeConfigFromBackend(src.check_id, cfg);
       this.config = cfg;
       this.advancedJson = null;
     } else {
@@ -195,6 +200,74 @@ export class SafetyRuleDialog extends LitElement {
     }
   }
 
+  // ---- config format converters (backend ↔ internal display) ----
+
+  // Convert backend-stored config → internal UI format on load.
+  // Each check uses different field names from what the UI stores internally.
+  private _normalizeConfigFromBackend(checkId: string, cfg: Record<string, unknown>): void {
+    if (checkId === 'pii.regex') {
+      // Backend: { patterns: { SSN: true, CREDIT_CARD: true, ... } }
+      // Internal: Set<backendKey> stored as cfg['_piiKeys'] (a string[])
+      const patterns = (cfg['patterns'] as Record<string, boolean> | undefined) ?? {};
+      cfg['_piiKeys'] = Object.keys(patterns).filter((k) => patterns[k]);
+      delete cfg['patterns'];
+    } else if (checkId === 'presidio.pii') {
+      // Backend: { block_codes: [...], redact_codes: [...], score_threshold: 0.4 }
+      // Internal: { routing: { CODE: 'block'|'redact' }, threshold: 0.4 }
+      const blockCodes = (cfg['block_codes'] as string[]) ?? [];
+      const redactCodes = (cfg['redact_codes'] as string[]) ?? [];
+      const routing: Record<string, string> = {};
+      for (const c of blockCodes) routing[c] = 'block';
+      for (const c of redactCodes) routing[c] = 'redact';
+      cfg['routing'] = routing;
+      cfg['threshold'] = cfg['score_threshold'] ?? 0.4;
+      delete cfg['block_codes'];
+      delete cfg['redact_codes'];
+      delete cfg['score_threshold'];
+      delete cfg['language'];
+    } else if (checkId === 'openai_moderation') {
+      // Backend: { block_categories: [...], warn_categories: [...] }
+      // Internal: { routing: { category: 'block'|'warn' } }
+      const blockCats = (cfg['block_categories'] as string[]) ?? [];
+      const warnCats = (cfg['warn_categories'] as string[]) ?? [];
+      const routing: Record<string, string> = {};
+      for (const c of blockCats) routing[c] = 'block';
+      for (const c of warnCats) routing[c] = 'warn';
+      cfg['routing'] = routing;
+      delete cfg['block_categories'];
+      delete cfg['warn_categories'];
+    }
+    // secret_scanner: backend only has action_override (already stripped above).
+    // No additional conversion needed.
+  }
+
+  // Convert internal UI format → backend config on save.
+  private _buildBackendConfig(cfg: Record<string, unknown>): Record<string, unknown> {
+    const out = { ...cfg };
+    if (this.checkId === 'pii.regex') {
+      const keys = (out['_piiKeys'] as string[]) ?? [];
+      delete out['_piiKeys'];
+      const patterns: Record<string, boolean> = {};
+      for (const k of keys) patterns[k] = true;
+      out['patterns'] = patterns;
+    } else if (this.checkId === 'presidio.pii') {
+      const routing = (out['routing'] as Record<string, string>) ?? {};
+      delete out['routing'];
+      const threshold = out['threshold'];
+      delete out['threshold'];
+      out['block_codes'] = Object.entries(routing).filter(([, a]) => a === 'block').map(([c]) => c);
+      out['redact_codes'] = Object.entries(routing).filter(([, a]) => a === 'redact').map(([c]) => c);
+      out['score_threshold'] = threshold ?? 0.4;
+    } else if (this.checkId === 'openai_moderation') {
+      const routing = (out['routing'] as Record<string, string>) ?? {};
+      delete out['routing'];
+      out['block_categories'] = Object.entries(routing).filter(([, a]) => a === 'block').map(([c]) => c);
+      out['warn_categories'] = Object.entries(routing).filter(([, a]) => a === 'warn').map(([c]) => c);
+    }
+    // secret_scanner: action_override only — no extra fields.
+    return out;
+  }
+
   // ---- editor-experience selection (spec §6.11.1) ----
 
   private showActionPanel(): boolean {
@@ -223,7 +296,7 @@ export class SafetyRuleDialog extends LitElement {
         }
       }
     }
-    const cfg: Record<string, unknown> = { ...this.config };
+    let cfg: Record<string, unknown> = { ...this.config };
     // action_override is only written for the fixed picker experience, only
     // when the user picked a non-natural, override-writable action.
     if (this.showActionPanel() && this.pickedAction) {
@@ -231,6 +304,8 @@ export class SafetyRuleDialog extends LitElement {
       const nat = naturalAction(check, this.stage as SafetyStage);
       if (this.pickedAction !== nat) cfg['action_override'] = this.pickedAction;
     }
+    // Convert internal UI format → backend field names before submitting.
+    cfg = this._buildBackendConfig(cfg);
     return cfg;
   }
 
@@ -527,41 +602,47 @@ export class SafetyRuleDialog extends LitElement {
   private renderCfgForm(check: SafetyCheck, cfgKind: string): TemplateResult {
     switch (cfgKind) {
       case 'pii-entities':
-        return this.renderCheckboxGrid('What to look for', 'entities', PII_REGEX_ENTITIES);
+        // Internally stored as _piiKeys (Set<backendKey>); converted to
+        // { patterns: { SSN: true, ... } } on save (see _buildBackendConfig).
+        return this.renderPiiEntityGrid();
       case 'secret-plugins':
-        return this.renderCheckboxGrid('Types of secrets to look for', 'plugins', SECRET_PLUGINS);
+        // Backend SecretScannerConfig has action_override only — no plugin
+        // selection. Show an info note instead of a broken checkbox grid.
+        return this.renderSecretScannerNote();
       case 'threshold':
         return this.renderThreshold('How sensitive should the check be?', 0.7);
       case 'host-list':
         return this.renderHostList();
       case 'presidio-routing':
+        // Stored internally as { routing: {CODE→action}, threshold } and
+        // converted to { block_codes, redact_codes, score_threshold } on save.
         return this.renderRouting(check, 'type', PRESIDIO_ENTITIES, true);
       case 'moderation-routing':
-        return this.renderRouting(check, 'category', MODERATION_CATEGORIES, false);
+        // Stored internally as { routing: {cat→action} } and converted to
+        // { block_categories, warn_categories } on save. Only block/warn
+        // are expressible per-category (no require_approval_categories field).
+        return this.renderModerationRouting(check);
       default:
         return html``;
     }
   }
 
-  private renderCheckboxGrid(
-    label: string,
-    key: 'entities' | 'plugins',
-    options: [string, string][],
-  ): TemplateResult {
-    const selected = new Set((this.config[key] as string[]) ?? []);
+  private renderPiiEntityGrid(): TemplateResult {
+    // _piiKeys holds the Set of selected backend keys (SSN, CREDIT_CARD, …).
+    const selected = new Set((this.config['_piiKeys'] as string[]) ?? []);
     return html`
-      <label class="block text-[12.5px] font-medium mb-1">${label}</label>
+      <label class="block text-[12.5px] font-medium mb-1">What to look for</label>
       <div class="rm-saf-cfg-checks">
-        ${options.map(
-          ([value, lbl]) => html`<label>
+        ${PII_REGEX_ENTITIES.map(
+          ([backendKey, lbl]) => html`<label>
             <input
               type="checkbox"
-              ?checked=${selected.has(value)}
+              ?checked=${selected.has(backendKey)}
               @change=${(e: Event) => {
                 const next = new Set(selected);
-                if ((e.target as HTMLInputElement).checked) next.add(value);
-                else next.delete(value);
-                this.config = { ...this.config, [key]: [...next] };
+                if ((e.target as HTMLInputElement).checked) next.add(backendKey);
+                else next.delete(backendKey);
+                this.config = { ...this.config, _piiKeys: [...next] };
               }}
             />
             ${lbl}
@@ -571,7 +652,74 @@ export class SafetyRuleDialog extends LitElement {
     `;
   }
 
+  private renderSecretScannerNote(): TemplateResult {
+    // SecretScannerConfig only accepts action_override — there is no plugin
+    // selection in the current backend schema. The check runs all built-in
+    // detectors automatically.
+    return html`
+      <p class="text-[12.5px] text-ink-3 dark:text-d-ink-3 leading-snug">
+        This check runs all built-in secret detectors automatically. No
+        additional configuration is needed — use the action picker above to
+        choose what happens when a secret is found.
+      </p>
+    `;
+  }
+
+  // Moderation routing: only block/warn per category — the schema has no
+  // require_approval_categories field, so we filter it from the options.
+  private renderModerationRouting(check: SafetyCheck): TemplateResult {
+    const stage = this.stage as SafetyStage;
+    const routing = (this.config['routing'] as Record<string, string>) ?? {};
+    // Only block and warn are expressible per-category.
+    const options = supportedActions(check, stage).filter(
+      (a) => a !== 'allow' && a !== 'require_approval' && a !== 'redact',
+    );
+    const anyRouted = Object.values(routing).some(Boolean);
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">
+        Choose an action for each category
+        <span class="rm-saf-lblnote">leave any blank to let it through</span>
+      </label>
+      <div class="rm-saf-routing-table" data-testid="saf-routing">
+        ${MODERATION_CATEGORIES.map(
+          ([code, lbl]) => html`<div class="rm-saf-routing-row">
+            <div>
+              <div class="rm-saf-rcode">${lbl}</div>
+              <div class="rm-saf-rdesc">${code}</div>
+            </div>
+            <select
+              data-routing-code=${code}
+              @change=${(e: Event) => {
+                const v = (e.target as HTMLSelectElement).value;
+                const next = { ...routing };
+                if (v) next[code] = v;
+                else delete next[code];
+                this.config = { ...this.config, routing: next };
+              }}
+            >
+              <option value="" ?selected=${!routing[code]}>— allow these —</option>
+              ${options.map(
+                (a) => html`<option value=${a} ?selected=${routing[code] === a}>
+                  ${SAF_ACTION_LABEL[a]}
+                </option>`,
+              )}
+            </select>
+          </div>`,
+        )}
+      </div>
+      ${!anyRouted
+        ? html`<div class="rm-saf-routing-inert" data-testid="saf-routing-inert">
+            <b>Nothing set yet.</b> The check runs on every input but won't do
+            anything. Pick an action for at least one category above to make it
+            active.
+          </div>`
+        : nothing}
+    `;
+  }
+
   private renderThreshold(label: string, fallback: number): TemplateResult {
+    // Internally stored as `threshold`; presidio uses `score_threshold` on
+    // the backend — converted in _buildBackendConfig.
     const value = (this.config['threshold'] as number) ?? fallback;
     return html`
       <label class="block text-[12.5px] font-medium mb-1">${label}</label>

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -622,6 +622,10 @@ export class SafetyRuleDialog extends LitElement {
         // { block_categories, warn_categories } on save. Only block/warn
         // are expressible per-category (no require_approval_categories field).
         return this.renderModerationRouting(check);
+      case 'jailbreak-phrases':
+        // Backend: { phrases: list[str], case_sensitive: bool }
+        // Different from llm_guard.prompt_injection / toxicity (threshold).
+        return this.renderJailbreakPhrases();
       default:
         return html``;
     }
@@ -661,6 +665,51 @@ export class SafetyRuleDialog extends LitElement {
         This check runs all built-in secret detectors automatically. No
         additional configuration is needed — use the action picker above to
         choose what happens when a secret is found.
+      </p>
+    `;
+  }
+
+  private renderJailbreakPhrases(): TemplateResult {
+    // Backend: { phrases: list[str], case_sensitive: bool }
+    // phrases defaults to the built-in set on the server; leave empty to use it.
+    const phrases = ((this.config['phrases'] as string[]) ?? []).join('\n');
+    const caseSensitive = (this.config['case_sensitive'] as boolean) ?? false;
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">
+        Custom detection phrases
+        <span class="rm-saf-lblnote">one per line · leave blank to use the built-in list</span>
+      </label>
+      <textarea
+        class="${INPUT_CLASS} font-mono text-[12.5px]"
+        style="min-height:72px"
+        data-testid="saf-jailbreak-phrases"
+        placeholder="ignore all previous instructions&#10;pretend you have no restrictions"
+        .value=${phrases}
+        @input=${(e: Event) => {
+          const lines = (e.target as HTMLTextAreaElement).value
+            .split('\n')
+            .map((s) => s.trim())
+            .filter(Boolean);
+          this.config = { ...this.config, phrases: lines };
+        }}
+      ></textarea>
+      <label class="flex items-center gap-2 mt-2 text-[12.5px]">
+        <input
+          type="checkbox"
+          data-testid="saf-case-sensitive"
+          ?checked=${caseSensitive}
+          @change=${(e: Event) => {
+            this.config = {
+              ...this.config,
+              case_sensitive: (e.target as HTMLInputElement).checked,
+            };
+          }}
+        />
+        Case-sensitive matching
+      </label>
+      <p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-2 leading-snug">
+        Leave the phrases box empty to use the built-in set. Add custom phrases
+        to catch tenant-specific jailbreak patterns.
       </p>
     `;
   }

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -1,0 +1,772 @@
+// <rm-safety-rule-dialog> — create / edit / duplicate a safety rule (spec §6.11).
+//
+// One dialog backs all three flows (mirrors approval-policy-dialog):
+//   - editing non-null     → edit  (PATCH; scope LOCKED — §6.11.3)
+//   - duplicating non-null → create, pre-filled (POST; scope editable)
+//   - both null            → create, defaults (POST)
+//
+// THREE EDITOR EXPERIENCES for the action (spec §6.11.1), chosen from the
+// wire check's action_model + cfgKind — but the taxonomy name is never shown
+// (§8.5). The user sees behaviour, not classification:
+//   1. fixed (non host-list): a segmented control with the natural action
+//      marked and unsupported / non-overridable actions disabled.
+//   2. config_routed (presidio.pii / openai_moderation): NO action field —
+//      the per-finding routing table in the config section IS the editor.
+//   3. host-list (domain_allowlist / egress.domain_rule): NO action field —
+//      the host list is the whole rule ("allow these, block the rest").
+// A fully-inert field is removed, not greyed (§8.5 #4).
+//
+// Writes go through safety-admin-client (admin-privileged per design §3
+// Phase 4). On edit we NEVER send coworker_id — scope is immutable for audit
+// consistency (SafetyRuleUpdate has no such field; this is the belt-and-
+// suspenders backstop).
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+import './dialog.js';
+import type {
+  SafetyCheck,
+  SafetyRule,
+  SafetyStage,
+  SafetyVerdictAction,
+} from '../api/client.js';
+import {
+  createRule,
+  updateRule,
+  type CoworkerSummary,
+} from '../services/safety-admin-client.js';
+import {
+  SAFETY_CHECK_CATALOG,
+  SAF_ACTION_LABEL,
+  SAF_ACTION_ORDER,
+  SAF_ACTION_SUB,
+  SAF_CONTROL_STAGES,
+  SAF_STAGE_LABEL,
+  actionButtonState,
+  naturalAction,
+  safSentence,
+  supportedActions,
+} from './safety-catalog.js';
+
+const INPUT_CLASS =
+  'w-full text-[13.5px] px-3 py-2 rounded-md border border-surface-3 ' +
+  'dark:border-d-surface-3 bg-surface-1 dark:bg-d-surface-1 ' +
+  'text-ink-0 dark:text-d-ink-0 focus:outline-none focus:ring-2 focus:ring-brand';
+
+// Presentation lists for the per-check config forms. Human label first, the
+// technical code as a muted subtitle (§8.5: behaviour primary, code for
+// debugging). These are UI-only; the backend keys are the codes.
+const PII_REGEX_ENTITIES: [string, string][] = [
+  ['ssn', 'US Social Security numbers'],
+  ['credit_card', 'Credit card numbers'],
+  ['email', 'Email addresses'],
+  ['phone', 'Phone numbers'],
+  ['ip', 'IP addresses'],
+];
+const PRESIDIO_ENTITIES: [string, string][] = [
+  ['EMAIL_ADDRESS', 'Email addresses'],
+  ['PHONE_NUMBER', 'Phone numbers'],
+  ['US_SSN', 'US Social Security numbers'],
+  ['CREDIT_CARD', 'Credit card numbers'],
+  ['PERSON', "People's names"],
+  ['LOCATION', 'Locations'],
+  ['IP_ADDRESS', 'IP addresses'],
+  ['DATE_TIME', 'Dates and times'],
+];
+const MODERATION_CATEGORIES: [string, string][] = [
+  ['sexual', 'Sexual content'],
+  ['hate', 'Hate speech'],
+  ['harassment', 'Harassment'],
+  ['self-harm', 'Self-harm'],
+  ['violence', 'Violence'],
+];
+const SECRET_PLUGINS: [string, string][] = [
+  ['aws', 'AWS keys'],
+  ['github', 'GitHub tokens'],
+  ['slack', 'Slack tokens'],
+  ['stripe', 'Stripe keys'],
+  ['jwt', 'Login tokens (JWT)'],
+  ['basic_auth', 'Basic auth credentials'],
+  ['private_key', 'Private keys'],
+];
+
+@customElement('rm-safety-rule-dialog')
+export class SafetyRuleDialog extends LitElement {
+  @property({ type: Boolean }) open = false;
+  @property({ attribute: false }) editing: SafetyRule | null = null;
+  @property({ attribute: false }) duplicating: SafetyRule | null = null;
+  /** Check catalog + coworker list — fetched once by the page, passed down. */
+  @property({ attribute: false }) checks: SafetyCheck[] = [];
+  @property({ attribute: false }) coworkers: CoworkerSummary[] = [];
+
+  @state() private checkId = '';
+  @state() private stage: SafetyStage | '' = '';
+  /** Override action for fixed checks; null ⇒ use the natural action. */
+  @state() private pickedAction: SafetyVerdictAction | null = null;
+  @state() private coworkerId: string | null = null;
+  @state() private priority = 100;
+  @state() private enabled = true;
+  /** cfgKind-specific config (entities / routing / threshold / hosts / …). */
+  @state() private config: Record<string, unknown> = {};
+  /** Raw-JSON escape hatch; null ⇒ visual form is authoritative. */
+  @state() private advancedJson: string | null = null;
+  @state() private busy = false;
+  @state() private err: string | null = null;
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  override willUpdate(changed: Map<string, unknown>) {
+    if (changed.has('open') && this.open) {
+      this.seedForm();
+      this.err = null;
+    }
+  }
+
+  private get isEdit(): boolean {
+    return this.editing !== null;
+  }
+
+  private seedSource(): SafetyRule | null {
+    return this.editing ?? this.duplicating;
+  }
+
+  private currentCheck(): SafetyCheck | null {
+    return this.checks.find((c) => c.id === this.checkId) ?? null;
+  }
+
+  private seedForm(): void {
+    const src = this.seedSource();
+    if (src) {
+      this.checkId = src.check_id;
+      this.stage = src.stage;
+      this.coworkerId = src.coworker_id ?? null;
+      this.priority = src.priority;
+      this.enabled = src.enabled;
+      const cfg = { ...(src.config ?? {}) } as Record<string, unknown>;
+      const override = cfg['action_override'];
+      this.pickedAction =
+        typeof override === 'string' ? (override as SafetyVerdictAction) : null;
+      delete cfg['action_override'];
+      this.config = cfg;
+      this.advancedJson = null;
+    } else {
+      const first = this.checks[0];
+      this.checkId = first?.id ?? '';
+      this.stage = (first?.stages?.[0] as SafetyStage) ?? '';
+      this.coworkerId = null;
+      this.priority = 100;
+      this.enabled = true;
+      this.pickedAction = null;
+      this.config = {};
+      this.advancedJson = null;
+    }
+  }
+
+  private close = () => {
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  };
+
+  // ---- check / stage change resets dependent state ----
+
+  private onCheckChange(id: string): void {
+    this.checkId = id;
+    const check = this.currentCheck();
+    // Reset stage to the check's first supported stage, drop any override +
+    // config from the previous (different-shaped) check.
+    this.stage = (check?.stages?.[0] as SafetyStage) ?? '';
+    this.pickedAction = null;
+    this.config = {};
+    this.advancedJson = null;
+  }
+
+  private onStageChange(stage: SafetyStage): void {
+    this.stage = stage;
+    // An override valid on the old stage may be unsupported on the new one;
+    // drop it so we never submit an unsupported action.
+    if (this.pickedAction) {
+      const check = this.currentCheck();
+      const nat = naturalAction(check, stage);
+      const st = actionButtonState(check, stage, this.pickedAction, nat);
+      if (!st.enabled) this.pickedAction = null;
+    }
+  }
+
+  // ---- editor-experience selection (spec §6.11.1) ----
+
+  private showActionPanel(): boolean {
+    const check = this.currentCheck();
+    if (!check) return false;
+    const cfgKind = SAFETY_CHECK_CATALOG[check.id]?.cfgKind;
+    if (cfgKind === 'host-list') return false; // Experience 3
+    if (check.action_model === 'config_routed') return false; // Experience 2
+    return check.action_model === 'fixed'; // Experience 1
+  }
+
+  // ---- config assembly ----
+
+  private buildConfig(): Record<string, unknown> {
+    // Advanced JSON wins when visible, non-empty, and parseable (§6.12).
+    if (this.advancedJson !== null) {
+      const trimmed = this.advancedJson.trim();
+      if (trimmed) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+          }
+        } catch {
+          /* fall through to the form */
+        }
+      }
+    }
+    const cfg: Record<string, unknown> = { ...this.config };
+    // action_override is only written for the fixed picker experience, only
+    // when the user picked a non-natural, override-writable action.
+    if (this.showActionPanel() && this.pickedAction) {
+      const check = this.currentCheck();
+      const nat = naturalAction(check, this.stage as SafetyStage);
+      if (this.pickedAction !== nat) cfg['action_override'] = this.pickedAction;
+    }
+    return cfg;
+  }
+
+  private async submit(): Promise<void> {
+    if (!this.checkId || !this.stage) {
+      this.err = 'Pick a check and a stage.';
+      return;
+    }
+    this.busy = true;
+    this.err = null;
+    try {
+      const config = this.buildConfig();
+      // createRule / updateRule return the admin-shaped row; the page holds
+      // v1-client rows (with source/tier/editable), so we hand back only the
+      // id and let the page re-fetch — the two-tier split must come from a
+      // fresh authoritative read anyway.
+      let savedId: string;
+      if (this.isEdit && this.editing) {
+        // Scope (coworker_id) intentionally omitted — immutable on edit.
+        const saved = await updateRule(this.editing.id, {
+          check_id: this.checkId,
+          stage: this.stage,
+          config,
+          priority: this.priority,
+          enabled: this.enabled,
+        });
+        savedId = saved.id;
+      } else {
+        const saved = await createRule({
+          check_id: this.checkId,
+          stage: this.stage,
+          coworker_id: this.coworkerId,
+          config,
+          priority: this.priority,
+          enabled: this.enabled,
+        });
+        savedId = saved.id;
+      }
+      this.dispatchEvent(
+        new CustomEvent('safety-rule-saved', {
+          detail: { id: savedId },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      this.close();
+    } catch (err) {
+      this.err = err instanceof Error ? err.message : String(err);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  /** Edit-mode scope hint → close edit, reopen as duplicate (the only path to
+   *  change scope, §6.11.3). The page owns the flow. */
+  private duplicateFromEdit(): void {
+    const id = this.editing?.id;
+    if (!id) return;
+    this.dispatchEvent(
+      new CustomEvent('safety-rule-duplicate-from-edit', {
+        detail: { id },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  // ---- render ----
+
+  private dialogTitle(): string {
+    if (this.isEdit) return 'Edit safety rule';
+    if (this.duplicating) return 'Duplicate safety rule';
+    return 'New safety rule';
+  }
+
+  override render(): TemplateResult {
+    const check = this.currentCheck();
+    const pres = check ? SAFETY_CHECK_CATALOG[check.id] : undefined;
+    return html`
+      <rm-dialog
+        title=${this.dialogTitle()}
+        ?open=${this.open}
+        ?close-on-backdrop=${!this.busy}
+        ?close-on-esc=${!this.busy}
+        width="600px"
+        @close=${this.close}
+      >
+        <p class="text-[12.5px] text-ink-2 dark:text-d-ink-2 mb-3">
+          Safety rules run automatically — no one in the loop — except when you
+          set the action to <b>Approve</b>, which routes to the same approval
+          inbox as business policies. Changes apply to new agent tasks;
+          already-running tasks finish with the current rules.
+        </p>
+
+        ${this.renderCheckField(pres)}
+        ${this.renderStageField(check)}
+        ${this.showActionPanel() ? this.renderActionPanel(check) : nothing}
+        ${this.renderConfigField(check, pres)}
+        ${this.renderScopeField()}
+        ${this.renderPriorityEnabled()}
+        ${this.renderPreview(check)}
+
+        ${this.err
+          ? html`<div
+              class="text-[12.5px] text-red-600 dark:text-red-300 mt-2"
+              role="alert"
+              data-testid="saf-form-error"
+            >${this.err}</div>`
+          : nothing}
+
+        <div slot="footer" style="display: flex; gap: 8px; justify-content: flex-end;">
+          <button type="button" class="rm-btn rm-btn--secondary"
+            ?disabled=${this.busy} @click=${this.close}>Cancel</button>
+          <button type="button" class="rm-btn rm-btn--primary"
+            data-testid="saf-submit" ?disabled=${this.busy}
+            @click=${() => void this.submit()}
+          >${this.busy ? 'Saving…' : this.isEdit ? 'Save changes' : 'Create rule'}</button>
+        </div>
+      </rm-dialog>
+    `;
+  }
+
+  private renderCheckField(
+    pres: (typeof SAFETY_CHECK_CATALOG)[string] | undefined,
+  ): TemplateResult {
+    // Group the check <select> by category (Sensitive data / … / Network),
+    // each option suffixed with its cost so the user sees the latency tradeoff.
+    const byCategory = new Map<string, SafetyCheck[]>();
+    for (const c of this.checks) {
+      const cat = SAFETY_CHECK_CATALOG[c.id]?.category ?? 'Other';
+      const list = byCategory.get(cat) ?? [];
+      list.push(c);
+      byCategory.set(cat, list);
+    }
+    const check = this.currentCheck();
+    const slow = check?.cost_class === 'slow';
+    return html`
+      <div class="mb-2">
+        <label class="block text-[12.5px] font-medium mb-1">Check</label>
+        <select
+          class=${INPUT_CLASS}
+          data-testid="saf-check"
+          ?disabled=${this.busy}
+          @change=${(e: Event) =>
+            this.onCheckChange((e.target as HTMLSelectElement).value)}
+        >
+          ${[...byCategory.entries()].map(
+            ([cat, list]) => html`<optgroup label=${cat}>
+              ${list.map(
+                (c) => html`<option value=${c.id} ?selected=${c.id === this.checkId}>
+                  ${SAFETY_CHECK_CATALOG[c.id]?.label ?? c.id}
+                  (${c.cost_class})
+                </option>`,
+              )}
+            </optgroup>`,
+          )}
+        </select>
+        ${pres
+          ? html`<p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-1 leading-snug">
+              ${pres.desc}
+            </p>`
+          : nothing}
+        ${slow
+          ? html`<p class="text-[11.5px] text-amber-700 dark:text-amber-400 mt-1"
+              data-testid="saf-slow-warn">
+              This check adds noticeable latency — avoid putting it on a
+              fast-path stage like “before tool calls”.
+            </p>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderStageField(check: SafetyCheck | null): TemplateResult {
+    const stages = (check?.stages ?? []) as SafetyStage[];
+    const control = this.stage && SAF_CONTROL_STAGES.has(this.stage);
+    return html`
+      <div class="mb-2">
+        <label class="block text-[12.5px] font-medium mb-1">Where it runs</label>
+        <select
+          class=${INPUT_CLASS}
+          data-testid="saf-stage"
+          ?disabled=${this.busy}
+          @change=${(e: Event) =>
+            this.onStageChange((e.target as HTMLSelectElement).value as SafetyStage)}
+        >
+          ${stages.map(
+            (s) => html`<option value=${s} ?selected=${s === this.stage}>
+              ${SAF_STAGE_LABEL[s] ?? s}
+            </option>`,
+          )}
+        </select>
+        ${this.stage
+          ? html`<p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-1 leading-snug">
+              ${control
+                ? 'If this check errors here, the call is blocked by default.'
+                : 'If this check errors here, the call is let through.'}
+            </p>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderActionPanel(check: SafetyCheck | null): TemplateResult {
+    const stage = this.stage as SafetyStage;
+    const natural = naturalAction(check, stage);
+    const current = this.pickedAction ?? natural;
+    const naturalLabel = natural ? SAF_ACTION_LABEL[natural].toLowerCase() : 'act on';
+    return html`
+      <div class="mb-2" data-testid="saf-action-field">
+        <label class="block text-[12.5px] font-medium mb-1">When it triggers, do this</label>
+        <div class="rm-saf-action-panel">
+          By default, this check
+          <span class="rm-saf-natural rm-saf-act-${natural ?? 'block'}">${naturalLabel}s</span>
+          anything it finds. You can change the action below.
+        </div>
+        <div class="rm-saf-seg" role="group" data-testid="saf-action-seg">
+          ${SAF_ACTION_ORDER.map((a) => {
+            const st = actionButtonState(check, stage, a, natural);
+            const on = a === current && st.enabled;
+            return html`<button
+              type="button"
+              class="${on ? `rm-saf-on rm-saf-act-${a}` : ''}"
+              data-action=${a}
+              ?disabled=${!st.enabled || this.busy}
+              data-reason=${st.enabled ? nothing : st.reason}
+              @click=${() => {
+                this.pickedAction = a === natural ? null : a;
+              }}
+            >
+              ${SAF_ACTION_LABEL[a]}
+              <div class="rm-saf-sub">${SAF_ACTION_SUB[a]}</div>
+              ${a === natural
+                ? html`<span class="rm-saf-nat-dot" title="Default for this check"></span>`
+                : nothing}
+            </button>`;
+          })}
+        </div>
+        <p class="rm-saf-seg-legend">
+          <span class="rm-saf-nat-dot"></span> = the default. Pick something else
+          to override.
+        </p>
+      </div>
+    `;
+  }
+
+  // ---- config forms (one per cfgKind, spec §6.12) ----
+
+  private renderConfigField(
+    check: SafetyCheck | null,
+    pres: (typeof SAFETY_CHECK_CATALOG)[string] | undefined,
+  ): TemplateResult {
+    if (!check || !pres?.cfgKind) return html``;
+    const adv = this.advancedJson !== null;
+    return html`
+      <div class="mb-3" data-testid="saf-config">
+        ${adv ? this.renderAdvancedJson() : this.renderCfgForm(check, pres.cfgKind)}
+        <button
+          type="button"
+          class="text-[11.5px] text-accent mt-2"
+          style="color: var(--rm-accent); background: none; border: none; cursor: pointer; padding: 0;"
+          data-testid="saf-adv-toggle"
+          @click=${() => this.toggleAdvanced()}
+        >
+          ${adv ? 'Use the visual form' : 'Advanced: edit as JSON'}
+        </button>
+      </div>
+    `;
+  }
+
+  private toggleAdvanced(): void {
+    if (this.advancedJson === null) {
+      this.advancedJson = JSON.stringify(this.buildConfig(), null, 2);
+    } else {
+      this.advancedJson = null;
+    }
+  }
+
+  private renderAdvancedJson(): TemplateResult {
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">Configuration (JSON)</label>
+      <textarea
+        class="${INPUT_CLASS} font-mono text-[12px]"
+        rows="6"
+        data-testid="saf-config-json"
+        .value=${this.advancedJson ?? ''}
+        @input=${(e: Event) => {
+          this.advancedJson = (e.target as HTMLTextAreaElement).value;
+        }}
+      ></textarea>
+    `;
+  }
+
+  private renderCfgForm(check: SafetyCheck, cfgKind: string): TemplateResult {
+    switch (cfgKind) {
+      case 'pii-entities':
+        return this.renderCheckboxGrid('What to look for', 'entities', PII_REGEX_ENTITIES);
+      case 'secret-plugins':
+        return this.renderCheckboxGrid('Types of secrets to look for', 'plugins', SECRET_PLUGINS);
+      case 'threshold':
+        return this.renderThreshold('How sensitive should the check be?', 0.7);
+      case 'host-list':
+        return this.renderHostList();
+      case 'presidio-routing':
+        return this.renderRouting(check, 'type', PRESIDIO_ENTITIES, true);
+      case 'moderation-routing':
+        return this.renderRouting(check, 'category', MODERATION_CATEGORIES, false);
+      default:
+        return html``;
+    }
+  }
+
+  private renderCheckboxGrid(
+    label: string,
+    key: 'entities' | 'plugins',
+    options: [string, string][],
+  ): TemplateResult {
+    const selected = new Set((this.config[key] as string[]) ?? []);
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">${label}</label>
+      <div class="rm-saf-cfg-checks">
+        ${options.map(
+          ([value, lbl]) => html`<label>
+            <input
+              type="checkbox"
+              ?checked=${selected.has(value)}
+              @change=${(e: Event) => {
+                const next = new Set(selected);
+                if ((e.target as HTMLInputElement).checked) next.add(value);
+                else next.delete(value);
+                this.config = { ...this.config, [key]: [...next] };
+              }}
+            />
+            ${lbl}
+          </label>`,
+        )}
+      </div>
+    `;
+  }
+
+  private renderThreshold(label: string, fallback: number): TemplateResult {
+    const value = (this.config['threshold'] as number) ?? fallback;
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">${label}</label>
+      <div class="rm-saf-threshold">
+        <span class="text-[12px] text-ink-3 dark:text-d-ink-3" style="min-width:80px">Sensitivity</span>
+        <input
+          type="range" min="0" max="1" step="0.05"
+          data-testid="saf-threshold"
+          .value=${String(value)}
+          @input=${(e: Event) => {
+            this.config = {
+              ...this.config,
+              threshold: parseFloat((e.target as HTMLInputElement).value),
+            };
+          }}
+        />
+        <span class="rm-saf-tval">${value}</span>
+      </div>
+      <div class="rm-saf-thint"><span>stricter (catches more)</span><span>looser (catches less)</span></div>
+    `;
+  }
+
+  private renderHostList(): TemplateResult {
+    const hosts = ((this.config['hosts'] as string[]) ?? []).join('\n');
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">
+        Allowed hosts
+        <span class="rm-saf-lblnote">one per line · wildcards like *.stripe.com</span>
+      </label>
+      <textarea
+        class="${INPUT_CLASS} font-mono text-[12.5px]"
+        style="min-height:80px"
+        data-testid="saf-hosts"
+        placeholder="api.stripe.com&#10;*.internal.acme.com"
+        .value=${hosts}
+        @input=${(e: Event) => {
+          const lines = (e.target as HTMLTextAreaElement).value
+            .split(/\s+/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+          this.config = { ...this.config, hosts: lines };
+        }}
+      ></textarea>
+      <p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-2 leading-snug">
+        The coworker can only reach these hosts. Any other outbound request is
+        blocked.
+      </p>
+    `;
+  }
+
+  // Per-finding routing table (Experience 2). Each row: human label + code +
+  // a dropdown of supportable actions (server-driven, minus allow — the empty
+  // "— allow these —" option is the allow case). presidio also has a threshold.
+  private renderRouting(
+    check: SafetyCheck,
+    noun: 'type' | 'category',
+    rows: [string, string][],
+    withThreshold: boolean,
+  ): TemplateResult {
+    const stage = this.stage as SafetyStage;
+    const routing = (this.config['routing'] as Record<string, string>) ?? {};
+    const options = supportedActions(check, stage).filter((a) => a !== 'allow');
+    const anyRouted = Object.values(routing).some(Boolean);
+    return html`
+      <label class="block text-[12.5px] font-medium mb-1">
+        Choose an action for each ${noun}
+        <span class="rm-saf-lblnote">leave any blank to let it through</span>
+      </label>
+      <div class="rm-saf-routing-table" data-testid="saf-routing">
+        ${rows.map(
+          ([code, lbl]) => html`<div class="rm-saf-routing-row">
+            <div>
+              <div class="rm-saf-rcode">${lbl}</div>
+              <div class="rm-saf-rdesc">${code}</div>
+            </div>
+            <select
+              data-routing-code=${code}
+              @change=${(e: Event) => {
+                const v = (e.target as HTMLSelectElement).value;
+                const next = { ...routing };
+                if (v) next[code] = v;
+                else delete next[code];
+                this.config = { ...this.config, routing: next };
+              }}
+            >
+              <option value="" ?selected=${!routing[code]}>— allow these —</option>
+              ${options.map(
+                (a) => html`<option value=${a} ?selected=${routing[code] === a}>
+                  ${SAF_ACTION_LABEL[a]}
+                </option>`,
+              )}
+            </select>
+          </div>`,
+        )}
+      </div>
+      ${!anyRouted
+        ? html`<div class="rm-saf-routing-inert" data-testid="saf-routing-inert">
+            <b>Nothing set yet.</b> The check runs on every input but won't do
+            anything. Pick an action for at least one ${noun} above to make it
+            active.
+          </div>`
+        : nothing}
+      ${withThreshold ? this.renderThreshold('Confidence', 0.6) : nothing}
+    `;
+  }
+
+  private renderScopeField(): TemplateResult {
+    const locked = this.isEdit;
+    return html`
+      <div class="mb-2">
+        <label class="block text-[12.5px] font-medium mb-1">Applies to</label>
+        <select
+          class=${INPUT_CLASS}
+          data-testid="saf-scope"
+          ?disabled=${locked || this.busy}
+          style=${locked ? 'opacity:0.55;cursor:not-allowed' : ''}
+          @change=${(e: Event) => {
+            const v = (e.target as HTMLSelectElement).value;
+            this.coworkerId = v === '' ? null : v;
+          }}
+        >
+          <option value="" ?selected=${!this.coworkerId}>All coworkers</option>
+          ${this.coworkers.map(
+            (c) => html`<option value=${c.id} ?selected=${c.id === this.coworkerId}>
+              ${c.name}
+            </option>`,
+          )}
+        </select>
+        ${locked
+          ? html`<div class="rm-saf-scope-locked" data-testid="saf-scope-locked">
+              <span>🔒</span>
+              <span>Scope is fixed after creation (for audit consistency). To
+                move scope,
+                <a @click=${() => this.duplicateFromEdit()}>duplicate this rule</a>
+                with the new scope, then delete this one.</span>
+            </div>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderPriorityEnabled(): TemplateResult {
+    return html`
+      <div class="mb-2 flex items-end gap-4">
+        <label class="text-[12.5px] font-medium">
+          Priority
+          <span class="text-ink-3 dark:text-d-ink-3 font-normal">higher wins on ties</span>
+          <input
+            type="number"
+            class="${INPUT_CLASS} w-24 mt-1 block"
+            data-testid="saf-priority"
+            .value=${String(this.priority)}
+            @input=${(e: Event) => {
+              this.priority = parseInt((e.target as HTMLInputElement).value, 10) || 0;
+            }}
+            ?disabled=${this.busy}
+          />
+        </label>
+        <div class="text-[12.5px] font-medium">
+          Status
+          <button
+            type="button"
+            class="rm-pol-toggle ${this.enabled ? 'rm-pol-toggle--on' : ''} mt-1"
+            data-testid="saf-enabled"
+            aria-pressed=${this.enabled}
+            @click=${() => {
+              this.enabled = !this.enabled;
+            }}
+            ?disabled=${this.busy}
+          >
+            <span>${this.enabled ? 'Enabled' : 'Disabled'}</span>
+            <span class="rm-switch"></span>
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderPreview(check: SafetyCheck | null): TemplateResult {
+    if (!this.checkId || !this.stage) return html``;
+    const cwName = this.coworkerId
+      ? (this.coworkers.find((c) => c.id === this.coworkerId)?.name ?? null)
+      : null;
+    const sentence = safSentence(
+      { check_id: this.checkId, stage: this.stage, config: this.buildConfig() },
+      check,
+      cwName,
+    );
+    const disabledTail = this.enabled
+      ? ''
+      : ' <i>(disabled — won\'t run until re-enabled)</i>';
+    return html`
+      <div class="rm-pol-preview" data-testid="saf-preview">
+        ${unsafeHTML(`${sentence} Priority <b>${this.priority}</b>.${disabledTail}`)}
+      </div>
+    `;
+  }
+}

--- a/web/src/components/safety-rules-page.test.ts
+++ b/web/src/components/safety-rules-page.test.ts
@@ -1,19 +1,17 @@
 // @vitest-environment happy-dom
-// Safety rules page — pins the v1/admin read-vs-write split.
+// Safety rules page (spec §6) — pins the v1/admin read-vs-write split AND the
+// revamped two-tier list behaviour.
 //
 // What this test catches:
-//   * Reads on mount go through the typed v1 ApiClient
-//     (listSafetyRules / listSafetyChecks / listSafetyRuleAudit).
-//   * Writes (create/update/delete + toggle) keep using
-//     safety-admin-client (admin POST/PATCH/DELETE).
-//   * A refactor that "helpfully" repointed a write to v1 would
-//     blow up at runtime (no v1 write endpoint exists), so we
-//     pin the routing here.
+//   * Reads on mount go through the typed v1 ApiClient.
+//   * Writes (toggle / delete) keep using safety-admin-client (admin).
+//   * Platform-tier rows are audit-only — no edit / duplicate / delete and the
+//     toggle is inert (a regression that exposed those would let an org mutate
+//     a cross-tenant default it doesn't own).
+//   * The card renders the human label, sentence, action pill, and chips.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Hoisted spies so the factories below (which run before
-// top-level `const`s) can reference them.
 const {
   listSafetyRulesSpy,
   listSafetyChecksSpy,
@@ -59,7 +57,8 @@ vi.mock('../services/safety-admin-client.js', async () => {
   };
 });
 
-import { SafetyRulesPage } from './safety-rules-page.js';
+import { SafetyRulesPage, auditSummary } from './safety-rules-page.js';
+import type { SafetyCheck, SafetyRule, SafetyRuleAuditEntry } from '../api/client.js';
 
 async function waitUntilLoaded(page: SafetyRulesPage): Promise<void> {
   for (let i = 0; i < 30; i++) {
@@ -71,257 +70,264 @@ async function waitUntilLoaded(page: SafetyRulesPage): Promise<void> {
   throw new Error('SafetyRulesPage did not finish loading');
 }
 
-function makeRule(overrides: Record<string, unknown> = {}) {
+function piiCheck(): SafetyCheck {
+  return {
+    id: 'pii.regex',
+    version: '1',
+    stages: ['input_prompt', 'pre_tool_call'],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: { input_prompt: 'block', pre_tool_call: 'block' },
+    supported_actions: {
+      input_prompt: ['allow', 'block', 'require_approval', 'warn'],
+      pre_tool_call: ['allow', 'block', 'require_approval', 'warn'],
+    },
+    supported_codes: [],
+    config_schema: null,
+  } as SafetyCheck;
+}
+
+function makeRule(overrides: Partial<SafetyRule> = {}): SafetyRule {
   return {
     id: 'r1',
     tenant_id: 't1',
     coworker_id: null,
-    stage: 'input_prompt' as const,
-    check_id: 'prompt-pii',
-    config: {},
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: { entities: ['ssn'] },
     priority: 100,
     enabled: true,
     description: '',
     created_at: '2026-05-21T00:00:00Z',
     updated_at: '2026-05-21T00:00:00Z',
+    source: 'tenant',
+    tier: null,
+    editable: true,
     ...overrides,
-  };
+  } as SafetyRule;
 }
 
-describe('SafetyRulesPage routing', () => {
+async function mount(rules: SafetyRule[]): Promise<SafetyRulesPage> {
+  listSafetyRulesSpy.mockResolvedValue(rules);
+  const page = new SafetyRulesPage();
+  document.body.appendChild(page);
+  await waitUntilLoaded(page);
+  await page.updateComplete;
+  return page;
+}
+
+describe('SafetyRulesPage', () => {
   beforeEach(() => {
     listSafetyRulesSpy.mockResolvedValue([]);
-    listSafetyChecksSpy.mockResolvedValue([]);
+    listSafetyChecksSpy.mockResolvedValue([piiCheck()]);
     listSafetyRuleAuditSpy.mockResolvedValue([]);
     createRuleSpy.mockResolvedValue(makeRule());
     updateRuleSpy.mockResolvedValue(makeRule({ enabled: false }));
     deleteRuleSpy.mockResolvedValue(undefined);
-    listCoworkersSpy.mockResolvedValue([]);
+    listCoworkersSpy.mockResolvedValue([{ id: 'ops', name: 'Ops coworker' }]);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    document.body.innerHTML = '';
   });
 
-  it('reads via the typed v1 ApiClient on mount', async () => {
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-
+  it('reads via the typed v1 ApiClient + admin coworker list on mount', async () => {
+    const page = await mount([]);
     expect(listSafetyRulesSpy).toHaveBeenCalledTimes(1);
     expect(listSafetyChecksSpy).toHaveBeenCalledTimes(1);
-    // Coworker list is admin-side (CSV export + sidebar share it);
-    // the v1 read split deliberately doesn't reach for it.
     expect(listCoworkersSpy).toHaveBeenCalledTimes(1);
-    document.body.removeChild(page);
+    page.remove();
   });
 
-  it('audit timeline call routes to the v1 client', async () => {
-    const rule = makeRule();
-    listSafetyRulesSpy.mockResolvedValue([rule]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-
-    // @ts-expect-error — invoking private method directly to pin
-    //                    the routing without spinning up a click.
-    await page.openDetail(rule);
-
-    expect(listSafetyRuleAuditSpy).toHaveBeenCalledTimes(1);
-    expect(listSafetyRuleAuditSpy).toHaveBeenCalledWith('r1');
-    document.body.removeChild(page);
+  it('shows the rich empty state when there are no rules', async () => {
+    const page = await mount([]);
+    expect(page.querySelector('[data-testid="saf-empty"]')).not.toBeNull();
+    page.remove();
   });
 
-  it('toggleEnabled write goes through admin updateRule, NOT v1', async () => {
-    const rule = makeRule({ enabled: true });
-    listSafetyRulesSpy.mockResolvedValue([rule]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-
-    // @ts-expect-error — exercise the write handler directly.
-    await page.toggleEnabled(rule);
-
-    expect(updateRuleSpy).toHaveBeenCalledTimes(1);
-    expect(updateRuleSpy).toHaveBeenCalledWith('r1', { enabled: false });
-    // Critically: no v1-write call exists. If a refactor wires a
-    // write to the v1 client, this assertion would still pass —
-    // but the runtime would 404. The negative side is structural
-    // (no v1 write method on ApiClient).
-    document.body.removeChild(page);
+  it('renders the human label, sentence, and action pill on a card', async () => {
+    const page = await mount([makeRule()]);
+    const row = page.querySelector('[data-testid="saf-row"]')!;
+    expect(row.querySelector('.rm-mn b')?.textContent).toContain('Personal data (regex)');
+    expect(row.querySelector('[data-testid="saf-sentence"]')?.textContent).toContain(
+      'Before tool calls',
+    );
+    // pii.regex natural action is block — the pill reflects the effective action.
+    expect(row.querySelector('[data-testid="saf-action-pill"]')?.textContent?.trim()).toBe(
+      'block',
+    );
+    page.remove();
   });
 
-  it('delete uses admin deleteRule', async () => {
-    const rule = makeRule();
-    listSafetyRulesSpy.mockResolvedValue([rule]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
+  it('shows the scope chip only for a coworker-scoped rule', async () => {
+    const page = await mount([
+      makeRule({ id: 'org-wide', coworker_id: null }),
+      makeRule({ id: 'scoped', coworker_id: 'ops' }),
+    ]);
+    const rows = page.querySelectorAll('[data-testid="saf-row"]');
+    const byId = (id: string) =>
+      [...rows].find((r) => r.getAttribute('data-rule-id') === id)!;
+    expect(byId('org-wide').querySelector('.rm-saf-scope')).toBeNull();
+    expect(byId('scoped').querySelector('.rm-saf-scope')?.textContent).toContain(
+      'Ops coworker',
+    );
+    page.remove();
+  });
 
-    // happy-dom does not implement window.confirm — assign a stub.
-    window.confirm = () => true;
+  describe('two-tier platform / organization split (§6.2)', () => {
+    it('renders the platform banner only when a platform rule exists', async () => {
+      const orgOnly = await mount([makeRule()]);
+      expect(orgOnly.querySelector('[data-testid="saf-platform-banner"]')).toBeNull();
+      orgOnly.remove();
 
-    // @ts-expect-error — exercise the write handler directly.
-    await page.removeRule(rule);
+      const withPlatform = await mount([
+        makeRule({ id: 'plt', source: 'platform', tier: 'floor', editable: false }),
+      ]);
+      expect(
+        withPlatform.querySelector('[data-testid="saf-platform-banner"]'),
+      ).not.toBeNull();
+      withPlatform.remove();
+    });
 
-    expect(deleteRuleSpy).toHaveBeenCalledTimes(1);
-    expect(deleteRuleSpy).toHaveBeenCalledWith('r1');
-    document.body.removeChild(page);
+    it('platform rows expose audit only — no edit / duplicate / delete', async () => {
+      const page = await mount([
+        makeRule({ id: 'plt', source: 'platform', tier: 'floor', editable: false }),
+      ]);
+      const card = page.querySelector('[data-rule-id="plt"]')!;
+      expect(card.querySelector('[data-testid="saf-audit"]')).not.toBeNull();
+      expect(card.querySelector('[data-testid="saf-edit"]')).toBeNull();
+      expect(card.querySelector('[data-testid="saf-duplicate"]')).toBeNull();
+      expect(card.querySelector('[data-testid="saf-delete"]')).toBeNull();
+      page.remove();
+    });
+
+    it('platform toggle is inert (a span, not a clickable button)', async () => {
+      const page = await mount([
+        makeRule({ id: 'plt', source: 'platform', tier: 'floor', editable: false }),
+      ]);
+      const toggle = page
+        .querySelector('[data-rule-id="plt"]')!
+        .querySelector('[data-testid="saf-toggle"]')!;
+      expect(toggle.tagName).toBe('SPAN');
+      // org rows render a <button> toggle instead:
+      page.remove();
+      const orgPage = await mount([makeRule({ id: 'org' })]);
+      const orgToggle = orgPage
+        .querySelector('[data-rule-id="org"]')!
+        .querySelector('[data-testid="saf-toggle"]')!;
+      expect(orgToggle.tagName).toBe('BUTTON');
+      orgPage.remove();
+    });
+
+    it('does not toggle a platform rule even if toggleEnabled is called', async () => {
+      const page = await mount([
+        makeRule({ id: 'plt', source: 'platform', tier: 'floor', editable: false }),
+      ]);
+      // @ts-expect-error — exercise the guard directly
+      await page.toggleEnabled(page.rules[0]);
+      expect(updateRuleSpy).not.toHaveBeenCalled();
+      page.remove();
+    });
+  });
+
+  it('toggle on an org rule PATCHes via the admin client (optimistic)', async () => {
+    const page = await mount([makeRule({ id: 'org', enabled: true })]);
+    const toggle = page
+      .querySelector('[data-rule-id="org"]')!
+      .querySelector('[data-testid="saf-toggle"]') as HTMLButtonElement;
+    toggle.click();
+    await page.updateComplete;
+    expect(updateRuleSpy).toHaveBeenCalledWith('org', { enabled: false });
+    page.remove();
+  });
+
+  it('delete confirm DELETEs via the admin client', async () => {
+    const page = await mount([makeRule({ id: 'org' })]);
+    (
+      page
+        .querySelector('[data-rule-id="org"]')!
+        .querySelector('[data-testid="saf-delete"]') as HTMLButtonElement
+    ).click();
+    await page.updateComplete;
+    const confirm = page.querySelector('rm-confirm-dialog')!;
+    confirm.dispatchEvent(new CustomEvent('confirm'));
+    await page.updateComplete;
+    await Promise.resolve();
+    expect(deleteRuleSpy).toHaveBeenCalledWith('org');
+    page.remove();
+  });
+
+  it('audit drawer reads the timeline from the v1 client', async () => {
+    listSafetyRuleAuditSpy.mockResolvedValue([
+      {
+        id: 'a1',
+        rule_id: 'org',
+        tenant_id: 't1',
+        actor_user_id: 'u1',
+        action: 'created',
+        before_state: null,
+        after_state: { check_id: 'pii.regex', stage: 'pre_tool_call' },
+        note: null,
+        created_at: '2026-05-21T00:00:00Z',
+      } as SafetyRuleAuditEntry,
+    ]);
+    const page = await mount([makeRule({ id: 'org' })]);
+    (
+      page
+        .querySelector('[data-rule-id="org"]')!
+        .querySelector('[data-testid="saf-audit"]') as HTMLButtonElement
+    ).click();
+    await page.updateComplete;
+    await Promise.resolve();
+    await page.updateComplete;
+    expect(listSafetyRuleAuditSpy).toHaveBeenCalledWith('org');
+    page.remove();
   });
 });
 
-// ---------------------------------------------------------------------------
-// Action matrix panel — server-driven default badge + override picker.
-// ---------------------------------------------------------------------------
+describe('auditSummary', () => {
+  const base = (a: Partial<SafetyRuleAuditEntry>): SafetyRuleAuditEntry =>
+    ({
+      id: 'x',
+      rule_id: 'r',
+      tenant_id: 't',
+      actor_user_id: null,
+      before_state: null,
+      after_state: null,
+      note: null,
+      created_at: '2026-05-21T00:00:00Z',
+      action: 'updated',
+      ...a,
+    }) as SafetyRuleAuditEntry;
 
-function makeCheck(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 'pii.regex',
-    version: '1',
-    stages: ['input_prompt', 'model_output'],
-    cost_class: 'cheap' as const,
-    supported_codes: [],
-    config_schema: null,
-    action_model: 'fixed' as const,
-    natural_actions: { input_prompt: 'block', model_output: 'block' },
-    supported_actions: {
-      // pii.regex @ input_prompt cannot redact (no modified_payload) and
-      // require_approval is valid; @ model_output drops warn.
-      input_prompt: ['allow', 'block', 'require_approval', 'warn'],
-      model_output: ['allow', 'block', 'require_approval'],
-    },
-    ...overrides,
-  };
-}
-
-async function openDraftFor(
-  page: SafetyRulesPage,
-  check_id: string,
-  stage: string,
-): Promise<void> {
-  // Drive the private draft state directly — the panel renders from
-  // (check_id, stage); we don't need to click through the selects.
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  (page as any).draftMode = 'create';
-  (page as any).draft = {
-    stage,
-    check_id,
-    coworker_id: null,
-    config: '{}',
-    priority: 100,
-    enabled: true,
-    description: '',
-  };
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-  page.requestUpdate();
-  await page.updateComplete;
-}
-
-describe('SafetyRulesPage action panel', () => {
-  beforeEach(() => {
-    listSafetyRulesSpy.mockResolvedValue([]);
-    listSafetyRuleAuditSpy.mockResolvedValue([]);
-    createRuleSpy.mockResolvedValue(makeRule());
-    updateRuleSpy.mockResolvedValue(makeRule());
-    deleteRuleSpy.mockResolvedValue(undefined);
-    listCoworkersSpy.mockResolvedValue([]);
+  it('summarizes a create with the check label', () => {
+    const s = auditSummary(base({ action: 'created', after_state: { check_id: 'pii.regex', stage: 'pre_tool_call' } }));
+    expect(s).toContain('Created');
+    expect(s).toContain('Personal data (regex)');
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
+  it('diffs a priority change with friendly arrows', () => {
+    const s = auditSummary(
+      base({ before_state: { priority: 50 }, after_state: { priority: 100 } }),
+    );
+    expect(s).toBe('priority: 50 → 100');
   });
 
-  it('shows the fixed-default badge and greys out unsupported actions', async () => {
-    listSafetyChecksSpy.mockResolvedValue([makeCheck()]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-    await openDraftFor(page, 'pii.regex', 'input_prompt');
-
-    const badge = page.querySelector('[data-testid="action-badge"]');
-    expect(badge?.textContent).toContain('This check defaults to');
-    expect(badge?.textContent?.toLowerCase()).toContain('block');
-
-    const select = page.querySelector(
-      '[data-testid="action-override-select"]',
-    ) as HTMLSelectElement | null;
-    expect(select).not.toBeNull();
-    const opt = (v: string) =>
-      Array.from(select!.options).find((o) => o.value === v)!;
-    // redact is NOT in supported_actions -> disabled with a reason.
-    expect(opt('redact').disabled).toBe(true);
-    expect(opt('redact').title).toContain('rewrite the payload');
-    // block / require_approval ARE supported -> selectable.
-    expect(opt('block').disabled).toBe(false);
-    expect(opt('require_approval').disabled).toBe(false);
-    document.body.removeChild(page);
+  it('renders enabled changes as on/off, not true/false', () => {
+    const s = auditSummary(
+      base({ before_state: { enabled: false }, after_state: { enabled: true } }),
+    );
+    expect(s).toBe('enabled: off → on');
   });
 
-  it('config_routed checks show "no fixed default" wording', async () => {
-    listSafetyChecksSpy.mockResolvedValue([
-      makeCheck({
-        id: 'presidio.pii',
-        action_model: 'config_routed',
-        stages: ['input_prompt'],
-        natural_actions: { input_prompt: 'allow' },
-        supported_actions: {
-          input_prompt: ['allow', 'block', 'redact', 'warn', 'require_approval'],
-        },
+  it('surfaces an action_override change buried in config', () => {
+    const s = auditSummary(
+      base({
+        before_state: { config: {} },
+        after_state: { config: { action_override: 'warn' } },
       }),
-    ]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-    await openDraftFor(page, 'presidio.pii', 'input_prompt');
-
-    const badge = page.querySelector('[data-testid="action-badge"]');
-    expect(badge?.textContent).toContain('No fixed default');
-    // redact IS supported for presidio -> selectable.
-    const select = page.querySelector(
-      '[data-testid="action-override-select"]',
-    ) as HTMLSelectElement;
-    const redact = Array.from(select.options).find((o) => o.value === 'redact')!;
-    expect(redact.disabled).toBe(false);
-    document.body.removeChild(page);
-  });
-
-  it('aggregated checks explain the voting/aggregation semantics', async () => {
-    listSafetyChecksSpy.mockResolvedValue([
-      makeCheck({
-        id: 'egress.domain_rule',
-        action_model: 'aggregated',
-        stages: ['egress_request'],
-        natural_actions: { egress_request: 'allow' },
-        supported_actions: { egress_request: ['allow', 'block'] },
-      }),
-    ]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-    await openDraftFor(page, 'egress.domain_rule', 'egress_request');
-
-    const badge = page.querySelector('[data-testid="action-badge"]');
-    expect(badge?.textContent?.toLowerCase()).toContain('aggregation');
-    document.body.removeChild(page);
-  });
-
-  it('picking an override writes action_override into the config JSON', async () => {
-    listSafetyChecksSpy.mockResolvedValue([makeCheck()]);
-    const page = new SafetyRulesPage();
-    document.body.appendChild(page);
-    await waitUntilLoaded(page);
-    await openDraftFor(page, 'pii.regex', 'input_prompt');
-
-    const select = page.querySelector(
-      '[data-testid="action-override-select"]',
-    ) as HTMLSelectElement;
-    select.value = 'warn';
-    select.dispatchEvent(new Event('change'));
-    await page.updateComplete;
-
-    // @ts-expect-error — read private draft state for the assertion.
-    const cfg = JSON.parse(page.draft.config);
-    expect(cfg.action_override).toBe('warn');
-    document.body.removeChild(page);
+    );
+    expect(s).toContain('action: default → warn');
   });
 });

--- a/web/src/components/safety-rules-page.ts
+++ b/web/src/components/safety-rules-page.ts
@@ -1,61 +1,93 @@
-import { LitElement, html, nothing } from 'lit';
+// Safety rules page (#/manage/safety) — spec §6.
+//
+// Lists the organization's safety rules in two tiers (spec §6.2): platform
+// defaults (PR #49 — cross-tenant, read-only, audit-only) on top, then the
+// organization's own rules. Each row reuses the approval-policy card chrome
+// (priority badge / sentence / always-visible toggle / hover actions) plus
+// safety-specific chips (slow / scope / action pill). Create/edit/duplicate
+// go through <rm-safety-rule-dialog>; delete through <rm-confirm-dialog>; a
+// per-rule change history opens in an audit drawer.
+//
+// Reads go through the typed v1 ApiClient. Writes (toggle / delete) stay on
+// safety-admin-client because safety-rule mutation is admin-privileged
+// (design §3 Phase 4); this file is on the lint:no-admin-chat allowlist.
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import {
-  getApiClient,
-  type SafetyCheck,
-  type SafetyRule,
-  type SafetyRuleAuditEntry,
-  type SafetyStage,
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+import { getApiClient } from '../api/client.js';
+import type {
+  SafetyCheck,
+  SafetyRule,
+  SafetyRuleAuditEntry,
 } from '../api/client.js';
 import {
-  createRule,
   deleteRule,
   listCoworkers,
   updateRule,
   type CoworkerSummary,
 } from '../services/safety-admin-client.js';
+import './dialog.js';
+import './confirm-dialog.js';
+import './safety-rule-dialog.js';
+import { iconCopy, iconPencil, iconTrash } from './icons.js';
+import {
+  checkLabel,
+  effectiveAction,
+  safActionPillClass,
+  safSentence,
+} from './safety-catalog.js';
 
-type DraftRule = {
-  stage: SafetyStage | '';
-  check_id: string;
-  coworker_id: string | null;
-  config: string; // JSON string being edited
-  priority: number;
-  enabled: boolean;
-  description: string;
-};
+/** Priority badge tint — mirrors approval policies (≥10 amber, 0 muted). */
+export function priorityBadgeClass(priority: number): string {
+  if (priority >= 10) return 'rm-pol-pri--hi';
+  if (priority === 0) return 'rm-pol-pri--zero';
+  return '';
+}
 
-const EMPTY_DRAFT: DraftRule = {
-  stage: '',
-  check_id: '',
-  coworker_id: null,
-  config: '{}',
-  priority: 100,
-  enabled: true,
-  description: '',
-};
+/** Sort within a tier: priority desc, then newest first on ties (§6.6). */
+export function sortRules(rows: SafetyRule[]): SafetyRule[] {
+  return [...rows].sort(
+    (a, b) =>
+      b.priority - a.priority ||
+      Date.parse(b.created_at) - Date.parse(a.created_at),
+  );
+}
 
-// Full action set, in the order the picker lists them. Whether each is
-// offered for a given (check, stage) comes from the check's
-// server-driven ``supported_actions`` — we never hardcode that here.
-const ALL_ACTIONS = [
-  'block',
-  'redact',
-  'warn',
-  'allow',
-  'require_approval',
-] as const;
+/** Human one-line summary of an audit entry (§6.9). The wire ships
+ *  before_state / after_state snapshots (no server summary), so we diff the
+ *  fields an operator cares about. Kept deliberately small + deterministic. */
+export function auditSummary(entry: SafetyRuleAuditEntry): string {
+  if (entry.action === 'created') {
+    const a = entry.after_state ?? {};
+    const check = checkLabel(String(a['check_id'] ?? ''));
+    return `Created — ${check}${a['stage'] ? `, ${String(a['stage'])}` : ''}`;
+  }
+  if (entry.action === 'deleted') return 'Deleted';
+  const before = entry.before_state ?? {};
+  const after = entry.after_state ?? {};
+  const fields = ['priority', 'enabled', 'stage'];
+  const parts: string[] = [];
+  for (const f of fields) {
+    if (JSON.stringify(before[f]) !== JSON.stringify(after[f])) {
+      parts.push(`${f}: ${fmtVal(before[f])} → ${fmtVal(after[f])}`);
+    }
+  }
+  // action_override lives inside config; surface it specifically.
+  const bOv = (before['config'] as Record<string, unknown> | undefined)?.['action_override'];
+  const aOv = (after['config'] as Record<string, unknown> | undefined)?.['action_override'];
+  if (JSON.stringify(bOv) !== JSON.stringify(aOv)) {
+    parts.push(`action: ${fmtVal(bOv ?? 'default')} → ${fmtVal(aOv ?? 'default')}`);
+  }
+  return parts.length ? parts.join('; ') : 'Configuration updated';
+}
 
-// Why an action is unavailable for a (check, stage), shown as a tooltip
-// on the greyed-out picker option. The server is the source of truth for
-// WHICH are unavailable; these strings only explain the common reasons.
-const UNSUPPORTED_REASON: Record<string, string> = {
-  redact: 'this check cannot rewrite the payload',
-  warn: 'nothing consumes warning context at this stage',
-  require_approval: 'no approval step exists at this stage',
-  block: 'not meaningful for this check at this stage',
-  allow: 'not meaningful for this check at this stage',
-};
+function fmtVal(v: unknown): string {
+  if (v === true) return 'on';
+  if (v === false) return 'off';
+  return String(v);
+}
 
 @customElement('rm-safety-rules-page')
 export class SafetyRulesPage extends LitElement {
@@ -63,13 +95,26 @@ export class SafetyRulesPage extends LitElement {
   @state() private checks: SafetyCheck[] = [];
   @state() private coworkers: CoworkerSummary[] = [];
   @state() private loading = true;
-  @state() private error: string | null = null;
-  @state() private editingId: string | null = null;
-  @state() private draft: DraftRule = { ...EMPTY_DRAFT };
-  @state() private draftMode: 'closed' | 'create' | 'edit' = 'closed';
-  @state() private busy = false;
-  @state() private detailRuleId: string | null = null;
-  @state() private detailAudit: SafetyRuleAuditEntry[] = [];
+  @state() private listError: string | null = null;
+
+  @state() private dialogOpen = false;
+  @state() private editTarget: SafetyRule | null = null;
+  @state() private duplicateSource: SafetyRule | null = null;
+
+  @state() private deleteTarget: SafetyRule | null = null;
+  @state() private deleteInFlight = false;
+
+  @state() private auditTarget: SafetyRule | null = null;
+  @state() private auditEntries: SafetyRuleAuditEntry[] = [];
+  @state() private auditLoading = false;
+
+  @state() private togglingIds: Set<string> = new Set();
+  @state() private toast: string | null = null;
+  @state() private highlightId: string | null = null;
+
+  private readonly api = getApiClient();
+  private toastTimer: number | null = null;
+  private highlightTimer: number | null = null;
 
   protected override createRenderRoot() {
     return this;
@@ -80,32 +125,37 @@ export class SafetyRulesPage extends LitElement {
     void this.refresh();
   }
 
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    if (this.highlightTimer) clearTimeout(this.highlightTimer);
+  }
+
   private async refresh(): Promise<void> {
     this.loading = true;
-    this.error = null;
+    this.listError = null;
     try {
-      // Reads go through the typed v1 ApiClient; writes (create /
-      // update / delete) keep using safety-admin-client because
-      // safety rule mutation is an admin-only operation per design
-      // §3 Phase 4.
-      const api = getApiClient();
       const [rules, checks, coworkers] = await Promise.all([
-        api.listSafetyRules(),
-        api.listSafetyChecks(),
+        this.api.listSafetyRules(),
+        this.api.listSafetyChecks(),
         listCoworkers(),
       ]);
       this.rules = rules;
       this.checks = checks;
       this.coworkers = coworkers;
     } catch (err) {
-      this.error = err instanceof Error ? err.message : String(err);
+      this.listError = this.errMessage(err);
     } finally {
       this.loading = false;
     }
   }
 
-  private coworkerName(id: string | null): string {
-    if (!id) return '(tenant-wide)';
+  private errMessage(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  private coworkerName(id: string | null | undefined): string | null {
+    if (!id) return null;
     const cw = this.coworkers.find((c) => c.id === id);
     return cw ? cw.name : id.slice(0, 8);
   }
@@ -114,551 +164,491 @@ export class SafetyRulesPage extends LitElement {
     return this.checks.find((c) => c.id === id) ?? null;
   }
 
-  // -- Action matrix helpers (server-driven; see SafetyCheck Protocol) --
+  private isPlatform(r: SafetyRule): boolean {
+    return r.source === 'platform';
+  }
 
-  // True only when the config textarea holds a JSON object — the
-  // override picker writes into it, so we refuse to touch un-parseable
-  // JSON rather than clobber the operator's in-progress edit.
-  private configIsObject(): boolean {
+  // ---- dialog flows ----
+
+  private openCreate = (): void => {
+    this.editTarget = null;
+    this.duplicateSource = null;
+    this.dialogOpen = true;
+  };
+
+  private openEdit(r: SafetyRule): void {
+    if (this.isPlatform(r)) return;
+    this.editTarget = r;
+    this.duplicateSource = null;
+    this.dialogOpen = true;
+  }
+
+  private openDuplicate(r: SafetyRule): void {
+    this.editTarget = null;
+    this.duplicateSource = r;
+    this.dialogOpen = true;
+  }
+
+  private closeDialog = (): void => {
+    this.dialogOpen = false;
+    this.editTarget = null;
+    this.duplicateSource = null;
+  };
+
+  // Edit-dialog "duplicate this rule" link (§6.11.3 — the path to move scope).
+  private onDuplicateFromEdit = (e: CustomEvent<{ id: string }>): void => {
+    const src = this.rules.find((r) => r.id === e.detail.id) ?? null;
+    this.dialogOpen = false;
+    this.editTarget = null;
+    // Reopen as duplicate on the next frame so the dialog re-seeds cleanly.
+    void this.updateComplete.then(() => {
+      this.duplicateSource = src;
+      this.dialogOpen = true;
+    });
+  };
+
+  private async onSaved(id: string): Promise<void> {
+    await this.refresh();
+    this.pulse(id);
+  }
+
+  private pulse(id: string): void {
+    this.highlightId = id;
+    if (this.highlightTimer) clearTimeout(this.highlightTimer);
+    void this.updateComplete.then(() => {
+      this.querySelector(`[data-rule-id="${id}"]`)?.scrollIntoView({
+        block: 'center',
+        behavior: 'smooth',
+      });
+    });
+    this.highlightTimer = window.setTimeout(() => {
+      this.highlightId = null;
+    }, 1800);
+  }
+
+  // ---- toggle (optimistic) ----
+
+  private async toggleEnabled(r: SafetyRule): Promise<void> {
+    if (this.isPlatform(r) || this.togglingIds.has(r.id)) return;
+    const next = !r.enabled;
+    this.rules = this.rules.map((x) =>
+      x.id === r.id ? { ...x, enabled: next } : x,
+    );
+    this.togglingIds = new Set(this.togglingIds).add(r.id);
     try {
-      const o = JSON.parse(this.draft.config || '{}');
-      return typeof o === 'object' && o !== null && !Array.isArray(o);
+      await updateRule(r.id, { enabled: next });
     } catch {
-      return false;
-    }
-  }
-
-  private currentActionOverride(): string {
-    try {
-      const o = JSON.parse(this.draft.config || '{}');
-      const v = (o as Record<string, unknown>)?.action_override;
-      return typeof v === 'string' ? v : '';
-    } catch {
-      return '';
-    }
-  }
-
-  // Patch (or clear, when action === '') the ``action_override`` key in
-  // the draft config JSON, keeping the textarea authoritative.
-  private setActionOverride(action: string): void {
-    let obj: Record<string, unknown> = {};
-    try {
-      const parsed = JSON.parse(this.draft.config || '{}');
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        obj = parsed as Record<string, unknown>;
-      }
-    } catch {
-      obj = {};
-    }
-    if (action === '') delete obj['action_override'];
-    else obj['action_override'] = action;
-    this.draft = { ...this.draft, config: JSON.stringify(obj, null, 2) };
-  }
-
-  // The action a hit defaults to for the selected stage, or null when
-  // the stage is not declared by the check.
-  private naturalAction(meta: SafetyCheck, stage: SafetyStage): string | null {
-    const na = meta.natural_actions as
-      | Record<string, string | undefined>
-      | undefined;
-    return na?.[stage] ?? null;
-  }
-
-  private supportedActions(meta: SafetyCheck, stage: SafetyStage): string[] {
-    const sa = meta.supported_actions as
-      | Record<string, string[] | undefined>
-      | undefined;
-    return sa?.[stage] ?? [];
-  }
-
-  private openCreate(): void {
-    this.draft = { ...EMPTY_DRAFT };
-    this.draftMode = 'create';
-    this.editingId = null;
-  }
-
-  private openEdit(rule: SafetyRule): void {
-    this.draft = {
-      stage: rule.stage,
-      check_id: rule.check_id,
-      // v1 SafetyRule.coworker_id is `string | null | undefined`
-      // (codegen surfaces "optional + nullable" as both). Collapse
-      // to a strict `string | null` for the draft state so the
-      // <select> never receives `undefined` (DOM coerces to "").
-      coworker_id: rule.coworker_id ?? null,
-      config: JSON.stringify(rule.config ?? {}, null, 2),
-      priority: rule.priority,
-      enabled: rule.enabled,
-      description: rule.description,
-    };
-    this.draftMode = 'edit';
-    this.editingId = rule.id;
-  }
-
-  private closeDraft(): void {
-    this.draftMode = 'closed';
-    this.editingId = null;
-    this.error = null;
-  }
-
-  private async submitDraft(): Promise<void> {
-    this.busy = true;
-    this.error = null;
-    try {
-      let config: Record<string, unknown>;
-      try {
-        config = JSON.parse(this.draft.config || '{}');
-      } catch (err) {
-        throw new Error(
-          `config must be valid JSON: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-      if (!this.draft.stage) throw new Error('stage is required');
-      if (!this.draft.check_id) throw new Error('check_id is required');
-
-      if (this.draftMode === 'create') {
-        await createRule({
-          stage: this.draft.stage,
-          check_id: this.draft.check_id,
-          coworker_id: this.draft.coworker_id,
-          config,
-          priority: this.draft.priority,
-          enabled: this.draft.enabled,
-          description: this.draft.description,
-        });
-      } else if (this.draftMode === 'edit' && this.editingId) {
-        await updateRule(this.editingId, {
-          stage: this.draft.stage,
-          check_id: this.draft.check_id,
-          config,
-          priority: this.draft.priority,
-          enabled: this.draft.enabled,
-          description: this.draft.description,
-        });
-      }
-      this.closeDraft();
-      await this.refresh();
-    } catch (err) {
-      this.error = err instanceof Error ? err.message : String(err);
+      this.rules = this.rules.map((x) =>
+        x.id === r.id ? { ...x, enabled: r.enabled } : x,
+      );
+      this.showToast('Couldn’t update — try again');
     } finally {
-      this.busy = false;
+      const ids = new Set(this.togglingIds);
+      ids.delete(r.id);
+      this.togglingIds = ids;
     }
   }
 
-  private async toggleEnabled(rule: SafetyRule): Promise<void> {
-    this.busy = true;
-    this.error = null;
+  // ---- delete ----
+
+  private askDelete(r: SafetyRule): void {
+    if (this.isPlatform(r)) return;
+    this.deleteTarget = r;
+  }
+
+  private cancelDelete = (): void => {
+    if (this.deleteInFlight) return;
+    this.deleteTarget = null;
+  };
+
+  private async performDelete(): Promise<void> {
+    const r = this.deleteTarget;
+    if (!r || this.deleteInFlight) return;
+    this.deleteInFlight = true;
     try {
-      await updateRule(rule.id, { enabled: !rule.enabled });
-      await this.refresh();
+      await deleteRule(r.id);
+      this.rules = this.rules.filter((x) => x.id !== r.id);
+      this.deleteTarget = null;
     } catch (err) {
-      this.error = err instanceof Error ? err.message : String(err);
+      this.deleteTarget = null;
+      this.showToast(this.errMessage(err));
     } finally {
-      this.busy = false;
+      this.deleteInFlight = false;
     }
   }
 
-  private async removeRule(rule: SafetyRule): Promise<void> {
-    if (!confirm(`Delete rule for ${rule.check_id} at ${rule.stage}?`)) return;
-    this.busy = true;
-    this.error = null;
+  // ---- audit drawer ----
+
+  private async openAudit(r: SafetyRule): Promise<void> {
+    this.auditTarget = r;
+    this.auditEntries = [];
+    this.auditLoading = true;
     try {
-      await deleteRule(rule.id);
-      await this.refresh();
+      const entries = await this.api.listSafetyRuleAudit(r.id);
+      // Reverse-chronological (§6.9).
+      this.auditEntries = [...entries].sort(
+        (a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),
+      );
     } catch (err) {
-      this.error = err instanceof Error ? err.message : String(err);
+      this.showToast(this.errMessage(err));
     } finally {
-      this.busy = false;
+      this.auditLoading = false;
     }
   }
 
-  private async openDetail(rule: SafetyRule): Promise<void> {
-    this.detailRuleId = rule.id;
-    this.detailAudit = [];
-    try {
-      // tenant_id flows from the bearer token server-side (v1
-      // surface) — no admin /tenant round-trip needed.
-      this.detailAudit = await getApiClient().listSafetyRuleAudit(rule.id);
-    } catch (err) {
-      this.error = err instanceof Error ? err.message : String(err);
-    }
+  private closeAudit = (): void => {
+    this.auditTarget = null;
+    this.auditEntries = [];
+  };
+
+  // ---- toast ----
+
+  private showToast(msg: string): void {
+    this.toast = msg;
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    this.toastTimer = window.setTimeout(() => {
+      this.toast = null;
+    }, 3200);
   }
 
-  private closeDetail(): void {
-    this.detailRuleId = null;
-    this.detailAudit = [];
-  }
+  // ---- render ----
 
-  // Server-driven action panel: a "defaults to" badge whose wording
-  // depends on action_model, plus an override picker that greys out
-  // actions the check cannot carry out for the selected stage.
-  private renderActionPanel(meta: SafetyCheck | null) {
-    const stage = this.draft.stage;
-    if (!meta || !stage || !meta.stages.includes(stage as SafetyStage)) {
-      return nothing;
-    }
-    const st = stage as SafetyStage;
-    const natural = this.naturalAction(meta, st);
-    const supported = this.supportedActions(meta, st);
-    const model = meta.action_model;
-
-    const badge =
-      model === 'fixed'
-        ? html`This check defaults to:
-            <span class="font-mono font-semibold uppercase"
-              >${natural ?? 'allow'}</span
-            >`
-        : model === 'config_routed'
-          ? html`No fixed default — the action is chosen per-category in
-              the config below; the check is inert until configured.`
-          : html`This check votes
-              <span class="font-mono">allow</span> on a match; the gateway
-              blocks when no rule allows (effective action decided by
-              aggregation).`;
-
-    const override = this.currentActionOverride();
-    const canEdit = this.configIsObject();
-
+  override render(): TemplateResult {
+    const sorted = sortRules(this.rules);
+    const platform = sorted.filter((r) => this.isPlatform(r));
+    const org = sorted.filter((r) => !this.isPlatform(r));
     return html`
-      <div
-        class="col-span-2 text-xs border rounded p-2 bg-surface-2 dark:bg-d-surface-2"
-        data-testid="action-panel"
-      >
-        <div class="mb-2" data-testid="action-badge">${badge}</div>
-        <label class="flex flex-col gap-1">
-          <span class="text-gray-500"
-            >Action override${canEdit
-              ? nothing
-              : html` <span class="text-amber-600"
-                  >(fix config JSON to edit)</span
-                >`}</span
-          >
-          <select
-            class="border rounded px-2 py-1 bg-transparent"
-            data-testid="action-override-select"
-            ?disabled=${!canEdit}
-            .value=${override}
-            @change=${(e: Event) =>
-              this.setActionOverride((e.target as HTMLSelectElement).value)}
-          >
-            <option value="">
-              (use default${natural ? `: ${natural}` : ''})
-            </option>
-            ${ALL_ACTIONS.map((a) => {
-              const ok = supported.includes(a);
-              return html`<option
-                value=${a}
-                ?disabled=${!ok}
-                title=${ok ? '' : (UNSUPPORTED_REASON[a] ?? '')}
-              >
-                ${a}${ok ? '' : ' — unavailable'}
-              </option>`;
-            })}
-          </select>
-        </label>
-      </div>
-    `;
-  }
-
-  private renderDraftForm() {
-    if (this.draftMode === 'closed') return nothing;
-    const meta = this.checkMeta(this.draft.check_id);
-    const supportedStages = meta?.stages ?? [];
-    return html`
-      <div class="border rounded-md p-4 mb-4 bg-surface-1 dark:bg-d-surface-1">
-        <h3 class="font-semibold mb-3">
-          ${this.draftMode === 'create' ? 'New rule' : 'Edit rule'}
-        </h3>
-        <div class="grid grid-cols-2 gap-3">
-          <label class="flex flex-col text-sm">
-            Check
-            <select
-              class="mt-1 border rounded px-2 py-1 bg-transparent"
-              .value=${this.draft.check_id}
-              @change=${(e: Event) => {
-                this.draft = {
-                  ...this.draft,
-                  check_id: (e.target as HTMLSelectElement).value,
-                };
-              }}
-            >
-              <option value="">(select)</option>
-              ${this.checks.map(
-                (c) => html`<option value=${c.id}>${c.id} (${c.cost_class})</option>`,
-              )}
-            </select>
-          </label>
-          <label class="flex flex-col text-sm">
-            Stage
-            <select
-              class="mt-1 border rounded px-2 py-1 bg-transparent"
-              .value=${this.draft.stage}
-              @change=${(e: Event) => {
-                this.draft = {
-                  ...this.draft,
-                  stage: (e.target as HTMLSelectElement).value as SafetyStage,
-                };
-              }}
-            >
-              <option value="">(select)</option>
-              ${supportedStages.map((s) => html`<option value=${s}>${s}</option>`)}
-              ${supportedStages.length === 0
-                ? ['input_prompt', 'pre_tool_call', 'post_tool_result', 'model_output'].map(
-                    (s) => html`<option value=${s}>${s}</option>`,
-                  )
-                : nothing}
-            </select>
-          </label>
-          ${this.renderActionPanel(meta)}
-          <label class="flex flex-col text-sm">
-            Coworker
-            <select
-              class="mt-1 border rounded px-2 py-1 bg-transparent"
-              .value=${this.draft.coworker_id ?? ''}
-              @change=${(e: Event) => {
-                const v = (e.target as HTMLSelectElement).value;
-                this.draft = {
-                  ...this.draft,
-                  coworker_id: v === '' ? null : v,
-                };
-              }}
-              ?disabled=${this.draftMode === 'edit'}
-            >
-              <option value="">(tenant-wide)</option>
-              ${this.coworkers.map(
-                (c) => html`<option value=${c.id}>${c.name}</option>`,
-              )}
-            </select>
-          </label>
-          <label class="flex flex-col text-sm">
-            Priority
-            <input
-              type="number"
-              class="mt-1 border rounded px-2 py-1 bg-transparent"
-              .value=${String(this.draft.priority)}
-              @change=${(e: Event) => {
-                const v = Number((e.target as HTMLInputElement).value);
-                this.draft = { ...this.draft, priority: Number.isFinite(v) ? v : 100 };
-              }}
-            />
-          </label>
-          <label class="flex items-center gap-2 text-sm col-span-2">
-            <input
-              type="checkbox"
-              ?checked=${this.draft.enabled}
-              @change=${(e: Event) => {
-                this.draft = {
-                  ...this.draft,
-                  enabled: (e.target as HTMLInputElement).checked,
-                };
-              }}
-            />
-            enabled
-          </label>
-          <label class="flex flex-col text-sm col-span-2">
-            Description
-            <input
-              type="text"
-              class="mt-1 border rounded px-2 py-1 bg-transparent"
-              .value=${this.draft.description}
-              @input=${(e: Event) => {
-                this.draft = {
-                  ...this.draft,
-                  description: (e.target as HTMLInputElement).value,
-                };
-              }}
-            />
-          </label>
-          <label class="flex flex-col text-sm col-span-2">
-            Config (JSON)
-            <textarea
-              class="mt-1 border rounded px-2 py-1 bg-transparent font-mono text-xs"
-              rows="6"
-              .value=${this.draft.config}
-              @input=${(e: Event) => {
-                this.draft = {
-                  ...this.draft,
-                  config: (e.target as HTMLTextAreaElement).value,
-                };
-              }}
-            ></textarea>
-            ${meta?.config_schema
-              ? html`<details class="text-xs text-gray-500 mt-1">
-                  <summary>schema</summary>
-                  <pre class="overflow-x-auto">${JSON.stringify(meta.config_schema, null, 2)}</pre>
-                </details>`
-              : nothing}
-          </label>
-        </div>
-        ${this.error
-          ? html`<div class="text-red-500 text-sm mt-2">${this.error}</div>`
-          : nothing}
-        <div class="flex justify-end gap-2 mt-3">
-          <button
-            class="px-3 py-1 border rounded text-sm"
-            ?disabled=${this.busy}
-            @click=${this.closeDraft}
-          >
-            Cancel
-          </button>
-          <button
-            class="px-3 py-1 bg-blue-600 text-white rounded text-sm"
-            ?disabled=${this.busy}
-            @click=${this.submitDraft}
-          >
-            ${this.busy ? 'Saving…' : 'Save'}
+      <div class="rm-spane">
+        <div class="rm-ch">
+          <h2>Safety rules</h2>
+          <button type="button" class="rm-add" @click=${this.openCreate}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            New rule
           </button>
         </div>
-      </div>
-    `;
-  }
-
-  private renderDetailModal() {
-    if (!this.detailRuleId) return nothing;
-    return html`
-      <div
-        class="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
-        @click=${this.closeDetail}
-      >
-        <div
-          class="bg-surface-0 dark:bg-d-surface-0 border rounded-md w-[720px] max-w-[95vw] max-h-[80vh] overflow-auto p-4"
-          @click=${(e: Event) => e.stopPropagation()}
-        >
-          <div class="flex justify-between items-center mb-3">
-            <h3 class="font-semibold">Rule audit — ${this.detailRuleId.slice(0, 8)}</h3>
-            <button class="text-sm px-2" @click=${this.closeDetail}>×</button>
-          </div>
-          ${this.detailAudit.length === 0
-            ? html`<div class="text-sm text-gray-500">No audit events.</div>`
-            : html`
-                <table class="w-full text-sm">
-                  <thead>
-                    <tr class="text-left border-b">
-                      <th class="py-1">When</th>
-                      <th>Action</th>
-                      <th>Actor</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${this.detailAudit.map(
-                      (e) => html`
-                        <tr class="border-b">
-                          <td class="py-1">
-                            ${new Date(e.created_at).toLocaleString()}
-                          </td>
-                          <td>${e.action}</td>
-                          <td>${e.actor_user_id ?? '(system)'}</td>
-                        </tr>
-                      `,
-                    )}
-                  </tbody>
-                </table>
-              `}
-        </div>
-      </div>
-    `;
-  }
-
-  override render() {
-    return html`
-      <div class="p-6 max-w-5xl mx-auto">
-        <a href="#" class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 dark:hover:text-gray-100 mb-3">
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>
-          Back to chat
-        </a>
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-xl font-semibold">Safety rules</h2>
-          <div class="flex gap-2">
-            <button
-              class="px-3 py-1 border rounded text-sm"
-              @click=${() => void this.refresh()}
-              ?disabled=${this.loading}
-            >
-              Refresh
-            </button>
-            <button
-              class="px-3 py-1 bg-blue-600 text-white rounded text-sm"
-              @click=${this.openCreate}
-            >
-              + New rule
-            </button>
-          </div>
-        </div>
-
-        ${this.renderDraftForm()}
+        <p class="rm-sub">
+          Automatic guardrails that scan for personal data, prompt injection,
+          secrets, or untrusted domains. Unlike approval policies these run with
+          no human in the loop — except when a rule's action is set to Approve,
+          which routes to the same approval inbox. See past triggers in the
+          <a href="#/manage/safety-log" class="rm-saf-link"
+            style="color: var(--rm-accent)">Safety log →</a>.
+        </p>
 
         ${this.loading
-          ? html`<div class="text-gray-500">Loading…</div>`
-          : this.error && this.draftMode === 'closed'
-            ? html`<div class="text-red-500">${this.error}</div>`
+          ? html`<div class="rm-banner-loading">Loading…</div>`
+          : this.listError
+            ? html`<div class="rm-banner-err">${this.listError}</div>`
             : this.rules.length === 0
-              ? html`<div class="text-gray-500">
-                  No safety rules configured. Click <strong>+ New rule</strong> to
-                  add one.
-                </div>`
+              ? this.renderEmpty()
               : html`
-                  <table class="w-full text-sm border">
-                    <thead class="bg-surface-1 dark:bg-d-surface-1">
-                      <tr class="text-left">
-                        <th class="p-2">Check</th>
-                        <th>Stage</th>
-                        <th>Scope</th>
-                        <th>Priority</th>
-                        <th>Enabled</th>
-                        <th></th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      ${this.rules.map(
-                        (r) => html`
-                          <tr class="border-t hover:bg-surface-1 dark:hover:bg-d-surface-1">
-                            <td class="p-2 font-mono text-xs">
-                              <div>${r.check_id}</div>
-                              ${r.description
-                                ? html`<div class="text-gray-500 font-sans">
-                                    ${r.description}
-                                  </div>`
-                                : nothing}
-                            </td>
-                            <td>${r.stage}</td>
-                            <td>${this.coworkerName(r.coworker_id ?? null)}</td>
-                            <td>${r.priority}</td>
-                            <td>
-                              <input
-                                type="checkbox"
-                                ?checked=${r.enabled}
-                                ?disabled=${this.busy}
-                                @change=${() => void this.toggleEnabled(r)}
-                              />
-                            </td>
-                            <td class="text-right whitespace-nowrap p-2">
-                              <button
-                                class="text-xs underline mr-2"
-                                @click=${() => void this.openDetail(r)}
-                              >
-                                audit
-                              </button>
-                              <button
-                                class="text-xs underline mr-2"
-                                @click=${() => this.openEdit(r)}
-                              >
-                                edit
-                              </button>
-                              <button
-                                class="text-xs underline text-red-500"
-                                @click=${() => void this.removeRule(r)}
-                              >
-                                delete
-                              </button>
-                            </td>
-                          </tr>
-                        `,
-                      )}
-                    </tbody>
-                  </table>
+                  ${platform.length ? this.renderPlatformBanner() : nothing}
+                  ${platform.map((r) => this.renderCard(r))}
+                  ${platform.length && org.length
+                    ? html`<div class="rm-saf-section-label">
+                        Your organization's rules
+                      </div>`
+                    : nothing}
+                  ${org.map((r) => this.renderCard(r))}
+                  ${this.renderHint()}
                 `}
-        ${this.renderDetailModal()}
+
+        <rm-safety-rule-dialog
+          ?open=${this.dialogOpen}
+          .editing=${this.editTarget}
+          .duplicating=${this.duplicateSource}
+          .checks=${this.checks}
+          .coworkers=${this.coworkers}
+          @close=${this.closeDialog}
+          @safety-rule-saved=${(e: CustomEvent<{ id: string }>) =>
+            void this.onSaved(e.detail.id)}
+          @safety-rule-duplicate-from-edit=${this.onDuplicateFromEdit}
+        ></rm-safety-rule-dialog>
+
+        ${this.renderDeleteDialog()}
+        ${this.renderAuditDrawer()}
+
+        ${this.toast
+          ? html`<div class="rm-toast" role="status" data-testid="saf-toast">
+              ${this.toast}
+            </div>`
+          : nothing}
       </div>
     `;
   }
+
+  private renderPlatformBanner(): TemplateResult {
+    return html`
+      <div class="rm-saf-platform-banner" data-testid="saf-platform-banner">
+        ${iconShieldCheck()}
+        <span>
+          <b>Platform defaults</b> — these rules apply to every organization and
+          can't be edited or disabled here. Contact the platform admin to
+          change.
+        </span>
+      </div>
+    `;
+  }
+
+  private renderHint(): TemplateResult {
+    return html`
+      <p class="rm-pol-hint" data-testid="saf-hint">
+        Higher-priority rules run first; ties go to the newest. Changes apply to
+        new agent tasks — already-running tasks finish with the current rules.
+      </p>
+    `;
+  }
+
+  private renderEmpty(): TemplateResult {
+    return html`
+      <div class="rm-pol-empty" data-testid="saf-empty">
+        <div class="rm-pol-empty-icon" style="color: var(--rm-accent)">
+          ${iconShieldCheck(22)}
+        </div>
+        <p>No safety rules yet.</p>
+        <p class="rm-pol-empty-sub">
+          Coworkers run with no automatic guardrails. Create your first rule to
+          scan for personal data, prompt injection, or untrusted domains.
+        </p>
+        <button type="button" @click=${this.openCreate}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.2" aria-hidden="true">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+          Create your first rule
+        </button>
+      </div>
+    `;
+  }
+
+  private renderCard(r: SafetyRule): TemplateResult {
+    const platform = this.isPlatform(r);
+    const meta = this.checkMeta(r.check_id);
+    const cwName = this.coworkerName(r.coworker_id);
+    const dim = r.enabled ? '' : ' rm-card--dim';
+    const hi = this.highlightId === r.id ? ' rm-card--highlight' : '';
+    const tier = platform ? ' rm-card--platform' : '';
+    const action = effectiveAction(
+      { check_id: r.check_id, stage: r.stage, config: (r.config ?? {}) as Record<string, unknown> },
+      meta,
+    );
+    const slow = meta?.cost_class === 'slow';
+    const toggling = this.togglingIds.has(r.id);
+    return html`
+      <div
+        class="rm-card${dim}${hi}${tier}"
+        data-rule-id=${r.id}
+        data-testid="saf-row"
+      >
+        <span
+          class="rm-pol-pri ${priorityBadgeClass(r.priority)}"
+          data-testid="saf-priority"
+        >priority ${r.priority}</span>
+        <span class="rm-mn">
+          <b>${checkLabel(r.check_id)}</b>
+          <span class="rm-pol-sent" data-testid="saf-sentence">
+            ${unsafeHTML(
+              safSentence(
+                { check_id: r.check_id, stage: r.stage, config: (r.config ?? {}) as Record<string, unknown> },
+                meta,
+                cwName,
+              ),
+            )}
+          </span>
+        </span>
+        ${slow ? html`<span class="rm-saf-slowchip">slow</span>` : nothing}
+        ${cwName ? html`<span class="rm-saf-scope">${cwName}</span>` : nothing}
+        ${action
+          ? html`<span class="rm-pill ${safActionPillClass(action)}"
+              data-testid="saf-action-pill">${action}</span>`
+          : nothing}
+        ${this.renderToggle(r, platform, toggling)}
+        ${this.renderRowActs(r, platform)}
+      </div>
+    `;
+  }
+
+  private renderToggle(
+    r: SafetyRule,
+    platform: boolean,
+    toggling: boolean,
+  ): TemplateResult {
+    if (platform) {
+      // Fixed-on, click is a no-op (§6.2.1).
+      return html`<span
+        class="rm-pol-toggle rm-pol-toggle--on"
+        style="cursor: default; opacity: 0.7"
+        title="Platform-tier rules are always enabled"
+        data-testid="saf-toggle"
+      ><span>Enabled</span><span class="rm-switch"></span></span>`;
+    }
+    return html`<button
+      type="button"
+      class="rm-pol-toggle ${r.enabled ? 'rm-pol-toggle--on' : ''}"
+      title=${r.enabled ? 'Click to disable' : 'Click to enable'}
+      data-testid="saf-toggle"
+      ?disabled=${toggling}
+      @click=${(e: Event) => {
+        e.stopPropagation();
+        void this.toggleEnabled(r);
+      }}
+    ><span>${r.enabled ? 'Enabled' : 'Disabled'}</span><span class="rm-switch"></span></button>`;
+  }
+
+  private renderRowActs(r: SafetyRule, platform: boolean): TemplateResult {
+    const auditBtn = html`<button
+      type="button"
+      class="rm-iconbtn"
+      title="Change history"
+      data-testid="saf-audit"
+      @click=${(e: Event) => {
+        e.stopPropagation();
+        void this.openAudit(r);
+      }}
+    >${iconClock(15)}</button>`;
+    if (platform) {
+      // Platform rules: audit only (no edit / duplicate / delete) — §6.2.2.
+      return html`<span class="rm-row-acts" style="opacity: 1">${auditBtn}</span>`;
+    }
+    return html`
+      <span class="rm-row-acts">
+        <button type="button" class="rm-iconbtn" title="Edit rule"
+          data-testid="saf-edit"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.openEdit(r);
+          }}
+        >${iconPencil(15)}</button>
+        <button type="button" class="rm-iconbtn"
+          title="Duplicate — useful for moving scope or branching config"
+          data-testid="saf-duplicate"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.openDuplicate(r);
+          }}
+        >${iconCopy(15)}</button>
+        ${auditBtn}
+        <button type="button" class="rm-iconbtn rm-iconbtn--danger" title="Delete rule"
+          data-testid="saf-delete"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.askDelete(r);
+          }}
+        >${iconTrash(15)}</button>
+      </span>
+    `;
+  }
+
+  private renderDeleteDialog(): TemplateResult {
+    const r = this.deleteTarget;
+    const meta = r ? this.checkMeta(r.check_id) : null;
+    const sentence = r
+      ? safSentence(
+          { check_id: r.check_id, stage: r.stage, config: (r.config ?? {}) as Record<string, unknown> },
+          meta,
+          this.coworkerName(r.coworker_id),
+        )
+      : '';
+    return html`
+      <rm-confirm-dialog
+        ?open=${r !== null}
+        title="Delete safety rule?"
+        tone="danger"
+        confirm-label="Delete rule"
+        busy-label="Deleting…"
+        ?busy=${this.deleteInFlight}
+        @confirm=${() => void this.performDelete()}
+        @cancel=${this.cancelDelete}
+        @close=${this.cancelDelete}
+      >
+        ${r
+          ? html`<p>
+                You're about to delete the rule
+                <b>${checkLabel(r.check_id)}</b> —
+                ${unsafeHTML(sentence)}
+              </p>
+              <p>
+                After deletion, this check stops running on new agent tasks.
+                Tasks already in progress keep using this rule until they
+                finish, then move on.
+              </p>
+              <p>
+                Past safety log entries are kept. The change history for this
+                rule is also kept — you can review it later if there's ever an
+                audit.
+              </p>`
+          : nothing}
+      </rm-confirm-dialog>
+    `;
+  }
+
+  private renderAuditDrawer(): TemplateResult {
+    const r = this.auditTarget;
+    return html`
+      <rm-dialog
+        ?open=${r !== null}
+        title="Rule history"
+        width="520px"
+        @close=${this.closeAudit}
+      >
+        ${r
+          ? html`<p class="text-[12.5px] text-ink-3 dark:text-d-ink-3 mb-3">
+              ${checkLabel(r.check_id)}
+            </p>`
+          : nothing}
+        ${this.auditLoading
+          ? html`<div class="rm-banner-loading">Loading…</div>`
+          : this.auditEntries.length === 0
+            ? html`<div class="rm-banner-loading" data-testid="saf-audit-empty">
+                No change history yet.
+              </div>`
+            : html`<div class="rm-saf-audit" data-testid="saf-audit-list">
+                ${this.auditEntries.map((e) => this.renderAuditRow(e))}
+              </div>`}
+        <div slot="footer" style="display: flex; justify-content: flex-end">
+          <button type="button" class="rm-btn rm-btn--secondary" @click=${this.closeAudit}>
+            Close
+          </button>
+        </div>
+      </rm-dialog>
+    `;
+  }
+
+  private renderAuditRow(e: SafetyRuleAuditEntry): TemplateResult {
+    const verb = e.action.toUpperCase();
+    return html`
+      <div class="rm-saf-audit-row">
+        <div class="rm-saf-ahead">
+          <span class="rm-saf-averb rm-saf-verb-${e.action}">${verb}</span>
+          <span class="rm-saf-actor"
+            >by ${e.actor_user_id ?? 'the system'}</span
+          >
+          <span class="rm-saf-ats">${new Date(e.created_at).toLocaleString()}</span>
+        </div>
+        <div class="rm-saf-achange">${auditSummary(e)}</div>
+      </div>
+    `;
+  }
+}
+
+// History/clock icon — no iconClock in icons.ts, so inline (matches the
+// stroke style of the shared icon set).
+function iconClock(size = 15): TemplateResult {
+  return html`<svg width=${size} height=${size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 6v6l4 2" />
+  </svg>`;
+}
+
+// Shield-with-check — platform banner + empty-state glyph.
+function iconShieldCheck(size = 14): TemplateResult {
+  return html`<svg width=${size} height=${size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    <path d="M9 12l2 2 4-4" />
+  </svg>`;
 }

--- a/web/src/components/settings-shell.test.ts
+++ b/web/src/components/settings-shell.test.ts
@@ -144,6 +144,7 @@ describe('<rm-settings-shell>', () => {
     ['models',             'Models',             'rm-models-page'],
     ['credentials',        'Credentials',        'rm-credentials-page'],
     ['safety',             'Safety rules',       'rm-safety-rules-page'],
+    ['safety-log',         'Safety log',         'rm-safety-decisions-page'],
     ['approval-policies',  'Approval policies',  'rm-approval-policies-page'],
     ['general',            'General',            'rm-coming-soon'],
     ['members',            'Members',            'rm-coming-soon'],

--- a/web/src/components/settings-shell.ts
+++ b/web/src/components/settings-shell.ts
@@ -33,7 +33,9 @@ import {
   iconBook,
   iconChevronDown,
   iconChip,
+  iconClipboardCheck,
   iconClose,
+  iconFileText,
   iconHome,
   iconKey,
   iconLink,
@@ -52,6 +54,7 @@ import './skills-page.js';
 import './models-page.js';
 import './credentials-page.js';
 import './safety-rules-page.js';
+import './safety-decisions-page.js';
 import './approval-policies-page.js';
 import './appearance-page.js';
 import './coming-soon.js';
@@ -135,7 +138,7 @@ const NAV_GROUPS: NavGroup[] = [
       {
         slug: 'approval-policies',
         label: 'Approval policies',
-        icon: () => iconShield(16),
+        icon: () => iconClipboardCheck(16),
         render: () =>
           html`<rm-approval-policies-page></rm-approval-policies-page>`,
       },
@@ -144,6 +147,12 @@ const NAV_GROUPS: NavGroup[] = [
         label: 'Safety rules',
         icon: () => iconShield(16),
         render: () => html`<rm-safety-rules-page></rm-safety-rules-page>`,
+      },
+      {
+        slug: 'safety-log',
+        label: 'Safety log',
+        icon: () => iconFileText(16),
+        render: () => html`<rm-safety-decisions-page></rm-safety-decisions-page>`,
       },
     ],
   },

--- a/web/src/router.test.ts
+++ b/web/src/router.test.ts
@@ -26,7 +26,9 @@ describe('applyLegacyRedirect', () => {
     ['#/credentials',            '#/manage/credentials'],
     ['#/skills',                 '#/manage/skills'],
     ['#/admin/safety/rules',     '#/manage/safety'],
-    ['#/admin/safety/decisions', '#/activity/safety-decisions'],
+    // Safety log moved to Settings → Governance (spec §7).
+    ['#/admin/safety/decisions', '#/manage/safety-log'],
+    ['#/activity/safety-decisions', '#/manage/safety-log'],
   ];
 
   it.each(TABLE)('rewrites %s → %s', (oldHash, newHash) => {
@@ -48,7 +50,7 @@ describe('applyLegacyRedirect', () => {
 
   it('returns null for hashes that are already on the v2 IA', () => {
     expect(applyLegacyRedirect('#/manage/coworkers')).toBeNull();
-    expect(applyLegacyRedirect('#/activity/safety-decisions')).toBeNull();
+    expect(applyLegacyRedirect('#/manage/safety-log')).toBeNull();
     expect(applyLegacyRedirect('#/')).toBeNull();
     expect(applyLegacyRedirect('')).toBeNull();
   });
@@ -154,6 +156,6 @@ describe('installLegacyRedirects', () => {
     });
     window.dispatchEvent(new HashChangeEvent('hashchange'));
     expect(calls.length).toBe(1);
-    expect(calls[0]).toMatch(/#\/activity\/safety-decisions$/);
+    expect(calls[0]).toMatch(/#\/manage\/safety-log$/);
   });
 });

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -25,7 +25,11 @@ const LEGACY_REDIRECTS: ReadonlyMap<string, string> = new Map([
   ['#/credentials',              '#/manage/credentials'],
   ['#/skills',                   '#/manage/skills'],
   ['#/admin/safety/rules',       '#/manage/safety'],
-  ['#/admin/safety/decisions',   '#/activity/safety-decisions'],
+  // Safety log moved from the Activity surface to Settings → Governance
+  // (spec §7). Both the v1.1 admin bookmark and the interim v2 Activity
+  // path now land on the canonical settings home.
+  ['#/admin/safety/decisions',   '#/manage/safety-log'],
+  ['#/activity/safety-decisions', '#/manage/safety-log'],
 ]);
 
 /**

--- a/web/src/styles/settings-pages.css
+++ b/web/src/styles/settings-pages.css
@@ -208,6 +208,8 @@
 .rm-pill.rm-pill-warn  { background: var(--rm-warn-subtle);   color: var(--rm-warn); }
 .rm-pill.rm-pill-off   { background: var(--rm-surface-3);     color: var(--rm-ink-3); }
 .rm-pill.rm-pill-bad   { background: var(--rm-bad-subtle);    color: var(--rm-bad); }
+/* require_approval pill — terracotta accent (the 5th safety action colour). */
+.rm-pill.rm-pill-appr  { background: var(--rm-accent-subtle); color: var(--rm-accent); }
 
 /* "X coworkers" muted meta count. Monospace to match the prototype's
  * data-density treatment. */
@@ -557,3 +559,450 @@
  * sees the SVG plus the native ▶ glyph stacked together. */
 summary.list-none::-webkit-details-marker { display: none; }
 summary.list-none::marker { content: ''; }
+
+/* ── Safety rules + safety log (spec §6 / §7) ─────────────────────
+ * Ported from the prototype's saf-* / routing-row / finding styles,
+ * re-prefixed rm-saf-* and re-pointed at the --rm-* token palette.
+ * Rule rows reuse .rm-card / .rm-pol-pri / .rm-mn / .rm-pol-toggle /
+ * .rm-row-acts; the classes below add the safety-specific chips,
+ * the action segmented control, the per-finding routing table, the
+ * decision log grid, the finding cards, and the audit timeline. */
+
+/* "slow" latency chip on a rule card. */
+.rm-saf-slowchip {
+  font-size: 10px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 99px;
+  background: var(--rm-surface-3);
+  color: var(--rm-ink-3);
+  flex-shrink: 0;
+}
+
+/* Per-coworker scope chip — accent when scoped, hidden when org-wide. */
+.rm-saf-scope {
+  font-size: 11px;
+  color: var(--rm-accent);
+  background: var(--rm-accent-subtle);
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 5px;
+  flex-shrink: 0;
+}
+
+/* Muted scope clause inside a rule sentence ("All coworkers." etc.). */
+.rm-saf-scope-mute { color: var(--rm-ink-3); }
+
+/* Platform-defaults informational banner (spec §6.2). */
+.rm-saf-platform-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--rm-ink-3);
+  padding: 9px 12px;
+  background: var(--rm-surface-2);
+  border: 1px solid var(--rm-border-2);
+  border-radius: 8px;
+  margin: 0 0 10px;
+  line-height: 1.5;
+}
+.rm-saf-platform-banner svg { flex-shrink: 0; margin-top: 1px; color: var(--rm-ink-3); }
+.rm-saf-platform-banner b { color: var(--rm-ink-2); font-weight: 600; }
+
+/* "Your organization's rules" small-caps section divider. */
+.rm-saf-section-label {
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--rm-ink-3);
+  font-weight: 600;
+  margin: 16px 0 8px;
+  padding-left: 2px;
+}
+
+/* Platform-tier card: accent priority badge (the toggle/edit/dup/delete
+ * are simply not rendered for these rows — handled in the template). */
+.rm-card.rm-card--platform .rm-pol-pri {
+  background: var(--rm-accent-subtle);
+  color: var(--rm-accent);
+}
+
+/* ---- rule dialog: action segmented control (spec §6.11.1 Experience 1) ---- */
+
+/* Plain-language panel above the control — NO "action model" header (§8.5). */
+.rm-saf-action-panel {
+  border: 1px solid var(--rm-border-2);
+  border-radius: 8px;
+  padding: 10px 13px;
+  margin-bottom: 11px;
+  background: var(--rm-surface-2);
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--rm-ink-2);
+}
+.rm-saf-action-panel .rm-saf-natural {
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 5px;
+  font-size: 11.5px;
+  text-transform: capitalize;
+}
+.rm-saf-action-panel .rm-saf-natural.rm-saf-act-block { background: var(--rm-bad-subtle); color: var(--rm-bad); }
+.rm-saf-action-panel .rm-saf-natural.rm-saf-act-allow { background: var(--rm-good-subtle); color: var(--rm-good); }
+
+.rm-saf-seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  background: var(--rm-surface-2);
+  padding: 3px;
+  border-radius: 8px;
+}
+.rm-saf-seg button {
+  padding: 5px 11px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--rm-ink-2);
+  background: none;
+  cursor: pointer;
+  position: relative;
+  font-family: inherit;
+  border: none;
+  transition: var(--rm-transition);
+  text-align: center;
+}
+.rm-saf-seg button.rm-saf-on { background: var(--rm-surface); color: var(--rm-ink); font-weight: 500; }
+.rm-saf-seg button.rm-saf-on.rm-saf-act-allow   { background: var(--rm-good-subtle); color: var(--rm-good); box-shadow: inset 0 0 0 1px var(--rm-good); }
+.rm-saf-seg button.rm-saf-on.rm-saf-act-warn    { background: var(--rm-surface-3); color: var(--rm-ink-2); box-shadow: inset 0 0 0 1px var(--rm-ink-3); }
+.rm-saf-seg button.rm-saf-on.rm-saf-act-redact  { background: var(--rm-warn-subtle); color: var(--rm-warn); box-shadow: inset 0 0 0 1px var(--rm-warn); }
+.rm-saf-seg button.rm-saf-on.rm-saf-act-require_approval { background: var(--rm-accent-subtle); color: var(--rm-accent); box-shadow: inset 0 0 0 1px var(--rm-accent); }
+.rm-saf-seg button.rm-saf-on.rm-saf-act-block   { background: var(--rm-bad-subtle); color: var(--rm-bad); box-shadow: inset 0 0 0 1px var(--rm-bad); }
+.rm-saf-seg button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  text-decoration: line-through;
+}
+.rm-saf-seg button .rm-saf-sub {
+  font-size: 10px;
+  color: var(--rm-ink-3);
+  font-weight: 400;
+  margin-top: 1px;
+}
+.rm-saf-nat-dot {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--rm-accent);
+  box-shadow: 0 0 0 2px var(--rm-surface);
+}
+.rm-saf-seg-legend {
+  font-size: 11px;
+  color: var(--rm-ink-3);
+  margin: 6px 0 0;
+  line-height: 1.6;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.rm-saf-seg-legend .rm-saf-nat-dot {
+  position: static;
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  box-shadow: none;
+  margin-right: 2px;
+}
+/* Disabled-action tooltip (the WHY, server-supplied reason in plain text). */
+.rm-saf-seg button[data-reason]:hover::after {
+  content: attr(data-reason);
+  position: absolute;
+  bottom: calc(100% + 7px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--rm-ink);
+  color: var(--rm-bg);
+  font-size: 11px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-weight: 400;
+  font-style: normal;
+  text-decoration: none;
+  z-index: 100;
+  pointer-events: none;
+  width: max-content;
+  max-width: 240px;
+  white-space: normal;
+  text-align: center;
+  line-height: 1.4;
+}
+
+/* ---- per-finding routing table (spec §6.11.1 Experience 2 / §6.12) ---- */
+.rm-saf-routing-table {
+  display: flex;
+  flex-direction: column;
+  margin-top: 6px;
+  border: 1px solid var(--rm-border-2);
+  border-radius: 7px;
+  background: var(--rm-surface);
+  overflow: hidden;
+}
+.rm-saf-routing-row {
+  display: grid;
+  grid-template-columns: 1fr 200px;
+  gap: 12px;
+  align-items: center;
+  padding: 9px 13px;
+  border-bottom: 1px solid var(--rm-border-2);
+  font-size: 12.5px;
+}
+.rm-saf-routing-row:last-child { border-bottom: none; }
+.rm-saf-routing-row .rm-saf-rcode { color: var(--rm-ink); }
+.rm-saf-routing-row .rm-saf-rdesc {
+  font-family: var(--rm-font-mono);
+  font-size: 11px;
+  color: var(--rm-ink-3);
+  margin-top: 2px;
+}
+.rm-saf-routing-row select {
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid var(--rm-border-2);
+  border-radius: 5px;
+  background: var(--rm-surface);
+  color: var(--rm-ink);
+  font-family: inherit;
+}
+.rm-saf-routing-inert {
+  font-size: 11.5px;
+  color: var(--rm-ink-3);
+  font-style: italic;
+  padding: 8px 13px;
+  background: var(--rm-warn-subtle);
+  border-radius: 6px;
+  margin-top: 8px;
+  border-left: 3px solid var(--rm-warn);
+}
+.rm-saf-routing-inert b { font-style: normal; color: var(--rm-warn); font-weight: 600; }
+
+/* Config form checkbox grid (pii-entities / secret-plugins). */
+.rm-saf-cfg-checks {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px 14px;
+  margin-top: 6px;
+}
+.rm-saf-cfg-checks label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  font-weight: 400;
+}
+
+/* Threshold slider. */
+.rm-saf-threshold { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+.rm-saf-threshold input[type='range'] { flex: 1; }
+.rm-saf-threshold .rm-saf-tval {
+  font-variant-numeric: tabular-nums;
+  font-size: 12.5px;
+  color: var(--rm-ink-2);
+  min-width: 40px;
+  text-align: right;
+  font-weight: 500;
+}
+.rm-saf-thint {
+  font-size: 11px;
+  color: var(--rm-ink-3);
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3px;
+}
+
+/* "leave any blank to let it through" inline note on a field label. */
+.rm-saf-lblnote { font-weight: 400; color: var(--rm-ink-3); font-size: 11px; margin-left: 5px; }
+
+/* Scope-locked hint in edit mode (spec §6.11.3). */
+.rm-saf-scope-locked {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--rm-ink-3);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+.rm-saf-scope-locked a { color: var(--rm-accent); cursor: pointer; }
+.rm-saf-scope-locked a:hover { text-decoration: underline; }
+
+/* ---- safety log (spec §7) ---- */
+.rm-saf-filters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.rm-saf-filters select {
+  padding: 5px 9px;
+  font-size: 12px;
+  border: 1px solid var(--rm-border-2);
+  border-radius: 6px;
+  background: var(--rm-surface);
+  color: var(--rm-ink);
+  font-family: inherit;
+}
+.rm-saf-filters .rm-saf-clear {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--rm-accent);
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-family: inherit;
+}
+.rm-saf-filters .rm-saf-clear:hover { text-decoration: underline; }
+
+.rm-saf-decisions {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--rm-border);
+  border-radius: var(--rm-r);
+  overflow: hidden;
+}
+.rm-saf-row {
+  display: grid;
+  grid-template-columns: 80px 78px 110px 150px 1fr 120px 18px;
+  gap: 11px;
+  align-items: center;
+  padding: 10px 13px;
+  font-size: 12.5px;
+  border-bottom: 1px solid var(--rm-border);
+  cursor: pointer;
+  transition: var(--rm-transition);
+  background: var(--rm-surface);
+  text-align: left;
+  width: 100%;
+  font-family: inherit;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+}
+.rm-saf-row:hover { background: var(--rm-surface-2); }
+.rm-saf-row:last-child { border-bottom: none; }
+.rm-saf-row .rm-saf-ts { font-variant-numeric: tabular-nums; font-size: 11.5px; color: var(--rm-ink-3); }
+.rm-saf-row .rm-saf-verdict {
+  font-size: 10.5px;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-weight: 600;
+  text-align: center;
+  width: fit-content;
+}
+.rm-saf-row .rm-saf-verdict.rm-saf-v-allow  { background: var(--rm-good-subtle); color: var(--rm-good); }
+.rm-saf-row .rm-saf-verdict.rm-saf-v-block  { background: var(--rm-bad-subtle); color: var(--rm-bad); }
+.rm-saf-row .rm-saf-verdict.rm-saf-v-redact { background: var(--rm-warn-subtle); color: var(--rm-warn); }
+.rm-saf-row .rm-saf-verdict.rm-saf-v-warn   { background: var(--rm-surface-3); color: var(--rm-ink-2); }
+.rm-saf-row .rm-saf-verdict.rm-saf-v-require_approval { background: var(--rm-accent-subtle); color: var(--rm-accent); }
+.rm-saf-row .rm-saf-stage { font-family: var(--rm-font-mono); font-size: 11px; color: var(--rm-ink-3); }
+.rm-saf-row .rm-saf-check { font-size: 12px; color: var(--rm-ink-2); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rm-saf-row .rm-saf-summary { color: var(--rm-ink-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rm-saf-row .rm-saf-cw { font-size: 11.5px; color: var(--rm-ink-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rm-saf-row .rm-saf-arr { color: var(--rm-ink-3); text-align: right; }
+
+.rm-saf-pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+  font-size: 12px;
+  color: var(--rm-ink-3);
+}
+.rm-saf-pager .rm-saf-pager-btns { display: flex; gap: 6px; }
+
+/* ---- decision detail: metadata grid + findings + privacy note ---- */
+.rm-saf-meta {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 8px 14px;
+  font-size: 12.5px;
+  margin-bottom: 14px;
+}
+.rm-saf-meta .rm-saf-mlabel { color: var(--rm-ink-3); }
+.rm-saf-mono { font-family: var(--rm-font-mono); font-size: 11px; color: var(--rm-ink-3); }
+.rm-saf-section-cap {
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--rm-ink-3);
+  font-weight: 600;
+  margin: 14px 0 6px;
+}
+.rm-saf-findings { display: flex; flex-direction: column; gap: 8px; }
+.rm-saf-finding {
+  padding: 8px 12px;
+  border: 1px solid var(--rm-border-2);
+  border-radius: 7px;
+  background: var(--rm-surface-2);
+}
+.rm-saf-finding .rm-saf-fhead { display: flex; align-items: center; gap: 8px; margin-bottom: 3px; }
+.rm-saf-finding .rm-saf-fcode { font-family: var(--rm-font-mono); font-size: 11.5px; color: var(--rm-ink); font-weight: 500; }
+.rm-saf-finding .rm-saf-fsev {
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 7px;
+  border-radius: 99px;
+  font-weight: 600;
+}
+.rm-saf-finding .rm-saf-fsev.rm-saf-sev-critical,
+.rm-saf-finding .rm-saf-fsev.rm-saf-sev-high { background: var(--rm-bad-subtle); color: var(--rm-bad); }
+.rm-saf-finding .rm-saf-fsev.rm-saf-sev-medium { background: var(--rm-warn-subtle); color: var(--rm-warn); }
+.rm-saf-finding .rm-saf-fsev.rm-saf-sev-low,
+.rm-saf-finding .rm-saf-fsev.rm-saf-sev-info { background: var(--rm-surface-3); color: var(--rm-ink-3); }
+.rm-saf-finding .rm-saf-fmsg { font-size: 12.5px; color: var(--rm-ink-2); line-height: 1.45; }
+.rm-saf-finding .rm-saf-fmeta { font-size: 11px; color: var(--rm-ink-3); font-family: var(--rm-font-mono); margin-top: 5px; }
+
+.rm-saf-privacy {
+  font-size: 11.5px;
+  color: var(--rm-ink-3);
+  line-height: 1.55;
+  padding: 9px 12px;
+  background: var(--rm-surface-2);
+  border-left: 3px solid var(--rm-accent);
+  border-radius: 0 6px 6px 0;
+  margin-top: 14px;
+}
+.rm-saf-privacy b {
+  color: var(--rm-ink-2);
+  font-weight: 600;
+  display: block;
+  margin-bottom: 3px;
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* ---- audit drawer timeline (spec §6.9) ---- */
+.rm-saf-audit { display: flex; flex-direction: column; gap: 8px; }
+.rm-saf-audit-row {
+  padding: 9px 12px;
+  border: 1px solid var(--rm-border-2);
+  border-radius: 7px;
+  background: var(--rm-surface);
+}
+.rm-saf-audit-row .rm-saf-ahead { display: flex; align-items: center; gap: 8px; font-size: 12.5px; margin-bottom: 3px; }
+.rm-saf-audit-row .rm-saf-averb { font-weight: 600; letter-spacing: 0.03em; }
+.rm-saf-audit-row .rm-saf-averb.rm-saf-verb-created { color: var(--rm-good); }
+.rm-saf-audit-row .rm-saf-averb.rm-saf-verb-updated { color: var(--rm-ink-2); }
+.rm-saf-audit-row .rm-saf-averb.rm-saf-verb-deleted { color: var(--rm-bad); }
+.rm-saf-audit-row .rm-saf-actor { font-size: 11.5px; color: var(--rm-ink-3); }
+.rm-saf-audit-row .rm-saf-ats { font-size: 11px; color: var(--rm-ink-3); margin-left: auto; font-variant-numeric: tabular-nums; }
+.rm-saf-audit-row .rm-saf-achange { font-size: 11.5px; color: var(--rm-ink-2); margin-top: 5px; padding-left: 8px; border-left: 2px solid var(--rm-border-2); }


### PR DESCRIPTION
## Summary

Implements the Safety UI surfaces described in the spec (§6/§7/§3.10/§4.10), plus four backend bugfixes discovered during integration testing.

### Features (4 commits)

- **Contract fields** — `ApprovalTriggeredBy` schema + `triggered_by` on `ApprovalRequest`/`WsServerEventApprovalRequested`; catch-up `source`/`tier`/`editable` on `SafetyRule`/`SafetyDecision` (PR #49 backend already shipped these, openapi was stale)
- **Safety rules page** — full revamp: two-tier platform/org list, rule cards (sentence/slow chip/scope chip/action pill/toggle/hover acts), empty state, audit drawer, delete modal. New `safety-rule-dialog` with three editor experiences (§6.11.1): segmented picker for fixed checks, per-finding routing table for config_routed checks (action field hidden), host list for allowlist checks (action field hidden). `action_override` correctly restricted to `{block,warn,require_approval}`. Scope locked in edit mode with duplicate-to-move hint. Client-side `safety-catalog.ts` bridges wire behaviour with presentation metadata (label/desc/category/cfgKind).
- **Safety log page** — filter bar (verdict/stage/coworker + time), 7-column decision rows, pagination, CSV export, decision detail dialog (metadata grid dual-display stage, findings with severity pills, data-minimization privacy note). Moved from Activity surface to **Settings → Governance**; old paths redirect.
- **Approval safety indicators** — §3.10 amber banner on chat card + §4.10 shield icon on inbox row when `triggered_by.kind === 'safety_rule'`; three-way degradation (null / safety_rule / unknown kind). Always null today (safety→approval bridge unbuilt); field and frontend are ready.

### Bugfixes (4 commits)

- **`egress_request` stage rejected by admin write** — `_SAFETY_STAGE_PATTERN` hardcoded 5 stages, missing the 6th added by PR #50. Now derived from the canonical `SafetyStage` literal so it can't drift again.
- **`domain_allowlist` config key mismatch** — frontend sent `hosts:[...]`, backend expects `allowed_hosts:[...]`.
- **Config field names misaligned with backend schemas across 4 checks** — `pii.regex` (`entities` → `patterns:{KEY:true}`), `presidio.pii` (`routing` → `block_codes/redact_codes/score_threshold`), `openai_moderation` (`routing` → `block_categories/warn_categories`), `secret_scanner` (`plugins` → `{}` only). Dialog now converts on load/save.
- **`llm_guard.jailbreak` wrong cfgKind** — shared `threshold` form with prompt_injection/toxicity, but jailbreak's config is `{phrases,case_sensitive}`. Now has its own form.

### Known constraints (documented in code + PR)

- `triggered_by` is always null end-to-end — the safety→approval bridge (pipeline `require_approval` verdict → ApprovalCoordinator) is unbuilt and out of scope here.
- Safety log filter bar has 3 server-backed dropdowns (verdict/stage/coworker); the 4th "check" filter is omitted because the v1 `/safety/decisions` endpoint has no `check_id` param and we don't extend the contract here.
- `egress.domain_rule` config form deferred — its schema (`domain_pattern` single string + optional `ports`) differs enough from the shared host-list form that a proper UX needs a design pass first.

## Test plan

- [ ] Settings → Governance shows three items: Approval policies / Safety rules / Safety log (with correct icons)
- [ ] Safety rules: two-tier platform/org display; platform rows have audit-only affordances; org rules show edit/dup/audit/delete on hover
- [ ] New rule dialog: check dropdown shows all registered checks grouped by category; three editor experiences render correctly for pii.regex / presidio.pii / domain_allowlist
- [ ] Create/edit for each check type saves without 400: pii.regex, presidio.pii, openai_moderation, secret_scanner, llm_guard.*, domain_allowlist, egress.domain_rule
- [ ] Safety log: filter bar, row click opens detail modal, privacy note visible
- [ ] Old URLs redirect: `#/admin/safety/decisions` and `#/activity/safety-decisions` → `#/manage/safety-log`
- [ ] Activity overview card navigates to Settings → Safety log (not in-shell tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)