### PR TITLE
feat(safety): add check_id + rule_id filters to GET /safety/decisions

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -1399,6 +1399,22 @@ paths:
           in: query
           required: false
           schema: { $ref: '#/components/schemas/SafetyStage' }
+        - name: check_id
+          in: query
+          required: false
+          description: |
+            Narrow to decisions triggered by a rule using this check.
+            A decision stores no check_id directly; the server resolves
+            the check to its rule ids (tenant + platform catalogs) and
+            matches by array overlap on triggered_rule_ids.
+          schema: { type: string }
+        - name: rule_id
+          in: query
+          required: false
+          description: |
+            Narrow to decisions whose triggered_rule_ids contains this
+            rule id (array containment).
+          schema: { type: string, format: uuid }
         - name: from_ts
           in: query
           required: false

--- a/src/rolemesh/db/safety.py
+++ b/src/rolemesh/db/safety.py
@@ -539,8 +539,23 @@ def _safety_decision_where_clauses(
     stage: str | None,
     from_ts: str | None,
     to_ts: str | None,
+    check_id: str | None = None,
+    rule_id: str | None = None,
 ) -> tuple[str, list[Any]]:
-    """Shared WHERE-clause builder for list + count calls."""
+    """Shared WHERE-clause builder for list + count calls.
+
+    ``rule_id`` matches decisions whose ``triggered_rule_ids`` array
+    contains that rule (``@>`` array-contains).
+
+    ``check_id`` has no direct column on ``safety_decisions`` — a
+    decision records the *rules* it triggered, and ``check_id`` lives on
+    the rule. So we translate the check into its rule ids and test for
+    array overlap (``&&``). The ids may belong to either the tenant's own
+    ``safety_rules`` (RLS-scoped to the caller within this connection, so
+    a foreign tenant's rule can never resolve here) or the global,
+    read-only ``platform_safety_rules`` catalog — a triggered rule can be
+    platform-owned, so both must be considered.
+    """
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if verdict_action is not None:
@@ -558,6 +573,18 @@ def _safety_decision_where_clauses(
     if to_ts is not None:
         params.append(to_ts)
         clauses.append(f"created_at <= ${len(params)}::timestamptz")
+    if rule_id is not None:
+        params.append(rule_id)
+        clauses.append(f"triggered_rule_ids @> ARRAY[${len(params)}::uuid]")
+    if check_id is not None:
+        params.append(check_id)
+        n = len(params)
+        clauses.append(
+            "triggered_rule_ids && ("
+            f"ARRAY(SELECT id FROM safety_rules WHERE check_id = ${n}) || "
+            f"ARRAY(SELECT id FROM platform_safety_rules WHERE check_id = ${n})"
+            ")"
+        )
     return " AND ".join(clauses), params
 
 
@@ -569,6 +596,8 @@ async def count_safety_decisions(
     stage: str | None = None,
     from_ts: str | None = None,
     to_ts: str | None = None,
+    check_id: str | None = None,
+    rule_id: str | None = None,
 ) -> int:
     """Total count for a matching filter set.
 
@@ -584,6 +613,8 @@ async def count_safety_decisions(
         stage=stage,
         from_ts=from_ts,
         to_ts=to_ts,
+        check_id=check_id,
+        rule_id=rule_id,
     )
     async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchval(
@@ -601,6 +632,8 @@ async def list_safety_decisions(
     stage: str | None = None,
     from_ts: str | None = None,
     to_ts: str | None = None,
+    check_id: str | None = None,
+    rule_id: str | None = None,
     limit: int = 200,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
@@ -618,6 +651,8 @@ async def list_safety_decisions(
         stage=stage,
         from_ts=from_ts,
         to_ts=to_ts,
+        check_id=check_id,
+        rule_id=rule_id,
     )
     params.append(limit)
     params.append(offset)

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -1179,6 +1179,14 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "CREATE INDEX IF NOT EXISTS idx_safety_decisions_verdict "
         "ON safety_decisions (tenant_id, verdict_action, created_at DESC)"
     )
+    # The check_id / rule_id filters on the decisions list match against
+    # the triggered_rule_ids array (``&&`` overlap / ``@>`` contains). A
+    # GIN index turns those array predicates from a tenant-wide seq scan
+    # into an index probe.
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_safety_decisions_triggered_rules "
+        "ON safety_decisions USING gin (triggered_rule_ids)"
+    )
 
     # Rule-change audit log. Every INSERT / UPDATE / DELETE on
     # safety_rules appends one append-only row here via the trigger

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -361,6 +361,8 @@ async def list_decisions(
     verdict_action: SafetyVerdictAction | None = None,
     coworker_id: str | None = None,
     stage: SafetyStage | None = None,
+    check_id: str | None = None,
+    rule_id: str | None = None,
     from_ts: str | None = None,
     to_ts: str | None = None,
     limit: int = Query(default=50, ge=1, le=200),
@@ -372,6 +374,12 @@ async def list_decisions(
     Two parallel DB calls (count + page) so a misbehaving client
     that asks for offset=100k pays for the count once rather than
     once per page. Filter args mirror the admin shape verbatim.
+
+    ``check_id`` and ``rule_id`` narrow to decisions a given check /
+    rule triggered. A decision carries no ``check_id`` directly, so the
+    helper translates the check into its rule ids (tenant + platform
+    catalogs) and tests for array overlap; ``rule_id`` tests array
+    containment against ``triggered_rule_ids``.
     """
     total = await count_safety_decisions(
         user.tenant_id,
@@ -380,6 +388,8 @@ async def list_decisions(
         stage=stage,
         from_ts=from_ts,
         to_ts=to_ts,
+        check_id=check_id,
+        rule_id=rule_id,
     )
     items = await list_safety_decisions(
         user.tenant_id,
@@ -388,6 +398,8 @@ async def list_decisions(
         stage=stage,
         from_ts=from_ts,
         to_ts=to_ts,
+        check_id=check_id,
+        rule_id=rule_id,
         limit=limit,
         offset=offset,
     )

--- a/tests/safety/test_db.py
+++ b/tests/safety/test_db.py
@@ -19,6 +19,7 @@ import uuid
 import pytest
 
 from rolemesh.db import (
+    count_safety_decisions,
     create_coworker,
     create_safety_rule,
     create_tenant,
@@ -28,6 +29,7 @@ from rolemesh.db import (
     list_safety_decisions,
     list_safety_rules,
     list_safety_rules_for_coworker,
+    list_visible_platform_rules,
     update_safety_rule,
 )
 
@@ -238,3 +240,70 @@ class TestSafetyDecisions:
             findings=[], context_digest="z" * 64, context_summary="",
         )
         assert await list_safety_decisions(tid_b) == []
+
+    @pytest.mark.asyncio
+    async def test_rule_id_filter(self) -> None:
+        tid, _ = await _tenant_and_coworker()
+        r1 = await create_safety_rule(
+            tenant_id=tid, stage="pre_tool_call", check_id="pii.regex",
+            config={},
+        )
+        r2 = await create_safety_rule(
+            tenant_id=tid, stage="pre_tool_call", check_id="pii.regex",
+            config={},
+        )
+        await insert_safety_decision(
+            tenant_id=tid, stage="pre_tool_call", verdict_action="block",
+            triggered_rule_ids=[r1.id], findings=[],
+            context_digest="a" * 64, context_summary="hit-r1",
+        )
+        await insert_safety_decision(
+            tenant_id=tid, stage="pre_tool_call", verdict_action="block",
+            triggered_rule_ids=[r2.id], findings=[],
+            context_digest="b" * 64, context_summary="hit-r2",
+        )
+        rows = await list_safety_decisions(tid, rule_id=r1.id)
+        assert [d["context_summary"] for d in rows] == ["hit-r1"]
+        assert await count_safety_decisions(tid, rule_id=r1.id) == 1
+
+    @pytest.mark.asyncio
+    async def test_check_id_filter(self) -> None:
+        tid, _ = await _tenant_and_coworker()
+        pii = await create_safety_rule(
+            tenant_id=tid, stage="pre_tool_call", check_id="pii.regex",
+            config={},
+        )
+        host = await create_safety_rule(
+            tenant_id=tid, stage="pre_tool_call",
+            check_id="domain_allowlist", config={},
+        )
+        await insert_safety_decision(
+            tenant_id=tid, stage="pre_tool_call", verdict_action="block",
+            triggered_rule_ids=[pii.id], findings=[],
+            context_digest="a" * 64, context_summary="pii-hit",
+        )
+        await insert_safety_decision(
+            tenant_id=tid, stage="pre_tool_call", verdict_action="block",
+            triggered_rule_ids=[host.id], findings=[],
+            context_digest="b" * 64, context_summary="host-hit",
+        )
+        rows = await list_safety_decisions(tid, check_id="pii.regex")
+        assert [d["context_summary"] for d in rows] == ["pii-hit"]
+        assert await count_safety_decisions(tid, check_id="pii.regex") == 1
+
+    @pytest.mark.asyncio
+    async def test_check_id_covers_platform_rules(self) -> None:
+        """A decision triggered by a platform rule is found by check_id —
+        the resolver must look in platform_safety_rules, not just the
+        tenant's own safety_rules."""
+        tid, _ = await _tenant_and_coworker()
+        platform = await list_visible_platform_rules(tid)
+        prule = next(p for p in platform if p["check_id"] == "pii.regex")
+        await insert_safety_decision(
+            tenant_id=tid, stage="input_prompt", verdict_action="block",
+            triggered_rule_ids=[str(prule["id"])], findings=[],
+            context_digest="c" * 64, context_summary="platform-pii",
+        )
+        rows = await list_safety_decisions(tid, check_id="pii.regex")
+        assert [d["context_summary"] for d in rows] == ["platform-pii"]
+        assert rows[0]["source"] == "platform"

--- a/tests/webui/test_v1_safety.py
+++ b/tests/webui/test_v1_safety.py
@@ -551,6 +551,48 @@ async def test_list_decisions_pagination_limit_offset() -> None:
     assert a_ids.isdisjoint(b_ids)
 
 
+async def test_list_decisions_filters_by_rule_and_check() -> None:
+    """check_id / rule_id narrow the list to decisions a given rule (or
+    a given check's rules) triggered. The decision carries no check_id,
+    so the server resolves check -> rule ids and matches the array."""
+    user, _ = await _make_user("flt")
+    pii = await create_safety_rule(
+        tenant_id=user.tenant_id, stage="pre_tool_call",
+        check_id="pii.regex", config={},
+    )
+    host = await create_safety_rule(
+        tenant_id=user.tenant_id, stage="pre_tool_call",
+        check_id="domain_allowlist", config={},
+    )
+    pii_dec = await insert_safety_decision(
+        tenant_id=user.tenant_id, stage="pre_tool_call",
+        verdict_action="block", triggered_rule_ids=[pii.id], findings=[],
+        context_digest="d" * 16, context_summary="pii",
+    )
+    await insert_safety_decision(
+        tenant_id=user.tenant_id, stage="pre_tool_call",
+        verdict_action="block", triggered_rule_ids=[host.id], findings=[],
+        context_digest="d" * 16, context_summary="host",
+    )
+
+    async with _client(_build_app(user)) as ac:
+        by_check = (
+            await ac.get(
+                "/api/v1/safety/decisions?check_id=pii.regex", headers=_HDRS,
+            )
+        ).json()
+        by_rule = (
+            await ac.get(
+                f"/api/v1/safety/decisions?rule_id={pii.id}", headers=_HDRS,
+            )
+        ).json()
+
+    assert by_check["total"] == 1
+    assert [it["id"] for it in by_check["items"]] == [pii_dec]
+    assert by_rule["total"] == 1
+    assert [it["id"] for it in by_rule["items"]] == [pii_dec]
+
+
 async def test_list_decisions_limit_caps_at_200() -> None:
     """A misbehaving caller asking for limit=10_000 must not scan
     the whole table — Pydantic's ``Query(le=200)`` clamps it via a

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -3687,6 +3687,18 @@ export interface operations {
                 verdict_action?: components["schemas"]["SafetyVerdictAction"];
                 coworker_id?: string;
                 stage?: components["schemas"]["SafetyStage"];
+                /**
+                 * @description Narrow to decisions triggered by a rule using this check.
+                 *     A decision stores no check_id directly; the server resolves
+                 *     the check to its rule ids (tenant + platform catalogs) and
+                 *     matches by array overlap on triggered_rule_ids.
+                 */
+                check_id?: string;
+                /**
+                 * @description Narrow to decisions whose triggered_rule_ids contains this
+                 *     rule id (array containment).
+                 */
+                rule_id?: string;
                 from_ts?: string;
                 to_ts?: string;
                 limit?: number;


### PR DESCRIPTION
## Background

The safety log (`GET /api/v1/safety/decisions`) can already filter by verdict / coworker / stage / time, but two common admin workflows were blocked:

1. **Filter by check** — "show only pii.regex decisions" (the front-end already reserves a 4th dropdown for this).
2. **Filter by rule** — the approval card's "view in safety log →" wants to pre-filter by rule_id and auto-open the matching decision detail (`jumpToSafetyDecision(ruleId)` already has the param reserved).

Both depend on endpoint filters that did not exist. This PR adds the **backend** side only (the front-end dropdown / deep-link is a separate task).

## Key design

`safety_decisions` has **no check_id column** — a decision records the *rules* it triggered (`triggered_rule_ids UUID[]`); check_id lives on the rule. So:

- **`rule_id`**: array containment, `triggered_rule_ids @> ARRAY[$rule_id]`.
- **`check_id`**: resolve the check to its rule ids, then match by array overlap (`&&`). The rule ids must be looked up in BOTH:
  - the tenant's own `safety_rules` (RLS-scoped inside the `tenant_conn` connection, so a foreign tenant's rule can never resolve here);
  - the global read-only `platform_safety_rules` catalog (a triggered rule can be platform-owned — that's how `source='platform'` is derived).

```sql
WHERE triggered_rule_ids && (
    ARRAY(SELECT id FROM safety_rules          WHERE check_id = $X)
 || ARRAY(SELECT id FROM platform_safety_rules WHERE check_id = $X)
)
```

A GIN index on `triggered_rule_ids` is added so the `&&` / `@>` predicates probe an index instead of seq-scanning.

## Changes (+195 / −1, 7 files)

| Category | Files |
|---|---|
| Production (+56/−1) | `db/safety.py` (WHERE builder + pass-through in list/count), `webui/v1/safety.py` (two query params on the handler), `db/schema.py` (GIN index) |
| Tests (+111) | `tests/safety/test_db.py` (rule_id / check_id / check_id covers platform rules), `tests/webui/test_v1_safety.py` (API-level filter) |
| Contract + artifact (+28) | `contracts/openapi.yaml`, `web/src/api/generated/types.ts` (codegen re-run, adds only the two optional params; keeps `openapi:check` green) |

## Verification

Run against a local Postgres 16 with real SQL:

- `tests/safety/test_db.py` + `test_platform_rules_db.py` + `test_v1_safety.py` + `test_csv_export.py` — **56 passed** (includes the platform-rule-triggered case, asserting `source == "platform"`).
- `ruff check` clean; `tests/test_openapi_contract.py` — 34 passed.
- `npm run openapi:check` (the CI codegen diff) — exit 0.

## Scope

Backend + contract sync only. The front-end 4th dropdown and the `jumpToSafetyDecision` deep-link / auto-open-detail are out of scope; the endpoint is ready for them to wire up later.

https://claude.ai/code/session_01DjXvCtaE3AMiKJNZtZ2iu5