### PR TITLE
safety(egress.domain_rule): config schema single pattern → list

### DIFF
--- a/src/rolemesh/safety/checks/egress_domain_rule.py
+++ b/src/rolemesh/safety/checks/egress_domain_rule.py
@@ -2,9 +2,19 @@
 
 This check is the EC stage's answer to ``pii.regex`` — a cheap,
 pure-Python detector with a small, closed config schema. Each rule row
-carries one ``domain_pattern`` and an optional ``ports`` list; the
-check reports whether the request host/port matches, and the gateway's
-aggregator decides allow vs block based on whether any rule matched.
+carries a list of ``domain_patterns`` and an optional ``ports`` list;
+the check reports whether the request host/port matches ANY pattern,
+and the gateway's aggregator decides allow vs block based on whether
+any rule matched.
+
+One rule carries many patterns deliberately. A typical operator
+allowlist is 5-10 hosts (Stripe + Amazon Ads + Slack; a handful of
+SaaS); modelling that as one rule — rather than N near-identical
+rows — keeps the Safety rules page legible, makes the audit story
+"patterns: [...] → [...]" a single record, and matches the shape of
+``domain_allowlist`` (``allowed_hosts: list[str]``). ``ports`` is
+shared across every pattern in the rule; patterns that need different
+port scoping belong in separate rules.
 
 Matching semantics:
 
@@ -22,9 +32,9 @@ service for an attacker with a matching SNI.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..types import Finding, Stage, Verdict
 
@@ -46,17 +56,39 @@ class EgressDomainRuleConfig(BaseModel):
 
     ``extra='forbid'`` so an admin typo like ``{"domains": ["x"]}`` (plural
     + wrong key) fails loud at rule create time rather than accepted-and-
-    silently-ignored at run time.
+    silently-ignored at run time. This is the property that makes the
+    closed schema worth keeping closed — there is intentionally no
+    back-compat ``domain_pattern`` (singular) alias, because accepting
+    two legal shapes is exactly the silent-typo hazard ``extra='forbid'``
+    exists to prevent.
 
-    ``domain_pattern``'s upper bound of 253 matches the DNS name length
-    limit. A longer "pattern" is either a bug or an attempt to sneak
-    one through.
+    ``domain_patterns`` is required and non-empty: an empty list overlaps
+    semantically with "delete the rule", so it is rejected rather than
+    silently meaning "match nothing". The ``max_length=100`` cap keeps a
+    single rule from ballooning past audit-readability — typical
+    allowlists are 5-10, extreme ones well under 50. Each element is
+    bounded to the DNS name length limit (253); a longer "pattern" is
+    either a bug or an attempt to sneak one through.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    domain_pattern: str = Field(..., min_length=1, max_length=253)
+    domain_patterns: Annotated[
+        list[Annotated[str, Field(min_length=1, max_length=253)]],
+        Field(min_length=1, max_length=100),
+    ]
     ports: list[int] | None = None
+
+    @field_validator("domain_patterns")
+    @classmethod
+    def _strip_patterns(cls, patterns: list[str]) -> list[str]:
+        # Reject whitespace-only entries so they can't sneak through as a
+        # silent "match nothing" slot. Element length bounds above run
+        # first; this normalisation only trims and re-checks emptiness.
+        clean = [p.strip() for p in patterns]
+        if any(not p for p in clean):
+            raise ValueError("domain_patterns entries must be non-empty")
+        return clean
 
 
 def _matches(host: str, pattern: str) -> bool:
@@ -127,9 +159,12 @@ class EgressDomainRuleCheck:
         port = int(ctx.payload.get("port", 0))
         if not host:
             return Verdict(action="allow")
-        if not _matches(host, cfg.domain_pattern):
-            return Verdict(action="allow")
         if cfg.ports is not None and port not in cfg.ports:
+            return Verdict(action="allow")
+        matched = next(
+            (p for p in cfg.domain_patterns if _matches(host, p)), None
+        )
+        if matched is None:
             return Verdict(action="allow")
         return Verdict(
             action="allow",
@@ -137,7 +172,7 @@ class EgressDomainRuleCheck:
                 Finding(
                     code=EgressDomainCode.DOMAIN_ALLOWED.value,
                     severity="info",
-                    message=f"matched {cfg.domain_pattern}",
+                    message=f"matched {matched}",
                 )
             ],
         )
@@ -163,15 +198,20 @@ def make_egress_domain_check() -> Any:
             return False, []
         host = getattr(request, "host", "")
         port = int(getattr(request, "port", 0))
-        if not host or not _matches(host, cfg.domain_pattern):
+        if not host:
             return False, []
         if cfg.ports is not None and port not in cfg.ports:
+            return False, []
+        matched = next(
+            (p for p in cfg.domain_patterns if _matches(host, p)), None
+        )
+        if matched is None:
             return False, []
         return True, [
             {
                 "code": EgressDomainCode.DOMAIN_ALLOWED.value,
                 "severity": "info",
-                "message": f"matched {cfg.domain_pattern}",
+                "message": f"matched {matched}",
                 "metadata": {"host": host, "port": port},
             }
         ]

--- a/tests/egress/integration/test_p0_connect.py
+++ b/tests/egress/integration/test_p0_connect.py
@@ -107,7 +107,7 @@ async def _bootstrap_rules(topology: Topology, *, allow_host: str) -> list[dict[
         "coworker_id": None,
         "stage": "egress_request",
         "check_id": "egress.domain_rule",
-        "config": {"domain_pattern": allow_host},
+        "config": {"domain_patterns": [allow_host]},
         "priority": 100,
         "enabled": True,
     }

--- a/tests/egress/integration/test_p0_dns.py
+++ b/tests/egress/integration/test_p0_dns.py
@@ -44,7 +44,7 @@ async def _seed_allowlist(topology: Topology, allow_host: str) -> None:
         "coworker_id": None,
         "stage": "egress_request",
         "check_id": "egress.domain_rule",
-        "config": {"domain_pattern": allow_host},
+        "config": {"domain_patterns": [allow_host]},
         "priority": 100,
         "enabled": True,
     }

--- a/tests/egress/integration/test_p0_hot_reload.py
+++ b/tests/egress/integration/test_p0_hot_reload.py
@@ -90,7 +90,7 @@ async def test_rule_disable_propagates_to_live_gateway(
         "coworker_id": None,
         "stage": "egress_request",
         "check_id": "egress.domain_rule",
-        "config": {"domain_pattern": topology.fake_upstream_name},
+        "config": {"domain_patterns": [topology.fake_upstream_name]},
         "priority": 100,
         "enabled": True,
     }

--- a/tests/egress/test_policy_cache.py
+++ b/tests/egress/test_policy_cache.py
@@ -17,7 +17,7 @@ def _make_rule(**overrides: object) -> dict[str, object]:
         "coworker_id": "coworker-x",
         "stage": "egress_request",
         "check_id": "egress.domain_rule",
-        "config": {"domain_pattern": "api.anthropic.com"},
+        "config": {"domain_patterns": ["api.anthropic.com"]},
         "priority": 100,
         "enabled": True,
     }
@@ -102,8 +102,15 @@ async def test_malformed_event_does_not_crash_cache() -> None:
 async def test_cached_rule_carries_config() -> None:
     cache = PolicyCache()
     await cache.seed(
-        [_make_rule(config={"domain_pattern": "*.github.com", "ports": [443]})]
+        [
+            _make_rule(
+                config={"domain_patterns": ["*.github.com"], "ports": [443]}
+            )
+        ]
     )
     rule = cache.get_rules_for("tenant-a", "coworker-x")[0]
     assert isinstance(rule, CachedRule)
-    assert rule.config == {"domain_pattern": "*.github.com", "ports": [443]}
+    assert rule.config == {
+        "domain_patterns": ["*.github.com"],
+        "ports": [443],
+    }

--- a/tests/safety/test_action_matrix.py
+++ b/tests/safety/test_action_matrix.py
@@ -234,7 +234,7 @@ FIRE_SPECS: dict[str, FireSpec] = {
         build=lambda: EgressDomainRuleCheck(),
         inputs={
             Stage.EGRESS_REQUEST: (
-                {"domain_pattern": "api.example.com"},
+                {"domain_patterns": ["api.example.com"]},
                 {"host": "api.example.com", "port": 443},
             ),
         },

--- a/tests/safety/test_egress_domain_rule.py
+++ b/tests/safety/test_egress_domain_rule.py
@@ -71,25 +71,71 @@ class TestMatches:
 class TestConfigValidation:
     def test_valid_minimal_config(self) -> None:
         cfg = EgressDomainRuleConfig.model_validate(
-            {"domain_pattern": "api.anthropic.com"}
+            {"domain_patterns": ["api.anthropic.com"]}
         )
+        assert cfg.domain_patterns == ["api.anthropic.com"]
         assert cfg.ports is None
 
-    def test_empty_domain_pattern_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            EgressDomainRuleConfig.model_validate({"domain_pattern": ""})
+    def test_valid_multi_pattern_config(self) -> None:
+        cfg = EgressDomainRuleConfig.model_validate(
+            {
+                "domain_patterns": [
+                    "api.stripe.com",
+                    "*.slack.com",
+                    "ads.amazon.com",
+                ],
+                "ports": [443],
+            }
+        )
+        assert len(cfg.domain_patterns) == 3
+        assert cfg.ports == [443]
 
-    def test_overlong_domain_pattern_rejected(self) -> None:
+    def test_patterns_stripped(self) -> None:
+        cfg = EgressDomainRuleConfig.model_validate(
+            {"domain_patterns": ["  api.anthropic.com  "]}
+        )
+        assert cfg.domain_patterns == ["api.anthropic.com"]
+
+    def test_empty_list_rejected(self) -> None:
+        """An empty list overlaps with 'delete the rule' — reject it."""
+        with pytest.raises(ValidationError):
+            EgressDomainRuleConfig.model_validate({"domain_patterns": []})
+
+    def test_whitespace_only_entry_rejected(self) -> None:
         with pytest.raises(ValidationError):
             EgressDomainRuleConfig.model_validate(
-                {"domain_pattern": "x" * 254}
+                {"domain_patterns": ["api.anthropic.com", "   "]}
+            )
+
+    def test_overlong_list_rejected(self) -> None:
+        """The 100-entry cap keeps one rule from ballooning past
+        audit-readability."""
+        with pytest.raises(ValidationError):
+            EgressDomainRuleConfig.model_validate(
+                {"domain_patterns": [f"h{i}.example.com" for i in range(101)]}
+            )
+
+    def test_overlong_single_entry_rejected(self) -> None:
+        """One bad element (>253 chars) fails the whole config."""
+        with pytest.raises(ValidationError):
+            EgressDomainRuleConfig.model_validate(
+                {"domain_patterns": ["ok.example.com", "x" * 254]}
+            )
+
+    def test_old_singular_field_name_rejected(self) -> None:
+        """The retired ``domain_pattern`` (singular) shape must 400 at
+        REST time — there is intentionally no back-compat alias, so the
+        old wire shape fails loud instead of silently matching nothing."""
+        with pytest.raises(ValidationError):
+            EgressDomainRuleConfig.model_validate(
+                {"domain_pattern": "api.anthropic.com"}
             )
 
     def test_extra_keys_rejected(self) -> None:
         """Typo like ``domains`` (plural) must fail loud at REST time."""
         with pytest.raises(ValidationError):
             EgressDomainRuleConfig.model_validate(
-                {"domain_pattern": "x.com", "domains": ["y.com"]}
+                {"domain_patterns": ["x.com"], "domains": ["y.com"]}
             )
 
 
@@ -103,35 +149,68 @@ class TestGatewayAdapter:
         check = make_egress_domain_check()
         matched, findings = await check(
             _FakeRequest(host="api.anthropic.com", port=443),
-            {"domain_pattern": "api.anthropic.com"},
+            {"domain_patterns": ["api.anthropic.com"]},
         )
         assert matched is True
         assert len(findings) == 1
         assert findings[0]["code"] == EgressDomainCode.DOMAIN_ALLOWED.value
 
-    async def test_non_match_returns_false_no_findings(self) -> None:
+    async def test_any_pattern_match_votes_allow(self) -> None:
+        """A multi-pattern rule matches the request host against ANY of
+        its patterns; the finding reports the specific pattern hit."""
+        check = make_egress_domain_check()
+        matched, findings = await check(
+            _FakeRequest(host="raw.slack.com", port=443),
+            {
+                "domain_patterns": [
+                    "api.stripe.com",
+                    "*.slack.com",
+                    "ads.amazon.com",
+                ]
+            },
+        )
+        assert matched is True
+        assert len(findings) == 1
+        assert findings[0]["message"] == "matched *.slack.com"
+
+    async def test_no_pattern_match_misses(self) -> None:
         check = make_egress_domain_check()
         matched, findings = await check(
             _FakeRequest(host="api.openai.com", port=443),
-            {"domain_pattern": "api.anthropic.com"},
+            {"domain_patterns": ["api.stripe.com", "*.slack.com"]},
         )
         assert matched is False
         assert findings == []
 
-    async def test_port_restriction_enforced(self) -> None:
-        """domain_pattern matches but port doesn't — must miss."""
+    async def test_non_match_returns_false_no_findings(self) -> None:
         check = make_egress_domain_check()
-        matched, _ = await check(
-            _FakeRequest(host="api.anthropic.com", port=80),
-            {"domain_pattern": "api.anthropic.com", "ports": [443]},
+        matched, findings = await check(
+            _FakeRequest(host="api.openai.com", port=443),
+            {"domain_patterns": ["api.anthropic.com"]},
         )
         assert matched is False
+        assert findings == []
+
+    async def test_ports_shared_across_patterns(self) -> None:
+        """``ports`` is shared by every pattern in the rule. A host that
+        matches a pattern but hits a non-listed port still misses."""
+        check = make_egress_domain_check()
+        cfg = {
+            "domain_patterns": ["api.stripe.com", "*.slack.com"],
+            "ports": [443],
+        }
+        # pattern matches, port allowed → match
+        ok, _ = await check(_FakeRequest(host="api.slack.com", port=443), cfg)
+        assert ok is True
+        # pattern matches, port NOT allowed → miss (shared ports)
+        bad, _ = await check(_FakeRequest(host="api.stripe.com", port=80), cfg)
+        assert bad is False
 
     async def test_port_none_matches_any(self) -> None:
         check = make_egress_domain_check()
         matched, _ = await check(
             _FakeRequest(host="api.anthropic.com", port=8080),
-            {"domain_pattern": "api.anthropic.com"},
+            {"domain_patterns": ["api.anthropic.com"]},
         )
         assert matched is True
 
@@ -141,7 +220,18 @@ class TestGatewayAdapter:
         check = make_egress_domain_check()
         matched, _ = await check(
             _FakeRequest(host="api.anthropic.com"),
-            {},  # missing domain_pattern
+            {},  # missing domain_patterns
+        )
+        assert matched is False
+
+    async def test_old_singular_field_misses_safely(self) -> None:
+        """The retired ``domain_pattern`` shape is an invalid config now;
+        the gateway treats it as a miss (and the caller logs it) rather
+        than silently honouring the old key."""
+        check = make_egress_domain_check()
+        matched, _ = await check(
+            _FakeRequest(host="api.anthropic.com", port=443),
+            {"domain_pattern": "api.anthropic.com"},
         )
         assert matched is False
 
@@ -172,7 +262,7 @@ class TestSafetyCheckProtocol:
             payload={"host": "api.anthropic.com", "port": 443},
         )
         verdict = await check.check(
-            ctx, {"domain_pattern": "api.anthropic.com"}
+            ctx, {"domain_patterns": ["api.anthropic.com"]}
         )
         assert verdict.action == "allow"
         assert len(verdict.findings) == 1
@@ -191,7 +281,7 @@ class TestSafetyCheckProtocol:
             payload={"host": "api.openai.com", "port": 443},
         )
         verdict = await check.check(
-            ctx, {"domain_pattern": "api.anthropic.com"}
+            ctx, {"domain_patterns": ["api.anthropic.com"]}
         )
         assert verdict.action == "allow"
         assert verdict.findings == []


### PR DESCRIPTION
## Summary

Changes the `egress.domain_rule` safety check config from a single `domain_pattern` to a `domain_patterns` list, so one rule carries a whole allowlist instead of N near-identical rows.

A typical operator allowlist is 5-10 hosts (Stripe + Amazon Ads + Slack; a handful of SaaS). Modelling that as N separate rules caused visual noise on the Safety rules page, a mental-model mismatch ("my allowlist" vs "10 independent rules"), no bulk operations (N toggles / N delete approvals), and audit pollution (one record per domain change). This fixes it at the schema layer rather than papering over it with frontend grouping, and aligns with `domain_allowlist`'s existing `allowed_hosts: list[str]` shape for internal consistency.

## Changes

- **Schema** (`EgressDomainRuleConfig`): `domain_pattern: str` → `domain_patterns: list[str]`
  - `min_length=1` — an empty list overlaps with "delete the rule", so it is rejected
  - `max_length=100` — keeps a single rule from ballooning past audit-readability (typical 5-10, extreme well under 50)
  - each element bounded to 1-253 chars (DNS name limit) and stripped; whitespace-only entries rejected
- **Check logic** (both call sites — the `SafetyCheck` Protocol `check()` and the gateway adapter `make_egress_domain_check`): iterate `domain_patterns` and vote `allow` on **any** match. The finding reports the specific pattern that matched. The aggregator behaviour is unchanged — one rule still contributes exactly one vote.
- **ports**: stays shared across all patterns in a rule (patterns needing different port scoping belong in separate rules). `_matches` is unchanged.
- **No back-compat alias**: `extra='forbid'` is the core safety property of these closed config schemas (it makes admin typos fail loud instead of being silently ignored). Keeping a `domain_pattern` alias would create two legal shapes — exactly the ambiguity `extra='forbid'` exists to prevent — so the old singular shape now fails loud (REST 400 / gateway miss).

## Scope notes (greenfield)

This project has no production data yet, so it is treated as greenfield:

- **No data migration.** The schema changes directly; there is no Alembic migration / backfill.
- **No platform-default change.** No platform-tier default rule uses `egress.domain_rule` (`_PLATFORM_DEFAULT_RULES` contains only `secret_scanner`, `pii.regex`, and the three `llm_guard.*` checks).
- **No manual OpenAPI / types.ts sync.** `config_schema` is generated from `config_model.model_json_schema()` at runtime; `contracts/openapi.yaml` declares it as a generic object, so changing the Pydantic model is sufficient.
- **Frontend deliberately untouched.** `web/src/components/safety-catalog.ts` still reads the old `domain_pattern` key; under the new schema it degrades gracefully to the generic "allow listed domains" summary (no build break). The frontend UI change is a follow-up PR.

## Tests

- Multi-pattern voting (any pattern matches → allow; none match → no vote), with the finding naming the matched pattern
- `ports` shared-across-patterns behaviour
- Empty list rejected, oversized list (>100) rejected, oversized element (>253) rejected, whitespace-only entry rejected
- Retired singular `domain_pattern` shape rejected at REST (400) and treated as a safe miss at the gateway
- Existing tests that fed the old shape (action-matrix, policy-cache, the three P0 egress integration tests) updated to the list shape

Target suites: `100 passed, 10 skipped`; ruff clean.

## Invariants

1. **No admin action required** — there is no existing data to migrate (greenfield).
2. **Intentional wire breaking change** — `{domain_pattern: "x"}` API requests now 400; the frontend PR will update in sync.
3. **Better audit story** — editing one pattern shows as `patterns: [...] → [...]` (a single audit record) instead of delete-one-rule + create-another (two records).

https://claude.ai/code/session_01UmVvYf1V3P2Qy38orQAiPc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UmVvYf1V3P2Qy38orQAiPc)_