### PR TITLE
feat(safety-ui): Safety UI v20 — G1-G7 (egress form, dup-detect, Ajv, schema-enums, log filters)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "rolemesh-webui",
       "version": "1.0.0",
+      "dependencies": {
+        "ajv": "^8.20.0"
+      },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.1",
         "happy-dom": "^20.9.0",
@@ -1410,6 +1413,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -1613,8 +1632,23 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1745,7 +1779,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -2225,7 +2258,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/web/package.json
+++ b/web/package.json
@@ -24,5 +24,8 @@
     "typescript": "^5.7",
     "vite": "^6",
     "vitest": "^4.1.7"
+  },
+  "dependencies": {
+    "ajv": "^8.20.0"
   }
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -671,6 +671,8 @@ export class ApiClient {
     stage?: SafetyStage | null;
     fromTs?: string | null;
     toTs?: string | null;
+    checkId?: string | null;
+    ruleId?: string | null;
     limit?: number;
     offset?: number;
   }): Promise<SafetyDecisionPage> {
@@ -680,6 +682,8 @@ export class ApiClient {
     if (filters?.stage) qs.set('stage', filters.stage);
     if (filters?.fromTs) qs.set('from_ts', filters.fromTs);
     if (filters?.toTs) qs.set('to_ts', filters.toTs);
+    if (filters?.checkId) qs.set('check_id', filters.checkId);
+    if (filters?.ruleId) qs.set('rule_id', filters.ruleId);
     if (filters?.limit !== undefined) qs.set('limit', String(filters.limit));
     if (filters?.offset !== undefined) qs.set('offset', String(filters.offset));
     const url = `${this.baseUrl}/api/v1/safety/decisions${qs.size ? `?${qs}` : ''}`;

--- a/web/src/components/approval-card.test.ts
+++ b/web/src/components/approval-card.test.ts
@@ -323,7 +323,7 @@ describe('<rm-approval-card> safety-triggered banner (§3.10)', () => {
     expect($(el, '[data-testid="approval-safety-banner"]')).toBeNull();
   });
 
-  it('jumps to the settings safety log when "view in safety log" is clicked', async () => {
+  it('jumps to safety log with ?rule_id=Y when "view in safety log" is clicked (G5+G6)', async () => {
     el = await mount({
       mcpServerName: 'stripe',
       toolName: 'refund.create',
@@ -336,6 +336,7 @@ describe('<rm-approval-card> safety-triggered banner (§3.10)', () => {
     });
     location.hash = '#/';
     ($(el, '[data-testid="approval-safety-link"]') as HTMLButtonElement).click();
-    expect(location.hash).toBe('#/manage/safety-log');
+    // G6: the deep link sets ?rule_id so the safety log mounts the chip filter.
+    expect(location.hash).toBe('#/manage/safety-log?rule_id=sr-1');
   });
 });

--- a/web/src/components/approval-card.ts
+++ b/web/src/components/approval-card.ts
@@ -328,12 +328,12 @@ export class ApprovalCard extends LitElement {
     `;
   }
 
-  // Navigate to Settings → Safety log (spec §3.10). The log can't yet deep-
-  // filter by rule_id (the v1 endpoint exposes no rule_id filter), so this
-  // opens the log rather than a pre-filtered, auto-opened decision. The
-  // rule_id is accepted now so the call site is stable when that lands.
-  private jumpToSafetyDecision(_ruleId: string): void {
-    location.hash = '#/manage/safety-log';
+  // Navigate to Settings → Safety log filtered by rule_id (spec §3.10).
+  // The log mounts the rule_id chip from the URL's ?rule_id= query param
+  // (G6 / PR #57); landing on a filtered list lets the user see the rule's
+  // broader behavior before deciding.
+  private jumpToSafetyDecision(ruleId: string): void {
+    location.hash = `#/manage/safety-log?rule_id=${encodeURIComponent(ruleId)}`;
   }
 
   private renderToolChip(): TemplateResult | typeof nothing {

--- a/web/src/components/safety-catalog.test.ts
+++ b/web/src/components/safety-catalog.test.ts
@@ -219,6 +219,28 @@ describe('safWhatPhrase', () => {
     );
     expect(safWhatPhrase('domain_allowlist', { allowed_hosts: ['a.com'] })).toBe('allow only 1 host');
   });
+
+  // G1/G2 fix: egress.domain_rule now uses domain_patterns (list), not the
+  // pre-PR-#55 singular domain_pattern (string).
+  it('counts domain_patterns for egress.domain_rule (post-PR-#55 shape)', () => {
+    expect(
+      safWhatPhrase('egress.domain_rule', { domain_patterns: ['api.stripe.com', '*.acme.com'] }),
+    ).toBe('allow 2 domains');
+    expect(
+      safWhatPhrase('egress.domain_rule', { domain_patterns: ['api.stripe.com'] }),
+    ).toBe('allow 1 domain');
+  });
+
+  it('falls back gracefully for egress.domain_rule with empty or missing domain_patterns', () => {
+    expect(safWhatPhrase('egress.domain_rule', {})).toBe('allow listed domains');
+    expect(safWhatPhrase('egress.domain_rule', { domain_patterns: [] })).toBe('allow listed domains');
+  });
+
+  it('ignores the old singular domain_pattern key for egress.domain_rule', () => {
+    // Pre-PR-#55 shape — must NOT be read anymore.
+    const phrase = safWhatPhrase('egress.domain_rule', { domain_pattern: 'api.stripe.com' });
+    expect(phrase).toBe('allow listed domains'); // treated as empty/unknown
+  });
 });
 
 describe('safSentence', () => {

--- a/web/src/components/safety-catalog.ts
+++ b/web/src/components/safety-catalog.ts
@@ -412,9 +412,10 @@ export function safWhatPhrase(
     return `allow only ${n || 'listed'} host${n === 1 ? '' : 's'}`;
   }
   if (checkId === 'egress.domain_rule') {
-    // egress.domain_rule uses `domain_pattern` (single string per rule).
-    const p = config?.['domain_pattern'] as string | undefined;
-    return p ? `allow ${p}` : 'allow listed domains';
+    // Post PR #55: domain_patterns is list[str] (was singular domain_pattern: str).
+    const patterns = (config?.['domain_patterns'] as string[]) ?? [];
+    const n = patterns.length;
+    return n > 0 ? `allow ${n} domain${n === 1 ? '' : 's'}` : 'allow listed domains';
   }
   if (checkId === 'openai_moderation') {
     // Backend: { block_categories: [...], warn_categories: [...] }

--- a/web/src/components/safety-decisions-page.test.ts
+++ b/web/src/components/safety-decisions-page.test.ts
@@ -2,9 +2,8 @@
 // Safety log page (spec §7) — pins the v1 read split + the revamped list.
 //
 // Reads (list + detail + rules-for-labels) go through the typed v1 ApiClient;
-// CSV export stays on admin (not on v1 per design §3 Phase 4). Also pins the
-// filter set: verdict / stage / coworker — NO check dropdown (the v1 endpoint
-// has no check_id filter and we don't extend the contract).
+// CSV export stays on admin (not on v1 per design §3 Phase 4).
+// G6: check dropdown + rule_id chip + URL deep-link params (PR #57 backend).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -12,12 +11,14 @@ const {
   listDecisionsSpy,
   getDecisionSpy,
   listRulesSpy,
+  listChecksSpy,
   getTenantIdSpy,
   listCoworkersSpy,
 } = vi.hoisted(() => ({
   listDecisionsSpy: vi.fn(),
   getDecisionSpy: vi.fn(),
   listRulesSpy: vi.fn(),
+  listChecksSpy: vi.fn(),
   getTenantIdSpy: vi.fn(),
   listCoworkersSpy: vi.fn(),
 }));
@@ -32,6 +33,7 @@ vi.mock('../api/client.js', async () => {
       listSafetyDecisions: listDecisionsSpy,
       getSafetyDecision: getDecisionSpy,
       listSafetyRules: listRulesSpy,
+      listSafetyChecks: listChecksSpy,
     }),
   };
 });
@@ -93,6 +95,7 @@ describe('SafetyDecisionsPage', () => {
     listDecisionsSpy.mockResolvedValue({ total: 0, items: [] });
     getDecisionSpy.mockResolvedValue(makeDecision());
     listRulesSpy.mockResolvedValue([]);
+    listChecksSpy.mockResolvedValue([{ id: 'pii.regex', version: '1', stages: [], cost_class: 'cheap', action_model: 'fixed', natural_actions: {}, supported_actions: {}, supported_codes: [], config_schema: null }]);
     getTenantIdSpy.mockResolvedValue('t1');
     listCoworkersSpy.mockResolvedValue([{ id: 'ops', name: 'Ops coworker' }]);
   });
@@ -144,13 +147,64 @@ describe('SafetyDecisionsPage', () => {
     page.remove();
   });
 
-  it('exposes verdict / stage / coworker filters but NOT a check filter', async () => {
+  it('exposes verdict / stage / coworker / check filter dropdowns (G6)', async () => {
     const page = await mount([]);
     expect(page.querySelector('[data-testid="saf-filter-verdict"]')).not.toBeNull();
     expect(page.querySelector('[data-testid="saf-filter-stage"]')).not.toBeNull();
     expect(page.querySelector('[data-testid="saf-filter-coworker"]')).not.toBeNull();
-    // The v1 endpoint has no check_id filter — the 4th dropdown is omitted.
-    expect(page.querySelector('[data-testid="saf-filter-check"]')).toBeNull();
+    // G6: check filter is now present (PR #57 added check_id param to backend).
+    expect(page.querySelector('[data-testid="saf-filter-check"]')).not.toBeNull();
+    page.remove();
+  });
+
+  // G6: check_id filter passes through to listSafetyDecisions
+  it('check filter sends check_id to the API (G6)', async () => {
+    const page = await mount([]);
+    const checkSel = page.querySelector('[data-testid="saf-filter-check"]') as HTMLSelectElement;
+    checkSel.value = 'pii.regex';
+    checkSel.dispatchEvent(new Event('change'));
+    await page.updateComplete;
+    await Promise.resolve();
+    const lastArgs = listDecisionsSpy.mock.calls.at(-1)![0];
+    expect(lastArgs.checkId).toBe('pii.regex');
+    page.remove();
+  });
+
+  // G6: rule_id chip filter
+  it('rule_id chip is hidden when no ruleIdFilter is set (G6)', async () => {
+    const page = await mount([]);
+    expect(page.querySelector('[data-testid="saf-rule-id-chip"]')).toBeNull();
+    page.remove();
+  });
+
+  it('rule_id chip × removes chip and clears filter from API call (G6)', async () => {
+    const page = await mount([]);
+    // @ts-expect-error private
+    page.ruleIdFilter = 'sr-123';
+    await page.updateComplete;
+    const chip = page.querySelector('[data-testid="saf-rule-id-chip"]');
+    expect(chip).not.toBeNull();
+    const closeBtn = page.querySelector('[data-testid="saf-rule-chip-remove"]') as HTMLButtonElement;
+    closeBtn.click();
+    await page.updateComplete;
+    await Promise.resolve();
+    expect(page.querySelector('[data-testid="saf-rule-id-chip"]')).toBeNull();
+    const lastArgs = listDecisionsSpy.mock.calls.at(-1)![0];
+    expect(lastArgs.ruleId).toBeUndefined();
+    page.remove();
+  });
+
+  it('clearFilters resets ruleIdFilter too (G6)', async () => {
+    const page = await mount([]);
+    // @ts-expect-error private
+    page.ruleIdFilter = 'sr-123';
+    await page.updateComplete;
+    (page.querySelector('[data-testid="saf-clear-filters"]') as HTMLButtonElement).click();
+    await page.updateComplete;
+    await Promise.resolve();
+    expect(page.querySelector('[data-testid="saf-rule-id-chip"]')).toBeNull();
+    const lastArgs = listDecisionsSpy.mock.calls.at(-1)![0];
+    expect(lastArgs.ruleId).toBeUndefined();
     page.remove();
   });
 

--- a/web/src/components/safety-decisions-page.ts
+++ b/web/src/components/safety-decisions-page.ts
@@ -9,17 +9,16 @@
 // surface (v1 is GET-only, no CSV — design §3 Phase 4), so this file is on
 // the lint:no-admin-chat allowlist.
 //
-// Filter bar caveat: the v1 `/safety/decisions` endpoint filters by verdict /
-// stage / coworker / time, but NOT by check — there is no `check_id` query
-// param on the contract and we don't extend it here. So the spec's 4th "check"
-// dropdown is intentionally omitted (a note in the bar says so). Finding codes
-// in each row already convey what a decision caught.
+// G6: check_id filter dropdown + rule_id chip deep-link (PR #57 added both
+// params to GET /safety/decisions). URL params ?check_id=X and ?rule_id=Y
+// are read on mount and applied as initial filters.
 
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import {
   getApiClient,
+  type SafetyCheck,
   type SafetyDecision,
   type SafetyDecisionPage,
   type SafetyRule,
@@ -43,6 +42,7 @@ type Filters = {
   stage?: SafetyStage;
   from_ts?: string;
   to_ts?: string;
+  check_id?: string;
 };
 
 const VERDICTS: SafetyVerdictAction[] = [
@@ -68,12 +68,16 @@ export class SafetyDecisionsPage extends LitElement {
   @state() private tenantId: string | null = null;
   @state() private decisions: SafetyDecisionPage = { total: 0, items: [] };
   @state() private coworkers: CoworkerSummary[] = [];
+  @state() private checks: SafetyCheck[] = [];
   // rule_id → check label, for the detail modal's "triggered rule" cell.
   @state() private ruleLabels: Record<string, string> = {};
   @state() private loading = true;
   @state() private error: string | null = null;
   @state() private offset = 0;
   @state() private filters: Filters = {};
+  /** rule_id chip filter — set from ?rule_id=Y URL param or approval card
+   *  deep-link. Distinct from Filters so clearFilters() can selectively reset. */
+  @state() private ruleIdFilter: string | null = null;
   @state() private selected: SafetyDecision | null = null;
 
   private readonly api = getApiClient();
@@ -84,6 +88,17 @@ export class SafetyDecisionsPage extends LitElement {
 
   override async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    // G6: read initial filters from URL hash query params (?check_id=X&rule_id=Y).
+    // The app uses hash routing (#/manage/safety-log?check_id=...).
+    const hash = window.location.hash;
+    const qmark = hash.indexOf('?');
+    if (qmark !== -1) {
+      const params = new URLSearchParams(hash.slice(qmark + 1));
+      const checkId = params.get('check_id');
+      const ruleId = params.get('rule_id');
+      if (checkId) this.filters = { ...this.filters, check_id: checkId };
+      if (ruleId) this.ruleIdFilter = ruleId;
+    }
     // Admin-surface lookups (tenant id for CSV, coworker names) and the rule
     // list (for the detail modal's rule→label map) are best-effort — a failure
     // must not block the v1 decisions read.
@@ -96,6 +111,11 @@ export class SafetyDecisionsPage extends LitElement {
       this.coworkers = await listCoworkers();
     } catch {
       this.coworkers = [];
+    }
+    try {
+      this.checks = await this.api.listSafetyChecks();
+    } catch {
+      this.checks = [];
     }
     try {
       const rules = await this.api.listSafetyRules();
@@ -118,6 +138,8 @@ export class SafetyDecisionsPage extends LitElement {
         stage: this.filters.stage,
         fromTs: this.filters.from_ts,
         toTs: this.filters.to_ts,
+        checkId: this.filters.check_id,
+        ruleId: this.ruleIdFilter ?? undefined,
         limit: PAGE_SIZE,
         offset: this.offset,
       });
@@ -145,6 +167,13 @@ export class SafetyDecisionsPage extends LitElement {
 
   private clearFilters(): void {
     this.filters = {};
+    this.ruleIdFilter = null; // Clear filters resets everything including rule_id chip.
+    this.offset = 0;
+    void this.refresh();
+  }
+
+  private clearRuleIdFilter(): void {
+    this.ruleIdFilter = null;
     this.offset = 0;
     void this.refresh();
   }
@@ -260,6 +289,18 @@ export class SafetyDecisionsPage extends LitElement {
   private renderFilters(): TemplateResult {
     return html`
       <div class="rm-saf-filters" data-testid="saf-filters">
+        ${this.ruleIdFilter
+          ? html`<span class="rm-saf-rule-chip" data-testid="saf-rule-id-chip">
+              🛡 Rule: ${this.ruleLabels[this.ruleIdFilter] ?? this.ruleIdFilter.slice(0, 8)}
+              <button
+                type="button"
+                class="rm-saf-chip-close"
+                aria-label="Remove rule filter"
+                data-testid="saf-rule-chip-remove"
+                @click=${() => this.clearRuleIdFilter()}
+              >×</button>
+            </span>`
+          : nothing}
         <select
           aria-label="Filter by verdict"
           data-testid="saf-filter-verdict"
@@ -296,6 +337,19 @@ export class SafetyDecisionsPage extends LitElement {
           ${this.coworkers.map(
             (c) => html`<option value=${c.id} ?selected=${this.filters.coworker_id === c.id}>
               ${c.name}
+            </option>`,
+          )}
+        </select>
+        <select
+          aria-label="Filter by check"
+          data-testid="saf-filter-check"
+          @change=${(e: Event) =>
+            this.setFilter('check_id', (e.target as HTMLSelectElement).value)}
+        >
+          <option value="" ?selected=${!this.filters.check_id}>all checks</option>
+          ${this.checks.map(
+            (c) => html`<option value=${c.id} ?selected=${this.filters.check_id === c.id}>
+              ${c.id}
             </option>`,
           )}
         </select>

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -478,6 +478,67 @@ describe('SafetyRuleDialog — host-list onBlur normalization (G1/G2)', () => {
   });
 });
 
+// G7 — schema-driven enum rendering (spec §6.12.5)
+import { enumLabel, getSchemaEnum } from './safety-rule-dialog.js';
+
+describe('getSchemaEnum (G7)', () => {
+  const piiWithSchema: SafetyCheck = {
+    ...piiRegex,
+    config_schema: {
+      type: 'object',
+      properties: {
+        patterns: {
+          type: 'object',
+          propertyNames: { enum: ['SSN', 'CREDIT_CARD', 'EMAIL'] },
+        },
+        block_codes: { type: 'array', items: { enum: ['PII.SSN', 'PII.EMAIL'] } },
+      },
+    },
+  };
+
+  it('reads propertyNames.enum for dict-key fields', () => {
+    const keys = getSchemaEnum(piiWithSchema, 'patterns', 'propertyNames');
+    expect(keys).toEqual(['SSN', 'CREDIT_CARD', 'EMAIL']);
+  });
+
+  it('reads items.enum for array fields', () => {
+    const keys = getSchemaEnum(piiWithSchema, 'block_codes', 'items');
+    expect(keys).toEqual(['PII.SSN', 'PII.EMAIL']);
+  });
+
+  it('returns [] when check is null', () => {
+    expect(getSchemaEnum(null, 'patterns', 'propertyNames')).toEqual([]);
+  });
+
+  it('returns [] when config_schema is null', () => {
+    expect(getSchemaEnum(piiRegex, 'patterns', 'propertyNames')).toEqual([]);
+  });
+
+  it('returns [] when field is not in schema', () => {
+    expect(getSchemaEnum(piiWithSchema, 'nonexistent_field', 'items')).toEqual([]);
+  });
+
+  it('returns [] when the enum node is missing', () => {
+    const noEnum: SafetyCheck = {
+      ...piiRegex,
+      config_schema: { type: 'object', properties: { patterns: { type: 'object' } } },
+    };
+    expect(getSchemaEnum(noEnum, 'patterns', 'propertyNames')).toEqual([]);
+  });
+});
+
+describe('enumLabel (G7)', () => {
+  it('returns human label for known keys', () => {
+    expect(enumLabel('SSN')).toBe('US Social Security numbers');
+    expect(enumLabel('sexual')).toBe('Sexual content');
+  });
+
+  it('falls back to raw value for unknown keys', () => {
+    expect(enumLabel('PII.WAS_FORM_C')).toBe('PII.WAS_FORM_C');
+    expect(enumLabel('UNKNOWN_CAT')).toBe('UNKNOWN_CAT');
+  });
+});
+
 // G4 — client-side schema validation (spec §6.12.3 / §6.18)
 describe('SafetyRuleDialog — schema validation (G4)', () => {
   // A SafetyCheck with a realistic config_schema for pii.regex.

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -229,13 +229,13 @@ describe('SafetyRuleDialog — action_override write rule', () => {
 
   it('never writes action_override for a config_routed check; converts to backend format', async () => {
     // Backend format for presidio is block_codes/redact_codes, not routing.
-    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result', config: { block_codes: ['US_SSN'], redact_codes: [] } }) });
+    const el = await mount({ duplicating: makeRule({ check_id: 'presidio.pii', stage: 'post_tool_result', config: { block_codes: ['PII.SSN'], redact_codes: [] } }) });
     ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
     await el.updateComplete;
     await Promise.resolve();
     const [body] = createRuleSpy.mock.calls[0];
     expect((body.config as Record<string, unknown>).action_override).toBeUndefined();
-    expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
+    expect((body.config as Record<string, unknown>).block_codes).toEqual(['PII.SSN']);
     expect((body.config as Record<string, unknown>).redact_codes).toEqual([]);
     el.remove();
   });
@@ -250,13 +250,13 @@ describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-tr
         id: 'r5',
         check_id: 'presidio.pii',
         stage: 'post_tool_result',
-        config: { block_codes: ['US_SSN'], redact_codes: ['EMAIL_ADDRESS'], score_threshold: 0.6 },
+        config: { block_codes: ['PII.SSN'], redact_codes: ['PII.EMAIL'], score_threshold: 0.6 },
       }),
     });
     // The routing select for EMAIL_ADDRESS should exist (loaded from redact_codes).
     const emailSel = $<HTMLSelectElement>(
       el,
-      '[data-testid="saf-routing"] select[data-routing-code="EMAIL_ADDRESS"]',
+      '[data-testid="saf-routing"] select[data-routing-code="PII.EMAIL"]',
     )!;
     expect(emailSel).not.toBeNull();
     // Save without touching → round-trips back to block_codes/redact_codes.
@@ -264,8 +264,8 @@ describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-tr
     await el.updateComplete;
     await Promise.resolve();
     const [, body] = updateRuleSpy.mock.calls[0];
-    expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
-    expect((body.config as Record<string, unknown>).redact_codes).toEqual(['EMAIL_ADDRESS']);
+    expect((body.config as Record<string, unknown>).block_codes).toEqual(['PII.SSN']);
+    expect((body.config as Record<string, unknown>).redact_codes).toEqual(['PII.EMAIL']);
     expect((body.config as Record<string, unknown>).score_threshold).toBeDefined();
     el.remove();
   });
@@ -310,12 +310,12 @@ describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-tr
         id: 'r6',
         check_id: 'presidio.pii',
         stage: 'post_tool_result',
-        config: { block_codes: ['US_SSN'], redact_codes: ['EMAIL_ADDRESS'] },
+        config: { block_codes: ['PII.SSN'], redact_codes: ['PII.EMAIL'] },
       }),
     });
     const emailSel = $<HTMLSelectElement>(
       el,
-      '[data-testid="saf-routing"] select[data-routing-code="EMAIL_ADDRESS"]',
+      '[data-testid="saf-routing"] select[data-routing-code="PII.EMAIL"]',
     )!;
     // Clear EMAIL_ADDRESS routing → it should vanish from redact_codes.
     emailSel.value = '';
@@ -325,7 +325,7 @@ describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-tr
     await el.updateComplete;
     await Promise.resolve();
     const [, body] = updateRuleSpy.mock.calls[0];
-    expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
+    expect((body.config as Record<string, unknown>).block_codes).toEqual(['PII.SSN']);
     expect((body.config as Record<string, unknown>).redact_codes).toEqual([]);
     el.remove();
   });
@@ -530,7 +530,9 @@ describe('getSchemaEnum (G7)', () => {
 describe('enumLabel (G7)', () => {
   it('returns human label for known keys', () => {
     expect(enumLabel('SSN')).toBe('US Social Security numbers');
-    expect(enumLabel('sexual')).toBe('Sexual content');
+    // Backend stable codes (MODERATION.*)
+    expect(enumLabel('MODERATION.SEXUAL')).toBe('Sexual content');
+    expect(enumLabel('PII.SSN')).toBe('US Social Security numbers');
   });
 
   it('falls back to raw value for unknown keys', () => {

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -17,11 +17,9 @@ vi.mock('../services/safety-admin-client.js', async () => {
   return { ...actual, createRule: createRuleSpy, updateRule: updateRuleSpy };
 });
 
-// Side-effect import registers the custom element. The named import below is
-// type-only (used in `as SafetyRuleDialog`), so without this the module — and
-// its customElements.define — would be elided and the element never defined.
-import './safety-rule-dialog.js';
-import type { SafetyRuleDialog } from './safety-rule-dialog.js';
+// Value import registers the custom element (via @customElement decorator) AND
+// makes SafetyRuleDialog available for static method access in G4 tests.
+import { SafetyRuleDialog } from './safety-rule-dialog.js';
 import type { SafetyCheck, SafetyRule } from '../api/client.js';
 
 const piiRegex: SafetyCheck = {
@@ -477,6 +475,152 @@ describe('SafetyRuleDialog — host-list onBlur normalization (G1/G2)', () => {
     await el.updateComplete;
     expect(ta.value).toBe('*.stripe.com');
     el.remove();
+  });
+});
+
+// G4 — client-side schema validation (spec §6.12.3 / §6.18)
+describe('SafetyRuleDialog — schema validation (G4)', () => {
+  // A SafetyCheck with a realistic config_schema for pii.regex.
+  const piiWithSchema: SafetyCheck = {
+    ...piiRegex,
+    config_schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        patterns: {
+          type: 'object',
+          propertyNames: { enum: ['SSN', 'CREDIT_CARD', 'EMAIL', 'PHONE_US', 'IP_ADDRESS'] },
+          additionalProperties: { type: 'boolean' },
+        },
+      },
+    },
+  };
+
+  // A SafetyCheck with minItems on domain_patterns.
+  const egressWithSchema: SafetyCheck = {
+    ...egressDomainRule,
+    config_schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        domain_patterns: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        ports: { type: 'array', items: { type: 'integer' } },
+      },
+      required: ['domain_patterns'],
+    },
+  };
+
+  it('Ajv catches additionalProperties violation', async () => {
+    const el = await mount({
+      checks: [piiWithSchema, presidio, domainAllowlist, egressDomainRule],
+    });
+    // Inject bad config via advanced JSON textarea.
+    const adv = $<HTMLButtonElement>(el, '[data-testid="saf-adv-toggle"]');
+    adv?.click();
+    await el.updateComplete;
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-config-json"]');
+    if (ta) {
+      ta.value = '{"patterns": {}, "unknown_extra_field": true}';
+      ta.dispatchEvent(new Event('input'));
+    }
+    await el.updateComplete;
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    // Should NOT have called createRule.
+    expect(createRuleSpy).not.toHaveBeenCalled();
+    expect($<HTMLElement>(el, '[data-testid="saf-error-banner"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('sanity check fires when patterns is empty (config_schema present)', async () => {
+    const el = await mount({
+      checks: [piiWithSchema, presidio, domainAllowlist, egressDomainRule],
+    });
+    // Open config and submit without selecting any pattern (empty patterns).
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    expect(createRuleSpy).not.toHaveBeenCalled();
+    expect($<HTMLElement>(el, '[data-testid="saf-error-banner"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('sanity check does NOT fire when config_schema is null', async () => {
+    // piiRegex has config_schema: null — submission should go through.
+    createRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount();
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    await Promise.resolve();
+    expect(createRuleSpy).toHaveBeenCalledTimes(1);
+    el.remove();
+  });
+
+  it('Ajv catches minItems violation (egress domain_patterns empty)', async () => {
+    const el = await mount({
+      checks: [piiRegex, presidio, domainAllowlist, egressWithSchema],
+      duplicating: makeRule({ check_id: 'egress.domain_rule', stage: 'egress_request', config: {} }),
+    });
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    expect(createRuleSpy).not.toHaveBeenCalled();
+    expect($<HTMLElement>(el, '[data-testid="saf-error-banner"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('error banner lists all errors', async () => {
+    const el = await mount({
+      checks: [piiWithSchema, presidio, domainAllowlist, egressDomainRule],
+    });
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    const banner = $<HTMLElement>(el, '[data-testid="saf-error-banner"]')!;
+    expect(banner).not.toBeNull();
+    expect(banner.querySelector('ul')).not.toBeNull();
+    el.remove();
+  });
+});
+
+// G4 — FastAPI 4xx translator (SafetyRuleDialog._parseBackend400)
+describe('SafetyRuleDialog — FastAPI 4xx translator (G4)', () => {
+  it('translates extra_forbidden to user-friendly message', () => {
+    const result = SafetyRuleDialog._parseBackend400({
+      detail: [{ type: 'extra_forbidden', loc: ['body', 'config', 'hosts'], msg: 'Extra inputs are not permitted' }],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toMatch(/unknown field/i);
+    expect(result[0].message).toMatch(/hosts/);
+  });
+
+  it('translates missing to user-friendly message', () => {
+    const result = SafetyRuleDialog._parseBackend400({
+      detail: [{ type: 'missing', loc: ['body', 'config', 'domain_patterns'], msg: 'Field required' }],
+    });
+    expect(result[0].message).toMatch(/required field/i);
+    expect(result[0].message).toMatch(/domain_patterns/);
+  });
+
+  it('translates enum to message', () => {
+    const result = SafetyRuleDialog._parseBackend400({
+      detail: [{ type: 'enum', loc: ['body', 'config', 'patterns', 'SNN'], msg: 'Input should be one of SSN, CREDIT_CARD' }],
+    });
+    expect(result[0].message).toMatch(/invalid value/i);
+  });
+
+  it('translates int_parsing to user-friendly message', () => {
+    const result = SafetyRuleDialog._parseBackend400({
+      detail: [{ type: 'int_parsing', loc: ['body', 'config', 'ports', '0'], msg: 'Input should be a valid integer' }],
+    });
+    expect(result[0].message).toMatch(/must be a number/i);
+  });
+
+  it('returns empty array when detail is missing', () => {
+    expect(SafetyRuleDialog._parseBackend400({})).toEqual([]);
+    expect(SafetyRuleDialog._parseBackend400(null)).toEqual([]);
+    expect(SafetyRuleDialog._parseBackend400({ other: 'key' })).toEqual([]);
+  });
+
+  it('returns empty array for non-array detail', () => {
+    expect(SafetyRuleDialog._parseBackend400({ detail: 'string error' })).toEqual([]);
   });
 });
 

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -63,7 +63,19 @@ const domainAllowlist: SafetyCheck = {
   config_schema: null,
 } as SafetyCheck;
 
-const ALL_CHECKS = [piiRegex, presidio, domainAllowlist];
+const egressDomainRule: SafetyCheck = {
+  id: 'egress.domain_rule',
+  version: '1',
+  stages: ['egress_request'],
+  cost_class: 'cheap',
+  action_model: 'aggregated',
+  natural_actions: { egress_request: 'allow' },
+  supported_actions: { egress_request: ['allow', 'block'] },
+  supported_codes: [],
+  config_schema: null,
+} as SafetyCheck;
+
+const ALL_CHECKS = [piiRegex, presidio, domainAllowlist, egressDomainRule];
 
 function makeRule(over: Partial<SafetyRule> = {}): SafetyRule {
   return {
@@ -260,6 +272,39 @@ describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-tr
     el.remove();
   });
 
+  it('host-list check reads existing allowed_hosts into the textarea on load', async () => {
+    const el = await mount({
+      editing: makeRule({
+        check_id: 'domain_allowlist',
+        stage: 'pre_tool_call',
+        config: { allowed_hosts: ['api.stripe.com', '*.internal.acme.com'] },
+      }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    expect(ta.value).toContain('api.stripe.com');
+    expect(ta.value).toContain('*.internal.acme.com');
+    el.remove();
+  });
+
+  it('host-list check writes allowed_hosts to backend on save', async () => {
+    updateRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({
+      editing: makeRule({
+        id: 'r7',
+        check_id: 'domain_allowlist',
+        stage: 'pre_tool_call',
+        config: { allowed_hosts: ['api.stripe.com'] },
+      }),
+    });
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [, body] = updateRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).allowed_hosts).toEqual(['api.stripe.com']);
+    expect((body.config as Record<string, unknown>).domain_patterns).toBeUndefined();
+    el.remove();
+  });
+
   it('clearing a routing dropdown removes entity from the output lists', async () => {
     updateRuleSpy.mockResolvedValue(makeRule());
     const el = await mount({
@@ -284,6 +329,153 @@ describe('SafetyRuleDialog — presidio routing form ⇄ backend format round-tr
     const [, body] = updateRuleSpy.mock.calls[0];
     expect((body.config as Record<string, unknown>).block_codes).toEqual(['US_SSN']);
     expect((body.config as Record<string, unknown>).redact_codes).toEqual([]);
+    el.remove();
+  });
+});
+
+// G1/G2 — egress.domain_rule shared host-list form (spec §6.12.1)
+describe('SafetyRuleDialog — egress.domain_rule host-list form (G1/G2)', () => {
+  it('shows the domain_patterns textarea (not allowed_hosts) for egress', async () => {
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'egress.domain_rule', stage: 'egress_request', config: {} }),
+    });
+    expect($(el, '[data-testid="saf-hosts"]')).not.toBeNull();
+    // ports input is egress-only
+    expect($(el, '[data-testid="saf-egress-ports"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('does NOT show the ports input for domain_allowlist', async () => {
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'domain_allowlist', stage: 'pre_tool_call', config: {} }),
+    });
+    expect($(el, '[data-testid="saf-egress-ports"]')).toBeNull();
+    el.remove();
+  });
+
+  it('loads existing domain_patterns into the textarea', async () => {
+    const el = await mount({
+      editing: makeRule({
+        check_id: 'egress.domain_rule',
+        stage: 'egress_request',
+        config: { domain_patterns: ['api.stripe.com', '*.slack.com'], ports: [443] },
+      }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    expect(ta.value).toContain('api.stripe.com');
+    expect(ta.value).toContain('*.slack.com');
+    const portsInput = $<HTMLInputElement>(el, '[data-testid="saf-egress-ports"]')!;
+    expect(portsInput.value).toContain('443');
+    el.remove();
+  });
+
+  it('writes domain_patterns (not allowed_hosts) to backend on save', async () => {
+    updateRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({
+      editing: makeRule({
+        id: 'r8',
+        check_id: 'egress.domain_rule',
+        stage: 'egress_request',
+        config: { domain_patterns: ['api.stripe.com'] },
+      }),
+    });
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [, body] = updateRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).domain_patterns).toEqual(['api.stripe.com']);
+    expect((body.config as Record<string, unknown>).allowed_hosts).toBeUndefined();
+    expect((body.config as Record<string, unknown>).domain_pattern).toBeUndefined(); // old singular key gone
+    el.remove();
+  });
+
+  it('includes ports in backend config when set', async () => {
+    createRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'egress.domain_rule', stage: 'egress_request', config: {} }),
+    });
+    // Simulate typing domain_patterns
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    ta.value = 'api.stripe.com';
+    ta.dispatchEvent(new Event('input'));
+    // Simulate ports input
+    const portsInput = $<HTMLInputElement>(el, '[data-testid="saf-egress-ports"]')!;
+    portsInput.value = '443, 8443';
+    portsInput.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [body] = createRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).ports).toEqual([443, 8443]);
+    el.remove();
+  });
+
+  it('omits ports from backend config when the ports input is empty', async () => {
+    createRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'egress.domain_rule', stage: 'egress_request', config: {} }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    ta.value = 'api.stripe.com';
+    ta.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+    ($(el, '[data-testid="saf-submit"]') as HTMLButtonElement).click();
+    await el.updateComplete;
+    await Promise.resolve();
+    const [body] = createRuleSpy.mock.calls[0];
+    expect((body.config as Record<string, unknown>).ports).toBeUndefined();
+    el.remove();
+  });
+});
+
+// G1/G2 — onBlur domain normalization (spec §6.12.1)
+describe('SafetyRuleDialog — host-list onBlur normalization (G1/G2)', () => {
+  it('strips https:// scheme on blur for egress', async () => {
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'egress.domain_rule', stage: 'egress_request', config: {} }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    ta.value = 'https://www.reddit.com/\nhttps://api.stripe.com/v1/charges';
+    ta.dispatchEvent(new Event('blur'));
+    await el.updateComplete;
+    expect(ta.value).toBe('www.reddit.com\napi.stripe.com');
+    el.remove();
+  });
+
+  it('lowercases domain entries on blur', async () => {
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'domain_allowlist', stage: 'pre_tool_call', config: {} }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    ta.value = 'Www.Stripe.Com\nAPI.Example.COM';
+    ta.dispatchEvent(new Event('blur'));
+    await el.updateComplete;
+    expect(ta.value).toBe('www.stripe.com\napi.example.com');
+    el.remove();
+  });
+
+  it('drops blank lines on blur', async () => {
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'egress.domain_rule', stage: 'egress_request', config: {} }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    ta.value = 'api.stripe.com\n\n\n*.slack.com\n';
+    ta.dispatchEvent(new Event('blur'));
+    await el.updateComplete;
+    expect(ta.value).toBe('api.stripe.com\n*.slack.com');
+    el.remove();
+  });
+
+  it('preserves wildcard prefixes on blur', async () => {
+    const el = await mount({
+      duplicating: makeRule({ check_id: 'domain_allowlist', stage: 'pre_tool_call', config: {} }),
+    });
+    const ta = $<HTMLTextAreaElement>(el, '[data-testid="saf-hosts"]')!;
+    ta.value = '*.stripe.com';
+    ta.dispatchEvent(new Event('blur'));
+    await el.updateComplete;
+    expect(ta.value).toBe('*.stripe.com');
     el.remove();
   });
 });

--- a/web/src/components/safety-rule-dialog.test.ts
+++ b/web/src/components/safety-rule-dialog.test.ts
@@ -479,3 +479,152 @@ describe('SafetyRuleDialog — host-list onBlur normalization (G1/G2)', () => {
     el.remove();
   });
 });
+
+// G3 — duplicate-rule detection (spec §6.10a)
+describe('SafetyRuleDialog — duplicate detection (G3)', () => {
+  // Default seedForm picks stages[0] = 'input_prompt' for pii.regex.
+  // existingRule must share the same (check, scope, stage) triple.
+  const existingRule = makeRule({
+    id: 'existing-r1',
+    check_id: 'pii.regex',
+    stage: 'input_prompt',
+    coworker_id: null,
+    config: { patterns: { SSN: true } },
+    priority: 50,
+    enabled: false,
+    source: 'tenant',
+  });
+
+  it('detects a triple match and shows the info banner', async () => {
+    const el = await mount({ rules: [existingRule] });
+    // Default create mode opens with pii.regex / pre_tool_call / all coworkers
+    // which matches existingRule's triple.
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('flips the dialog title to "Edit existing rule" on match', async () => {
+    const el = await mount({ rules: [existingRule] });
+    // The title is passed as an attribute to <rm-dialog>; check the attribute.
+    const dlg = $<HTMLElement>(el, 'rm-dialog')!;
+    expect(dlg.getAttribute('title')).toBe('Edit existing rule');
+    el.remove();
+  });
+
+  it('pre-loads the existing rule config, priority, and enabled state', async () => {
+    const el = await mount({ rules: [existingRule] });
+    expect($<HTMLInputElement>(el, '[data-testid="saf-priority"]')!.value).toBe('50');
+    // enabled toggle should reflect existingRule.enabled = false
+    const toggle = $<HTMLButtonElement>(el, '[data-testid="saf-enabled"]')!;
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    el.remove();
+  });
+
+  it('locks the scope select when in dup-target mode', async () => {
+    const el = await mount({ rules: [existingRule] });
+    const scope = $<HTMLSelectElement>(el, '[data-testid="saf-scope"]')!;
+    expect(scope.disabled).toBe(true);
+    el.remove();
+  });
+
+  it('"Create a separate rule anyway" clears dupTarget and shows warn banner', async () => {
+    const el = await mount({ rules: [existingRule] });
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).not.toBeNull();
+    ($<HTMLButtonElement>(el, '[data-testid="saf-dup-force-create"]'))!.click();
+    await el.updateComplete;
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).toBeNull();
+    expect($(el, '[data-testid="saf-dup-banner-warn"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('save btn label changes: info→"Save changes", force-create→"Create separate rule"', async () => {
+    const el = await mount({ rules: [existingRule] });
+    const btn = $<HTMLButtonElement>(el, '[data-testid="saf-submit"]')!;
+    expect(btn.textContent?.trim()).toBe('Save changes');
+    ($<HTMLButtonElement>(el, '[data-testid="saf-dup-force-create"]'))!.click();
+    await el.updateComplete;
+    expect(btn.textContent?.trim()).toBe('Create separate rule');
+    el.remove();
+  });
+
+  it('"Switch back" clears forceCreate and re-detects (restores info banner)', async () => {
+    const el = await mount({ rules: [existingRule] });
+    ($<HTMLButtonElement>(el, '[data-testid="saf-dup-force-create"]'))!.click();
+    await el.updateComplete;
+    expect($(el, '[data-testid="saf-dup-banner-warn"]')).not.toBeNull();
+    ($<HTMLButtonElement>(el, '[data-testid="saf-dup-switch-back"]'))!.click();
+    await el.updateComplete;
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('skip: real edit mode — no detection fires', async () => {
+    const el = await mount({ editing: existingRule, rules: [existingRule] });
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).toBeNull();
+    el.remove();
+  });
+
+  it('skip: force-create already on — triple change does not re-flip', async () => {
+    const el = await mount({ rules: [existingRule] });
+    ($<HTMLButtonElement>(el, '[data-testid="saf-dup-force-create"]'))!.click();
+    await el.updateComplete;
+    // Stage change should NOT re-flip to info banner while forceCreate is true.
+    const stageSelect = $<HTMLSelectElement>(el, '[data-testid="saf-stage"]');
+    if (stageSelect) {
+      stageSelect.value = 'input_prompt';
+      stageSelect.dispatchEvent(new Event('change'));
+      await el.updateComplete;
+    }
+    // Still in force-create mode (no re-trigger).
+    expect($(el, '[data-testid="saf-dup-banner-warn"]')).not.toBeNull();
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).toBeNull();
+    el.remove();
+  });
+
+  it('platform-tier overlap shows FYI banner, not info banner', async () => {
+    const platformRule = makeRule({
+      id: 'plat-r1',
+      check_id: 'pii.regex',
+      stage: 'input_prompt', // matches default seedForm triple
+      coworker_id: null,
+      source: 'platform',
+    });
+    const el = await mount({ rules: [platformRule] });
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).toBeNull();
+    expect($(el, '[data-testid="saf-dup-banner-fyi"]')).not.toBeNull();
+    el.remove();
+  });
+
+  it('routes to updateRule(existingRule.id) when submitting in dup-target mode', async () => {
+    updateRuleSpy.mockResolvedValue(makeRule({ id: 'existing-r1' }));
+    const el = await mount({ rules: [existingRule] });
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).not.toBeNull();
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    await Promise.resolve();
+    expect(updateRuleSpy).toHaveBeenCalledTimes(1);
+    expect(updateRuleSpy.mock.calls[0][0]).toBe('existing-r1');
+    expect(createRuleSpy).not.toHaveBeenCalled();
+    el.remove();
+  });
+
+  it('routes to createRule when submitting in force-create mode', async () => {
+    createRuleSpy.mockResolvedValue(makeRule());
+    const el = await mount({ rules: [existingRule] });
+    ($<HTMLButtonElement>(el, '[data-testid="saf-dup-force-create"]'))!.click();
+    await el.updateComplete;
+    ($<HTMLButtonElement>(el, '[data-testid="saf-submit"]'))!.click();
+    await el.updateComplete;
+    await Promise.resolve();
+    expect(createRuleSpy).toHaveBeenCalledTimes(1);
+    expect(updateRuleSpy).not.toHaveBeenCalled();
+    el.remove();
+  });
+
+  it('does not detect duplicating rule against itself', async () => {
+    // Duplicating a rule: the source (existingRule) should not match against itself.
+    const el = await mount({ duplicating: existingRule, rules: [existingRule] });
+    expect($(el, '[data-testid="saf-dup-banner-info"]')).toBeNull();
+    el.remove();
+  });
+});

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -108,25 +108,34 @@ function _translateFastApiError(err: {
 // raw-value display (reverse-drift property: backend adds new enum → frontend
 // renders it immediately with the raw code as fallback label).
 const ENUM_LABELS: Record<string, string> = {
-  // pii.regex pattern keys (uppercase)
+  // pii.regex pattern keys (uppercase, from _CONFIG_KEY_TO_CODE in pii_regex.py)
   SSN: 'US Social Security numbers',
   CREDIT_CARD: 'Credit card numbers',
   EMAIL: 'Email addresses',
   PHONE_US: 'Phone numbers (US)',
   IP_ADDRESS: 'IP addresses',
-  // presidio.pii entity codes (PII.* prefix not used in current backend enum)
-  EMAIL_ADDRESS: 'Email addresses',
-  PHONE_NUMBER: 'Phone numbers',
-  US_SSN: 'US Social Security numbers',
-  PERSON: "People's names",
-  LOCATION: 'Locations',
-  DATE_TIME: 'Dates and times',
-  // openai_moderation categories (lowercase codes from backend enum)
-  sexual: 'Sexual content',
-  hate: 'Hate speech',
-  harassment: 'Harassment',
-  'self-harm': 'Self-harm',
-  violence: 'Violence',
+  // presidio.pii entity codes (PII.* stable codes from PresidioPIICode enum)
+  'PII.SSN': 'US Social Security numbers',
+  'PII.CREDIT_CARD': 'Credit card numbers',
+  'PII.EMAIL': 'Email addresses',
+  'PII.PHONE': 'Phone numbers',
+  'PII.IP_ADDRESS': 'IP addresses',
+  'PII.PERSON_NAME': "People's names",
+  'PII.LOCATION': 'Locations',
+  'PII.DATE_TIME': 'Dates and times',
+  'PII.URL': 'URLs',
+  'PII.IBAN': 'IBAN bank account numbers',
+  'PII.US_BANK_NUMBER': 'US bank account numbers',
+  'PII.US_DRIVER_LICENSE': 'US driver license numbers',
+  'PII.US_PASSPORT': 'US passport numbers',
+  'PII.MEDICAL_LICENSE': 'Medical license numbers',
+  // openai_moderation stable codes (MODERATION.* from ModerationCode enum)
+  'MODERATION.HARASSMENT': 'Harassment',
+  'MODERATION.HATE': 'Hate speech',
+  'MODERATION.VIOLENCE': 'Violence',
+  'MODERATION.SEXUAL': 'Sexual content',
+  'MODERATION.SELF_HARM': 'Self-harm',
+  'MODERATION.ILLICIT': 'Illicit content',
 };
 
 export function enumLabel(v: string): string {
@@ -153,13 +162,21 @@ export function getSchemaEnum(
 }
 
 // Fallback entity lists for when config_schema is absent (pre-PR-#58 deploys
-// or null schema). Keeps the form functional even without schema data.
+// or null schema). Must use the backend's stable codes, NOT Presidio library
+// entity names or OpenAI API category strings — verified against:
+//   PresidioPIICode  in src/rolemesh/safety/checks/presidio_pii.py
+//   ModerationCode   in src/rolemesh/safety/checks/openai_moderation.py
 const PII_REGEX_FALLBACK: string[] = ['SSN', 'CREDIT_CARD', 'EMAIL', 'PHONE_US', 'IP_ADDRESS'];
 const PRESIDIO_FALLBACK: string[] = [
-  'EMAIL_ADDRESS', 'PHONE_NUMBER', 'US_SSN', 'CREDIT_CARD',
-  'PERSON', 'LOCATION', 'IP_ADDRESS', 'DATE_TIME',
+  'PII.SSN', 'PII.CREDIT_CARD', 'PII.EMAIL', 'PII.PHONE', 'PII.IP_ADDRESS',
+  'PII.PERSON_NAME', 'PII.LOCATION', 'PII.DATE_TIME', 'PII.URL',
+  'PII.IBAN', 'PII.US_BANK_NUMBER', 'PII.US_DRIVER_LICENSE',
+  'PII.US_PASSPORT', 'PII.MEDICAL_LICENSE',
 ];
-const MODERATION_FALLBACK: string[] = ['sexual', 'hate', 'harassment', 'self-harm', 'violence'];
+const MODERATION_FALLBACK: string[] = [
+  'MODERATION.HARASSMENT', 'MODERATION.HATE', 'MODERATION.VIOLENCE',
+  'MODERATION.SEXUAL', 'MODERATION.SELF_HARM', 'MODERATION.ILLICIT',
+];
 
 @customElement('rm-safety-rule-dialog')
 export class SafetyRuleDialog extends LitElement {

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -103,45 +103,63 @@ function _translateFastApiError(err: {
   }
 }
 
-// Presentation lists for the per-check config forms. Human label first, the
-// technical code as a muted subtitle (§8.5: behaviour primary, code for
-// debugging). These are UI-only; the backend keys are the codes.
+// G7 — schema-driven enum rendering (spec §6.12.5).
+// Human-readable labels for known enum values. Unknown values fall through to
+// raw-value display (reverse-drift property: backend adds new enum → frontend
+// renders it immediately with the raw code as fallback label).
+const ENUM_LABELS: Record<string, string> = {
+  // pii.regex pattern keys (uppercase)
+  SSN: 'US Social Security numbers',
+  CREDIT_CARD: 'Credit card numbers',
+  EMAIL: 'Email addresses',
+  PHONE_US: 'Phone numbers (US)',
+  IP_ADDRESS: 'IP addresses',
+  // presidio.pii entity codes (PII.* prefix not used in current backend enum)
+  EMAIL_ADDRESS: 'Email addresses',
+  PHONE_NUMBER: 'Phone numbers',
+  US_SSN: 'US Social Security numbers',
+  PERSON: "People's names",
+  LOCATION: 'Locations',
+  DATE_TIME: 'Dates and times',
+  // openai_moderation categories (lowercase codes from backend enum)
+  sexual: 'Sexual content',
+  hate: 'Hate speech',
+  harassment: 'Harassment',
+  'self-harm': 'Self-harm',
+  violence: 'Violence',
+};
 
-// pii.regex: backend key is `patterns: { SSN: true, ... }` (uppercase, dict of bool).
-// Each entry: [backendKey, humanLabel]. Frontend stores as Set<backendKey>.
-const PII_REGEX_ENTITIES: [string, string][] = [
-  ['SSN', 'US Social Security numbers'],
-  ['CREDIT_CARD', 'Credit card numbers'],
-  ['EMAIL', 'Email addresses'],
-  ['PHONE_US', 'Phone numbers'],
-  ['IP_ADDRESS', 'IP addresses'],
+export function enumLabel(v: string): string {
+  return ENUM_LABELS[v] ?? v;
+}
+
+/** Read enum values from a check's config_schema field.
+ *  `kind` is 'items' for array-item enums (presidio codes, moderation
+ *  categories) or 'propertyNames' for dict-key enums (pii.regex patterns).
+ *  Returns [] when schema or the field is absent — caller falls back to the
+ *  hardcoded ENUM_LABELS keys (defensive §6, hard constraint #6). */
+export function getSchemaEnum(
+  check: SafetyCheck | null,
+  fieldPath: string,
+  kind: 'items' | 'propertyNames',
+): string[] {
+  const schema = check?.config_schema as Record<string, unknown> | null | undefined;
+  if (!schema || typeof schema !== 'object') return [];
+  const props = (schema['properties'] as Record<string, unknown> | undefined) ?? {};
+  const field = props[fieldPath] as Record<string, unknown> | undefined;
+  if (!field) return [];
+  const node = (field[kind] as Record<string, unknown> | undefined) ?? {};
+  return Array.isArray(node['enum']) ? (node['enum'] as string[]) : [];
+}
+
+// Fallback entity lists for when config_schema is absent (pre-PR-#58 deploys
+// or null schema). Keeps the form functional even without schema data.
+const PII_REGEX_FALLBACK: string[] = ['SSN', 'CREDIT_CARD', 'EMAIL', 'PHONE_US', 'IP_ADDRESS'];
+const PRESIDIO_FALLBACK: string[] = [
+  'EMAIL_ADDRESS', 'PHONE_NUMBER', 'US_SSN', 'CREDIT_CARD',
+  'PERSON', 'LOCATION', 'IP_ADDRESS', 'DATE_TIME',
 ];
-const PRESIDIO_ENTITIES: [string, string][] = [
-  ['EMAIL_ADDRESS', 'Email addresses'],
-  ['PHONE_NUMBER', 'Phone numbers'],
-  ['US_SSN', 'US Social Security numbers'],
-  ['CREDIT_CARD', 'Credit card numbers'],
-  ['PERSON', "People's names"],
-  ['LOCATION', 'Locations'],
-  ['IP_ADDRESS', 'IP addresses'],
-  ['DATE_TIME', 'Dates and times'],
-];
-const MODERATION_CATEGORIES: [string, string][] = [
-  ['sexual', 'Sexual content'],
-  ['hate', 'Hate speech'],
-  ['harassment', 'Harassment'],
-  ['self-harm', 'Self-harm'],
-  ['violence', 'Violence'],
-];
-const SECRET_PLUGINS: [string, string][] = [
-  ['aws', 'AWS keys'],
-  ['github', 'GitHub tokens'],
-  ['slack', 'Slack tokens'],
-  ['stripe', 'Stripe keys'],
-  ['jwt', 'Login tokens (JWT)'],
-  ['basic_auth', 'Basic auth credentials'],
-  ['private_key', 'Private keys'],
-];
+const MODERATION_FALLBACK: string[] = ['sexual', 'hate', 'harassment', 'self-harm', 'violence'];
 
 @customElement('rm-safety-rule-dialog')
 export class SafetyRuleDialog extends LitElement {
@@ -948,7 +966,7 @@ export class SafetyRuleDialog extends LitElement {
       case 'pii-entities':
         // Internally stored as _piiKeys (Set<backendKey>); converted to
         // { patterns: { SSN: true, ... } } on save (see _buildBackendConfig).
-        return this.renderPiiEntityGrid();
+        return this.renderPiiEntityGrid(check);
       case 'secret-plugins':
         // Backend SecretScannerConfig has action_override only — no plugin
         // selection. Show an info note instead of a broken checkbox grid.
@@ -960,7 +978,7 @@ export class SafetyRuleDialog extends LitElement {
       case 'presidio-routing':
         // Stored internally as { routing: {CODE→action}, threshold } and
         // converted to { block_codes, redact_codes, score_threshold } on save.
-        return this.renderRouting(check, 'type', PRESIDIO_ENTITIES, true);
+        return this.renderRouting(check, 'type', true);
       case 'moderation-routing':
         // Stored internally as { routing: {cat→action} } and converted to
         // { block_categories, warn_categories } on save. Only block/warn
@@ -975,14 +993,19 @@ export class SafetyRuleDialog extends LitElement {
     }
   }
 
-  private renderPiiEntityGrid(): TemplateResult {
+  private renderPiiEntityGrid(check: SafetyCheck): TemplateResult {
+    // G7: read enum values from config_schema; fall back to static list.
+    const keys =
+      getSchemaEnum(check, 'patterns', 'propertyNames').length > 0
+        ? getSchemaEnum(check, 'patterns', 'propertyNames')
+        : PII_REGEX_FALLBACK;
     // _piiKeys holds the Set of selected backend keys (SSN, CREDIT_CARD, …).
     const selected = new Set((this.config['_piiKeys'] as string[]) ?? []);
     return html`
       <label class="block text-[12.5px] font-medium mb-1">What to look for</label>
       <div class="rm-saf-cfg-checks">
-        ${PII_REGEX_ENTITIES.map(
-          ([backendKey, lbl]) => html`<label>
+        ${keys.map(
+          (backendKey) => html`<label>
             <input
               type="checkbox"
               ?checked=${selected.has(backendKey)}
@@ -993,7 +1016,7 @@ export class SafetyRuleDialog extends LitElement {
                 this.config = { ...this.config, _piiKeys: [...next] };
               }}
             />
-            ${lbl}
+            ${enumLabel(backendKey)}
           </label>`,
         )}
       </div>
@@ -1061,6 +1084,11 @@ export class SafetyRuleDialog extends LitElement {
   // Moderation routing: only block/warn per category — the schema has no
   // require_approval_categories field, so we filter it from the options.
   private renderModerationRouting(check: SafetyCheck): TemplateResult {
+    // G7: read categories from config_schema; fall back to static list.
+    const categoryKeys =
+      getSchemaEnum(check, 'block_categories', 'items').length > 0
+        ? getSchemaEnum(check, 'block_categories', 'items')
+        : MODERATION_FALLBACK;
     const stage = this.stage as SafetyStage;
     const routing = (this.config['routing'] as Record<string, string>) ?? {};
     // Only block and warn are expressible per-category.
@@ -1074,10 +1102,10 @@ export class SafetyRuleDialog extends LitElement {
         <span class="rm-saf-lblnote">leave any blank to let it through</span>
       </label>
       <div class="rm-saf-routing-table" data-testid="saf-routing">
-        ${MODERATION_CATEGORIES.map(
-          ([code, lbl]) => html`<div class="rm-saf-routing-row">
+        ${categoryKeys.map(
+          (code) => html`<div class="rm-saf-routing-row">
             <div>
-              <div class="rm-saf-rcode">${lbl}</div>
+              <div class="rm-saf-rcode">${enumLabel(code)}</div>
               <div class="rm-saf-rdesc">${code}</div>
             </div>
             <select
@@ -1244,15 +1272,18 @@ export class SafetyRuleDialog extends LitElement {
     `;
   }
 
-  // Per-finding routing table (Experience 2). Each row: human label + code +
-  // a dropdown of supportable actions (server-driven, minus allow — the empty
-  // "— allow these —" option is the allow case). presidio also has a threshold.
+  // Per-finding routing table (Experience 2). For presidio.pii only.
+  // Codes are read from config_schema items.enum; fall back to static list.
   private renderRouting(
     check: SafetyCheck,
     noun: 'type' | 'category',
-    rows: [string, string][],
     withThreshold: boolean,
   ): TemplateResult {
+    // G7: derive entity codes from config_schema (block_codes items.enum).
+    const codes =
+      getSchemaEnum(check, 'block_codes', 'items').length > 0
+        ? getSchemaEnum(check, 'block_codes', 'items')
+        : PRESIDIO_FALLBACK;
     const stage = this.stage as SafetyStage;
     const routing = (this.config['routing'] as Record<string, string>) ?? {};
     const options = supportedActions(check, stage).filter((a) => a !== 'allow');
@@ -1263,10 +1294,10 @@ export class SafetyRuleDialog extends LitElement {
         <span class="rm-saf-lblnote">leave any blank to let it through</span>
       </label>
       <div class="rm-saf-routing-table" data-testid="saf-routing">
-        ${rows.map(
-          ([code, lbl]) => html`<div class="rm-saf-routing-row">
+        ${codes.map(
+          (code) => html`<div class="rm-saf-routing-row">
             <div>
-              <div class="rm-saf-rcode">${lbl}</div>
+              <div class="rm-saf-rcode">${enumLabel(code)}</div>
               <div class="rm-saf-rdesc">${code}</div>
             </div>
             <select

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -103,6 +103,8 @@ export class SafetyRuleDialog extends LitElement {
   /** Check catalog + coworker list — fetched once by the page, passed down. */
   @property({ attribute: false }) checks: SafetyCheck[] = [];
   @property({ attribute: false }) coworkers: CoworkerSummary[] = [];
+  /** All existing rules — used for duplicate-detection (G3, spec §6.10a). */
+  @property({ attribute: false }) rules: SafetyRule[] = [];
 
   @state() private checkId = '';
   @state() private stage: SafetyStage | '' = '';
@@ -117,6 +119,16 @@ export class SafetyRuleDialog extends LitElement {
   @state() private advancedJson: string | null = null;
   @state() private busy = false;
   @state() private err: string | null = null;
+  // --- G3: duplicate-detection state (spec §6.10a) ---
+  /** Org-tier rule matching the current (check, scope, stage) triple when in
+   *  create/duplicate mode. When set, the form auto-flips to edit that rule. */
+  @state() private _dupTarget: SafetyRule | null = null;
+  /** True after the user clicked "Create a separate rule anyway" — bypasses
+   *  auto-flip and forces a POST. Resets when dialog closes. */
+  @state() private _forceCreate = false;
+  /** Platform-tier rule covering the same triple; shows the gray FYI banner
+   *  but does NOT flip to edit (user can't edit platform rules). */
+  @state() private _platformOverlap: SafetyRule | null = null;
 
   protected override createRenderRoot() {
     return this;
@@ -124,6 +136,9 @@ export class SafetyRuleDialog extends LitElement {
 
   override willUpdate(changed: Map<string, unknown>) {
     if (changed.has('open') && this.open) {
+      this._dupTarget = null;
+      this._forceCreate = false;
+      this._platformOverlap = null;
       this.seedForm();
       this.err = null;
     }
@@ -169,6 +184,8 @@ export class SafetyRuleDialog extends LitElement {
       this.config = {};
       this.advancedJson = null;
     }
+    // G3: run detection after all form fields are set (skips in edit mode).
+    this._checkDuplicateRule();
   }
 
   private close = () => {
@@ -186,6 +203,9 @@ export class SafetyRuleDialog extends LitElement {
     this.pickedAction = null;
     this.config = {};
     this.advancedJson = null;
+    this._dupTarget = null; // triple changed — reset before re-detecting
+    this._platformOverlap = null;
+    this._checkDuplicateRule();
   }
 
   private onStageChange(stage: SafetyStage): void {
@@ -198,6 +218,141 @@ export class SafetyRuleDialog extends LitElement {
       const st = actionButtonState(check, stage, this.pickedAction, nat);
       if (!st.enabled) this.pickedAction = null;
     }
+    this._dupTarget = null;
+    this._platformOverlap = null;
+    this._checkDuplicateRule();
+  }
+
+  private onScopeChange(v: string): void {
+    this.coworkerId = v === '' ? null : v;
+    this._dupTarget = null;
+    this._platformOverlap = null;
+    this._checkDuplicateRule();
+  }
+
+  // ---- G3: duplicate-rule detection (spec §6.10a) ----
+
+  // Detect whether the current (check_id, coworker_id, stage) triple matches an
+  // existing rule. Skipped in edit mode, when _forceCreate is already true, or
+  // when check/stage are not yet set. On a match the form auto-flips to edit
+  // the existing rule (or shows a gray FYI for platform-tier overlaps).
+  private _checkDuplicateRule(): void {
+    if (this.isEdit) return;         // real edit — user picked this rule explicitly
+    if (this._forceCreate) return;   // user opted out of auto-flip
+    if (!this.checkId || !this.stage) return;
+
+    const matchesTriple = (r: SafetyRule) =>
+      r.check_id === this.checkId &&
+      r.stage === this.stage &&
+      (r.coworker_id ?? null) === this.coworkerId;
+
+    // Org-tier collision: an editable rule with the same triple (excluding the
+    // duplicating source so we don't detect a rule against itself).
+    const orgMatch = this.rules.find(
+      (r) =>
+        r.source === 'tenant' &&
+        matchesTriple(r) &&
+        r.id !== this.duplicating?.id,
+    );
+
+    if (orgMatch) {
+      this._dupTarget = orgMatch;
+      this._platformOverlap = null;
+      // Pre-load existing rule's config/priority/enabled — user is editing it.
+      const cfg = { ...(orgMatch.config ?? {}) } as Record<string, unknown>;
+      const override = cfg['action_override'];
+      this.pickedAction =
+        typeof override === 'string' ? (override as SafetyVerdictAction) : null;
+      delete cfg['action_override'];
+      this._normalizeConfigFromBackend(orgMatch.check_id, cfg);
+      this.config = cfg;
+      this.priority = orgMatch.priority;
+      this.enabled = orgMatch.enabled;
+      this.coworkerId = orgMatch.coworker_id ?? null;
+      return;
+    }
+
+    this._dupTarget = null;
+
+    // Platform-tier overlap: show FYI banner, do NOT flip to edit.
+    const platformMatch = this.rules.find(
+      (r) => r.source === 'platform' && matchesTriple(r),
+    );
+    this._platformOverlap = platformMatch ?? null;
+  }
+
+  // "Create a separate rule anyway" — lock in forced-create mode.
+  private _onForceCreate(): void {
+    this._forceCreate = true;
+    this._dupTarget = null;
+    this._platformOverlap = null;
+    // Reset to defaults; keep check/stage the user selected.
+    this.config = {};
+    this.pickedAction = null;
+    this.priority = 100;
+    this.enabled = true;
+    this.coworkerId = null; // unlock scope
+  }
+
+  // "Switch back to editing the existing one" — re-run detection.
+  private _onSwitchBackToEdit(): void {
+    this._forceCreate = false;
+    this._checkDuplicateRule();
+  }
+
+  // Banner rendered above the check field when dup detection fires (§6.10a).
+  private _renderDupBanner(): TemplateResult | typeof nothing {
+    if (this._dupTarget && !this._forceCreate) {
+      const label = this._dupTarget.check_id;
+      const stageLbl = SAF_STAGE_LABEL[this._dupTarget.stage as SafetyStage] ?? this._dupTarget.stage;
+      const scope = this._dupTarget.coworker_id
+        ? (this.coworkers.find((c) => c.id === this._dupTarget!.coworker_id)?.name ?? this._dupTarget.coworker_id)
+        : 'all coworkers';
+      return html`
+        <div class="rm-dup-banner rm-dup-banner--info" data-testid="saf-dup-banner-info">
+          <span>ℹ</span>
+          <span>
+            You already have a <b>${label}</b> rule for <b>${stageLbl}</b> on
+            <b>${scope}</b>. You're editing that rule now (not creating a new one).
+            <button
+              type="button"
+              class="rm-dup-link"
+              data-testid="saf-dup-force-create"
+              @click=${() => this._onForceCreate()}
+            >Create a separate rule anyway</button>
+          </span>
+        </div>
+      `;
+    }
+    if (this._forceCreate) {
+      return html`
+        <div class="rm-dup-banner rm-dup-banner--warn" data-testid="saf-dup-banner-warn">
+          <span>⚠</span>
+          <span>
+            Creating a second rule for the same surface — they may conflict.
+            <button
+              type="button"
+              class="rm-dup-link"
+              data-testid="saf-dup-switch-back"
+              @click=${() => this._onSwitchBackToEdit()}
+            >Switch back to editing the existing one</button>
+          </span>
+        </div>
+      `;
+    }
+    if (this._platformOverlap) {
+      const label = this._platformOverlap.check_id;
+      return html`
+        <div class="rm-dup-banner rm-dup-banner--fyi" data-testid="saf-dup-banner-fyi">
+          <span>🛡</span>
+          <span>
+            A platform default <b>${label}</b> already covers this surface — your
+            org rule will run alongside it.
+          </span>
+        </div>
+      `;
+    }
+    return nothing;
   }
 
   // ---- config format converters (backend ↔ internal display) ----
@@ -333,6 +488,17 @@ export class SafetyRuleDialog extends LitElement {
           enabled: this.enabled,
         });
         savedId = saved.id;
+      } else if (this._dupTarget && !this._forceCreate) {
+        // G3: auto-flipped to edit existing rule — PATCH that rule, not POST.
+        // Scope omitted (immutable on edit, same as real edit mode).
+        const saved = await updateRule(this._dupTarget.id, {
+          check_id: this.checkId,
+          stage: this.stage,
+          config,
+          priority: this.priority,
+          enabled: this.enabled,
+        });
+        savedId = saved.id;
       } else {
         const saved = await createRule({
           check_id: this.checkId,
@@ -377,8 +543,16 @@ export class SafetyRuleDialog extends LitElement {
 
   private dialogTitle(): string {
     if (this.isEdit) return 'Edit safety rule';
+    if (this._dupTarget && !this._forceCreate) return 'Edit existing rule';
+    if (this._forceCreate) return 'Create separate rule';
     if (this.duplicating) return 'Duplicate safety rule';
     return 'New safety rule';
+  }
+
+  private saveBtnLabel(): string {
+    if (this.isEdit || (this._dupTarget && !this._forceCreate)) return 'Save changes';
+    if (this._forceCreate) return 'Create separate rule';
+    return 'Create rule';
   }
 
   override render(): TemplateResult {
@@ -400,6 +574,7 @@ export class SafetyRuleDialog extends LitElement {
           already-running tasks finish with the current rules.
         </p>
 
+        ${this._renderDupBanner()}
         ${this.renderCheckField(pres)}
         ${this.renderStageField(check)}
         ${this.showActionPanel() ? this.renderActionPanel(check) : nothing}
@@ -422,7 +597,7 @@ export class SafetyRuleDialog extends LitElement {
           <button type="button" class="rm-btn rm-btn--primary"
             data-testid="saf-submit" ?disabled=${this.busy}
             @click=${() => void this.submit()}
-          >${this.busy ? 'Saving…' : this.isEdit ? 'Save changes' : 'Create rule'}</button>
+          >${this.busy ? 'Saving…' : this.saveBtnLabel()}</button>
         </div>
       </rm-dialog>
     `;
@@ -957,7 +1132,9 @@ export class SafetyRuleDialog extends LitElement {
   }
 
   private renderScopeField(): TemplateResult {
-    const locked = this.isEdit;
+    // Scope is locked in real edit mode AND when auto-flipped to edit an
+    // existing rule via dup-detection (same audit-consistency reason).
+    const locked = this.isEdit || (this._dupTarget !== null && !this._forceCreate);
     return html`
       <div class="mb-2">
         <label class="block text-[12.5px] font-medium mb-1">Applies to</label>
@@ -966,10 +1143,7 @@ export class SafetyRuleDialog extends LitElement {
           data-testid="saf-scope"
           ?disabled=${locked || this.busy}
           style=${locked ? 'opacity:0.55;cursor:not-allowed' : ''}
-          @change=${(e: Event) => {
-            const v = (e.target as HTMLSelectElement).value;
-            this.coworkerId = v === '' ? null : v;
-          }}
+          @change=${(e: Event) => this.onScopeChange((e.target as HTMLSelectElement).value)}
         >
           <option value="" ?selected=${!this.coworkerId}>All coworkers</option>
           ${this.coworkers.map(

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -387,7 +387,13 @@ export class SafetyRuleDialog extends LitElement {
   }
 
   // Banner rendered above the check field when dup detection fires (§6.10a).
+  // Style mirrors the prototype's .dup-banner-edit / .dup-banner-warn / .dup-banner-info.
   private _renderDupBanner(): TemplateResult | typeof nothing {
+    const BASE =
+      'flex items-start gap-[9px] px-[13px] py-[10px] mb-[14px] rounded-[7px] text-[12.5px] leading-[1.5]';
+    const LINK =
+      'underline cursor-pointer font-[500] whitespace-nowrap ml-[6px] bg-transparent border-none p-0 text-inherit';
+
     if (this._dupTarget && !this._forceCreate) {
       const label = this._dupTarget.check_id;
       const stageLbl = SAF_STAGE_LABEL[this._dupTarget.stage as SafetyStage] ?? this._dupTarget.stage;
@@ -395,14 +401,17 @@ export class SafetyRuleDialog extends LitElement {
         ? (this.coworkers.find((c) => c.id === this._dupTarget!.coworker_id)?.name ?? this._dupTarget.coworker_id)
         : 'all coworkers';
       return html`
-        <div class="rm-dup-banner rm-dup-banner--info" data-testid="saf-dup-banner-info">
-          <span>ℹ</span>
+        <div
+          class="${BASE} bg-blue-50 dark:bg-blue-900/20 border-l-[3px] border-blue-600 dark:border-blue-500 text-blue-800 dark:text-blue-200"
+          data-testid="saf-dup-banner-info"
+        >
+          <span class="shrink-0 mt-px">ℹ</span>
           <span>
             You already have a <b>${label}</b> rule for <b>${stageLbl}</b> on
             <b>${scope}</b>. You're editing that rule now (not creating a new one).
             <button
               type="button"
-              class="rm-dup-link"
+              class="${LINK}"
               data-testid="saf-dup-force-create"
               @click=${() => this._onForceCreate()}
             >Create a separate rule anyway</button>
@@ -412,13 +421,16 @@ export class SafetyRuleDialog extends LitElement {
     }
     if (this._forceCreate) {
       return html`
-        <div class="rm-dup-banner rm-dup-banner--warn" data-testid="saf-dup-banner-warn">
-          <span>⚠</span>
+        <div
+          class="${BASE} bg-amber-50 dark:bg-amber-900/20 border-l-[3px] border-amber-500 dark:border-amber-600 text-amber-800 dark:text-amber-200"
+          data-testid="saf-dup-banner-warn"
+        >
+          <span class="shrink-0 mt-px">⚠</span>
           <span>
             Creating a second rule for the same surface — they may conflict.
             <button
               type="button"
-              class="rm-dup-link"
+              class="${LINK}"
               data-testid="saf-dup-switch-back"
               @click=${() => this._onSwitchBackToEdit()}
             >Switch back to editing the existing one</button>
@@ -429,8 +441,11 @@ export class SafetyRuleDialog extends LitElement {
     if (this._platformOverlap) {
       const label = this._platformOverlap.check_id;
       return html`
-        <div class="rm-dup-banner rm-dup-banner--fyi" data-testid="saf-dup-banner-fyi">
-          <span>🛡</span>
+        <div
+          class="${BASE} text-[11.5px] bg-surface-2 dark:bg-d-surface-2 border-l-[3px] border-ink-3 dark:border-d-ink-3 text-ink-2 dark:text-d-ink-2"
+          data-testid="saf-dup-banner-fyi"
+        >
+          <span class="shrink-0 mt-px">🛡</span>
           <span>
             A platform default <b>${label}</b> already covers this surface — your
             org rule will run alongside it.

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -21,6 +21,7 @@
 // consistency (SafetyRuleUpdate has no such field; this is the belt-and-
 // suspenders backstop).
 
+import Ajv, { type ValidateFunction } from 'ajv';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
@@ -54,6 +55,53 @@ const INPUT_CLASS =
   'w-full text-[13.5px] px-3 py-2 rounded-md border border-surface-3 ' +
   'dark:border-d-surface-3 bg-surface-1 dark:bg-d-surface-1 ' +
   'text-ink-0 dark:text-d-ink-0 focus:outline-none focus:ring-2 focus:ring-brand';
+
+// G4: module-level Ajv instance + compiled-validator cache (§6.12.3).
+// Compiled once per config_schema, reused across dialog opens.
+const _ajv = new Ajv({ allErrors: true, strict: false });
+const _schemaValidators = new Map<string, ValidateFunction>();
+
+/** Compile (or return cached) an Ajv validator for a check's config_schema.
+ *  Returns null when config_schema is absent or null (defensive §6, hard
+ *  constraint #6). */
+function _getSchemaValidator(check: SafetyCheck): ValidateFunction | null {
+  const schema = check.config_schema as Record<string, unknown> | null | undefined;
+  if (!schema || typeof schema !== 'object') return null;
+  let v = _schemaValidators.get(check.id);
+  if (!v) {
+    v = _ajv.compile(schema);
+    _schemaValidators.set(check.id, v);
+  }
+  return v;
+}
+
+/** Translate a FastAPI 4xx detail array entry into a user-friendly message
+ *  (§6.18 Layer 2). The `loc` path is flattened to a dot-string for display. */
+function _translateFastApiError(err: {
+  type?: string;
+  loc?: unknown[];
+  msg?: string;
+}): string {
+  const loc = Array.isArray(err.loc)
+    ? err.loc.filter((s) => s !== 'body').join('.')
+    : '';
+  const field = loc ? `(field: ${loc})` : '';
+  switch (err.type) {
+    case 'extra_forbidden':
+      return `Unknown field${loc ? ` '${loc}'` : ''} — this check doesn't accept that setting.`;
+    case 'missing':
+      return `Required field${loc ? ` '${loc}'` : ''} is missing.`;
+    case 'int_parsing':
+    case 'float_parsing':
+      return `Field${loc ? ` '${loc}'` : ''} must be a number.`;
+    case 'enum':
+      return `Field${loc ? ` '${loc}'` : ''} has an invalid value. ${err.msg ?? ''} ${field}`.trim();
+    default:
+      return err.msg
+        ? `${err.msg} ${field}`.trim()
+        : `The server rejected this field ${field}.`.trim();
+  }
+}
 
 // Presentation lists for the per-check config forms. Human label first, the
 // technical code as a muted subtitle (§8.5: behaviour primary, code for
@@ -129,6 +177,8 @@ export class SafetyRuleDialog extends LitElement {
   /** Platform-tier rule covering the same triple; shows the gray FYI banner
    *  but does NOT flip to edit (user can't edit platform rules). */
   @state() private _platformOverlap: SafetyRule | null = null;
+  // --- G4: client-side validation errors (§6.12.3 / §6.18) ---
+  @state() private _saveErrors: { fieldId?: string; message: string }[] = [];
 
   protected override createRenderRoot() {
     return this;
@@ -139,6 +189,7 @@ export class SafetyRuleDialog extends LitElement {
       this._dupTarget = null;
       this._forceCreate = false;
       this._platformOverlap = null;
+      this._saveErrors = [];
       this.seedForm();
       this.err = null;
     }
@@ -355,6 +406,105 @@ export class SafetyRuleDialog extends LitElement {
     return nothing;
   }
 
+  // ---- G4: client-side schema validation (§6.12.3 / §6.18) ----
+
+  // Layer 1a — Ajv JSON Schema validation against config_schema.
+  // Returns array of {fieldId?, message} errors; empty = valid.
+  private _validateWithSchema(config: Record<string, unknown>): { fieldId?: string; message: string }[] {
+    const check = this.currentCheck();
+    if (!check) return [];
+    const validate = _getSchemaValidator(check);
+    if (!validate) return [];
+    if (validate(config)) return [];
+    return (validate.errors ?? []).map((e) => {
+      const path = e.instancePath?.replace(/^\//, '') ?? '';
+      return {
+        fieldId: path || undefined,
+        message: e.message ?? 'Invalid value',
+      };
+    });
+  }
+
+  // Layer 1b — hand-coded sanity checks for constraints JSON Schema can't express.
+  // Only runs when config_schema is present: without a schema the backend hasn't
+  // declared expected config shape, so we can't know whether {} is intentional.
+  private _sanityCheck(config: Record<string, unknown>): { fieldId?: string; message: string }[] {
+    const check = this.currentCheck();
+    if (!check?.config_schema) return []; // no schema → skip (Ajv already skipped too)
+    const errs: { fieldId?: string; message: string }[] = [];
+    if (this.checkId === 'pii.regex') {
+      const patterns = config['patterns'] as Record<string, boolean> | undefined;
+      if (!patterns || Object.keys(patterns).length === 0) {
+        errs.push({ fieldId: 'saf-config', message: 'Pick at least one type of personal data to look for.' });
+      }
+    } else if (this.checkId === 'presidio.pii') {
+      const bc = (config['block_codes'] as string[]) ?? [];
+      const rc = (config['redact_codes'] as string[]) ?? [];
+      if (bc.length === 0 && rc.length === 0) {
+        errs.push({ fieldId: 'saf-config', message: 'Set an action for at least one entity type.' });
+      }
+    } else if (this.checkId === 'openai_moderation') {
+      const bl = (config['block_categories'] as string[]) ?? [];
+      const wl = (config['warn_categories'] as string[]) ?? [];
+      if (bl.length === 0 && wl.length === 0) {
+        errs.push({ fieldId: 'saf-config', message: 'Set an action for at least one category.' });
+      }
+    } else if (this.checkId === 'domain_allowlist') {
+      const hosts = (config['allowed_hosts'] as string[]) ?? [];
+      if (hosts.length === 0) {
+        errs.push({ fieldId: 'saf-hosts', message: 'Add at least one host.' });
+      }
+    } else if (this.checkId === 'egress.domain_rule') {
+      const patterns = (config['domain_patterns'] as string[]) ?? [];
+      if (patterns.length === 0) {
+        errs.push({ fieldId: 'saf-hosts', message: 'Add at least one domain pattern.' });
+      }
+    }
+    return errs;
+  }
+
+  // Combined pre-save validation (Layer 1). Returns errors array.
+  private _validateBeforeSave(config: Record<string, unknown>): { fieldId?: string; message: string }[] {
+    return [...this._validateWithSchema(config), ...this._sanityCheck(config)];
+  }
+
+  // Parse a FastAPI 4xx { detail: [...] } body and return friendly messages
+  // (§6.18 Layer 2). Falls back gracefully if the shape is unexpected.
+  static _parseBackend400(body: unknown): { fieldId?: string; message: string }[] {
+    if (!body || typeof body !== 'object') return [];
+    const detail = (body as Record<string, unknown>)['detail'];
+    if (!Array.isArray(detail)) return [];
+    return detail
+      .filter((e): e is Record<string, unknown> => e && typeof e === 'object')
+      .map((e) => ({
+        fieldId: undefined,
+        message: _translateFastApiError({
+          type: e['type'] as string | undefined,
+          loc: e['loc'] as unknown[] | undefined,
+          msg: e['msg'] as string | undefined,
+        }),
+      }));
+  }
+
+  // Render inline error message next to an input (fieldId matches testid).
+  private _fieldError(fieldId: string): TemplateResult | typeof nothing {
+    const err = this._saveErrors.find((e) => e.fieldId === fieldId);
+    if (!err) return nothing;
+    return html`<p class="rm-field-error" data-testid="saf-err-${fieldId}">${err.message}</p>`;
+  }
+
+  // Render summary error banner at dialog bottom (§6.18).
+  private _renderErrorBanner(): TemplateResult | typeof nothing {
+    if (this._saveErrors.length === 0) return nothing;
+    const count = this._saveErrors.length;
+    return html`
+      <div class="rm-save-error-banner" data-testid="saf-error-banner">
+        <b>${count === 1 ? 'Fix this before saving' : 'Fix these before saving'}</b>
+        <ul>${this._saveErrors.map((e) => html`<li>${e.message}</li>`)}</ul>
+      </div>
+    `;
+  }
+
   // ---- config format converters (backend ↔ internal display) ----
 
   // Convert backend-stored config → internal UI format on load.
@@ -469,10 +619,17 @@ export class SafetyRuleDialog extends LitElement {
       this.err = 'Pick a check and a stage.';
       return;
     }
+    // G4: Layer 1 — client-side validation before any network call.
+    const config = this.buildConfig();
+    const errs = this._validateBeforeSave(config);
+    if (errs.length > 0) {
+      this._saveErrors = errs;
+      return;
+    }
+    this._saveErrors = [];
     this.busy = true;
     this.err = null;
     try {
-      const config = this.buildConfig();
       // createRule / updateRule return the admin-shaped row; the page holds
       // v1-client rows (with source/tier/editable), so we hand back only the
       // id and let the page re-fetch — the two-tier split must come from a
@@ -519,7 +676,18 @@ export class SafetyRuleDialog extends LitElement {
       );
       this.close();
     } catch (err) {
-      this.err = err instanceof Error ? err.message : String(err);
+      // G4: Layer 2 — try to parse FastAPI { detail: [...] } from the error.
+      const raw = err instanceof Error ? err.message : String(err);
+      let parsed: unknown;
+      try { parsed = JSON.parse(raw); } catch { /* not JSON */ }
+      if (parsed) {
+        const backend400 = SafetyRuleDialog._parseBackend400(parsed);
+        if (backend400.length > 0) {
+          this._saveErrors = backend400;
+          return;
+        }
+      }
+      this.err = raw;
     } finally {
       this.busy = false;
     }
@@ -590,6 +758,7 @@ export class SafetyRuleDialog extends LitElement {
               data-testid="saf-form-error"
             >${this.err}</div>`
           : nothing}
+        ${this._renderErrorBanner()}
 
         <div slot="footer" style="display: flex; gap: 8px; justify-content: flex-end;">
           <button type="button" class="rm-btn rm-btn--secondary"

--- a/web/src/components/safety-rule-dialog.ts
+++ b/web/src/components/safety-rule-dialog.ts
@@ -791,10 +791,88 @@ export class SafetyRuleDialog extends LitElement {
     `;
   }
 
+  // Postel's-Law normalizer: strip scheme + trailing path, lowercase.
+  // Truly-invalid lines (illegal chars) are left as-is so schema validation
+  // can surface a precise error rather than silently mangling them.
+  private _normalizeDomainLine(raw: string): string {
+    let s = raw.trim().toLowerCase();
+    s = s.replace(/^https?:\/\//, '');
+    const slash = s.indexOf('/');
+    if (slash !== -1) s = s.slice(0, slash);
+    return s;
+  }
+
+  // onBlur: normalize every non-empty line in the textarea and rewrite it.
+  private _onHostTextareaBlur(e: Event, configKey: string): void {
+    const ta = e.target as HTMLTextAreaElement;
+    const lines = ta.value
+      .split('\n')
+      .map((l) => this._normalizeDomainLine(l))
+      .filter(Boolean);
+    ta.value = lines.join('\n');
+    this.config = { ...this.config, [configKey]: lines };
+  }
+
   private renderHostList(): TemplateResult {
-    // domain_allowlist backend config key is `allowed_hosts` (DomainAllowlistConfig),
-    // not `hosts`. This was the 400 "extra_forbidden / missing allowed_hosts" bug.
-    const hosts = ((this.config['allowed_hosts'] as string[]) ?? []).join('\n');
+    const isEgress = this.checkId === 'egress.domain_rule';
+    // egress.domain_rule → domain_patterns + optional ports (EgressDomainRuleConfig).
+    // domain_allowlist  → allowed_hosts (DomainAllowlistConfig).
+    const configKey = isEgress ? 'domain_patterns' : 'allowed_hosts';
+    const hosts = ((this.config[configKey] as string[]) ?? []).join('\n');
+
+    if (isEgress) {
+      const portsRaw = ((this.config['ports'] as number[]) ?? []).join(', ');
+      return html`
+        <label class="block text-[12.5px] font-medium mb-1">
+          Allowed domains
+          <span class="rm-saf-lblnote">one per line · wildcards like *.stripe.com · we'll clean URLs on save</span>
+        </label>
+        <textarea
+          class="${INPUT_CLASS} font-mono text-[12.5px]"
+          style="min-height:80px"
+          data-testid="saf-hosts"
+          placeholder="api.stripe.com&#10;*.internal.acme.com"
+          .value=${hosts}
+          @input=${(e: Event) => {
+            const lines = (e.target as HTMLTextAreaElement).value
+              .split('\n')
+              .map((s) => s.trim())
+              .filter(Boolean);
+            this.config = { ...this.config, domain_patterns: lines };
+          }}
+          @blur=${(e: Event) => this._onHostTextareaBlur(e, 'domain_patterns')}
+        ></textarea>
+        <label class="block text-[12.5px] font-medium mt-2 mb-1">
+          Ports
+          <span class="rm-saf-lblnote">optional · comma-separated · leave blank for any port</span>
+        </label>
+        <input
+          type="text"
+          class="${INPUT_CLASS}"
+          data-testid="saf-egress-ports"
+          placeholder="443, 8443"
+          .value=${portsRaw}
+          @input=${(e: Event) => {
+            const raw = (e.target as HTMLInputElement).value;
+            const parsed = raw
+              .split(',')
+              .map((s) => parseInt(s.trim(), 10))
+              .filter((n) => !Number.isNaN(n) && n > 0 && n <= 65535);
+            const next = { ...this.config };
+            if (parsed.length) next['ports'] = parsed;
+            else delete next['ports'];
+            this.config = next;
+          }}
+        />
+        <p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-2 leading-snug">
+          The coworker can only reach these domains. Any other outbound request
+          is blocked. <code>*.acme.com</code> matches subdomains but not
+          <code>acme.com</code> itself.
+        </p>
+      `;
+    }
+
+    // domain_allowlist
     return html`
       <label class="block text-[12.5px] font-medium mb-1">
         Allowed hosts
@@ -808,11 +886,12 @@ export class SafetyRuleDialog extends LitElement {
         .value=${hosts}
         @input=${(e: Event) => {
           const lines = (e.target as HTMLTextAreaElement).value
-            .split(/\s+/)
+            .split('\n')
             .map((s) => s.trim())
             .filter(Boolean);
           this.config = { ...this.config, allowed_hosts: lines };
         }}
+        @blur=${(e: Event) => this._onHostTextareaBlur(e, 'allowed_hosts')}
       ></textarea>
       <p class="text-[11.5px] text-ink-3 dark:text-d-ink-3 mt-2 leading-snug">
         The coworker can only reach these hosts. Any other outbound request is

--- a/web/src/components/safety-rules-page.ts
+++ b/web/src/components/safety-rules-page.ts
@@ -362,6 +362,7 @@ export class SafetyRulesPage extends LitElement {
           .duplicating=${this.duplicateSource}
           .checks=${this.checks}
           .coworkers=${this.coworkers}
+          .rules=${this.rules}
           @close=${this.closeDialog}
           @safety-rule-saved=${(e: CustomEvent<{ id: string }>) =>
             void this.onSaved(e.detail.id)}


### PR DESCRIPTION
## Summary

Implements all 7 design changes from the v20 spec, rebased on post-PR #58 main (\`553fc84\`).

| Commit | G | Change |
|---|---|---|
| \`1fce489\` | **G1/G2** | Fix \`egress.domain_rule\` \`domain_pattern\`→\`domain_patterns\` bug; shared \`host-list\` form with \`domain_allowlist\`; optional \`ports\` field; onBlur Postel normalization (strip scheme/path, lowercase) |
| \`709de62\` | **G3** | Duplicate-rule detection on create: auto-flip to "edit existing" on \`(check_id, coworker_id, stage)\` triple match; blue info / amber warn / gray FYI banners; submit routes to PATCH existing id |
| \`137629d\` | **G4** | Install \`ajv@^8\`; compile \`config_schema\` validators once; pre-save validation (Ajv + hand-coded sanity checks); FastAPI \`{detail:[]}\` 4xx translator; inline + summary banner error display |
| \`3150a05\` | **G7** | \`getSchemaEnum()\` + \`ENUM_LABELS\` + \`enumLabel()\`; replace hardcoded arrays; reverse-drift property |
| \`05141fc\` | **G7 fix** | Align \`PRESIDIO_FALLBACK\`/\`MODERATION_FALLBACK\` to backend stable codes (\`PII.*\`/\`MODERATION.*\`); fix test fixtures |
| \`24512be\` | **G6** | Safety log check dropdown; removable \`rule_id\` chip; \`?check_id=X\`/\`?rule_id=Y\` URL params on mount; \`listSafetyDecisions()\` gains both params; delete stale comment |
| \`008c880\` | **G5+G6** | Wire \`jumpToSafetyDecision()\` to append \`?rule_id=Y\`; update existing test |
| \`d9c408a\` | **fix** | Replace unstyled \`rm-dup-banner--*\` class names (no CSS defined) with Tailwind inline utilities matching the prototype: blue left-border for info, amber for warn, surface-2/ink-3 for fyi |

## Stats

- **8 commits**, frontend-only (zero changes under \`src/rolemesh/\`)
- **553 tests passing** (was 517 on main — +36 new tests)
- **12 files changed**, ~1,300 net lines

## Schema verification

| Check | Backend model | Fields verified | Round-trip |
|---|---|---|---|
| \`egress.domain_rule\` | \`EgressDomainRuleConfig\` | \`domain_patterns: list[str]\`, \`ports: list[int]\|None\` | ✓ |
| \`domain_allowlist\` | \`DomainAllowlistConfig\` | \`allowed_hosts: list[str]\` | ✓ |
| \`pii.regex\` | \`PIIRegexConfig\` | \`patterns: dict[str, bool]\`, keys from \`_CONFIG_KEY_TO_CODE\` | ✓ |
| \`presidio.pii\` | \`PresidioPIIConfig\` + \`PresidioPIICode\` | \`block_codes\`/\`redact_codes\` in \`PII.*\` stable codes | ✓ |
| \`openai_moderation\` | \`OpenAIModerationConfig\` + \`ModerationCode\` | \`block_categories\`/\`warn_categories\` in \`MODERATION.*\` stable codes | ✓ |

\`PresidioPIICode\` verified against \`src/rolemesh/safety/checks/presidio_pii.py\` — all 14 codes in \`PRESIDIO_FALLBACK\` ✓

\`ModerationCode\` verified against \`src/rolemesh/safety/checks/openai_moderation.py\` — all 6 codes in \`MODERATION_FALLBACK\` ✓

## Test plan

- [x] \`safety-catalog.test.ts\` — egress \`domain_patterns\` phrase (G1/G2)
- [x] \`safety-rule-dialog.test.ts\` — host-list reader/writer, ports, normalization (G1/G2); dup-detection banners + skip cases + submit routing (G3); Ajv + FastAPI 4xx (G4); \`getSchemaEnum\`/\`enumLabel\` (G7)
- [x] \`safety-decisions-page.test.ts\` — check dropdown, \`check_id\` API param, rule_id chip (G6)
- [x] \`approval-card.test.ts\` — deep-link sets \`?rule_id=Y\` (G5+G6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)