### PR TITLE
feat(safety): bridge PRE_TOOL_CALL require_approval into HITL approval

### DIFF
--- a/docs/21-hitl-approval-S4-notes.md
+++ b/docs/21-hitl-approval-S4-notes.md
@@ -73,7 +73,14 @@ machine, the policy snapshot, or container lifecycle.
   `tests/test_openapi_contract.py` (they were already red — missing
   `request.stop` / `event.run.progress` / `event.message.appended`).
 
-## R4 (resolved + documented)
+## R4 (resolved + documented) — SUPERSEDED by the safety->approval bridge
+
+> **Update:** R4's original "safety `require_approval` never enters HITL" stance
+> was later revised. A PRE_TOOL_CALL `require_approval` verdict is now bridged
+> into a HITL ticket (carrying `triggered_by` provenance) — see §11.4 of
+> `docs/21-hitl-approval-plan.md`. The text below is the original S4 decision,
+> kept for history. The hard-block alias still holds for every stage *except*
+> PRE_TOOL_CALL (notably MODEL_OUTPUT, the branch named below).
 
 Safety `require_approval` **stays a hard block and does NOT enter HITL**. HITL
 gates only tenant MCP-tool *policy* matches (the block-and-await hook in

--- a/docs/21-hitl-approval-plan.md
+++ b/docs/21-hitl-approval-plan.md
@@ -38,7 +38,7 @@ keeps the architecture clean and free of the old model's assumptions.
 | Decision | Value | Rationale |
 |---|---|---|
 | `APPROVAL_TIMEOUT` default | **300_000 ms (5 min)** | Approver is the creator (self-approval); resolves in seconds–minutes. Short timeout cuts container-hold cost ~4× and keeps a wide margin below the container watchdog floor. |
-| Safety `require_approval` boundary | **Stays a hard block; does NOT enter HITL** | safety verdict `require_approval` is already a block alias on main. HITL serves **only MCP policy** matches. State this explicitly in code/docs so users aren't confused by two gate types. |
+| Safety `require_approval` boundary | **PRE_TOOL_CALL enters HITL; other stages stay a hard block** | The safety->approval bridge (§11.4) turns a PRE_TOOL_CALL `require_approval` verdict into a HITL ticket carrying `triggered_by` provenance, reusing the same block-and-await path as an MCP-policy approval. Every other stage (INPUT_PROMPT / MODEL_OUTPUT / POST_TOOL_RESULT) keeps the hard-block alias — only PRE_TOOL_CALL has both an awaiting agent and an approval surface. |
 
 ## 2. Scope redlines (locked for the whole implementation — do not expand)
 
@@ -280,8 +280,9 @@ row-level `status` transition is idempotent. Both sides converge.
 - **R2 (S3):** restart recovery must rebuild `_GroupState` + replay suspend for
   live containers, not just reload DB rows (see §8).
 - **R3 (resolved):** timeout default = 5 min (§1).
-- **R4 (resolved, document in S4):** safety `require_approval` stays a hard block;
-  HITL only for MCP policy (§1).
+- **R4 (revised — safety->approval bridge):** a PRE_TOOL_CALL safety
+  `require_approval` verdict now enters HITL via the bridge (§11.4), carrying
+  `triggered_by` provenance; other stages stay a hard block (§1).
 - **Operational:** each pending approval holds one container ≤ APPROVAL_TIMEOUT.
   Confirm `MAX_CONCURRENT_CONTAINERS` / `GLOBAL_MAX_CONTAINERS` headroom; accepted
   trade-off, but `log()` it if a cap is hit.
@@ -370,7 +371,8 @@ MVP = S1–S4.
   approval event; persist scheduled-task web notifications (survive disconnect).
 - Dual-channel result: soft (block `reason` → agent context) + hard (orchestrator
   deterministically edits the card to "❌ rejected" / "⏰ expired", no LLM).
-- **R4:** one-line in code/docs — safety `require_approval` stays hard block, not HITL.
+- **R4 (revised):** PRE_TOOL_CALL safety `require_approval` is bridged into HITL
+  (§11.4); other stages stay a hard block.
 - Verify: end-to-end `amount > 100` self-approval on **both** Telegram and Web
   (approve → agent gets result and continues; reject → agent gets block reason +
   user gets hard-channel card); resume ("continue" → retry tool → re-hit hook →
@@ -459,12 +461,35 @@ conversation is not wedged. The re-adoption path is correct for runtimes/configs
 that keep the container alive across a restart. (Tracked as an ops item, not an
 MVP blocker.)
 
-### 11.4 R4 (resolved, S4): two gate types, kept distinct
+### 11.4 R4 (revised): safety->approval bridge at PRE_TOOL_CALL
 
-Safety `require_approval` **stays a hard block and does not enter HITL**. HITL
-gates **only** tenant MCP-tool policy matches (the block-and-await hook). Pinned
-in code at the orchestrator MODEL_OUTPUT verdict branch
-(`verdict.action in ("block", "require_approval")`) and here. Do not merge them.
+The safety pipeline and the HITL approval system are connected at the one stage
+where it is meaningful: **PRE_TOOL_CALL**. There an agent is blocked waiting on a
+tool call (an approval surface) inside its own container, exactly like a business
+MCP-policy match — so a `require_approval` verdict is turned into a real HITL
+ticket instead of a terminal block.
+
+How it works (the container path, `agent_runner.safety.hook_handler`):
+
+- `pipeline_core` stamps the firing rule's provenance (`firing_rule_id` /
+  `firing_check_id`) onto a short-circuit verdict.
+- On a PRE_TOOL_CALL `require_approval` verdict, the handler builds a
+  `triggered_by = {kind: "safety_rule", rule_id, check_id, stage}` object and
+  publishes `approval_request` through the **shared `ApprovalAwaiter`** — the
+  same block-and-await primitive the business hook uses (`policy_id` is null;
+  the provenance rides `triggered_by`). It then blocks on the same
+  `APPROVAL_TIMEOUT` bound as a business approval.
+- The orchestrator persists `triggered_by` on the `approval_requests` row and
+  forwards it on the `event.approval.requested` WS push and the REST projection,
+  so the SPA renders the amber "paused by a safety rule" banner.
+- approve → the handler returns `None` and the tool runs in-band, same turn;
+  reject / timeout / cancel → a block verdict reaches the model.
+
+The other stages stay a hard-block alias for `require_approval`: INPUT_PROMPT and
+POST_TOOL_RESULT have no clean "approve then continue" semantics, and MODEL_OUTPUT
+runs orchestrator-side with no awaiting container. Two gate types still coexist
+(business MCP policy vs safety rule); the SPA tells them apart by the presence of
+`triggered_by`.
 
 ## 12. S5 deliverables (this session)
 

--- a/src/agent_runner/approval/awaiter.py
+++ b/src/agent_runner/approval/awaiter.py
@@ -1,0 +1,203 @@
+"""Container-side block-and-await primitive for HITL approvals.
+
+Both the business-policy approval hook (``hooks.handlers.approval``) and the
+safety-pipeline ``require_approval`` bridge (``agent_runner.safety``) need the
+exact same dance: mint a ``request_id``, publish ``agent.{job_id}.approval_request``,
+block in place on an ``asyncio.Future`` resolved by the orchestrator's
+``agent.{job_id}.approval_decision`` relay, and emit ``approval_cancel`` on every
+terminal path except a clean approve. This module owns that machinery once so the
+two call sites only differ in (a) the request body they supply and (b) how they
+map the outcome onto their backend-specific verdict type.
+
+It is intentionally decoupled from NATS: callers inject an awaitable ``publish``
+coroutine ``(subject, payload) -> None`` and drive resolution via
+:meth:`ApprovalAwaiter.resolve_decision`. That keeps it unit-testable against a
+stub broker with no real broker and no Postgres.
+
+Concurrency (docs/21-hitl-approval-plan.md §6): a single turn can dispatch
+multiple tool calls concurrently, so :meth:`await_decision` can be re-entered on
+the same awaiter. Each call owns a fresh ``request_id`` and its own ``Future`` in
+``_pending``; decisions route back by ``request_id`` so concurrent approvals
+never cross wires.
+
+Cleanup (§3.3 / §8 three-layer): the ``finally`` deterministically publishes
+``approval_cancel`` on reject / timeout / Stop (``CancelledError``) / exception —
+every terminal path except a clean approve, where the orchestrator already
+cleared its suspend via the decision. The orchestrator's resume is an idempotent
+``set.discard`` so a ``cancel`` that races the ``decision`` it already processed
+is a harmless no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    Publisher = Callable[[str, dict[str, Any]], Awaitable[None]]
+
+_log = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _new_request_id() -> str:
+    return str(uuid.uuid4())
+
+
+@dataclass(frozen=True)
+class ApprovalDecision:
+    """The terminal outcome of an :meth:`ApprovalAwaiter.await_decision` call.
+
+    Exactly one of ``approved`` / ``timed_out`` is true, or both are false for
+    an explicit (or unreadable, fail-closed) rejection. ``note`` carries the
+    approver's free-text note on a rejection. Callers build their own
+    backend-specific verdict + reason string from this so the wording stays
+    appropriate to the gate type (business policy vs safety rule).
+    """
+
+    approved: bool
+    timed_out: bool
+    note: str | None = None
+
+
+class ApprovalAwaiter:
+    """Publish an approval request and block until decided / timed out.
+
+    One instance per gate type per run; ``_pending`` is keyed by ``request_id``
+    so a single instance safely serves concurrent in-flight requests.
+    """
+
+    def __init__(
+        self,
+        *,
+        publish: Publisher,
+        job_id: str,
+        timeout_ms: int,
+        now: Callable[[], datetime] = _utcnow,
+        id_factory: Callable[[], str] = _new_request_id,
+    ) -> None:
+        self._publish = publish
+        self._job_id = job_id
+        self._timeout_ms = timeout_ms
+        self._now = now
+        self._id_factory = id_factory
+        # request_id -> the Future a decision (or a timeout cancel) resolves.
+        self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
+
+    async def await_decision(
+        self, request_body: dict[str, Any]
+    ) -> ApprovalDecision:
+        """Publish ``request_body`` as an approval request and await the verdict.
+
+        The awaiter mints ``request_id`` and stamps ``job_id`` / ``requested_at``
+        / ``expires_at`` onto the published payload; ``request_body`` supplies
+        every gate-specific field (tenant, tool, provenance, ...). The bounded
+        wait is ``timeout_ms`` — the in-band fallback for a SIGKILLed
+        orchestrator that never answers.
+        """
+        request_id = self._id_factory()
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending[request_id] = fut
+
+        requested_at = self._now()
+        expires_at = requested_at + timedelta(milliseconds=self._timeout_ms)
+
+        approved = False
+        try:
+            await self._publish(
+                self._subject("approval_request"),
+                {
+                    "request_id": request_id,
+                    "job_id": self._job_id,
+                    **request_body,
+                    "requested_at": requested_at.isoformat(),
+                    "expires_at": expires_at.isoformat(),
+                },
+            )
+
+            try:
+                decision = await asyncio.wait_for(
+                    fut, timeout=self._timeout_ms / 1000
+                )
+            except TimeoutError:
+                _log.info(
+                    "approval timed out (request %s)", request_id
+                )
+                return ApprovalDecision(approved=False, timed_out=True)
+
+            if str(decision.get("decision") or "") == "approve":
+                approved = True
+                return ApprovalDecision(approved=True, timed_out=False)
+
+            # Any non-approve decision is a deny (fail-closed): a reject, or a
+            # malformed decision we cannot read as an explicit approve.
+            note = decision.get("note")
+            return ApprovalDecision(
+                approved=False,
+                timed_out=False,
+                note=note if isinstance(note, str) and note else None,
+            )
+        finally:
+            self._pending.pop(request_id, None)
+            # §3.3: cancel covers reject / timeout / Stop / exception — every
+            # terminal path except a clean approve, where the round continues
+            # and the orchestrator already cleared suspend via the decision.
+            if not approved:
+                await self._safe_publish_cancel(request_id)
+
+    def resolve_decision(self, payload: dict[str, Any]) -> bool:
+        """Route an ``approval_decision`` payload back to its await point.
+
+        First-wins / idempotent: a decision for an unknown ``request_id``
+        (already timed out, already resolved, or never ours) is a no-op and
+        returns ``False``. A successfully-routed decision returns ``True``.
+        """
+        request_id = payload.get("request_id")
+        if not isinstance(request_id, str):
+            return False
+        fut = self._pending.get(request_id)
+        if fut is None or fut.done():
+            return False
+        fut.set_result(payload)
+        return True
+
+    async def _safe_publish_cancel(self, request_id: str) -> None:
+        """Publish ``approval_cancel`` best-effort; never mask the caller.
+
+        Deliberately a plain ``await`` (not shielded): the publish must record
+        even when this runs while the task is being cancelled (Stop). A
+        coroutine that completes without suspending runs to completion even
+        under a pending ``CancelledError``; the real NATS publish may instead be
+        interrupted, in which case the orchestrator's expiry watcher (§8 layer
+        3) is the backstop — hence "best-effort". Broker errors are swallowed
+        for the same reason; ``CancelledError`` is allowed to propagate so Stop
+        still unwinds the turn.
+        """
+        try:
+            await self._publish(
+                self._subject("approval_cancel"),
+                {"request_id": request_id},
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — cancel is best-effort (§8)
+            _log.warning(
+                "approval_cancel publish failed for request %s: %s",
+                request_id, exc,
+            )
+
+    def _subject(self, leaf: str) -> str:
+        return f"agent.{self._job_id}.{leaf}"
+
+
+__all__ = ["ApprovalAwaiter", "ApprovalDecision"]

--- a/src/agent_runner/hooks/handlers/approval.py
+++ b/src/agent_runner/hooks/handlers/approval.py
@@ -42,12 +42,11 @@ never runs, which also makes the ``cancel`` publish best-effort by design.
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from agent_runner.approval.awaiter import ApprovalAwaiter
 from agent_runner.approval.policy import (
     ApprovalPolicy,
     evaluate_condition_explained,
@@ -67,14 +66,6 @@ _log = logging.getLogger(__name__)
 
 # Prefix every MCP tool name carries: ``mcp__<server>__<tool>``.
 _MCP_PREFIX = "mcp__"
-
-
-def _utcnow() -> datetime:
-    return datetime.now(tz=UTC)
-
-
-def _new_request_id() -> str:
-    return str(uuid.uuid4())
 
 
 def parse_mcp_tool_name(tool_name: str) -> tuple[str, str] | None:
@@ -117,21 +108,35 @@ class ApprovalHookHandler:
         conversation_id: str | None = None,
         user_id: str | None = None,
         timeout_ms: int,
-        now: Callable[[], datetime] = _utcnow,
-        id_factory: Callable[[], str] = _new_request_id,
+        now: Callable[[], datetime] | None = None,
+        id_factory: Callable[[], str] | None = None,
     ) -> None:
-        self._publish = publish
         self._policies = list(policies)
-        self._job_id = job_id
         self._tenant_id = tenant_id
         self._coworker_id = coworker_id
         self._conversation_id = conversation_id
         self._user_id = user_id
         self._timeout_ms = timeout_ms
-        self._now = now
-        self._id_factory = id_factory
-        # request_id -> the Future a decision (or a timeout cancel) resolves.
-        self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        # The block-and-await machinery (publish request, await decision, emit
+        # cancel) lives in the shared ApprovalAwaiter so the safety bridge can
+        # reuse it; this handler only owns policy matching + the business
+        # request body + the business-flavoured verdict reasons.
+        awaiter_kwargs: dict[str, Any] = {}
+        if now is not None:
+            awaiter_kwargs["now"] = now
+        if id_factory is not None:
+            awaiter_kwargs["id_factory"] = id_factory
+        self._awaiter = ApprovalAwaiter(
+            publish=publish,
+            job_id=job_id,
+            timeout_ms=timeout_ms,
+            **awaiter_kwargs,
+        )
+
+    @property
+    def _pending(self) -> dict[str, Any]:
+        """Expose the awaiter's in-flight map (tests drive it directly)."""
+        return self._awaiter._pending
 
     # -- hook entrypoint ------------------------------------------------
 
@@ -186,14 +191,7 @@ class ApprovalHookHandler:
         (already timed out, already resolved, or never ours) is a no-op and
         returns ``False``. A successfully-routed decision returns ``True``.
         """
-        request_id = payload.get("request_id")
-        if not isinstance(request_id, str):
-            return False
-        fut = self._pending.get(request_id)
-        if fut is None or fut.done():
-            return False
-        fut.set_result(payload)
-        return True
+        return self._awaiter.resolve_decision(payload)
 
     # -- internals ------------------------------------------------------
 
@@ -205,106 +203,41 @@ class ApprovalHookHandler:
         policy: ApprovalPolicy,
         rationale: str | None = None,
     ) -> ToolCallVerdict | None:
-        request_id = self._id_factory()
-        loop = asyncio.get_running_loop()
-        fut: asyncio.Future[dict[str, Any]] = loop.create_future()
-        self._pending[request_id] = fut
-
-        requested_at = self._now()
-        expires_at = requested_at + timedelta(milliseconds=self._timeout_ms)
-
-        approved = False
-        try:
-            await self._publish(
-                self._subject("approval_request"),
-                {
-                    "request_id": request_id,
-                    "tenant_id": self._tenant_id,
-                    "coworker_id": self._coworker_id,
-                    "conversation_id": self._conversation_id,
-                    # Approver = creator; a null user_id is forwarded as-is so
-                    # the orchestrator fails closed on it (§3.1).
-                    "user_id": self._user_id,
-                    "job_id": self._job_id,
-                    "policy_id": policy.id,
-                    "mcp_server_name": server,
-                    "tool_name": tool,
-                    "params": params,
-                    "action_summary": _action_summary(server, tool, params),
-                    # The approval's "why". The agent-supplied rationale is not
-                    # wired yet (always None for a genuine match), but a
-                    # fail-closed match (un-evaluable condition) passes its
-                    # reason here so the user can see why the call was gated.
-                    "rationale": rationale,
-                    "requested_at": requested_at.isoformat(),
-                    "expires_at": expires_at.isoformat(),
-                },
+        decision = await self._awaiter.await_decision(
+            {
+                "tenant_id": self._tenant_id,
+                "coworker_id": self._coworker_id,
+                "conversation_id": self._conversation_id,
+                # Approver = creator; a null user_id is forwarded as-is so the
+                # orchestrator fails closed on it (§3.1).
+                "user_id": self._user_id,
+                "policy_id": policy.id,
+                "mcp_server_name": server,
+                "tool_name": tool,
+                "params": params,
+                "action_summary": _action_summary(server, tool, params),
+                # The approval's "why". The agent-supplied rationale is not
+                # wired yet (always None for a genuine match), but a fail-closed
+                # match (un-evaluable condition) passes its reason here so the
+                # user can see why the call was gated.
+                "rationale": rationale,
+            }
+        )
+        if decision.approved:
+            return None
+        if decision.timed_out:
+            return ToolCallVerdict(
+                block=True,
+                reason=(
+                    f"Approval request for {server}.{tool} timed out after "
+                    f"{self._timeout_ms // 1000}s without a decision; the "
+                    "tool call was not executed."
+                ),
             )
-
-            try:
-                decision = await asyncio.wait_for(
-                    fut, timeout=self._timeout_ms / 1000
-                )
-            except TimeoutError:
-                _log.info(
-                    "approval timed out for %s.%s (request %s)",
-                    server, tool, request_id,
-                )
-                return ToolCallVerdict(
-                    block=True,
-                    reason=(
-                        f"Approval request for {server}.{tool} timed out after "
-                        f"{self._timeout_ms // 1000}s without a decision; the "
-                        "tool call was not executed."
-                    ),
-                )
-
-            if str(decision.get("decision") or "") == "approve":
-                approved = True
-                return None
-
-            # Any non-approve decision is a deny (fail-closed): a reject, or a
-            # malformed decision we cannot read as an explicit approve.
-            note = decision.get("note")
-            reason = f"Tool call {server}.{tool} was rejected by the approver."
-            if isinstance(note, str) and note:
-                reason = f"{reason} Note: {note}"
-            return ToolCallVerdict(block=True, reason=reason)
-        finally:
-            self._pending.pop(request_id, None)
-            # §3.3: cancel covers reject / timeout / Stop / exception — every
-            # terminal path except a clean approve, where the round continues
-            # and the orchestrator already cleared suspend via the decision.
-            if not approved:
-                await self._safe_publish_cancel(request_id)
-
-    async def _safe_publish_cancel(self, request_id: str) -> None:
-        """Publish ``approval_cancel`` best-effort; never mask the caller.
-
-        Deliberately a plain ``await`` (not shielded): the publish must
-        record even when this runs while the task is being cancelled (Stop).
-        A coroutine that completes without suspending runs to completion even
-        under a pending ``CancelledError``; the real NATS publish may instead
-        be interrupted, in which case the orchestrator's expiry watcher (§8
-        layer 3) is the backstop — hence "best-effort". Broker errors are
-        swallowed for the same reason; ``CancelledError`` is allowed to
-        propagate so Stop still unwinds the turn.
-        """
-        try:
-            await self._publish(
-                self._subject("approval_cancel"),
-                {"request_id": request_id},
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:  # noqa: BLE001 — cancel is best-effort (§8)
-            _log.warning(
-                "approval_cancel publish failed for request %s: %s",
-                request_id, exc,
-            )
-
-    def _subject(self, leaf: str) -> str:
-        return f"agent.{self._job_id}.{leaf}"
+        reason = f"Tool call {server}.{tool} was rejected by the approver."
+        if decision.note:
+            reason = f"{reason} Note: {decision.note}"
+        return ToolCallVerdict(block=True, reason=reason)
 
 
 def _action_summary(server: str, tool: str, params: dict[str, Any]) -> str:

--- a/src/agent_runner/main.py
+++ b/src/agent_runner/main.py
@@ -307,6 +307,32 @@ async def run_query_loop(
     hook_registry = HookRegistry()
     hook_registry.register(TranscriptArchiveHandler(assistant_name=init.assistant_name))
 
+    # HITL approval plumbing (docs/21-hitl-approval-plan.md §6 / §11.4). Both the
+    # business-policy approval hook and the safety-pipeline require_approval
+    # bridge publish agent.{job_id}.approval_request and block on a decision
+    # relayed over agent.{job_id}.approval_decision (subscribed below).
+    # APPROVAL_TIMEOUT is the in-band fallback bound; the startup assertion in
+    # core/config keeps it strictly below the container watchdog floor.
+    from rolemesh.core.config import APPROVAL_TIMEOUT
+
+    from .approval.awaiter import ApprovalAwaiter
+    from .hooks.handlers import ApprovalHookHandler, policies_from_snapshot
+
+    async def _publish_approval(subject: str, payload: dict[str, Any]) -> None:
+        await js.publish(subject, json.dumps(payload).encode())
+
+    # Safety->approval bridge awaiter: wired only when this run carries safety
+    # rules, so a rule-free agent pays nothing. The awaiter owns the same
+    # block-and-await machinery the business hook uses; the safety hook calls it
+    # on a PRE_TOOL_CALL require_approval verdict.
+    safety_awaiter: ApprovalAwaiter | None = None
+    if init.safety_rules:
+        safety_awaiter = ApprovalAwaiter(
+            publish=_publish_approval,
+            job_id=job_id,
+            timeout_ms=APPROVAL_TIMEOUT,
+        )
+
     # Register SafetyHookHandler only when rules are provided. An empty
     # or missing safety_rules list means the Safety Framework is
     # inactive for this run, preserving zero runtime cost for agents
@@ -321,25 +347,16 @@ async def run_query_loop(
         tool_ctx=tool_ctx,
         slow_check_specs=init.slow_check_specs,
         nats_client=nc,
+        approval_awaiter=safety_awaiter,
     )
 
-    # HITL approval hook (docs/21-hitl-approval-plan.md §6). Registered only
-    # when this run carries a non-empty policy snapshot — mirrors the safety
-    # handler's zero-cost-when-inactive rule. The handler blocks a matched MCP
-    # tool call in place until the orchestrator relays a decision over
-    # agent.{job_id}.approval_decision (subscribed below). APPROVAL_TIMEOUT is
-    # the in-band fallback bound; the startup assertion in core/config keeps it
-    # strictly below the container watchdog floor.
-    from rolemesh.core.config import APPROVAL_TIMEOUT
-
-    from .hooks.handlers import ApprovalHookHandler, policies_from_snapshot
-
+    # Business-policy approval hook. Registered only when this run carries a
+    # non-empty policy snapshot — mirrors the safety handler's
+    # zero-cost-when-inactive rule. Blocks a matched MCP tool call in place
+    # until the orchestrator relays a decision.
     approval_handler: ApprovalHookHandler | None = None
     approval_policies = policies_from_snapshot(init.approval_policies)
     if approval_policies:
-        async def _publish_approval(subject: str, payload: dict[str, Any]) -> None:
-            await js.publish(subject, json.dumps(payload).encode())
-
         approval_handler = ApprovalHookHandler(
             publish=_publish_approval,
             policies=approval_policies,
@@ -404,13 +421,24 @@ async def run_query_loop(
     input_sub = await js.subscribe(f"agent.{job_id}.input")
 
     # Approval decisions are relayed by the orchestrator over JetStream. We ack
-    # on receipt and route the payload to the blocked hook's await point via
-    # ApprovalHookHandler.resolve_decision (first-wins: an unknown/stale
-    # request_id is a no-op). The container is awaiting a Future, not blocking
-    # the loop, so this push callback fires while an approval is pending.
+    # on receipt and route the payload to whichever awaiter owns the request_id:
+    # the business-policy hook and the safety bridge each own one, and request
+    # ids are disjoint, so a "try business, then safety" route is first-wins (an
+    # unknown/stale id is a no-op on both). The container is awaiting a Future,
+    # not blocking the loop, so this push callback fires while an approval is
+    # pending.
+    _approval_handler = approval_handler
+    _safety_awaiter = safety_awaiter
+
+    def _route_approval_decision(data: dict[str, Any]) -> bool:
+        if _approval_handler is not None and _approval_handler.resolve_decision(data):
+            return True
+        return bool(
+            _safety_awaiter is not None and _safety_awaiter.resolve_decision(data)
+        )
+
     approval_decision_sub = None
-    if approval_handler is not None:
-        _approval_handler = approval_handler
+    if approval_handler is not None or safety_awaiter is not None:
 
         async def handle_approval_decision(msg: Any) -> None:
             await msg.ack()
@@ -419,7 +447,7 @@ async def run_query_loop(
             except (ValueError, TypeError) as exc:
                 log(f"Malformed approval_decision dropped: {exc}")
                 return
-            if isinstance(data, dict) and not _approval_handler.resolve_decision(data):
+            if isinstance(data, dict) and not _route_approval_decision(data):
                 log(
                     "approval_decision for unknown/stale request dropped: "
                     f"{data.get('request_id')}"

--- a/src/agent_runner/safety/hook_handler.py
+++ b/src/agent_runner/safety/hook_handler.py
@@ -23,10 +23,13 @@ Verdict translation (V2 P0.2):
                          expose a replace-result channel, the handler
                          emits ``appended_context`` with a withhold
                          notice instead.
-  - require_approval   → treated identically to ``block``: the turn is
-                         refused. The orchestrator's audit ingestion
-                         records ``verdict_action=require_approval`` for
-                         reporting, but the runtime effect is a block.
+  - require_approval   → at PRE_TOOL_CALL, when an ``ApprovalAwaiter`` is
+                         wired, bridged into a HITL approval ticket
+                         (docs/21 §11.4): the call blocks until a human
+                         decides — approve runs the tool in-band, reject /
+                         timeout blocks. Everywhere else (no approval
+                         surface) it stays a ``block`` alias. The audit
+                         still records ``verdict_action=require_approval``.
   - redact             → PRE_TOOL_CALL replaces ``tool_input``.
                          POST_TOOL_RESULT falls back to appended_context
                          because the hook protocol cannot replace the
@@ -51,6 +54,7 @@ from rolemesh.safety.types import SafetyContext, Stage, ToolInfo
 from .pipeline import pipeline_run
 
 if TYPE_CHECKING:
+    from agent_runner.approval.awaiter import ApprovalAwaiter
     from agent_runner.hooks.events import (
         CompactionEvent,
         ToolCallEvent,
@@ -61,6 +65,7 @@ if TYPE_CHECKING:
         UserPromptVerdict,
     )
     from agent_runner.tools.context import ToolContext
+    from rolemesh.safety.types import Verdict
 
     from .registry import CheckRegistry
 
@@ -79,6 +84,7 @@ class SafetyHookHandler:
         rules: list[dict[str, Any]],
         registry: CheckRegistry,
         tool_ctx: ToolContext,
+        approval_awaiter: ApprovalAwaiter | None = None,
     ) -> None:
         # Rules are a snapshot taken at container start. Hot-update
         # semantics (§5.1) applies at the container restart boundary;
@@ -86,6 +92,12 @@ class SafetyHookHandler:
         self._rules = rules
         self._registry = registry
         self._tool_ctx = tool_ctx
+        # When wired (HITL is active for the run), a PRE_TOOL_CALL
+        # require_approval verdict is bridged into a real HITL approval ticket
+        # instead of a terminal block. None preserves the legacy behaviour
+        # (require_approval == block) for any stage/run without an approval
+        # surface. Only PRE_TOOL_CALL uses it — see docs/21 §11.4.
+        self._approval_awaiter = approval_awaiter
 
     # -- Context construction helper -----------------------------------
 
@@ -137,8 +149,19 @@ class SafetyHookHandler:
             publisher=self._tool_ctx.publish,
         )
 
+        if (
+            verdict.action == "require_approval"
+            and self._approval_awaiter is not None
+        ):
+            # Safety->approval bridge (docs/21 §11.4): PRE_TOOL_CALL is the one
+            # stage with both an awaiting agent and an approval surface, so a
+            # require_approval verdict becomes a HITL ticket. approve -> the
+            # tool runs in-band (return None); reject/timeout -> block.
+            return await self._request_approval(event, verdict)
+
         if verdict.action in ("block", "require_approval"):
-            # require_approval blocks the turn identically to block.
+            # block — or require_approval with no approval surface wired —
+            # refuses the turn identically.
             reason = verdict.reason or "Blocked by safety policy"
             return ToolCallVerdict(block=True, reason=reason)
 
@@ -163,6 +186,72 @@ class SafetyHookHandler:
         # has no appended_context). The audit event has already been
         # published; nothing more for the agent here.
         return None
+
+    async def _request_approval(
+        self, event: ToolCallEvent, verdict: Verdict
+    ) -> ToolCallVerdict | None:
+        """Bridge a PRE_TOOL_CALL require_approval verdict into a HITL ticket.
+
+        Builds the approval request body (with the safety ``triggered_by``
+        provenance) and blocks on the shared awaiter, exactly like a
+        business-policy approval. ``approve`` lets the tool run in-band;
+        ``reject`` / timeout returns a block verdict with a safety-flavoured
+        reason. Only reachable when ``self._approval_awaiter`` is wired.
+        """
+        from agent_runner.hooks.events import ToolCallVerdict
+        from agent_runner.hooks.handlers.approval import parse_mcp_tool_name
+
+        assert self._approval_awaiter is not None
+        tool_name = event.tool_name or ""
+        parsed = parse_mcp_tool_name(tool_name)
+        # MCP tools split into (server, tool); a builtin tool (Bash/Edit/...)
+        # has no server, so carry the bare name as tool_name and leave
+        # mcp_server_name empty. The SPA keys the safety banner off
+        # triggered_by, not the server name, so an empty server is fine.
+        if parsed is not None:
+            server, tool = parsed
+        else:
+            server, tool = "", tool_name
+        params = dict(event.tool_input) if isinstance(event.tool_input, dict) else {}
+
+        triggered_by = {
+            "kind": "safety_rule",
+            "rule_id": verdict.firing_rule_id or "",
+            "check_id": verdict.firing_check_id or "",
+            "stage": Stage.PRE_TOOL_CALL.value,
+        }
+        decision = await self._approval_awaiter.await_decision(
+            {
+                "tenant_id": self._tool_ctx.tenant_id,
+                "coworker_id": self._tool_ctx.coworker_id,
+                "conversation_id": self._tool_ctx.conversation_id or None,
+                # Approver = the user whose turn this is; a null id is forwarded
+                # as-is so the orchestrator fails closed on it (§3.1).
+                "user_id": self._tool_ctx.user_id or None,
+                # Not a business policy — provenance travels in triggered_by.
+                "policy_id": None,
+                "mcp_server_name": server,
+                "tool_name": tool,
+                "params": params,
+                "action_summary": f"{tool} held for approval by a safety rule",
+                "rationale": verdict.reason,
+                "triggered_by": triggered_by,
+            }
+        )
+        if decision.approved:
+            return None
+        if decision.timed_out:
+            return ToolCallVerdict(
+                block=True,
+                reason=(
+                    f"Safety approval for {tool} timed out without a decision; "
+                    "the tool call was not executed."
+                ),
+            )
+        reason = verdict.reason or "Tool call blocked by a safety rule."
+        if decision.note:
+            reason = f"{reason} Note: {decision.note}"
+        return ToolCallVerdict(block=True, reason=reason)
 
     # -- INPUT_PROMPT ---------------------------------------------------
 

--- a/src/rolemesh/db/approval.py
+++ b/src/rolemesh/db/approval.py
@@ -61,6 +61,9 @@ class ApprovalRequest:
     action: dict[str, Any]          # { tool_name, params }
     action_summary: str | None
     rationale: str | None           # agent's "why" (nullable; no fill yet)
+    # Safety->approval provenance {kind, rule_id, check_id, stage}; None for a
+    # business-policy approval. Set by the safety hook bridge (§3.10).
+    triggered_by: dict[str, Any] | None
     status: str
     decided_by: str | None
     note: str | None
@@ -74,6 +77,19 @@ def _json_to_dict(value: Any) -> dict[str, Any]:
     if isinstance(value, str):
         value = json.loads(value) if value else {}
     return value if isinstance(value, dict) else {}
+
+
+def _json_to_optional_dict(value: Any) -> dict[str, Any] | None:
+    """Like :func:`_json_to_dict` but preserves NULL as ``None``.
+
+    Used for nullable jsonb columns (``triggered_by``) where the absence of a
+    value is semantically distinct from an empty object.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = json.loads(value) if value else None
+    return value if isinstance(value, dict) else None
 
 
 def _record_to_policy(row: asyncpg.Record) -> ApprovalPolicy:
@@ -103,6 +119,7 @@ def _record_to_request(row: asyncpg.Record) -> ApprovalRequest:
         action=_json_to_dict(row["action"]),
         action_summary=row["action_summary"],
         rationale=row["rationale"],
+        triggered_by=_json_to_optional_dict(row["triggered_by"]),
         status=row["status"],
         decided_by=str(row["decided_by"]) if row["decided_by"] else None,
         note=row["note"],
@@ -265,6 +282,7 @@ async def create_approval_request(
     user_id: str | None = None,
     action_summary: str | None = None,
     rationale: str | None = None,
+    triggered_by: dict[str, Any] | None = None,
     request_id: str | None = None,
 ) -> ApprovalRequest:
     """Insert a ``pending`` approval request and return it.
@@ -274,6 +292,10 @@ async def create_approval_request(
     call. ``user_id`` is the approver (the task creator). A ``None``
     approver is persisted as-is so the caller can fail closed on it.
 
+    ``triggered_by`` is the safety-rule provenance {kind, rule_id, check_id,
+    stage} when the request was raised by the safety pipeline's
+    require_approval bridge; ``None`` for a business-policy approval.
+
     ``request_id`` lets the caller pin the row's primary key. The container
     mints the ``request_id`` it blocks on (§3.1) *before* the orchestrator
     persists, and the decision relay routes back by that same id (§3.2), so the
@@ -281,6 +303,7 @@ async def create_approval_request(
     relay could never find the awaiting call. Left ``None`` (e.g. S1 CRUD
     tests) the DB default mints a fresh id.
     """
+    triggered_by_json = json.dumps(triggered_by) if triggered_by is not None else None
     async with tenant_conn(tenant_id) as conn:
         if request_id is not None:
             row = await conn.fetchrow(
@@ -288,11 +311,11 @@ async def create_approval_request(
                 INSERT INTO approval_requests (
                     id, tenant_id, coworker_id, conversation_id, policy_id,
                     user_id, job_id, mcp_server_name, action, action_summary,
-                    rationale, expires_at
+                    rationale, triggered_by, expires_at
                 )
                 VALUES (
                     $1::uuid, $2::uuid, $3::uuid, $4::uuid, $5::uuid,
-                    $6::uuid, $7, $8, $9::jsonb, $10, $11, $12
+                    $6::uuid, $7, $8, $9::jsonb, $10, $11, $12::jsonb, $13
                 )
                 RETURNING *
                 """,
@@ -307,6 +330,7 @@ async def create_approval_request(
                 json.dumps(action),
                 action_summary,
                 rationale,
+                triggered_by_json,
                 expires_at,
             )
         else:
@@ -315,11 +339,11 @@ async def create_approval_request(
                 INSERT INTO approval_requests (
                     tenant_id, coworker_id, conversation_id, policy_id, user_id,
                     job_id, mcp_server_name, action, action_summary, rationale,
-                    expires_at
+                    triggered_by, expires_at
                 )
                 VALUES (
                     $1::uuid, $2::uuid, $3::uuid, $4::uuid, $5::uuid,
-                    $6, $7, $8::jsonb, $9, $10, $11
+                    $6, $7, $8::jsonb, $9, $10, $11::jsonb, $12
                 )
                 RETURNING *
                 """,
@@ -333,6 +357,7 @@ async def create_approval_request(
                 json.dumps(action),
                 action_summary,
                 rationale,
+                triggered_by_json,
                 expires_at,
             )
     assert row is not None

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -1422,6 +1422,16 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await conn.execute(
         "ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS rationale TEXT"
     )
+    # Safety->approval provenance (docs/21-hitl-approval-plan.md §3.10 / §11.4):
+    # a JSON {kind, rule_id, check_id, stage} object set when the safety pipeline
+    # raises a require_approval verdict at PRE_TOOL_CALL and the hook bridge turns
+    # it into a HITL ticket; null for a business-policy approval. Like
+    # ``policy_id`` it is deliberately not an FK — the rule/check it names may be
+    # edited or deleted while a historical request remains. Added after the table
+    # shipped, so use the idempotent ADD COLUMN IF NOT EXISTS form.
+    await conn.execute(
+        "ALTER TABLE approval_requests ADD COLUMN IF NOT EXISTS triggered_by JSONB"
+    )
 
     # Reference/seed data — see _seed_reference_data.
     await _seed_reference_data(conn)

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -519,11 +519,11 @@ async def _apply_model_output_safety(
             block=("[Response blocked by safety policy]", None)
         )
     if verdict.action in ("block", "require_approval"):
-        # R4 (docs/21-hitl-approval-plan.md §1): a safety ``require_approval``
-        # verdict is a HARD block and deliberately does NOT enter HITL tool
-        # approval. HITL gates only tenant MCP-tool *policy* matches (the
-        # block-and-await hook in agent_runner); the safety pipeline's
-        # require_approval stays a terminal block alias as it is on main.
+        # R4 (docs/21-hitl-approval-plan.md §11.4): the safety->approval bridge
+        # is scoped to PRE_TOOL_CALL — the one stage with an awaiting container
+        # and an approval surface. MODEL_OUTPUT runs orchestrator-side with no
+        # container to block, so a ``require_approval`` verdict stays a HARD
+        # block alias here (PRE_TOOL_CALL gets the HITL ticket instead).
         reason = verdict.reason or "[Response blocked by safety policy]"
         # Verdict at pipeline level doesn't carry rule_ids — the audit
         # path persists per-rule records to safety_decisions separately.

--- a/src/rolemesh/orchestration/approval_coordinator.py
+++ b/src/rolemesh/orchestration/approval_coordinator.py
@@ -176,6 +176,10 @@ class ApprovalCoordinator:
         action_summary = payload.get("action_summary")
         raw_rationale = payload.get("rationale")
         rationale = raw_rationale if isinstance(raw_rationale, str) else None
+        # Safety-rule provenance (§3.10): present only when the container's
+        # safety hook raised the request; a business-policy approval omits it.
+        raw_triggered_by = payload.get("triggered_by")
+        triggered_by = raw_triggered_by if isinstance(raw_triggered_by, dict) else None
         key = approval_queue_key(conversation_id, coworker_id)
 
         # Server-side truth for the tenant; the payload value is only a fallback
@@ -228,6 +232,7 @@ class ApprovalCoordinator:
                 user_id=user_id,
                 action_summary=action_summary,
                 rationale=rationale,
+                triggered_by=triggered_by,
                 request_id=request_id,
             )
         except Exception:

--- a/src/rolemesh/orchestration/approval_notify.py
+++ b/src/rolemesh/orchestration/approval_notify.py
@@ -267,6 +267,10 @@ class ApprovalNotifier:
                     "requested_at": req.requested_at.isoformat(),
                     "rationale": req.rationale,
                     "action_summary": req.action_summary,
+                    # Safety-rule provenance (§3.10); None for a business-policy
+                    # approval. The SPA renders the amber "paused by a safety
+                    # rule" banner from this.
+                    "triggered_by": req.triggered_by,
                     "expires_at": req.expires_at.isoformat(),
                 },
             )

--- a/src/rolemesh/safety/loader.py
+++ b/src/rolemesh/safety/loader.py
@@ -198,6 +198,7 @@ def maybe_register_safety_handler(
     *,
     slow_check_specs: list[dict[str, Any]] | None = None,
     nats_client: Any = None,
+    approval_awaiter: Any = None,
 ) -> bool:
     """Register a SafetyHookHandler iff rules are present.
 
@@ -219,6 +220,12 @@ def maybe_register_safety_handler(
     still use this function to wire the cheap-only registry — adding
     two required arguments would force callers to pass ``None`` / a
     live NATS client just to say "no slow checks please".
+
+    ``approval_awaiter`` (optional) wires the safety->approval bridge: when
+    provided, a PRE_TOOL_CALL ``require_approval`` verdict is turned into a HITL
+    approval ticket instead of a terminal block (docs/21 §11.4). Left ``None``
+    (the default) the handler keeps the legacy require_approval==block
+    behaviour, so callers without HITL wired pay nothing.
     """
     if not safety_rules:
         return False
@@ -255,6 +262,7 @@ def maybe_register_safety_handler(
             rules=safety_rules,
             registry=registry,
             tool_ctx=tool_ctx,
+            approval_awaiter=approval_awaiter,
         )
     )
     return True

--- a/src/rolemesh/safety/pipeline_core.py
+++ b/src/rolemesh/safety/pipeline_core.py
@@ -277,9 +277,17 @@ async def pipeline_run(
         if verdict.action in _SHORT_CIRCUIT_ACTIONS:
             # block + require_approval both exit the loop and both
             # refuse the turn. They are kept as distinct verdict
-            # actions for audit/reporting, but the runtime effect is
-            # identical: the turn is blocked.
-            return replace(verdict, findings=list(all_findings))
+            # actions for audit/reporting; the runtime effect differs
+            # only where a require_approval verdict reaches an approval
+            # surface (see the hook bridge). Stamp the firing rule's
+            # provenance so that bridge can attribute the approval
+            # ticket back to the rule/check that raised it.
+            return replace(
+                verdict,
+                findings=list(all_findings),
+                firing_rule_id=str(rule.get("id") or "") or None,
+                firing_check_id=check_id or None,
+            )
 
         if verdict.action == "redact":
             # Shape already validated above. Swap the ctx payload so

--- a/src/rolemesh/safety/types.py
+++ b/src/rolemesh/safety/types.py
@@ -190,9 +190,19 @@ class Verdict:
     appropriate payload shape with the offending content rewritten.
     ``action="warn"`` uses ``appended_context`` to inject a string into
     the agent's follow-up context (hook bridge wires this up at V2).
-    ``action="require_approval"`` is a verdict that blocks the turn —
-    the pipeline short-circuits on it exactly like ``block``. It is
-    kept as a distinct action for audit/reporting purposes.
+    ``action="require_approval"`` is a verdict that short-circuits the
+    pipeline exactly like ``block``. Where an approval surface exists
+    (PRE_TOOL_CALL), the hook bridge turns it into a HITL approval
+    ticket rather than a terminal block; everywhere else it remains a
+    block alias. It is kept as a distinct action for audit/reporting.
+
+    ``firing_rule_id`` / ``firing_check_id`` carry the provenance of the
+    rule that produced a short-circuit verdict (``block`` /
+    ``require_approval``). They are populated by the pipeline at the
+    short-circuit return — not by individual checks — and stay ``None``
+    on a synthesized tail verdict (redact/warn/allow), where no single
+    rule "fired" the outcome. The safety->approval bridge reads them to
+    fill the approval ticket's ``triggered_by`` provenance.
     """
 
     action: Action = "allow"
@@ -200,6 +210,8 @@ class Verdict:
     modified_payload: Any | None = None
     findings: list[Finding] = field(default_factory=list)
     appended_context: str | None = None
+    firing_rule_id: str | None = None
+    firing_check_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/webui/v1/approvals.py
+++ b/src/webui/v1/approvals.py
@@ -36,6 +36,7 @@ from webui.schemas_v1 import (
     ApprovalPolicyCreate,
     ApprovalPolicyUpdate,
     ApprovalRequest,
+    ApprovalTriggeredBy,
 )
 from webui.v1.errors import raise_error_response
 
@@ -61,6 +62,32 @@ def _policy_to_response(p: ApprovalPolicyValue) -> ApprovalPolicy:
     )
 
 
+def _triggered_by_to_response(
+    raw: dict[str, object] | None,
+) -> ApprovalTriggeredBy | None:
+    """Project the row's ``triggered_by`` jsonb into the wire model.
+
+    Only a fully-formed ``safety_rule`` provenance projects; anything else
+    (None, malformed, or an unknown kind) collapses to ``None`` so a bad row
+    degrades to a plain business-policy card rather than failing the response.
+    """
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("kind") != "safety_rule":
+        return None
+    rule_id = raw.get("rule_id")
+    check_id = raw.get("check_id")
+    stage = raw.get("stage")
+    if not all(isinstance(v, str) and v for v in (rule_id, check_id, stage)):
+        return None
+    return ApprovalTriggeredBy(
+        kind="safety_rule",
+        rule_id=str(rule_id),
+        check_id=str(check_id),
+        stage=str(stage),
+    )
+
+
 def _request_to_response(r: ApprovalRequestRow) -> ApprovalRequest:
     # ``action`` is the {tool_name, params} snapshot. The decision UX (§1.2)
     # needs the raw params to be informative — the user cannot meaningfully
@@ -81,6 +108,7 @@ def _request_to_response(r: ApprovalRequestRow) -> ApprovalRequest:
         params=params,
         coworker_id=r.coworker_id,
         rationale=r.rationale,
+        triggered_by=_triggered_by_to_response(r.triggered_by),
         status=r.status,
         decided_at=r.decided_at.isoformat() if r.decided_at else None,
         note=r.note,

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -250,6 +250,27 @@ def _build_approval_frame_or_none(
         expires_at = payload.get("expires_at")
         if isinstance(expires_at, str):
             frame["expires_at"] = expires_at
+        # Safety-rule provenance (§3.10). Whitelist exactly the four
+        # ApprovalTriggeredBy keys and forward only a fully-formed object so an
+        # unexpected internal key never reaches the browser; a malformed or
+        # absent provenance degrades to no banner (the SPA treats a missing
+        # triggered_by as a normal business-policy approval).
+        triggered_by = payload.get("triggered_by")
+        if isinstance(triggered_by, dict):
+            kind_v = triggered_by.get("kind")
+            rule_id = triggered_by.get("rule_id")
+            check_id = triggered_by.get("check_id")
+            stage = triggered_by.get("stage")
+            if all(
+                isinstance(v, str) and v
+                for v in (kind_v, rule_id, check_id, stage)
+            ):
+                frame["triggered_by"] = {
+                    "kind": kind_v,
+                    "rule_id": rule_id,
+                    "check_id": check_id,
+                    "stage": stage,
+                }
         return frame
     if kind == "approval.resolved":
         outcome = payload.get("outcome")

--- a/tests/agent/test_approval_awaiter.py
+++ b/tests/agent/test_approval_awaiter.py
@@ -1,0 +1,201 @@
+"""Unit tests for the shared container-side ApprovalAwaiter.
+
+The awaiter is the block-and-await primitive both the business-policy approval
+hook and the safety->approval bridge reuse. These drive it against a stub broker
+(no NATS) and a hand-driven ``resolve_decision``, asserting the wire contract
+(request_id / job_id / requested_at / expires_at injected onto the published
+body), the approve / reject / timeout outcomes, and the §3.3 cancel discipline.
+
+Each test runs its own loop via ``asyncio.run`` so the suite needs no
+pytest-asyncio mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from agent_runner.approval.awaiter import ApprovalAwaiter, ApprovalDecision
+
+_FIXED_NOW = datetime(2026, 5, 31, 12, 0, 0, tzinfo=UTC)
+
+
+class StubBroker:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    async def publish(self, subject: str, payload: dict[str, Any]) -> None:
+        self.published.append((subject, payload))
+
+    def by_leaf(self, leaf: str) -> list[dict[str, Any]]:
+        return [p for s, p in self.published if s.endswith(f".{leaf}")]
+
+    @property
+    def requests(self) -> list[dict[str, Any]]:
+        return self.by_leaf("approval_request")
+
+    @property
+    def cancels(self) -> list[dict[str, Any]]:
+        return self.by_leaf("approval_cancel")
+
+
+def _awaiter(
+    broker: StubBroker,
+    *,
+    timeout_ms: int = 300_000,
+    **kw: Any,
+) -> ApprovalAwaiter:
+    return ApprovalAwaiter(
+        publish=broker.publish, job_id="job-1", timeout_ms=timeout_ms, **kw
+    )
+
+
+async def _wait_for_requests(broker: StubBroker, n: int) -> None:
+    for _ in range(10_000):
+        if len(broker.requests) >= n:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"expected {n} request(s), got {len(broker.requests)}")
+
+
+def test_request_body_gets_ids_and_window_stamped() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(
+        broker, timeout_ms=300_000, now=lambda: _FIXED_NOW, id_factory=lambda: "rid"
+    )
+
+    async def go() -> None:
+        task = asyncio.create_task(
+            awaiter.await_decision({"tenant_id": "t1", "tool_name": "send"})
+        )
+        await _wait_for_requests(broker, 1)
+        awaiter.resolve_decision({"request_id": "rid", "decision": "approve"})
+        await task
+
+    asyncio.run(go())
+    req = broker.requests[0]
+    assert req["request_id"] == "rid"
+    assert req["job_id"] == "job-1"
+    assert req["tenant_id"] == "t1"
+    assert req["tool_name"] == "send"
+    assert req["requested_at"] == _FIXED_NOW.isoformat()
+    assert req["expires_at"] == (_FIXED_NOW + timedelta(milliseconds=300_000)).isoformat()
+    # Subject is namespaced to the job.
+    subject = broker.published[0][0]
+    assert subject == "agent.job-1.approval_request"
+
+
+def test_approve_returns_approved_and_does_not_cancel() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker)
+
+    async def go() -> ApprovalDecision:
+        task = asyncio.create_task(awaiter.await_decision({"tool_name": "send"}))
+        await _wait_for_requests(broker, 1)
+        rid = broker.requests[0]["request_id"]
+        assert awaiter.resolve_decision({"request_id": rid, "decision": "approve"}) is True
+        return await task
+
+    decision = asyncio.run(go())
+    assert decision.approved is True
+    assert decision.timed_out is False
+    assert broker.cancels == []  # clean approve does not cancel (§3.3)
+
+
+def test_reject_carries_note_and_emits_cancel() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker)
+
+    async def go() -> ApprovalDecision:
+        task = asyncio.create_task(awaiter.await_decision({"tool_name": "send"}))
+        await _wait_for_requests(broker, 1)
+        rid = broker.requests[0]["request_id"]
+        awaiter.resolve_decision(
+            {"request_id": rid, "decision": "reject", "note": "too risky"}
+        )
+        return await task
+
+    decision = asyncio.run(go())
+    assert decision.approved is False
+    assert decision.timed_out is False
+    assert decision.note == "too risky"
+    assert len(broker.cancels) == 1
+
+
+def test_unknown_decision_is_a_deny() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker)
+
+    async def go() -> ApprovalDecision:
+        task = asyncio.create_task(awaiter.await_decision({"tool_name": "send"}))
+        await _wait_for_requests(broker, 1)
+        rid = broker.requests[0]["request_id"]
+        awaiter.resolve_decision({"request_id": rid, "decision": "maybe-later"})
+        return await task
+
+    decision = asyncio.run(go())
+    assert decision.approved is False
+    assert decision.timed_out is False
+    assert len(broker.cancels) == 1
+
+
+def test_timeout_returns_timed_out_and_cancels() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker, timeout_ms=20)
+    decision = asyncio.run(awaiter.await_decision({"tool_name": "send"}))
+    assert decision.timed_out is True
+    assert decision.approved is False
+    assert len(broker.cancels) == 1
+
+
+def test_concurrent_requests_route_independently() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker)
+
+    async def go() -> tuple[ApprovalDecision, ApprovalDecision]:
+        task_a = asyncio.create_task(awaiter.await_decision({"tool_name": "a"}))
+        await _wait_for_requests(broker, 1)
+        task_b = asyncio.create_task(awaiter.await_decision({"tool_name": "b"}))
+        await _wait_for_requests(broker, 2)
+        rid_a = broker.requests[0]["request_id"]
+        rid_b = broker.requests[1]["request_id"]
+        assert rid_a != rid_b
+        awaiter.resolve_decision({"request_id": rid_b, "decision": "approve"})
+        awaiter.resolve_decision({"request_id": rid_a, "decision": "reject"})
+        return await task_a, await task_b
+
+    dec_a, dec_b = asyncio.run(go())
+    assert dec_a.approved is False  # A rejected
+    assert dec_b.approved is True   # B approved
+    assert len(broker.cancels) == 1  # only the rejected A cancels
+
+
+def test_resolve_unknown_or_late_is_noop() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker, timeout_ms=20)
+    asyncio.run(awaiter.await_decision({"tool_name": "send"}))
+    rid = broker.requests[0]["request_id"]
+    # The await point is gone; a late decision routes nothing.
+    assert awaiter.resolve_decision({"request_id": rid, "decision": "approve"}) is False
+    assert awaiter.resolve_decision({"decision": "approve"}) is False
+    assert awaiter.resolve_decision({"request_id": 123, "decision": "approve"}) is False
+
+
+def test_stop_cancellederror_emits_cancel_and_propagates() -> None:
+    broker = StubBroker()
+    awaiter = _awaiter(broker)
+
+    async def go() -> None:
+        task = asyncio.create_task(awaiter.await_decision({"tool_name": "send"}))
+        await _wait_for_requests(broker, 1)
+        rid = broker.requests[0]["request_id"]
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert len(broker.cancels) == 1
+        assert broker.cancels[0]["request_id"] == rid
+
+    asyncio.run(go())

--- a/tests/orchestration/test_approval_coordinator.py
+++ b/tests/orchestration/test_approval_coordinator.py
@@ -65,6 +65,7 @@ class _FakeStore:
         user_id: str | None = None,
         action_summary: str | None = None,
         rationale: str | None = None,
+        triggered_by: dict[str, Any] | None = None,
         request_id: str | None = None,
     ) -> ApprovalRequest:
         rid = request_id or str(uuid.uuid4())
@@ -80,6 +81,7 @@ class _FakeStore:
             action=action,
             action_summary=action_summary,
             rationale=rationale,
+            triggered_by=triggered_by,
             status="pending",
             decided_by=None,
             note=None,
@@ -187,6 +189,34 @@ async def test_request_suspends_and_persists() -> None:
     assert "req1" in store.rows
     assert q._get_group("conv1").idle_handle is None  # suspended, not armed
     assert decisions == []
+
+
+async def test_request_persists_safety_triggered_by() -> None:
+    # A safety-bridge request carries triggered_by; the coordinator must thread
+    # it into the persisted row so the REST/WS surfaces can render the banner.
+    coord, _q, store, _ = _make()
+    payload = _payload()
+    payload["policy_id"] = None
+    payload["triggered_by"] = {
+        "kind": "safety_rule",
+        "rule_id": "rule-9",
+        "check_id": "pii.regex",
+        "stage": "pre_tool_call",
+    }
+    await coord.on_approval_request(payload)
+    assert store.rows["req1"].triggered_by == {
+        "kind": "safety_rule",
+        "rule_id": "rule-9",
+        "check_id": "pii.regex",
+        "stage": "pre_tool_call",
+    }
+
+
+async def test_request_without_triggered_by_persists_none() -> None:
+    # A business-policy request omits triggered_by -> the row stores None.
+    coord, _q, store, _ = _make()
+    await coord.on_approval_request(_payload())
+    assert store.rows["req1"].triggered_by is None
 
 
 async def test_request_keyed_on_coworker_when_no_conversation() -> None:

--- a/tests/orchestration/test_approval_decision_funnel.py
+++ b/tests/orchestration/test_approval_decision_funnel.py
@@ -66,6 +66,7 @@ class _Store:
             policy_id=kw.get("policy_id"), user_id=kw.get("user_id"),
             action_summary=kw.get("action_summary"),
             rationale=kw.get("rationale"),
+            triggered_by=kw.get("triggered_by"),
             conversation_id=kw.get("conversation_id"),
             tenant_id=kw["tenant_id"], coworker_id=kw["coworker_id"],
             job_id=kw["job_id"], mcp_server_name=kw["mcp_server_name"],

--- a/tests/orchestration/test_approval_notify.py
+++ b/tests/orchestration/test_approval_notify.py
@@ -29,6 +29,7 @@ def _req(
     rationale: str | None = None,
     action: dict[str, Any] | None = None,
     mcp_server_name: str = "stripe",
+    triggered_by: dict[str, Any] | None = None,
 ) -> ApprovalRequest:
     now = datetime.now(tz=UTC)
     return ApprovalRequest(
@@ -43,6 +44,7 @@ def _req(
         action=action if action is not None else {"tool_name": "charge", "params": {"amount": 500}},
         action_summary=action_summary,
         rationale=rationale,
+        triggered_by=triggered_by,
         status="pending",
         decided_by=None,
         note=None,
@@ -240,6 +242,26 @@ async def test_web_requested_payload_carries_decision_fields() -> None:
     assert payload["conversation_id"] == "conv1"
     assert payload["rationale"] == "refunding duplicate order"
     assert payload["requested_at"]  # ISO timestamp present
+    # A business-policy approval has no safety provenance.
+    assert payload["triggered_by"] is None
+
+
+async def test_web_requested_payload_carries_safety_triggered_by() -> None:
+    # A safety-bridge approval forwards triggered_by so the SPA renders the
+    # amber "paused by a safety rule" banner from the push alone (§3.10).
+    provenance = {
+        "kind": "safety_rule",
+        "rule_id": "rule-9",
+        "check_id": "pii.regex",
+        "stage": "pre_tool_call",
+    }
+    h = _Harness(
+        conversations={"conv1": _conv()}, bindings={"bind1": _binding("web")}
+    )
+    n = h.notifier()
+    await n.notify_status(_req(triggered_by=provenance))
+    payload = h.web_events[0][2]
+    assert payload["triggered_by"] == provenance
 
 
 async def test_web_card_emits_cancelled_resolution() -> None:

--- a/tests/safety/test_hook_handler.py
+++ b/tests/safety/test_hook_handler.py
@@ -802,3 +802,164 @@ class TestPreCompact:
             )
         )
         assert tool_ctx.events == []
+
+
+class _StubBroker:
+    """Records approval publishes so the bridge tests can assert wire traffic."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    async def publish(self, subject: str, payload: dict[str, Any]) -> None:
+        self.published.append((subject, payload))
+
+    def by_leaf(self, leaf: str) -> list[dict[str, Any]]:
+        return [p for s, p in self.published if s.endswith(f".{leaf}")]
+
+    @property
+    def requests(self) -> list[dict[str, Any]]:
+        return self.by_leaf("approval_request")
+
+
+async def _wait_for_requests(broker: _StubBroker, n: int) -> None:
+    for _ in range(10_000):
+        if len(broker.requests) >= n:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"expected {n} approval_request(s), got {len(broker.requests)}")
+
+
+def _approval_stub_registry(check_id: str) -> CheckRegistry:
+    from rolemesh.safety.registry import CheckRegistry
+    from rolemesh.safety.types import Verdict
+
+    class _Stub:
+        id = check_id
+        version = "1"
+        stages = frozenset({Stage.PRE_TOOL_CALL})
+        cost_class = "cheap"
+        supported_codes: frozenset[str] = frozenset({"STUB"})
+        config_model = None
+
+        async def check(self, ctx, config):  # type: ignore[no-untyped-def]
+            return Verdict(action="require_approval", reason="needs a human")
+
+    reg = CheckRegistry()
+    reg.register(_Stub())
+    return reg
+
+
+class TestSafetyApprovalBridge:
+    """PRE_TOOL_CALL require_approval -> HITL ticket (docs/21 §11.4).
+
+    With an ApprovalAwaiter wired, a require_approval verdict publishes an
+    approval_request carrying the safety ``triggered_by`` provenance and blocks
+    until a decision: approve runs the tool in-band (None), reject/timeout
+    blocks. Without an awaiter the verdict stays a terminal block (covered by
+    TestVerdictTranslation).
+    """
+
+    def _handler(self, broker: _StubBroker, *, timeout_ms: int = 300_000):  # type: ignore[no-untyped-def]
+        from agent_runner.approval.awaiter import ApprovalAwaiter
+
+        tool_ctx = _FakeToolCtx()
+        awaiter = ApprovalAwaiter(
+            publish=broker.publish, job_id="job-1", timeout_ms=timeout_ms
+        )
+        rule = make_rule(
+            rule_id="rule-x",
+            check_id="stub.appr.bridge",
+            stage=Stage.PRE_TOOL_CALL,
+            config={},
+        )
+        handler = SafetyHookHandler(
+            rules=[rule],
+            registry=_approval_stub_registry("stub.appr.bridge"),
+            tool_ctx=tool_ctx,  # type: ignore[arg-type]
+            approval_awaiter=awaiter,
+        )
+        return handler, awaiter
+
+    @pytest.mark.asyncio
+    async def test_require_approval_publishes_request_with_triggered_by(self) -> None:
+        broker = _StubBroker()
+        handler, awaiter = self._handler(broker)
+
+        task = asyncio.create_task(
+            handler.on_pre_tool_use(
+                ToolCallEvent(tool_name="Bash", tool_input={"command": "rm -rf x"})
+            )
+        )
+        await _wait_for_requests(broker, 1)
+        req = broker.requests[0]
+        # Provenance is the whole point of the bridge.
+        assert req["triggered_by"] == {
+            "kind": "safety_rule",
+            "rule_id": "rule-x",
+            "check_id": "stub.appr.bridge",
+            "stage": "pre_tool_call",
+        }
+        # Not a business policy; the rationale surfaces the rule's reason.
+        assert req["policy_id"] is None
+        assert req["rationale"] == "needs a human"
+        # A builtin tool has no MCP server; the bare name rides tool_name.
+        assert req["mcp_server_name"] == ""
+        assert req["tool_name"] == "Bash"
+        assert req["params"] == {"command": "rm -rf x"}
+
+        awaiter.resolve_decision(
+            {"request_id": req["request_id"], "decision": "approve"}
+        )
+        assert await task is None  # approved -> tool runs in-band
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_splits_server_and_tool(self) -> None:
+        broker = _StubBroker()
+        handler, awaiter = self._handler(broker)
+        task = asyncio.create_task(
+            handler.on_pre_tool_use(
+                ToolCallEvent(tool_name="mcp__email__send", tool_input={"to": "x"})
+            )
+        )
+        await _wait_for_requests(broker, 1)
+        req = broker.requests[0]
+        assert req["mcp_server_name"] == "email"
+        assert req["tool_name"] == "send"
+        awaiter.resolve_decision(
+            {"request_id": req["request_id"], "decision": "approve"}
+        )
+        await task
+
+    @pytest.mark.asyncio
+    async def test_reject_blocks_with_reason(self) -> None:
+        broker = _StubBroker()
+        handler, awaiter = self._handler(broker)
+        task = asyncio.create_task(
+            handler.on_pre_tool_use(
+                ToolCallEvent(tool_name="Bash", tool_input={})
+            )
+        )
+        await _wait_for_requests(broker, 1)
+        awaiter.resolve_decision(
+            {
+                "request_id": broker.requests[0]["request_id"],
+                "decision": "reject",
+                "note": "no way",
+            }
+        )
+        verdict = await task
+        assert verdict is not None
+        assert verdict.block is True
+        assert "needs a human" in (verdict.reason or "")
+        assert "no way" in (verdict.reason or "")
+
+    @pytest.mark.asyncio
+    async def test_timeout_blocks(self) -> None:
+        broker = _StubBroker()
+        handler, _awaiter = self._handler(broker, timeout_ms=20)
+        verdict = await handler.on_pre_tool_use(
+            ToolCallEvent(tool_name="Bash", tool_input={})
+        )
+        assert verdict is not None
+        assert verdict.block is True
+        assert "timed out" in (verdict.reason or "")

--- a/tests/safety/test_pipeline.py
+++ b/tests/safety/test_pipeline.py
@@ -764,6 +764,10 @@ class TestRequireApproval:
         # Distinct action so P1.1 can dispatch.
         assert verdict.action == "require_approval"
         assert verdict.reason == "needs human"
+        # Provenance of the firing rule rides the short-circuit verdict so the
+        # safety->approval bridge can attribute the ticket (docs/21 §11.4).
+        assert verdict.firing_rule_id == "r1"
+        assert verdict.firing_check_id == "stub.approve"
 
     @pytest.mark.asyncio
     async def test_audit_event_carries_require_approval_string(

--- a/tests/webui/test_approval_triggered_by_projection.py
+++ b/tests/webui/test_approval_triggered_by_projection.py
@@ -1,0 +1,57 @@
+"""Unit tests for the REST ``triggered_by`` projection helper.
+
+``_triggered_by_to_response`` maps the ``approval_requests.triggered_by`` jsonb
+onto the ``ApprovalTriggeredBy`` wire model. These call it directly (no DB) to
+pin the "only a fully-formed safety_rule provenance projects" contract.
+"""
+
+from __future__ import annotations
+
+from webui.schemas_v1 import ApprovalTriggeredBy
+from webui.v1.approvals import _triggered_by_to_response
+
+
+def test_well_formed_safety_rule_projects() -> None:
+    out = _triggered_by_to_response(
+        {
+            "kind": "safety_rule",
+            "rule_id": "rule-9",
+            "check_id": "pii.regex",
+            "stage": "pre_tool_call",
+        }
+    )
+    assert isinstance(out, ApprovalTriggeredBy)
+    assert out.kind == "safety_rule"
+    assert out.rule_id == "rule-9"
+    assert out.check_id == "pii.regex"
+    assert out.stage == "pre_tool_call"
+
+
+def test_none_and_business_policy_project_none() -> None:
+    assert _triggered_by_to_response(None) is None
+    # A business-policy approval has no provenance object at all.
+    assert _triggered_by_to_response({}) is None
+
+
+def test_unknown_kind_degrades_to_none() -> None:
+    assert (
+        _triggered_by_to_response(
+            {
+                "kind": "scheduled_task",  # V1 only emits safety_rule
+                "rule_id": "r",
+                "check_id": "c",
+                "stage": "pre_tool_call",
+            }
+        )
+        is None
+    )
+
+
+def test_missing_or_empty_fields_degrade_to_none() -> None:
+    for bad in (
+        {"kind": "safety_rule", "rule_id": "r", "check_id": "c"},  # no stage
+        {"kind": "safety_rule", "rule_id": "", "check_id": "c", "stage": "s"},
+        {"kind": "safety_rule", "rule_id": 9, "check_id": "c", "stage": "s"},
+        "not-a-dict",
+    ):
+        assert _triggered_by_to_response(bad) is None  # type: ignore[arg-type]

--- a/tests/webui/test_ws_approval.py
+++ b/tests/webui/test_ws_approval.py
@@ -137,6 +137,53 @@ def test_build_requested_frame_carries_decision_fields() -> None:
     WsServerEventApprovalRequested.model_validate(frame)
 
 
+def test_build_requested_frame_projects_safety_triggered_by() -> None:
+    # §3.10: a well-formed safety provenance projects so the SPA can render the
+    # amber "paused by a safety rule" banner; the frame still validates.
+    frame = _build_approval_frame_or_none(
+        {
+            "type": "approval.requested",
+            "request_id": "r1",
+            "action_summary": "Bash held for approval by a safety rule",
+            "expires_at": "2026-05-31T00:00:00Z",
+            "triggered_by": {
+                "kind": "safety_rule",
+                "rule_id": "rule-9",
+                "check_id": "pii.regex",
+                "stage": "pre_tool_call",
+            },
+        }
+    )
+    assert frame is not None
+    assert frame["triggered_by"] == {
+        "kind": "safety_rule",
+        "rule_id": "rule-9",
+        "check_id": "pii.regex",
+        "stage": "pre_tool_call",
+    }
+    WsServerEventApprovalRequested.model_validate(frame)
+
+
+def test_build_requested_frame_drops_malformed_triggered_by() -> None:
+    # A provenance missing a required key (or carrying a non-string) must never
+    # reach the browser half-formed — it degrades to no banner.
+    for bad in (
+        {"kind": "safety_rule", "rule_id": "r", "check_id": "c"},  # no stage
+        {"kind": "safety_rule", "rule_id": "", "check_id": "c", "stage": "s"},  # empty
+        {"kind": "safety_rule", "rule_id": 9, "check_id": "c", "stage": "s"},  # non-str
+        "not-a-dict",
+    ):
+        frame = _build_approval_frame_or_none(
+            {
+                "type": "approval.requested",
+                "request_id": "r1",
+                "triggered_by": bad,
+            }
+        )
+        assert frame is not None
+        assert "triggered_by" not in frame
+
+
 def test_build_requested_frame_drops_non_dict_params() -> None:
     # A malformed params (not an object) must never reach the browser as one —
     # the schema types it as object|null, and the SPA reads keys off it.


### PR DESCRIPTION
## What

Connects the safety pipeline's `require_approval` verdict to the HITL approval system at **PRE_TOOL_CALL** — the one stage with both an awaiting container and an approval surface. A `require_approval` verdict there now becomes a real HITL ticket carrying safety-rule provenance instead of a terminal block: **approve** runs the tool in-band (same turn), **reject/timeout/cancel** blocks. Every other stage (INPUT_PROMPT / MODEL_OUTPUT / POST_TOOL_RESULT) keeps the hard-block alias.

This **revises decision R4** in `docs/21-hitl-approval-plan.md` (previously "safety `require_approval` never enters HITL"). The frontend contract groundwork (`ApprovalTriggeredBy`, the amber "paused by a safety rule" banner) was already merged in `feat/safety-ui` anticipating this backend bridge; this PR completes the path.

## Why PRE_TOOL_CALL only

The block-and-await substrate (publish `approval_request` → await a decision relayed over `approval_decision`) lives container-side at the PreToolUse hook. PRE_TOOL_CALL safety runs in that same layer, so it reuses the substrate cleanly. The other stages have no clean "approve then continue" semantics (POST_TOOL_RESULT already ran the tool; MODEL_OUTPUT runs orchestrator-side with no container to block), so they stay hard-block aliases.

## Mechanics

- **Provenance:** `pipeline_core` stamps the firing rule's `firing_rule_id` / `firing_check_id` onto a short-circuit verdict (new `Verdict` fields).
- **Shared awaiter:** extracted the container block-and-await machinery into `agent_runner/approval/awaiter.py::ApprovalAwaiter`. `ApprovalHookHandler` now delegates to it — **public API and wire payload unchanged** — and the safety hook reuses it for the bridge, publishing `triggered_by = {kind, rule_id, check_id, stage}` with `policy_id = null`.
- **Persistence + plumbing:** nullable `triggered_by` jsonb column on `approval_requests` (idempotent migration), threaded through the coordinator, the `event.approval.requested` WS push (whitelisted projection), and the REST projection.
- **Container wiring:** build the safety awaiter when the run carries safety rules; route approval decisions to whichever awaiter owns the `request_id` (first-wins).
- **Docs:** R4 updated in the plan (§1 / §2 / §10 / §11.4); S4 notes marked superseded; the MODEL_OUTPUT comment in `main.py` updated.

## Tests

New + updated, **223 passing** locally:
- `ApprovalAwaiter` unit suite (approve / reject / timeout / cancel / concurrent / wire-stamp)
- safety bridge (provenance, approve/reject/timeout, MCP-vs-builtin tool split, no-awaiter fallback)
- verdict provenance, coordinator / notify / WS-frame / REST `triggered_by` plumbing

ruff clean; mypy introduces no new errors. (DB/container-backed tests require Docker and aren't run in this environment.)

https://claude.ai/code/session_01JBFbkwj5iF1XspNDUTT2EH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBFbkwj5iF1XspNDUTT2EH)_