### PR TITLE
feat(safety): express check config enums in config_schema (P0-1)

### DIFF
--- a/src/rolemesh/safety/checks/openai_moderation.py
+++ b/src/rolemesh/safety/checks/openai_moderation.py
@@ -91,8 +91,11 @@ class OpenAIModerationConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     api_key_env: str = "OPENAI_API_KEY"
-    block_categories: list[str] = Field(default_factory=list)
-    warn_categories: list[str] = Field(default_factory=list)
+    # Typed as the closed ModerationCode enum (not bare str) so the JSON
+    # Schema dumps ``items.enum`` — the frontend reads the legal
+    # MODERATION.* code set straight off the schema.
+    block_categories: list[ModerationCode] = Field(default_factory=list)
+    warn_categories: list[ModerationCode] = Field(default_factory=list)
     timeout_ms: int = 2000
     action_override: str | None = None
 

--- a/src/rolemesh/safety/checks/pii_regex.py
+++ b/src/rolemesh/safety/checks/pii_regex.py
@@ -50,6 +50,22 @@ class PIICode(StrEnum):
     IP_ADDRESS = "PII.IP_ADDRESS"
 
 
+class PIIPatternKey(StrEnum):
+    """Closed set of ``patterns`` config keys (short, human-facing form).
+
+    Typing ``PIIRegexConfig.patterns`` as ``dict[PIIPatternKey, bool]``
+    is what makes ``model_json_schema()`` emit a ``propertyNames`` enum
+    constraint — the authoritative list of legal keys the frontend can
+    read straight off the schema instead of hardcoding it.
+    """
+
+    SSN = "SSN"
+    CREDIT_CARD = "CREDIT_CARD"
+    EMAIL = "EMAIL"
+    PHONE_US = "PHONE_US"
+    IP_ADDRESS = "IP_ADDRESS"
+
+
 # Explicit short-key → stable code mapping. Admin UI / REST API accept
 # the short form on the left; Finding.code uses the prefixed form on
 # the right. Any key not in this map is a typo and SHOULD be rejected
@@ -61,6 +77,14 @@ _CONFIG_KEY_TO_CODE: dict[str, PIICode] = {
     "PHONE_US": PIICode.PHONE_US,
     "IP_ADDRESS": PIICode.IP_ADDRESS,
 }
+
+# Single-source guard: the schema enum (PIIPatternKey) and the runtime
+# mapping must never drift apart. If someone adds a code to one but not
+# the other, import fails loudly instead of shipping a schema that lies
+# about which keys are legal.
+assert set(PIIPatternKey) == set(_CONFIG_KEY_TO_CODE), (
+    "PIIPatternKey and _CONFIG_KEY_TO_CODE are out of sync"
+)
 
 
 class PIIRegexConfig(BaseModel):
@@ -81,23 +105,16 @@ class PIIRegexConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # Keys are constrained to the closed ``PIIPatternKey`` set — pydantic
+    # rejects an unknown key like ``{"patterns": {"SNN": true}}`` with a
+    # 422 at admin time, and the constraint surfaces in the JSON Schema
+    # as ``propertyNames`` so the frontend never hardcodes the key list.
     # StrictBool rejects truthy strings like "yes" / "on" / "1" that
-    # pydantic's default bool coercion silently converts to True. The
+    # pydantic's default bool coercion silently converts to True: the
     # admin intent of {"patterns": {"SSN": "yes"}} is ambiguous — we
     # want them to write `true` / `false` explicitly.
-    patterns: dict[str, StrictBool] = Field(default_factory=dict)
+    patterns: dict[PIIPatternKey, StrictBool] = Field(default_factory=dict)
     action_override: str | None = None
-
-    def model_post_init(self, _ctx: Any) -> None:
-        # Validate each key against the stable mapping at admin time
-        # so the operator's feedback loop is tight. Unknown keys ->
-        # 422 through pydantic's standard error surface.
-        for key in self.patterns:
-            if key not in _CONFIG_KEY_TO_CODE:
-                valid = sorted(_CONFIG_KEY_TO_CODE.keys())
-                raise ValueError(
-                    f"Unknown PII pattern {key!r}; valid keys: {valid}"
-                )
 
 
 # Conservative regex set. CREDIT_CARD uses a loose 13-19-digit window
@@ -258,4 +275,4 @@ class PIIRegexCheck:
         return Verdict(action="allow")
 
 
-__all__ = ["PIICode", "PIIRegexCheck", "PIIRegexConfig"]
+__all__ = ["PIICode", "PIIPatternKey", "PIIRegexCheck", "PIIRegexConfig"]

--- a/src/rolemesh/safety/checks/presidio_pii.py
+++ b/src/rolemesh/safety/checks/presidio_pii.py
@@ -109,8 +109,11 @@ class PresidioPIIConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    block_codes: list[str] = Field(default_factory=list)
-    redact_codes: list[str] = Field(default_factory=list)
+    # Typed as the closed PresidioPIICode enum (not bare str) so the JSON
+    # Schema dumps ``items.enum`` — the frontend reads the legal PII.*
+    # code set straight off the schema instead of hardcoding it.
+    block_codes: list[PresidioPIICode] = Field(default_factory=list)
+    redact_codes: list[PresidioPIICode] = Field(default_factory=list)
     language: str = "en"
     score_threshold: float = 0.4
     action_override: str | None = None

--- a/tests/safety/test_api.py
+++ b/tests/safety/test_api.py
@@ -150,7 +150,9 @@ class TestCreateRule:
     async def test_unknown_pattern_key_400(self) -> None:
         # Previously, {"patterns": {"SNN": true}} was silently ignored
         # in the container — admins saw "rule created" then no actual
-        # detection. pydantic config_model now rejects at REST time.
+        # detection. The config_model now constrains pattern keys to the
+        # closed PIIPatternKey enum, so pydantic rejects the typo at REST
+        # time (and the same enum drives config_schema's propertyNames).
         tid, uid, _ = await _seed()
         app = _build_app(_authed_user(tid, uid))
         async with _client(app) as client:
@@ -163,7 +165,9 @@ class TestCreateRule:
                 },
             )
             assert r.status_code == 400
-            assert "Unknown PII pattern" in r.text
+            # The bad key is named and the legal set is surfaced.
+            assert "SNN" in r.text
+            assert "SSN" in r.text
 
     @pytest.mark.asyncio
     async def test_non_bool_pattern_value_400(self) -> None:

--- a/tests/safety/test_config_schema_dump.py
+++ b/tests/safety/test_config_schema_dump.py
@@ -1,0 +1,105 @@
+"""P0-1: every check's ``config_schema`` dump is non-empty and honest.
+
+The v1 ``/safety/checks`` endpoint exposes each check's
+``config_model.model_json_schema()`` so the SPA renders the config form
+from the authoritative source instead of hardcoding field names (the
+schema-drift incident the P0-1 spec calls out). These tests pin two
+things per check model: the dump is a non-trivial object with
+``additionalProperties: false`` (the ``extra='forbid'`` contract the
+frontend validator relies on to reject stray keys), and — for the
+enum-bearing checks — that the closed value set is expressed *in the
+schema* (``propertyNames`` / ``items.enum``) rather than hidden in
+Python-only validation.
+
+Config models import without the checks' heavy optional deps
+(presidio / llm_guard / detect_secrets), so this stays a pure unit test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.safety.checks.domain_allowlist import DomainAllowlistConfig
+from rolemesh.safety.checks.egress_domain_rule import EgressDomainRuleConfig
+from rolemesh.safety.checks.llm_guard_jailbreak import (
+    LLMGuardJailbreakConfig,
+)
+from rolemesh.safety.checks.llm_guard_prompt_injection import (
+    LLMGuardPromptInjectionConfig,
+)
+from rolemesh.safety.checks.llm_guard_toxicity import LLMGuardToxicityConfig
+from rolemesh.safety.checks.openai_moderation import OpenAIModerationConfig
+from rolemesh.safety.checks.pii_regex import PIIRegexConfig
+from rolemesh.safety.checks.presidio_pii import PresidioPIIConfig
+from rolemesh.safety.checks.secret_scanner import SecretScannerConfig
+
+# All nine V1/V2 check config models, keyed by check id.
+ALL_CONFIG_MODELS = {
+    "pii.regex": PIIRegexConfig,
+    "presidio.pii": PresidioPIIConfig,
+    "secret_scanner": SecretScannerConfig,
+    "domain_allowlist": DomainAllowlistConfig,
+    "egress.domain_rule": EgressDomainRuleConfig,
+    "llm_guard.prompt_injection": LLMGuardPromptInjectionConfig,
+    "llm_guard.jailbreak": LLMGuardJailbreakConfig,
+    "llm_guard.toxicity": LLMGuardToxicityConfig,
+    "openai_moderation": OpenAIModerationConfig,
+}
+
+
+@pytest.mark.parametrize("check_id", sorted(ALL_CONFIG_MODELS))
+def test_config_schema_dump_is_non_empty_object(check_id: str) -> None:
+    schema = ALL_CONFIG_MODELS[check_id].model_json_schema()
+    assert isinstance(schema, dict) and schema, check_id
+    assert schema.get("type") == "object", check_id
+    assert "properties" in schema, check_id
+
+
+@pytest.mark.parametrize("check_id", sorted(ALL_CONFIG_MODELS))
+def test_config_schema_forbids_extra_keys(check_id: str) -> None:
+    # extra='forbid' → additionalProperties:false. The frontend
+    # validator leans on this to reject arbitrary stray keys.
+    schema = ALL_CONFIG_MODELS[check_id].model_json_schema()
+    assert schema.get("additionalProperties") is False, check_id
+
+
+def _resolve(schema: dict, node: dict) -> dict:
+    """Follow a single ``$ref`` into ``$defs`` (Pydantic factors enums
+    out into ``$defs``; Ajv resolves the ref the same way)."""
+    ref = node.get("$ref")
+    if not ref:
+        return node
+    name = ref.rsplit("/", 1)[-1]
+    return schema["$defs"][name]
+
+
+def test_pii_regex_pattern_keys_are_constrained() -> None:
+    schema = PIIRegexConfig.model_json_schema()
+    patterns = schema["properties"]["patterns"]
+    # propertyNames is JSON Schema's "the dict's keys must be one of".
+    key_schema = _resolve(schema, patterns["propertyNames"])
+    assert set(key_schema["enum"]) == {
+        "SSN",
+        "CREDIT_CARD",
+        "EMAIL",
+        "PHONE_US",
+        "IP_ADDRESS",
+    }
+    # values stay booleans
+    assert patterns["additionalProperties"] == {"type": "boolean"}
+
+
+def test_presidio_codes_are_enum_constrained() -> None:
+    schema = PresidioPIIConfig.model_json_schema()
+    for field in ("block_codes", "redact_codes"):
+        items = _resolve(schema, schema["properties"][field]["items"])
+        assert "PII.SSN" in items["enum"], field
+        assert "PII.MEDICAL_LICENSE" in items["enum"], field
+
+
+def test_openai_categories_are_enum_constrained() -> None:
+    schema = OpenAIModerationConfig.model_json_schema()
+    for field in ("block_categories", "warn_categories"):
+        items = _resolve(schema, schema["properties"][field]["items"])
+        assert "MODERATION.HATE" in items["enum"], field
+        assert "MODERATION.VIOLENCE" in items["enum"], field


### PR DESCRIPTION
## What

`GET /api/v1/safety/checks` already dumps each check's `model_json_schema()` into `config_schema`, but the closed value sets lived only in Python-side validation, so the dumped schema could not express them. That forced the frontend to hardcode the legal values per check — the schema-drift risk the P0-1 spec calls out.

This tightens the Pydantic config models so the constraints surface in the schema itself, making the backend model the single authoritative source the frontend reads:

- **`pii.regex`** — `patterns` keys → `PIIPatternKey` enum, so the dump carries a `propertyNames` constraint. Drops the now-redundant `model_post_init` key check (pydantic enforces the enum); a module-level `assert` keeps `PIIPatternKey` and `_CONFIG_KEY_TO_CODE` from drifting apart.
- **`presidio.pii`** — `block_codes` / `redact_codes` → `list[PresidioPIICode]` (`items.enum`).
- **`openai_moderation`** — `block_categories` / `warn_categories` → `list[ModerationCode]` (`items.enum`).

Scope is P0-1 only. P0-2 (`rules:validate` dry-run) and P0-3 (rule filters) are intentionally out of scope.

## Why it is safe

Runtime `check()` reads the raw config dict, not the Pydantic model — so this only enriches REST-layer validation and the dumped schema. Behavior is unchanged.

## Contract impact

None. The static OpenAPI `SafetyCheck.config_schema` is already a generic `{type: object, additionalProperties: true}`; the enum constraints are dumped into the schema at runtime, inside that object. So `contracts/openapi.yaml` and the generated TS types do not change.

## Example

`PIIRegexConfig.model_json_schema()` now emits (Ajv resolves the `$defs` ref the same as an inline enum):

```json
{
  "$defs": {
    "PIIPatternKey": {
      "enum": ["SSN", "CREDIT_CARD", "EMAIL", "PHONE_US", "IP_ADDRESS"],
      "type": "string"
    }
  },
  "additionalProperties": false,
  "properties": {
    "patterns": {
      "type": "object",
      "additionalProperties": { "type": "boolean" },
      "propertyNames": { "$ref": "#/$defs/PIIPatternKey" }
    },
    "action_override": { "anyOf": [{"type": "string"}, {"type": "null"}], "default": null }
  }
}
```

## Tests

- New pure-unit `tests/safety/test_config_schema_dump.py`: every check's schema is a non-empty object with `additionalProperties: false`, and the three enum-bearing checks express their closed value sets (`propertyNames` / `items.enum`).
- Updated `tests/safety/test_api.py::test_unknown_pattern_key_400`: the bad-key rejection is now pydantic's enum error (still HTTP 400); assert the message names the bad key and surfaces the legal set.

## Verification

- ruff clean; mypy clean on the changed files (only the pre-existing `presidio_analyzer` optional-dep import warnings remain).
- Offline unit tests pass (52 passed, 19 skipped — skips are the presidio / llm_guard optional deps not installed locally).
- The one admin test that needs Postgres (`test_unknown_pattern_key_400`) was not run locally (no Docker in this environment); it runs in CI. Its asserted substrings were verified offline against the validation error string.

https://claude.ai/code/session_0153RXF2kHSwuckAB5tkDjDf

---
_Generated by [Claude Code](https://claude.ai/code/session_0153RXF2kHSwuckAB5tkDjDf)_