### PR TITLE
feat(authz): visibility-based access control + platform_admin + remove assignment mechanism

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -328,6 +328,55 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/coworkers/{id}/share:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    post:
+      tags: [Coworkers]
+      operationId: shareCoworker
+      summary: Make a coworker shared (tenant-wide)
+      description: |
+        Self-serve visibility flip to `shared` (feat/roles). A member
+        may share a coworker they created; owner/admin/platform_admin
+        may share any. Idempotent. Returns the updated coworker.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Coworker' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/coworkers/{id}/unshare:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    post:
+      tags: [Coworkers]
+      operationId: unshareCoworker
+      summary: Make a coworker private again (creator + managers only)
+      description: |
+        Visibility flip back to `private` (feat/roles). Same own-or-manage
+        gate as share. Returns the updated coworker.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Coworker' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/coworkers/{id}/conversations:
     parameters:
       - $ref: '#/components/parameters/IdInPath'
@@ -799,6 +848,55 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /api/v1/skills/{id}/share:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    post:
+      tags: [Skills]
+      operationId: shareSkill
+      summary: Make a skill shared (tenant-wide)
+      description: |
+        Self-serve visibility flip to `shared` (feat/roles). A member
+        may share a skill they created; owner/admin/platform_admin may
+        share any. Idempotent. Returns the updated skill.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Skill' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/skills/{id}/unshare:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    post:
+      tags: [Skills]
+      operationId: unshareSkill
+      summary: Make a skill private again (creator + managers only)
+      description: |
+        Visibility flip back to `private` (feat/roles). Same
+        own-or-manage gate as share. Returns the updated skill.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Skill' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/skills/{id}/files:
     parameters:
@@ -1869,6 +1967,16 @@ components:
       type: string
       enum: [active, paused, disabled]
 
+    Visibility:
+      type: string
+      enum: [private, shared]
+      description: |
+        Per-resource visibility (feat/roles). `private` — visible only
+        to the creator and role-managers (owner/admin/platform_admin);
+        `shared` — visible to and usable by every member of the tenant.
+        New resources default to `private`; legacy rows were backfilled
+        to `shared`.
+
     Coworker:
       type: object
       required:
@@ -1879,6 +1987,7 @@ components:
         - agent_backend
         - status
         - max_concurrent
+        - visibility
         - created_at
       properties:
         id: { type: string, format: uuid }
@@ -1901,6 +2010,7 @@ components:
           type: string
           format: uuid
           nullable: true
+        visibility: { $ref: '#/components/schemas/Visibility' }
         created_at: { type: string, format: date-time }
 
     CoworkerCreate:
@@ -2392,6 +2502,7 @@ components:
         - tenant_id
         - name
         - enabled
+        - visibility
         - created_at
         - updated_at
       properties:
@@ -2420,6 +2531,7 @@ components:
           type: string
           format: uuid
           nullable: true
+        visibility: { $ref: '#/components/schemas/Visibility' }
 
     SkillSummary:
       type: object
@@ -2433,6 +2545,7 @@ components:
         - description
         - enabled
         - bound_coworker_count
+        - visibility
         - created_at
         - updated_at
       properties:
@@ -2448,6 +2561,7 @@ components:
             Number of `coworker_skills` rows referencing this skill,
             any enabled state. The list page renders this so admins
             can spot orphaned vs heavily-shared skills.
+        visibility: { $ref: '#/components/schemas/Visibility' }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -52,6 +52,9 @@ extend-immutable-calls = [
     "fastapi.File",
     "fastapi.Cookie",
     "fastapi.Security",
+    # Pure dependency factory: builds a FastAPI dependency once at import,
+    # mirroring the framework's own ``Depends`` idiom in parameter defaults.
+    "webui.dependencies.require_action",
 ]
 
 [format]

--- a/src/rolemesh/admin/core.py
+++ b/src/rolemesh/admin/core.py
@@ -13,14 +13,14 @@ is idempotent so re-runs are safe. This replaces the static
 backdoor — with an explicit, auditable operator action bound to whoever
 already holds host + DB access.
 
-Role-model dependency (task §5): the four-role / platform-vs-tenant
-*scope* model is owned by a separate "role-model redesign" task. This
-module only *references* the ``platform_admin`` role value as a string;
-it does not define a scope column or wire authorization recognition of
-``platform_admin`` — that is left to that task ("引用,不接线"). Until it
-lands, a ``platform_admin`` row is anchored to the existing ``default``
-tenant to satisfy the NOT NULL ``users.tenant_id`` constraint; the
-eventual tenant-less / scoped representation is a later migration.
+Role-model dependency: the four-role / platform-vs-tenant *scope*
+model is now wired (``rolemesh.auth.permissions`` recognizes
+``platform_admin`` as the superset role). ``platform_admin`` is
+platform-scoped and has no tenant of its own, but ``users.tenant_id``
+is NOT NULL, so its row is anchored to a reserved sentinel tenant
+(slug ``__platform__``) created idempotently here — never to a real
+business tenant, and never NULL. The eventual tenant-less / scoped
+representation is a later migration.
 """
 
 from __future__ import annotations
@@ -30,7 +30,6 @@ import os
 from dataclasses import dataclass
 
 from rolemesh.db import (
-    DEFAULT_TENANT,
     admin_conn,
     create_tenant,
     create_user_with_external_sub,
@@ -41,9 +40,15 @@ from rolemesh.db import (
 
 logger = logging.getLogger(__name__)
 
-# The platform-plane role. Referenced as a plain string; the role model
-# that gives it scope + authorization meaning is a separate task.
+# The platform-plane role — superset of every tenant capability
+# (see ``rolemesh.auth.permissions``).
 PLATFORM_ADMIN_ROLE = "platform_admin"
+
+# Reserved sentinel tenant that anchors platform_admin rows. The leading/
+# trailing double-underscore slug is not a legal user-chosen tenant slug, so it
+# can never collide with a real business tenant. Created idempotently on first
+# platform_admin provisioning; reused on every subsequent run.
+PLATFORM_TENANT_SLUG = "__platform__"
 
 # Tenant-plane roles recognized by the existing role model. ``--role``
 # accepts these as an emergency escape hatch (scripts / tests / platform
@@ -124,16 +129,17 @@ async def create_admin(
 
     # Resolve the tenant the row hangs off. platform_admin is
     # platform-scoped and has no tenant of its own, but users.tenant_id
-    # is NOT NULL, so we anchor it to the default tenant until the
-    # role-model task introduces a scope representation. Tenant-scoped
+    # is NOT NULL, so we anchor it to the reserved ``__platform__``
+    # sentinel tenant (created idempotently). It never accepts an
+    # arbitrary --tenant; passing one is a usage error. Tenant-scoped
     # roles require an explicit --tenant.
     if role == PLATFORM_ADMIN_ROLE:
-        if tenant is not None and tenant != DEFAULT_TENANT:
+        if tenant is not None and tenant != PLATFORM_TENANT_SLUG:
             raise AdminProvisionError(
                 "platform_admin is platform-scoped; --tenant is only valid "
                 "for tenant-scoped roles (owner/admin/member)"
             )
-        tenant_slug = DEFAULT_TENANT
+        tenant_slug = PLATFORM_TENANT_SLUG
     else:
         if not tenant:
             raise AdminProvisionError(

--- a/src/rolemesh/auth/oidc/config.py
+++ b/src/rolemesh/auth/oidc/config.py
@@ -33,7 +33,6 @@ OIDC_CLAIM_TENANT_ID: str = os.environ.get("OIDC_CLAIM_TENANT_ID", "")
 OIDC_CLAIM_GROUPS: str = os.environ.get("OIDC_CLAIM_GROUPS", "")  # claim name carrying groups
 OIDC_GROUP_ROLE_MAP: str = os.environ.get("OIDC_GROUP_ROLE_MAP", "")  # JSON
 OIDC_ADAPTER: str = os.environ.get("OIDC_ADAPTER", "")  # module path
-OIDC_AUTO_ASSIGN_TO_ALL: bool = os.environ.get("OIDC_AUTO_ASSIGN_TO_ALL", "false").lower() == "true"
 
 # Refresh token cookie configuration (webui-only, not part of OIDCConfig)
 OIDC_COOKIE_SAMESITE: str = os.environ.get("OIDC_COOKIE_SAMESITE", "lax")  # lax | strict | none
@@ -63,7 +62,6 @@ class OIDCConfig:
     scope_role_map: dict[str, str] = field(default_factory=dict)
     group_role_map: dict[str, str] = field(default_factory=dict)
     adapter_spec: str = ""  # module.path.ClassName for OIDC_ADAPTER
-    auto_assign_to_all: bool = False
 
     @staticmethod
     def _parse_json_map(env_name: str) -> dict[str, str]:
@@ -97,7 +95,6 @@ class OIDCConfig:
             scope_role_map=cls._parse_json_map("OIDC_SCOPE_ROLE_MAP"),
             group_role_map=cls._parse_json_map("OIDC_GROUP_ROLE_MAP"),
             adapter_spec=os.environ.get("OIDC_ADAPTER", ""),
-            auto_assign_to_all=os.environ.get("OIDC_AUTO_ASSIGN_TO_ALL", "false").lower() == "true",
         )
 
 

--- a/src/rolemesh/auth/oidc/provider.py
+++ b/src/rolemesh/auth/oidc/provider.py
@@ -41,7 +41,6 @@ class OIDCAuthProvider:
         self._client_id = config.client_id
         self._audience = config.audience or config.client_id
         self._provider_key = config.provider_key
-        self._auto_assign_to_all = config.auto_assign_to_all
         self._jwks = JWKSManager(config.discovery_url)
         self._adapter: OIDCAdapter = adapter or DefaultOIDCAdapter()  # type: ignore[assignment]
 
@@ -203,23 +202,5 @@ class OIDCAuthProvider:
         )
         await self._adapter.on_user_provisioned(user.id, tenant_id, claims)
         logger.info("OIDC user provisioned", user_id=user.id, sub=external_sub)
-
-        # Auto-assign new users to every coworker in the tenant. Only fires on
-        # first-time creation; subsequent logins do not re-assign because an
-        # admin may have intentionally unassigned the user.
-        if self._auto_assign_to_all:
-            from rolemesh.db import (
-                assign_agent_to_user,
-                get_coworkers_for_tenant,
-            )
-
-            coworkers = await get_coworkers_for_tenant(tenant_id)
-            for cw in coworkers:
-                await assign_agent_to_user(user.id, cw.id, tenant_id)
-            logger.info(
-                "OIDC user auto-assigned to coworkers",
-                user_id=user.id,
-                count=len(coworkers),
-            )
 
         return user

--- a/src/rolemesh/auth/permissions.py
+++ b/src/rolemesh/auth/permissions.py
@@ -13,33 +13,100 @@ from typing import Literal
 # User roles
 # ---------------------------------------------------------------------------
 
-UserRole = Literal["owner", "admin", "member"]
+UserRole = Literal["platform_admin", "owner", "admin", "member"]
 
-_USER_ROLE_ACTIONS: dict[str, set[str]] = {
+# Tenant-plane role -> action capability table.
+#
+# Two families of actions live here side by side:
+#   * Coarse ``manage_*`` / ``use_agent`` / ``view_all_conversations`` actions
+#     serve the legacy ``/api/admin/*`` surface (do NOT remove them).
+#   * Fine-grained ``<resource>.<verb>`` actions gate the ``/api/v1/*`` surface
+#     (PLAN.md §4 matrix). Mutations on shared/infra resources require the
+#     matching ``*.manage`` / ``*.configure`` capability; an ownership-escape
+#     (``require_manage_or_owner``) lets a member act on their OWN resource
+#     even without the capability.
+#
+# ``platform_admin`` is intentionally absent from this literal table — it is
+# derived below as a superset so it can never silently drift out of date when a
+# new action is added to any tenant role.
+_TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
     "owner": {
+        # Legacy coarse actions (/api/admin/*).
         "manage_tenant",
         "manage_agents",
         "manage_users",
         "view_all_conversations",
         "use_agent",
+        # Fine-grained /api/v1 actions.
+        "agent.create",
+        "agent.manage",
+        "agent.use",
+        "skill.create",
+        "skill.manage",
+        "mcp.configure",
+        "approval_policy.manage",
+        "credential.byok.manage",
+        "safety.read",
     },
     "admin": {
+        # Legacy coarse actions (/api/admin/*).
         "manage_agents",
         "manage_users",
         "view_all_conversations",
         "use_agent",
+        # Fine-grained /api/v1 actions. Admin lacks BYOK credential
+        # management (owner-only) per the §4 matrix.
+        "agent.create",
+        "agent.manage",
+        "agent.use",
+        "skill.create",
+        "skill.manage",
+        "mcp.configure",
+        "approval_policy.manage",
+        "safety.read",
     },
     "member": {
+        # Legacy coarse action.
         "use_agent",
+        # A member may create and use agents/skills, and (via the
+        # ownership-escape helper) manage the ones they created — but the
+        # ``*.manage`` capability that reaches others'/shared resources is
+        # withheld here.
+        "agent.create",
+        "agent.use",
+        "skill.create",
     },
+}
+
+# Platform-plane-only actions (not granted to any tenant role). Empty today;
+# kept as an explicit seam so future platform-wide capabilities are added in
+# one obvious place.
+_PLATFORM_ONLY_ACTIONS: set[str] = set()
+
+
+def _all_known_actions() -> set[str]:
+    """Union of every action referenced by any tenant role + platform-only."""
+    actions: set[str] = set(_PLATFORM_ONLY_ACTIONS)
+    for role_actions in _TENANT_ROLE_ACTIONS.values():
+        actions |= role_actions
+    return actions
+
+
+# ``platform_admin`` is the superset of every action: every tenant-role action
+# plus any platform-only action. Derived (not hand-copied) so it cannot rot —
+# adding an action to any role above automatically grants it to platform_admin.
+_USER_ROLE_ACTIONS: dict[str, set[str]] = {
+    **_TENANT_ROLE_ACTIONS,
+    "platform_admin": _all_known_actions(),
 }
 
 
 def user_can(role: UserRole, action: str) -> bool:
-    """Check if a user role permits a given action.
+    """Check if a user role permits a given action. Fail-closed.
 
-    Actions: manage_tenant, manage_agents, manage_users,
-             view_all_conversations, use_agent.
+    Unknown roles and unknown actions deny by default
+    (``_USER_ROLE_ACTIONS.get(role, set())`` yields the empty set).
+    ``platform_admin`` is the superset of all known actions.
     """
     return action in _USER_ROLE_ACTIONS.get(role, set())
 

--- a/src/rolemesh/core/types.py
+++ b/src/rolemesh/core/types.py
@@ -154,6 +154,11 @@ class Coworker:
     # Coworker instances directly leaves them at None.
     model_id: str | None = None
     created_by_user_id: str | None = None
+    # feat/roles PR3 visibility: 'private' (creator + managers only) or
+    # 'shared' (whole tenant). New rows default to 'private' at the DB
+    # layer; legacy rows were backfilled to 'shared'. Kept last with a
+    # default so admin-side constructors that omit it stay valid.
+    visibility: str = "private"
 
     def __post_init__(self) -> None:
         if self.permissions is None:
@@ -195,6 +200,8 @@ class Skill:
     created_at: str = ""
     updated_at: str = ""
     created_by_user_id: str | None = None
+    # feat/roles PR3 visibility — see ``Coworker.visibility``.
+    visibility: str = "private"
     files: dict[str, SkillFile] = field(default_factory=dict)
 
 

--- a/src/rolemesh/db/_pool.py
+++ b/src/rolemesh/db/_pool.py
@@ -183,7 +183,6 @@ async def _init_test_database(
         await conn.execute("DROP TABLE IF EXISTS external_tenant_map CASCADE")
         await conn.execute("DROP TABLE IF EXISTS skill_files CASCADE")
         await conn.execute("DROP TABLE IF EXISTS skills CASCADE")
-        await conn.execute("DROP TABLE IF EXISTS user_agent_assignments CASCADE")
         await conn.execute("DROP TABLE IF EXISTS task_run_logs CASCADE")
         await conn.execute("DROP TABLE IF EXISTS messages CASCADE")
         await conn.execute("DROP TABLE IF EXISTS scheduled_tasks CASCADE")

--- a/src/rolemesh/db/coworker.py
+++ b/src/rolemesh/db/coworker.py
@@ -23,9 +23,13 @@ __all__ = [
     "get_coworker_by_folder",
     "get_coworkers_for_tenant",
     "get_users_for_agent",
+    "set_coworker_visibility",
     "unassign_agent_from_user",
     "update_coworker",
 ]
+
+# The two-valued visibility domain (mirrors the DB CHECK constraint).
+_VALID_VISIBILITY: frozenset[str] = frozenset({"private", "shared"})
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +71,7 @@ async def create_coworker(
     permissions: AgentPermissions | None = None,
     model_id: str | None = None,
     created_by_user_id: str | None = None,
+    visibility: str = "private",
 ) -> Coworker:
     """Create a new coworker row.
 
@@ -79,7 +84,15 @@ async def create_coworker(
     ``model_id`` and ``created_by_user_id`` are v1.1 additions (design
     §2.2). Both are NULLABLE on the DB so the existing admin call
     sites that omit them keep working — the v1 router populates them.
+
+    ``visibility`` (feat/roles PR3) defaults to ``'private'`` so a newly
+    created coworker is a personal draft until its creator shares it.
+    Validated against the same ``{'private','shared'}`` domain the DB
+    CHECK enforces, so a bad value fails fast rather than as an opaque
+    CHECK violation.
     """
+    if visibility not in _VALID_VISIBILITY:
+        raise ValueError(f"invalid visibility {visibility!r}")
     cc_json: str | None = None
     if container_config:
         cc_json = json.dumps(
@@ -97,9 +110,9 @@ async def create_coworker(
             """
             INSERT INTO coworkers (tenant_id, name, folder, agent_backend, system_prompt,
                 container_config, max_concurrent, permissions,
-                model_id, created_by_user_id)
+                model_id, created_by_user_id, visibility)
             VALUES ($1::uuid, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb,
-                $9::uuid, $10::uuid)
+                $9::uuid, $10::uuid, $11)
             RETURNING *
             """,
             tenant_id,
@@ -112,6 +125,7 @@ async def create_coworker(
             json.dumps(effective_perms.to_dict()),
             model_id,
             created_by_user_id,
+            visibility,
         )
     assert row is not None
     return _record_to_coworker(row)
@@ -144,6 +158,9 @@ def _record_to_coworker(row: asyncpg.Record) -> Coworker:
         permissions=permissions,
         model_id=str(model_id_val) if model_id_val else None,
         created_by_user_id=str(created_by_val) if created_by_val else None,
+        visibility=(
+            row.get("visibility") if hasattr(row, "get") else None
+        ) or "private",
     )
 
 
@@ -176,14 +193,73 @@ async def get_coworker_by_folder(tenant_id: str, folder: str) -> Coworker | None
     return _record_to_coworker(row)
 
 
-async def get_coworkers_for_tenant(tenant_id: str) -> list[Coworker]:
-    """Get all coworkers for a tenant."""
+async def get_coworkers_for_tenant(
+    tenant_id: str,
+    *,
+    requesting_user_id: str | None = None,
+    include_all: bool = True,
+) -> list[Coworker]:
+    """Get coworkers for a tenant.
+
+    ``include_all`` (the DEFAULT) preserves the historical unfiltered
+    behavior: every internal caller (orchestrator load paths, OIDC
+    auto-assign, the legacy admin surface) needs ALL rows and must NOT
+    be visibility-scoped. Only the v1 list endpoint opts in to filtering
+    by passing ``include_all=False`` together with ``requesting_user_id``.
+
+    When filtering, the visibility predicate is exactly the SQL mirror of
+    :func:`webui.dependencies.user_can_see_resource`'s SEE rule for a
+    non-manager caller:
+
+        visibility = 'shared' OR created_by_user_id = :requesting_user_id
+
+    ``created_by_user_id = $2`` is three-valued-logic safe: a row with
+    ``created_by_user_id IS NULL`` yields ``NULL`` (not TRUE) for that
+    comparison, so an un-attributed private row never leaks to a member.
+    Managers (owner/admin/platform_admin) call with ``include_all=True``
+    so no predicate is added and they see every row.
+    """
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            "SELECT * FROM coworkers WHERE tenant_id = $1::uuid ORDER BY name",
+        if include_all:
+            rows = await conn.fetch(
+                "SELECT * FROM coworkers WHERE tenant_id = $1::uuid "
+                "ORDER BY name",
+                tenant_id,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT * FROM coworkers WHERE tenant_id = $1::uuid "
+                "AND (visibility = 'shared' OR created_by_user_id = $2::uuid) "
+                "ORDER BY name",
+                tenant_id,
+                requesting_user_id,
+            )
+    return [_record_to_coworker(row) for row in rows]
+
+
+async def set_coworker_visibility(
+    coworker_id: str, *, visibility: str, tenant_id: str
+) -> Coworker | None:
+    """Flip a coworker's ``visibility`` (share / unshare).
+
+    Validates the value against the same domain the DB CHECK enforces so
+    a typo surfaces as ``ValueError`` rather than an opaque CHECK
+    violation. Returns the updated row, or ``None`` when no coworker with
+    that id exists in ``tenant_id`` (the handler maps that to 404).
+    """
+    if visibility not in _VALID_VISIBILITY:
+        raise ValueError(f"invalid visibility {visibility!r}")
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "UPDATE coworkers SET visibility = $1 "
+            "WHERE id = $2::uuid AND tenant_id = $3::uuid RETURNING *",
+            visibility,
+            coworker_id,
             tenant_id,
         )
-    return [_record_to_coworker(row) for row in rows]
+    if row is None:
+        return None
+    return _record_to_coworker(row)
 
 
 async def get_all_coworkers() -> list[Coworker]:

--- a/src/rolemesh/db/coworker.py
+++ b/src/rolemesh/db/coworker.py
@@ -1,4 +1,4 @@
-"""Coworker CRUD + user-agent assignments."""
+"""Coworker CRUD."""
 
 from __future__ import annotations
 
@@ -6,25 +6,20 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from rolemesh.auth.permissions import AgentPermissions
-from rolemesh.core.types import ContainerConfig, Coworker, User
+from rolemesh.core.types import ContainerConfig, Coworker
 from rolemesh.db._pool import admin_conn, tenant_conn
-from rolemesh.db.user import _record_to_user
 
 if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
-    "assign_agent_to_user",
     "create_coworker",
     "delete_coworker",
-    "get_agents_for_user",
     "get_all_coworkers",
     "get_coworker",
     "get_coworker_by_folder",
     "get_coworkers_for_tenant",
-    "get_users_for_agent",
     "set_coworker_visibility",
-    "unassign_agent_from_user",
     "update_coworker",
 ]
 
@@ -352,74 +347,5 @@ async def delete_coworker(coworker_id: str, *, tenant_id: str) -> bool:
             tenant_id,
         )
     return result == "DELETE 1"
-
-
-
-
-# ---------------------------------------------------------------------------
-# User-Agent assignment CRUD
-# ---------------------------------------------------------------------------
-
-
-async def assign_agent_to_user(user_id: str, coworker_id: str, tenant_id: str) -> None:
-    """Assign a coworker (agent) to a user."""
-    async with tenant_conn(tenant_id) as conn:
-        await conn.execute(
-            """
-            INSERT INTO user_agent_assignments (user_id, coworker_id, tenant_id)
-            VALUES ($1::uuid, $2::uuid, $3::uuid)
-            ON CONFLICT (user_id, coworker_id) DO NOTHING
-            """,
-            user_id,
-            coworker_id,
-            tenant_id,
-        )
-
-
-async def unassign_agent_from_user(
-    user_id: str, coworker_id: str, *, tenant_id: str
-) -> None:
-    """Remove a coworker assignment from a user."""
-    async with tenant_conn(tenant_id) as conn:
-        await conn.execute(
-            "DELETE FROM user_agent_assignments "
-            "WHERE user_id = $1::uuid AND coworker_id = $2::uuid "
-            "AND tenant_id = $3::uuid",
-            user_id,
-            coworker_id,
-            tenant_id,
-        )
-
-
-async def get_agents_for_user(user_id: str, *, tenant_id: str) -> list[Coworker]:
-    """Get all coworkers assigned to a user, scoped to ``tenant_id``."""
-    async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            """
-            SELECT c.* FROM coworkers c
-            JOIN user_agent_assignments uaa ON c.id = uaa.coworker_id
-            WHERE uaa.user_id = $1::uuid AND uaa.tenant_id = $2::uuid
-            ORDER BY c.name
-            """,
-            user_id,
-            tenant_id,
-        )
-    return [_record_to_coworker(row) for row in rows]
-
-
-async def get_users_for_agent(coworker_id: str, *, tenant_id: str) -> list[User]:
-    """Get all users assigned to a coworker, scoped to ``tenant_id``."""
-    async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            """
-            SELECT u.* FROM users u
-            JOIN user_agent_assignments uaa ON u.id = uaa.user_id
-            WHERE uaa.coworker_id = $1::uuid AND uaa.tenant_id = $2::uuid
-            ORDER BY u.name
-            """,
-            coworker_id,
-            tenant_id,
-        )
-    return [_record_to_user(row) for row in rows]
 
 

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -432,19 +432,12 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
             END IF;
         END $$
     """)
-    # User-agent assignment table
-    await conn.execute("""
-        CREATE TABLE IF NOT EXISTS user_agent_assignments (
-            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-            user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-            coworker_id UUID NOT NULL REFERENCES coworkers(id) ON DELETE CASCADE,
-            tenant_id UUID NOT NULL REFERENCES tenants(id),
-            assigned_at TIMESTAMPTZ DEFAULT now(),
-            UNIQUE (user_id, coworker_id)
-        )
-    """)
-    await conn.execute("CREATE INDEX IF NOT EXISTS idx_uaa_user ON user_agent_assignments(user_id)")
-    await conn.execute("CREATE INDEX IF NOT EXISTS idx_uaa_coworker ON user_agent_assignments(coworker_id)")
+    # The user-agent assignment table was removed (feat/roles): access is
+    # governed by coworker visibility + created_by_user_id ownership, never an
+    # explicit per-user grant table. Drop it idempotently so upgraded
+    # deployments that already created it shed the table (fresh DBs never
+    # create it in the first place).
+    await conn.execute("DROP TABLE IF EXISTS user_agent_assignments CASCADE")
 
     # Coworker <-> MCP server association (v1.1 §2.1). ``enabled_tools``
     # = NULL means "all tools enabled" (the common case); an empty
@@ -1576,7 +1569,6 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await _enable_rls_on(conn, "sessions")
     await _enable_rls_on(conn, "coworkers")            # D8
     await _enable_rls_on(conn, "channel_bindings")
-    await _enable_rls_on(conn, "user_agent_assignments")
     await _enable_rls_on(conn, "users")                # D9
     await _enable_rls_on(conn, "oidc_user_tokens")     # D10 (tenant_id backfilled above)
     await _enable_rls_on(conn, "skills")               # skills feature: standard tenant_id scope

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -395,6 +395,43 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "ALTER TABLE coworkers "
         "ADD COLUMN IF NOT EXISTS created_by_user_id UUID REFERENCES users(id)"
     )
+    # feat/roles PR3: per-resource visibility (personal draft space).
+    #   'private' — visible only to its creator + role-managers.
+    #   'shared'  — visible to every member of the tenant.
+    #
+    # The two-step ordering is load-bearing for a safe upgrade:
+    #   1. ``ADD COLUMN ... NOT NULL DEFAULT 'shared'`` runs the column's
+    #      default against EVERY pre-existing row, so legacy coworkers
+    #      (including the many with ``created_by_user_id IS NULL``) stay
+    #      visible to members exactly as they were before this column —
+    #      a 'private' backfill would have made them vanish from every
+    #      member's list.
+    #   2. ``ALTER COLUMN ... SET DEFAULT 'private'`` flips the default so
+    #      that NEW coworkers default to private (the personal-draft
+    #      semantics). The flip does not touch existing rows.
+    # On a fresh DB step 1 creates the column empty (no rows to backfill)
+    # and step 2 still leaves the column private-by-default — both an
+    # upgraded and a greenfield DB converge to the same end state.
+    await conn.execute(
+        "ALTER TABLE coworkers "
+        "ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'shared'"
+    )
+    await conn.execute(
+        "ALTER TABLE coworkers ALTER COLUMN visibility SET DEFAULT 'private'"
+    )
+    await conn.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'coworkers_visibility_check'
+                  AND conrelid = 'coworkers'::regclass
+            ) THEN
+                ALTER TABLE coworkers ADD CONSTRAINT coworkers_visibility_check
+                    CHECK (visibility IN ('private', 'shared'));
+            END IF;
+        END $$
+    """)
     # User-agent assignment table
     await conn.execute("""
         CREATE TABLE IF NOT EXISTS user_agent_assignments (
@@ -550,6 +587,29 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "CREATE INDEX IF NOT EXISTS idx_skills_tenant_enabled "
         "ON skills(tenant_id, enabled)"
     )
+    # feat/roles PR3: per-skill visibility — same two-step backfill
+    # contract as ``coworkers.visibility`` above (existing rows -> shared,
+    # new rows -> private). See that block for the ordering rationale.
+    await conn.execute(
+        "ALTER TABLE skills "
+        "ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'shared'"
+    )
+    await conn.execute(
+        "ALTER TABLE skills ALTER COLUMN visibility SET DEFAULT 'private'"
+    )
+    await conn.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'skills_visibility_check'
+                  AND conrelid = 'skills'::regclass
+            ) THEN
+                ALTER TABLE skills ADD CONSTRAINT skills_visibility_check
+                    CHECK (visibility IN ('private', 'shared'));
+            END IF;
+        END $$
+    """)
 
     # skill_files holds the file tree. Path validation: positive
     # whitelist (each segment alphanumeric-led, only [A-Za-z0-9_.-]),

--- a/src/rolemesh/db/skill.py
+++ b/src/rolemesh/db/skill.py
@@ -42,8 +42,12 @@ __all__ = [
     "list_skills_for_coworker",
     "list_skills_for_tenant",
     "set_skill_file",
+    "set_skill_visibility",
     "update_skill",
 ]
+
+# The two-valued visibility domain (mirrors the DB CHECK constraint).
+_VALID_VISIBILITY: frozenset[str] = frozenset({"private", "shared"})
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +80,10 @@ def _record_to_skill(row: asyncpg.Record, files: list[SkillFile] | None = None) 
             str(row["created_by_user_id"])
             if row["created_by_user_id"] else None
         ),
+        # ``.get`` defaults to None for any legacy row that pre-dates the
+        # column (none in practice — it is NOT NULL — but keeps the
+        # projection total); collapse to the private default.
+        visibility=row.get("visibility") or "private",
         files={f.path: f for f in (files or [])},
     )
 
@@ -103,8 +111,13 @@ async def create_skill(
     files: dict[str, SkillFile],
     enabled: bool = True,
     created_by_user_id: str | None = None,
+    visibility: str = "private",
 ) -> Skill:
     """Create a per-tenant skill plus its files in a single transaction.
+
+    ``visibility`` (feat/roles PR3) defaults to ``'private'`` — a new
+    skill is a personal draft until shared. Validated against the
+    ``{'private','shared'}`` domain the DB CHECK enforces.
 
     Caller is expected to have run the frontmatter splitter and
     ``validate_skill_*`` helpers from ``rolemesh.core.skills``
@@ -121,6 +134,8 @@ async def create_skill(
     """
     if SKILL_MANIFEST_NAME not in files:
         raise ValueError(f"skill files must contain {SKILL_MANIFEST_NAME}")
+    if visibility not in _VALID_VISIBILITY:
+        raise ValueError(f"invalid visibility {visibility!r}")
     fc_json = json.dumps(frontmatter_common)
     fb_json = json.dumps(frontmatter_backend)
     async with tenant_conn(tenant_id) as conn, conn.transaction():
@@ -128,8 +143,8 @@ async def create_skill(
             """
                 INSERT INTO skills (tenant_id, name,
                                     frontmatter_common, frontmatter_backend,
-                                    enabled, created_by_user_id)
-                VALUES ($1::uuid, $2, $3::jsonb, $4::jsonb, $5, $6::uuid)
+                                    enabled, created_by_user_id, visibility)
+                VALUES ($1::uuid, $2, $3::jsonb, $4::jsonb, $5, $6::uuid, $7)
                 RETURNING *
                 """,
             tenant_id,
@@ -138,6 +153,7 @@ async def create_skill(
             fb_json,
             enabled,
             created_by_user_id,
+            visibility,
         )
         assert row is not None
         skill_id = row["id"]
@@ -168,6 +184,7 @@ async def create_skill_for_coworker(
     files: dict[str, SkillFile],
     enabled: bool = True,
     created_by_user_id: str | None = None,
+    visibility: str = "shared",
 ) -> Skill:
     """Transactional convenience: catalog create + coworker bind.
 
@@ -181,9 +198,18 @@ async def create_skill_for_coworker(
     Returns the ``Skill`` dataclass for the freshly-created catalog
     row. The binding (``coworker_skills.enabled = TRUE``) is implicit
     and not surfaced on the return value.
+
+    ``visibility`` defaults to ``'shared'`` here (NOT ``'private'`` like
+    :func:`create_skill`): this is the admin / fixture "make + bind"
+    shape that historically produced a tenant-visible skill, and the
+    binding to a coworker already implies it's meant to be used. The
+    personal-draft default belongs on the bare :func:`create_skill`
+    catalog write that the v1 router calls.
     """
     if SKILL_MANIFEST_NAME not in files:
         raise ValueError(f"skill files must contain {SKILL_MANIFEST_NAME}")
+    if visibility not in _VALID_VISIBILITY:
+        raise ValueError(f"invalid visibility {visibility!r}")
     fc_json = json.dumps(frontmatter_common)
     fb_json = json.dumps(frontmatter_backend)
     async with tenant_conn(tenant_id) as conn, conn.transaction():
@@ -191,8 +217,8 @@ async def create_skill_for_coworker(
             """
                 INSERT INTO skills (tenant_id, name,
                                     frontmatter_common, frontmatter_backend,
-                                    enabled, created_by_user_id)
-                VALUES ($1::uuid, $2, $3::jsonb, $4::jsonb, $5, $6::uuid)
+                                    enabled, created_by_user_id, visibility)
+                VALUES ($1::uuid, $2, $3::jsonb, $4::jsonb, $5, $6::uuid, $7)
                 RETURNING *
                 """,
             tenant_id,
@@ -201,6 +227,7 @@ async def create_skill_for_coworker(
             fb_json,
             enabled,
             created_by_user_id,
+            visibility,
         )
         assert row is not None
         skill_id = row["id"]
@@ -260,18 +287,38 @@ async def list_skills_for_tenant(
     tenant_id: str,
     *,
     with_files: bool = False,
+    requesting_user_id: str | None = None,
+    include_all: bool = True,
 ) -> list[Skill]:
-    """List every catalog skill for ``tenant_id``.
+    """List catalog skills for ``tenant_id``.
 
     Backs the v1 flat ``GET /api/v1/skills``. ``with_files`` defaults
     False because the list shape drops body content; the per-skill
     detail endpoint passes True.
+
+    ``include_all`` (the DEFAULT) preserves the historical unfiltered
+    behavior for internal/admin callers. The v1 list endpoint opts into
+    visibility scoping by passing ``include_all=False`` +
+    ``requesting_user_id``; the predicate is the SQL mirror of
+    :func:`webui.dependencies.user_can_see_resource` for a non-manager
+    (``visibility = 'shared' OR created_by_user_id = :requesting_user_id``)
+    and is NULL-safe (a NULL ``created_by_user_id`` never equals the
+    caller, so an un-attributed private skill stays hidden).
     """
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            "SELECT * FROM skills WHERE tenant_id = $1::uuid ORDER BY name",
-            tenant_id,
-        )
+        if include_all:
+            rows = await conn.fetch(
+                "SELECT * FROM skills WHERE tenant_id = $1::uuid ORDER BY name",
+                tenant_id,
+            )
+        else:
+            rows = await conn.fetch(
+                "SELECT * FROM skills WHERE tenant_id = $1::uuid "
+                "AND (visibility = 'shared' OR created_by_user_id = $2::uuid) "
+                "ORDER BY name",
+                tenant_id,
+                requesting_user_id,
+            )
         result: list[Skill] = []
         if with_files and rows:
             ids = [r["id"] for r in rows]
@@ -450,6 +497,30 @@ async def update_skill(
             skill_id,
         )
     return _record_to_skill(row, [_record_to_skill_file(r) for r in file_rows])
+
+
+async def set_skill_visibility(
+    skill_id: str, *, visibility: str, tenant_id: str
+) -> Skill | None:
+    """Flip a skill's ``visibility`` (share / unshare).
+
+    Validates against ``{'private','shared'}`` before the write. Returns
+    the updated catalog row (without files), or ``None`` when no skill
+    with that id exists in ``tenant_id``.
+    """
+    if visibility not in _VALID_VISIBILITY:
+        raise ValueError(f"invalid visibility {visibility!r}")
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "UPDATE skills SET visibility = $1, updated_at = now() "
+            "WHERE id = $2::uuid AND tenant_id = $3::uuid RETURNING *",
+            visibility,
+            skill_id,
+            tenant_id,
+        )
+    if row is None:
+        return None
+    return _record_to_skill(row)
 
 
 async def delete_skill(skill_id: str, *, tenant_id: str) -> bool:

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -33,9 +33,7 @@ from webui.schemas import (
     AgentCreate,
     AgentDetailResponse,
     AgentResponse,
-    AgentSummary,
     AgentUpdate,
-    AssignRequest,
     BindingCreate,
     BindingResponse,
     BindingUpdate,
@@ -226,15 +224,6 @@ async def _load_mcp_configs(
     )
 
 
-def _coworker_to_summary(cw: Coworker) -> AgentSummary:
-    return AgentSummary(
-        id=cw.id,
-        name=cw.name,
-        folder=cw.folder,
-        status=cw.status,
-    )
-
-
 def _binding_to_response(b: ChannelBinding) -> BindingResponse:
     return BindingResponse(
         id=b.id,
@@ -380,12 +369,7 @@ async def get_user_detail(
     target = await db.get_user(user_id, tenant_id=user.tenant_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    agents = await db.get_agents_for_user(user_id, tenant_id=user.tenant_id)
-    resp = UserDetailResponse(
-        **_user_to_response(target).model_dump(),
-        assigned_agents=[_coworker_to_summary(a) for a in agents],
-    )
-    return resp
+    return UserDetailResponse(**_user_to_response(target).model_dump())
 
 
 @router.patch("/users/{user_id}", response_model=UserResponse)
@@ -547,47 +531,6 @@ async def delete_agent(
 ) -> None:
     await _get_agent_or_404(agent_id, user.tenant_id)
     await db.delete_coworker(agent_id, tenant_id=user.tenant_id)
-
-
-# ---------------------------------------------------------------------------
-# Assignment endpoints (admin+)
-# ---------------------------------------------------------------------------
-
-
-@router.get("/agents/{agent_id}/users", response_model=list[UserResponse])
-async def list_assigned_users(
-    agent_id: str,
-    user: AdminUser,
-) -> list[UserResponse]:
-    await _get_agent_or_404(agent_id, user.tenant_id)
-    users = await db.get_users_for_agent(agent_id, tenant_id=user.tenant_id)
-    return [_user_to_response(u) for u in users]
-
-
-@router.post("/agents/{agent_id}/assign", status_code=204)
-async def assign_agent(
-    agent_id: str,
-    body: AssignRequest,
-    user: AdminUser,
-) -> None:
-    await _get_agent_or_404(agent_id, user.tenant_id)
-    target = await db.get_user(body.user_id, tenant_id=user.tenant_id)
-    if target is None:
-        raise HTTPException(status_code=404, detail="User not found")
-    await db.assign_agent_to_user(body.user_id, agent_id, user.tenant_id)
-
-
-@router.delete("/agents/{agent_id}/assign/{user_id}", status_code=204)
-async def unassign_agent(
-    agent_id: str,
-    user_id: str,
-    user: AdminUser,
-) -> None:
-    await _get_agent_or_404(agent_id, user.tenant_id)
-    target = await db.get_user(user_id, tenant_id=user.tenant_id)
-    if target is None:
-        raise HTTPException(status_code=404, detail="User not found")
-    await db.unassign_agent_from_user(user_id, agent_id, tenant_id=user.tenant_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/webui/admin.py
+++ b/src/webui/admin.py
@@ -457,6 +457,12 @@ async def create_agent(
             system_prompt=body.system_prompt,
             max_concurrent=body.max_concurrent,
             permissions=permissions,
+            # feat/roles PR3: the legacy admin surface provisions
+            # tenant-wide agents (no per-user draft concept), so they are
+            # 'shared' — keeping them visible to members, as they were
+            # before the visibility column existed. The 'private'-by-
+            # default belongs to the self-serve /api/v1 create path.
+            visibility="shared",
         )
     except asyncpg.UniqueViolationError as exc:
         raise HTTPException(status_code=409, detail="Agent with this folder already exists in tenant") from exc

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Coroutine
 
-from fastapi import HTTPException, Request
+from fastapi import Depends, HTTPException, Request
 
 from rolemesh.auth.permissions import user_can
 from webui import auth
@@ -26,16 +26,65 @@ async def get_current_user(request: Request) -> AuthenticatedUser:
     return user
 
 
-def require_action(action: str):
-    """Factory that returns a dependency requiring a specific permission action."""
+def require_action(
+    action: str,
+) -> Callable[[AuthenticatedUser], Coroutine[None, None, AuthenticatedUser]]:
+    """Factory that returns a dependency requiring a specific permission action.
 
-    async def _check(request: Request) -> AuthenticatedUser:
-        user = await get_current_user(request)
+    The returned dependency resolves the caller via ``get_current_user`` as a
+    *sub-dependency* (not a direct call) so that FastAPI dependency overrides
+    in tests flow through, and so the capability gate composes cleanly with the
+    rest of the dependency chain.
+
+    The inner function is tagged with ``_required_action`` so the default-deny
+    meta-test (``tests/webui/test_v1_default_deny.py``) can walk a route's
+    dependency tree and confirm every ``/api/v1`` mutation is gated. Do not
+    rename or drop that attribute without updating the meta-test.
+    """
+
+    async def _check(
+        user: AuthenticatedUser = Depends(get_current_user),
+    ) -> AuthenticatedUser:
         if not user_can(user.role, action):  # type: ignore[arg-type]
-            raise HTTPException(status_code=403, detail=f"Insufficient permissions: requires {action}")
+            raise HTTPException(
+                status_code=403,
+                detail=f"Insufficient permissions: requires {action}",
+            )
         return user
 
+    # Tag so route introspection (meta-test) can detect the gate and which
+    # action it enforces.
+    _check._required_action = action  # type: ignore[attr-defined]
     return _check
+
+
+def require_manage_or_owner(
+    *, manage_action: str, resource: object, user: AuthenticatedUser
+) -> None:
+    """Ownership-escape gate: allow when the caller holds ``manage_action`` OR
+    owns the already-loaded ``resource``.
+
+    Called from *inside* a handler (it needs the loaded row), as the complement
+    to the route-level capability gate. The route should carry the lowest
+    sensible capability (e.g. ``agent.use``); this helper then lets a member
+    who created the resource manage their OWN copy while still blocking them
+    from others'/shared ones.
+
+    Three-valued logic is load-bearing: a resource whose ``created_by_user_id``
+    is NULL is treated as "not mine" — NULL never equals the caller, so such a
+    resource falls through to requiring ``manage_action``. This prevents a
+    member from claiming ownership of an un-attributed (system/legacy) row.
+
+    Raises 403 when neither the capability nor ownership holds.
+    """
+    created_by = getattr(resource, "created_by_user_id", None)
+    owns = created_by is not None and created_by == user.user_id
+    if user_can(user.role, manage_action) or owns:  # type: ignore[arg-type]
+        return
+    raise HTTPException(
+        status_code=403,
+        detail=f"Insufficient permissions: requires {manage_action} or resource ownership",
+    )
 
 
 # Pre-built dependencies for common use

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Coroutine
+from typing import TYPE_CHECKING
 
 from fastapi import Depends, HTTPException, Request
 
@@ -10,6 +10,8 @@ from rolemesh.auth.permissions import user_can
 from webui import auth
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
     from rolemesh.auth.provider import AuthenticatedUser
 
 

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -89,6 +89,41 @@ def require_manage_or_owner(
     )
 
 
+def user_can_see_resource(
+    *, manage_action: str, resource: object, user: AuthenticatedUser
+) -> bool:
+    """Single source of truth for "may this user SEE/USE this resource".
+
+    feat/roles PR3. A resource (coworker or skill) is visible/usable to a
+    caller when ANY of the following holds:
+
+    * it is ``shared`` (every tenant member may see and use it), OR
+    * the caller created it (``created_by_user_id == user.user_id``), OR
+    * the caller holds the manage capability (``manage_action``) — owner /
+      admin / platform_admin reach every row regardless of visibility.
+
+    USE is intentionally BROADER than the ``require_manage_or_owner``
+    write-gate: a shared resource is usable by everyone, but a member still
+    may not *manage* (edit/delete/share) it without the capability or
+    ownership. The two helpers therefore differ only in the ``shared``
+    clause, and both share the same three-valued-logic treatment of
+    ``created_by_user_id IS NULL`` (NULL never equals the caller, so an
+    un-attributed private row is invisible to members).
+
+    Every list / fetch / use / skill-bind path routes its visibility
+    decision through this helper (the LIST path mirrors the exact same
+    predicate in SQL so NULL does not leak — see
+    ``rolemesh.db.coworker.get_coworkers_for_tenant``). Keep them in sync.
+    """
+    visibility = getattr(resource, "visibility", "shared")
+    if visibility == "shared":
+        return True
+    created_by = getattr(resource, "created_by_user_id", None)
+    if created_by is not None and created_by == user.user_id:
+        return True
+    return user_can(user.role, manage_action)  # type: ignore[arg-type]
+
+
 # Pre-built dependencies for common use
 require_manage_tenant = require_action("manage_tenant")  # owner only
 require_manage_agents = require_action("manage_agents")  # admin+

--- a/src/webui/schemas.py
+++ b/src/webui/schemas.py
@@ -51,15 +51,10 @@ class UserUpdate(BaseModel):
     role: str | None = Field(None, pattern=r"^(owner|admin|member)$")
 
 
-class AgentSummary(BaseModel):
-    id: str
-    name: str
-    folder: str
-    status: str
-
-
 class UserDetailResponse(UserResponse):
-    assigned_agents: list[AgentSummary] = Field(default_factory=list)
+    """Detailed user view. Currently identical to ``UserResponse``; the former
+    per-user agent-grant list was removed with the user-agent assignment
+    mechanism (access is governed by coworker visibility + ownership)."""
 
 
 # ---------------------------------------------------------------------------
@@ -172,15 +167,6 @@ class TaskResponse(BaseModel):
     last_run: str | None = None
     status: str
     created_at: str
-
-
-# ---------------------------------------------------------------------------
-# Assignment
-# ---------------------------------------------------------------------------
-
-
-class AssignRequest(BaseModel):
-    user_id: str
 
 
 # ---------------------------------------------------------------------------

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -25,6 +25,9 @@ BackendName = Literal["claude", "pi"]
 ModelProvider = Literal["anthropic", "bedrock", "openai", "google"]
 ModelFamily = Literal["claude", "gpt", "gemini", "llama"]
 CoworkerStatus = Literal["active", "paused", "disabled"]
+# feat/roles PR3: per-resource visibility. 'private' = creator + managers
+# only; 'shared' = whole tenant.
+Visibility = Literal["private", "shared"]
 AuthMode = Literal["external", "oidc", "builtin", "bootstrap"]
 UserRole = Literal["owner", "admin", "member"]
 
@@ -143,6 +146,10 @@ class Coworker(BaseModel):
     status: CoworkerStatus
     max_concurrent: int = Field(ge=1)
     created_by_user_id: str | None = None
+    # Always populated server-side (the DB column is NOT NULL), so this is
+    # a REQUIRED response field — keep it without a default so the yaml
+    # ``required`` list and the model agree (test_openapi_contract).
+    visibility: Visibility
     created_at: str
 
 
@@ -609,6 +616,8 @@ class Skill(BaseModel):
     created_at: str
     updated_at: str
     created_by_user_id: str | None = None
+    # Required response field (DB column is NOT NULL) — see Coworker.
+    visibility: Visibility
 
 
 class SkillSummary(BaseModel):
@@ -627,6 +636,7 @@ class SkillSummary(BaseModel):
     description: str
     enabled: bool
     bound_coworker_count: int
+    visibility: Visibility
     created_at: str
     updated_at: str
 

--- a/src/webui/v1/approvals.py
+++ b/src/webui/v1/approvals.py
@@ -30,7 +30,7 @@ from rolemesh.db.approval import (
     list_pending_requests_for_tenant,
     update_approval_policy,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import (
     ApprovalPolicy,
     ApprovalPolicyCreate,
@@ -121,7 +121,7 @@ async def list_policies_endpoint(
 @policies_router.post("", response_model=ApprovalPolicy, status_code=201)
 async def create_policy_endpoint(
     body: ApprovalPolicyCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("approval_policy.manage")),
 ) -> ApprovalPolicy:
     """Create a policy. ``condition_expr`` is validated at the schema layer."""
     policy = await create_approval_policy(
@@ -148,7 +148,7 @@ async def get_policy_endpoint(
 async def patch_policy_endpoint(
     policy_id: str,
     body: ApprovalPolicyUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("approval_policy.manage")),
 ) -> ApprovalPolicy:
     """Partial update; absent fields are left alone (``model_fields_set``).
 
@@ -184,7 +184,7 @@ async def patch_policy_endpoint(
 @policies_router.delete("/{policy_id}", status_code=204)
 async def delete_policy_endpoint(
     policy_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("approval_policy.manage")),
 ) -> Response:
     """Delete a policy. 404 if it does not exist in the caller's tenant."""
     await _get_policy_or_404(policy_id, tenant_id=user.tenant_id)

--- a/src/webui/v1/bindings.py
+++ b/src/webui/v1/bindings.py
@@ -30,7 +30,7 @@ from rolemesh.db import (
     get_coworker,
     update_channel_binding,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import (
     ChannelBinding,
     ChannelBindingCreate,
@@ -107,7 +107,7 @@ async def list_bindings_endpoint(
 async def create_binding_endpoint(
     coworker_id: str,
     body: ChannelBindingCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.manage")),
 ) -> ChannelBinding:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     try:
@@ -153,7 +153,7 @@ async def update_binding_endpoint(
     coworker_id: str,
     binding_id: str,
     body: ChannelBindingUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.manage")),
 ) -> ChannelBinding:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     await _get_binding_for_coworker(
@@ -183,7 +183,7 @@ async def update_binding_endpoint(
 async def delete_binding_endpoint(
     coworker_id: str,
     binding_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.manage")),
 ) -> Response:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     await _get_binding_for_coworker(

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -31,7 +31,7 @@ from rolemesh.db import (
     list_requests_for_conversation,
     tenant_conn,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import (
     ApprovalRequest,
     Conversation,
@@ -133,7 +133,7 @@ async def list_coworker_conversations(
 async def create_coworker_conversation(
     coworker_id: str,
     body: ConversationCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> Conversation:
     """Create a new web conversation under a coworker.
 
@@ -177,7 +177,7 @@ async def get_conversation_endpoint(
 @conversations_router.delete("/{conversation_id}", status_code=204)
 async def delete_conversation_endpoint(
     conversation_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> Response:
     """Delete a conversation; FK ON DELETE CASCADE removes messages and runs.
 

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -118,7 +118,9 @@ async def list_coworker_conversations(
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> list[Conversation]:
     """List conversations for a coworker, ordered by ``created_at``."""
-    await _get_coworker_or_404(coworker_id, user.tenant_id)
+    # USE/SEE enforcement: a member may not enumerate conversations of a
+    # coworker they cannot see (another member's private one) — 404.
+    await _get_coworker_or_404(coworker_id, user.tenant_id, user=user)
     convs = await get_conversations_for_coworker(
         coworker_id, tenant_id=user.tenant_id
     )
@@ -142,7 +144,12 @@ async def create_coworker_conversation(
     and generates a unique ``channel_chat_id``. All conversations are
     1:1 — the agent always responds.
     """
-    cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
+    # USE enforcement (feat/roles PR3 feed-forward): a member must NOT be
+    # able to open a conversation against another member's PRIVATE
+    # coworker. ``_get_coworker_or_404(user=...)`` collapses not-visible
+    # to 404 so existence is not leaked; a shared coworker or the
+    # member's own private one passes.
+    cw = await _get_coworker_or_404(coworker_id, user.tenant_id, user=user)
     binding_id = await _ensure_web_binding(cw.id, user.tenant_id)  # type: ignore[attr-defined]
     chat_id = str(uuid.uuid4())
     conv = await create_conversation(

--- a/src/webui/v1/coworker_mcp.py
+++ b/src/webui/v1/coworker_mcp.py
@@ -28,7 +28,7 @@ from rolemesh.db import (
     set_coworker_mcp_enabled_tools,
     unbind_coworker_mcp_server,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import (
     CoworkerMCPBindingCreate,
     CoworkerMCPBindingResponse,
@@ -101,7 +101,7 @@ async def list_bindings_endpoint(
 async def bind_endpoint(
     coworker_id: str,
     body: CoworkerMCPBindingCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("mcp.configure")),
 ) -> CoworkerMCPBindingResponse:
     """Bind ``mcp_server_id`` to this coworker.
 
@@ -142,7 +142,7 @@ async def patch_binding_endpoint(
     coworker_id: str,
     mcp_id: str,
     body: CoworkerMCPBindingUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("mcp.configure")),
 ) -> CoworkerMCPBindingResponse:
     """Change ``enabled_tools`` on an existing binding.
 
@@ -191,7 +191,7 @@ async def patch_binding_endpoint(
 async def unbind_endpoint(
     coworker_id: str,
     mcp_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("mcp.configure")),
 ) -> Response:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     removed = await unbind_coworker_mcp_server(

--- a/src/webui/v1/coworkers.py
+++ b/src/webui/v1/coworkers.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Response
 
+from rolemesh.auth.permissions import user_can
 from rolemesh.core.backend_capabilities import BackendCompatError, validate_combo
 from rolemesh.db import (
     create_coworker,
@@ -34,6 +35,7 @@ from rolemesh.db import (
     get_coworker,
     get_coworkers_for_tenant,
     get_model_by_id,
+    set_coworker_visibility,
     tenant_has_credential_for_provider,
     update_coworker,
 )
@@ -41,6 +43,7 @@ from webui.dependencies import (
     get_current_user,
     require_action,
     require_manage_or_owner,
+    user_can_see_resource,
 )
 from webui.schemas_v1 import Coworker, CoworkerCreate, CoworkerUpdate
 from webui.v1 import coworker_events
@@ -73,6 +76,7 @@ def _coworker_to_response(cw: object) -> Coworker:
         status=cw.status,  # type: ignore[arg-type]
         max_concurrent=cw.max_concurrent,
         created_by_user_id=cw.created_by_user_id,
+        visibility=cw.visibility,  # type: ignore[attr-defined]
         created_at=cw.created_at,
     )
 
@@ -125,13 +129,22 @@ async def _validate_model_and_credential(
 async def list_coworkers(
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> list[Coworker]:
-    """List coworkers visible to the caller's tenant.
+    """List coworkers visible to the caller (feat/roles PR3 visibility).
 
-    No filtering by role today — Phase 1 surfaces every row in the
-    tenant. Visibility scoping (``created_by_user_id``) is a Phase 2
-    concern per design §8.
+    A manager (``agent.manage``: owner/admin/platform_admin) sees every
+    coworker in the tenant; a member sees only ``shared`` coworkers plus
+    the private ones they created. The row-level predicate lives in
+    :func:`rolemesh.db.get_coworkers_for_tenant`; it is the SQL mirror of
+    :func:`webui.dependencies.user_can_see_resource`. This is NOT a new
+    capability gate — the route stays auth-only (in the meta-test
+    allowlist); only the result SET narrows.
     """
-    cws = await get_coworkers_for_tenant(user.tenant_id)
+    can_manage = user_can(user.role, "agent.manage")  # type: ignore[arg-type]
+    cws = await get_coworkers_for_tenant(
+        user.tenant_id,
+        requesting_user_id=user.user_id,
+        include_all=can_manage,
+    )
     return [_coworker_to_response(c) for c in cws]
 
 
@@ -211,7 +224,12 @@ def _looks_like_uuid(value: str) -> bool:
     )
 
 
-async def _get_coworker_or_404(coworker_id: str, tenant_id: str) -> object:
+async def _get_coworker_or_404(
+    coworker_id: str,
+    tenant_id: str,
+    *,
+    user: AuthenticatedUser | None = None,
+) -> object:
     """Fetch one coworker; raise the v1 envelope on miss / wrong tenant.
 
     Catches ``DataError`` (raised when ``coworker_id`` is not a valid
@@ -219,12 +237,26 @@ async def _get_coworker_or_404(coworker_id: str, tenant_id: str) -> object:
     UUID case and the legitimate "not found" case present as the
     same 404 to the client. Surfacing them differently leaks the
     DB's parsing rules.
+
+    feat/roles PR3 USE/SEE enforcement: when ``user`` is supplied this
+    helper additionally hides a coworker the caller may not see/use
+    (a private coworker created by someone else, with the caller lacking
+    ``agent.manage``). It collapses "exists but not visible" to the SAME
+    404 as "does not exist" so the endpoint never leaks the existence of
+    another member's private draft. Read-only catalog reads that are
+    intentionally tenant-wide (and already allowlisted) pass ``user=None``
+    and keep the pre-PR3 behavior.
     """
     try:
         cw = await get_coworker(coworker_id, tenant_id=tenant_id)
     except asyncpg.DataError:
         cw = None
-    if cw is None:
+    if cw is None or (
+        user is not None
+        and not user_can_see_resource(
+            manage_action="agent.manage", resource=cw, user=user,
+        )
+    ):
         raise_error_response(
             "NOT_FOUND",
             "Coworker not found.",
@@ -239,7 +271,9 @@ async def get_coworker_endpoint(
     coworker_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> Coworker:
-    cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
+    # SEE enforcement: a member must not be able to fetch another
+    # member's private coworker — collapse to 404 (existence not leaked).
+    cw = await _get_coworker_or_404(coworker_id, user.tenant_id, user=user)
     return _coworker_to_response(cw)
 
 
@@ -341,3 +375,67 @@ async def delete_coworker_endpoint(
     )
     await delete_coworker(coworker_id, tenant_id=user.tenant_id)
     return Response(status_code=204)
+
+
+async def _set_visibility_or_404(
+    coworker_id: str, *, visibility: str, user: AuthenticatedUser
+) -> Coworker:
+    """Shared body for share / unshare: own-or-manage gate then flip.
+
+    The route already carries the low ``agent.use`` capability; this
+    helper escalates to ``require_manage_or_owner`` so a member may flip
+    their OWN coworker's visibility while a manager may flip any. The
+    initial fetch passes ``user=None`` so a member trying to share a
+    foreign PRIVATE coworker gets the consistent 403 from the ownership
+    gate (matching PATCH/DELETE) rather than a 404 — they are attempting
+    a MANAGE action, not a USE/SEE one.
+    """
+    cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
+    require_manage_or_owner(
+        manage_action="agent.manage", resource=cw, user=user,
+    )
+    updated = await set_coworker_visibility(
+        coworker_id, visibility=visibility, tenant_id=user.tenant_id,
+    )
+    if updated is None:
+        raise_error_response(
+            "NOT_FOUND",
+            "Coworker not found.",
+            status_code=404,
+            details={"coworker_id": coworker_id},
+        )
+    return _coworker_to_response(updated)
+
+
+@router.post("/{coworker_id}/share", response_model=Coworker)
+async def share_coworker_endpoint(
+    coworker_id: str,
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
+) -> Coworker:
+    """Make a coworker ``shared`` (visible to the whole tenant).
+
+    Self-serve, no review: a member shares their OWN draft; a manager
+    may share any. Idempotent — sharing an already-shared coworker is a
+    no-op flip. Gated by the ``agent.use`` route capability + the
+    in-handler ``require_manage_or_owner`` escalation (so this mutation
+    is NOT in the auth-only allowlist).
+    """
+    return await _set_visibility_or_404(
+        coworker_id, visibility="shared", user=user,
+    )
+
+
+@router.post("/{coworker_id}/unshare", response_model=Coworker)
+async def unshare_coworker_endpoint(
+    coworker_id: str,
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
+) -> Coworker:
+    """Make a coworker ``private`` again (creator + managers only).
+
+    The mirror of ``/share``; same own-or-manage gate. Note this does not
+    retro-actively close existing conversations other members already
+    opened — it only removes the coworker from their future list/use.
+    """
+    return await _set_visibility_or_404(
+        coworker_id, visibility="private", user=user,
+    )

--- a/src/webui/v1/coworkers.py
+++ b/src/webui/v1/coworkers.py
@@ -37,7 +37,11 @@ from rolemesh.db import (
     tenant_has_credential_for_provider,
     update_coworker,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import (
+    get_current_user,
+    require_action,
+    require_manage_or_owner,
+)
 from webui.schemas_v1 import Coworker, CoworkerCreate, CoworkerUpdate
 from webui.v1 import coworker_events
 from webui.v1.errors import ErrorResponseException, raise_error_response
@@ -134,7 +138,7 @@ async def list_coworkers(
 @router.post("", response_model=Coworker, status_code=201)
 async def create_coworker_endpoint(
     body: CoworkerCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.create")),
 ) -> Coworker:
     if body.model_id is not None:
         await _validate_model_and_credential(
@@ -243,7 +247,7 @@ async def get_coworker_endpoint(
 async def patch_coworker_endpoint(
     coworker_id: str,
     body: CoworkerUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> Coworker:
     """Update selected fields on a coworker.
 
@@ -256,6 +260,12 @@ async def patch_coworker_endpoint(
     even if the broadcast misses.
     """
     cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
+    # Ownership-escape gate: the route requires only ``agent.use`` (member-
+    # reachable); a member may PATCH a coworker they created, but reaching
+    # someone else's / a shared one requires ``agent.manage``.
+    require_manage_or_owner(
+        manage_action="agent.manage", resource=cw, user=user,
+    )
     model_changed = body.model_id is not None and body.model_id != cw.model_id
 
     if body.model_id is not None:
@@ -313,14 +323,21 @@ async def patch_coworker_endpoint(
 @router.delete("/{coworker_id}", status_code=204)
 async def delete_coworker_endpoint(
     coworker_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> Response:
     """Delete a coworker. DB FK ON DELETE CASCADE handles dependents.
 
     Per design §3 "DELETE 语义" table, a coworker DELETE cascades to
     conversations / runs / messages. No 409 path on this endpoint —
     the design treats coworkers as roots of their own subtree.
+
+    Ownership-escape gate: the route requires only ``agent.use``; a member
+    may delete their OWN coworker, others'/shared ones require
+    ``agent.manage``.
     """
-    await _get_coworker_or_404(coworker_id, user.tenant_id)
+    cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
+    require_manage_or_owner(
+        manage_action="agent.manage", resource=cw, user=user,
+    )
     await delete_coworker(coworker_id, tenant_id=user.tenant_id)
     return Response(status_code=204)

--- a/src/webui/v1/credentials.py
+++ b/src/webui/v1/credentials.py
@@ -23,7 +23,7 @@ from rolemesh.db import (
     list_tenant_credentials,
     upsert_tenant_credential,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import require_action
 from webui.schemas_v1 import CredentialResponse, CredentialUpsert, ModelProvider
 from webui.v1 import coworker_events
 from webui.v1._log_sanitize import sanitize_for_log
@@ -47,7 +47,7 @@ def _credential_to_response(row: CredentialRow) -> CredentialResponse:
 
 @router.get("", response_model=list[CredentialResponse])
 async def list_credentials_endpoint(
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("credential.byok.manage")),
 ) -> list[CredentialResponse]:
     rows = await list_tenant_credentials(user.tenant_id)
     return [_credential_to_response(r) for r in rows]
@@ -57,7 +57,7 @@ async def list_credentials_endpoint(
 async def put_credential_endpoint(
     provider: ModelProvider,
     body: CredentialUpsert,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("credential.byok.manage")),
 ) -> CredentialResponse:
     """Set or rotate the credential for one provider.
 
@@ -114,7 +114,7 @@ async def put_credential_endpoint(
 @router.delete("/{provider}", status_code=204)
 async def delete_credential_endpoint(
     provider: ModelProvider,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("credential.byok.manage")),
 ) -> Response:
     """Delete a credential.
 

--- a/src/webui/v1/mcp_servers.py
+++ b/src/webui/v1/mcp_servers.py
@@ -26,7 +26,7 @@ from rolemesh.db import (
     list_mcp_servers,
     update_mcp_server,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import MCPServer, MCPServerCreate, MCPServerUpdate
 from webui.v1 import mcp_events
 from webui.v1.errors import ErrorResponseException, raise_error_response
@@ -81,7 +81,7 @@ async def list_endpoint(
 @router.post("", response_model=MCPServer, status_code=201)
 async def create_endpoint(
     body: MCPServerCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("mcp.configure")),
 ) -> MCPServer:
     try:
         row = await create_mcp_server(
@@ -120,7 +120,7 @@ async def get_endpoint(
 async def patch_endpoint(
     mcp_id: str,
     body: MCPServerUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("mcp.configure")),
 ) -> MCPServer:
     """Partial update; ``None`` clears nullable columns, absent leaves alone.
 
@@ -168,7 +168,7 @@ async def patch_endpoint(
 @router.delete("/{mcp_id}", status_code=204)
 async def delete_endpoint(
     mcp_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("mcp.configure")),
 ) -> Response:
     """Delete an MCP server.
 

--- a/src/webui/v1/runs.py
+++ b/src/webui/v1/runs.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, Depends, Response
 
 from rolemesh.db import tenant_conn
 from rolemesh.runs import get_run
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import Run
 from webui.v1 import run_events
 from webui.v1.errors import raise_error_response
@@ -106,7 +106,7 @@ async def get_run_endpoint(
 async def cancel_run_endpoint(
     run_id: str,
     response: Response,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> Run:
     """Request cancellation of an in-flight run.
 

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -32,7 +32,7 @@ from rolemesh.db import (
     list_visible_platform_rules,
 )
 from rolemesh.safety.registry import get_orchestrator_registry
-from webui.dependencies import get_current_user
+from webui.dependencies import require_action
 from webui.schemas_v1 import (
     SafetyCheck,
     SafetyDecision,
@@ -221,7 +221,7 @@ async def list_rules(
     coworker_id: str | None = None,
     stage: SafetyStage | None = None,
     enabled: bool | None = None,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> list[SafetyRule]:
     """List safety rules for the caller's tenant.
 
@@ -260,7 +260,7 @@ async def list_rules(
 @router.get("/rules/{rule_id}", response_model=SafetyRule)
 async def get_rule(
     rule_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> SafetyRule:
     """Single rule, scoped to the caller's tenant.
 
@@ -296,7 +296,7 @@ async def get_rule(
 async def list_rule_audit(
     rule_id: str,
     limit: int = Query(default=200, ge=1, le=500),
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> list[SafetyRuleAuditEntry]:
     """Change-history timeline for one rule, newest first.
 
@@ -316,7 +316,7 @@ async def list_rule_audit(
 
 @router.get("/checks", response_model=list[SafetyCheck])
 async def list_checks(
-    _user: AuthenticatedUser = Depends(get_current_user),
+    _user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> list[SafetyCheck]:
     """Registered check metadata for the rule editor.
 
@@ -365,7 +365,7 @@ async def list_decisions(
     to_ts: str | None = None,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> SafetyDecisionPage:
     """Paginated decisions list with a total-count envelope.
 
@@ -400,7 +400,7 @@ async def list_decisions(
 @router.get("/decisions/{decision_id}", response_model=SafetyDecision)
 async def get_decision(
     decision_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> SafetyDecision:
     """One safety decision detail row.
 

--- a/src/webui/v1/skills.py
+++ b/src/webui/v1/skills.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import asyncpg
 from fastapi import APIRouter, Depends, Response
 
+from rolemesh.auth.permissions import user_can
 from rolemesh.core.skills import (
     SKILL_MANIFEST_NAME,
     SkillValidationError,
@@ -42,12 +43,14 @@ from rolemesh.db import (
     list_skills_for_coworker,
     list_skills_for_tenant,
     set_skill_file,
+    set_skill_visibility,
     update_skill,
 )
 from webui.dependencies import (
     get_current_user,
     require_action,
     require_manage_or_owner,
+    user_can_see_resource,
 )
 from webui.schemas_v1 import (
     CoworkerSkillBinding,
@@ -96,6 +99,7 @@ def _skill_to_response(s: SkillDataclass) -> Skill:
         created_at=s.created_at,
         updated_at=s.updated_at,
         created_by_user_id=s.created_by_user_id,
+        visibility=s.visibility,  # type: ignore[arg-type]
     )
 
 
@@ -118,6 +122,7 @@ def _skill_to_summary(s: SkillDataclass, bound_count: int) -> SkillSummary:
         description=description,
         enabled=s.enabled,
         bound_coworker_count=bound_count,
+        visibility=s.visibility,  # type: ignore[arg-type]
         created_at=s.created_at,
         updated_at=s.updated_at,
     )
@@ -160,12 +165,32 @@ def _normalize_files(
     return out
 
 
-async def _get_skill_or_404(skill_id: str, *, tenant_id: str) -> SkillDataclass:
+async def _get_skill_or_404(
+    skill_id: str,
+    *,
+    tenant_id: str,
+    user: AuthenticatedUser | None = None,
+) -> SkillDataclass:
+    """Fetch one skill; 404 on miss / wrong tenant.
+
+    feat/roles PR3: when ``user`` is supplied, a skill the caller may not
+    SEE/USE (another member's private skill, caller lacking
+    ``skill.manage``) collapses to the same 404 as "does not exist" so a
+    private draft's existence is not leaked. The manage paths (PATCH /
+    DELETE / file writes) pass ``user=None`` so a foreign private skill
+    surfaces as a 403 from ``require_manage_or_owner`` — matching the
+    pre-PR3 ownership-escape contract the S1 tests pin.
+    """
     try:
         skill = await get_skill(skill_id, tenant_id=tenant_id)
     except asyncpg.DataError:
         skill = None
-    if skill is None:
+    if skill is None or (
+        user is not None
+        and not user_can_see_resource(
+            manage_action="skill.manage", resource=skill, user=user,
+        )
+    ):
         raise_error_response(
             "NOT_FOUND",
             "Skill not found.",
@@ -219,7 +244,16 @@ async def _broadcast_skills_changed(
 async def list_skills_endpoint(
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> list[SkillSummary]:
-    skills = await list_skills_for_tenant(user.tenant_id)
+    # feat/roles PR3 visibility: a manager (skill.manage) sees every
+    # catalog skill; a member sees shared + their own private. Row-level
+    # predicate lives in ``list_skills_for_tenant`` (SQL mirror of
+    # ``user_can_see_resource``); the route stays auth-only (allowlisted).
+    can_manage = user_can(user.role, "skill.manage")  # type: ignore[arg-type]
+    skills = await list_skills_for_tenant(
+        user.tenant_id,
+        requesting_user_id=user.user_id,
+        include_all=can_manage,
+    )
     summaries: list[SkillSummary] = []
     for s in skills:
         bound = await list_coworkers_for_skill(s.id, tenant_id=user.tenant_id)
@@ -317,7 +351,9 @@ async def get_skill_endpoint(
     skill_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> Skill:
-    skill = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    skill = await _get_skill_or_404(
+        skill_id, tenant_id=user.tenant_id, user=user,
+    )
     return _skill_to_response(skill)
 
 
@@ -498,6 +534,62 @@ async def delete_skill_endpoint(
     return Response(status_code=204)
 
 
+async def _set_skill_visibility_or_404(
+    skill_id: str, *, visibility: str, user: AuthenticatedUser,
+) -> Skill:
+    """Shared body for skill share / unshare.
+
+    The route carries the low ``skill.create`` capability; this helper
+    escalates to ``require_manage_or_owner`` so a member may flip their
+    OWN skill while a manager may flip any. Fetch passes ``user=None`` so
+    a member targeting a foreign private skill gets the consistent 403
+    from the ownership gate (a MANAGE attempt), matching PATCH/DELETE.
+    """
+    existing = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    require_manage_or_owner(
+        manage_action="skill.manage", resource=existing, user=user,
+    )
+    updated = await set_skill_visibility(
+        skill_id, visibility=visibility, tenant_id=user.tenant_id,
+    )
+    if updated is None:
+        raise_error_response(
+            "NOT_FOUND",
+            "Skill not found.",
+            status_code=404,
+            details={"skill_id": skill_id},
+        )
+    return _skill_to_response(updated)
+
+
+@skills_router.post("/{skill_id}/share", response_model=Skill)
+async def share_skill_endpoint(
+    skill_id: str,
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
+) -> Skill:
+    """Make a skill ``shared`` (visible / bindable tenant-wide).
+
+    Self-serve: a member shares their OWN draft; a manager may share any.
+    Gated by the ``skill.create`` route capability + in-handler
+    ``require_manage_or_owner`` escalation (so this mutation is NOT in the
+    auth-only allowlist).
+    """
+    return await _set_skill_visibility_or_404(
+        skill_id, visibility="shared", user=user,
+    )
+
+
+@skills_router.post("/{skill_id}/unshare", response_model=Skill)
+async def unshare_skill_endpoint(
+    skill_id: str,
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
+) -> Skill:
+    """Make a skill ``private`` again (creator + managers only)."""
+    return await _set_skill_visibility_or_404(
+        skill_id, visibility="private", user=user,
+    )
+
+
 # ---------------------------------------------------------------------------
 # File endpoints
 # ---------------------------------------------------------------------------
@@ -508,7 +600,9 @@ async def list_skill_files_endpoint(
     skill_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> list[str]:
-    skill = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    skill = await _get_skill_or_404(
+        skill_id, tenant_id=user.tenant_id, user=user,
+    )
     return sorted(skill.files.keys())
 
 
@@ -518,7 +612,9 @@ async def get_skill_file_endpoint(
     path: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> SkillFile:
-    skill = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    skill = await _get_skill_or_404(
+        skill_id, tenant_id=user.tenant_id, user=user,
+    )
     if path not in skill.files:
         raise_error_response(
             "NOT_FOUND",
@@ -692,7 +788,12 @@ async def enable_coworker_skill_endpoint(
     require_manage_or_owner(
         manage_action="agent.manage", resource=cw, user=user,
     )
-    await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    # USE enforcement on the SKILL being attached: a member may only bind
+    # a skill they can see (shared, or their own private one). Binding a
+    # foreign private skill collapses to 404 — same existence-hiding
+    # convention as fetch. Passing ``user`` routes through the single
+    # ``user_can_see_resource`` helper.
+    await _get_skill_or_404(skill_id, tenant_id=user.tenant_id, user=user)
     ok = await enable_skill_for_coworker(
         skill_id=skill_id,
         coworker_id=coworker_id,

--- a/src/webui/v1/skills.py
+++ b/src/webui/v1/skills.py
@@ -44,7 +44,11 @@ from rolemesh.db import (
     set_skill_file,
     update_skill,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import (
+    get_current_user,
+    require_action,
+    require_manage_or_owner,
+)
 from webui.schemas_v1 import (
     CoworkerSkillBinding,
     Skill,
@@ -171,7 +175,7 @@ async def _get_skill_or_404(skill_id: str, *, tenant_id: str) -> SkillDataclass:
     return skill
 
 
-async def _ensure_coworker(coworker_id: str, *, tenant_id: str) -> None:
+async def _get_coworker_or_404(coworker_id: str, *, tenant_id: str) -> object:
     try:
         cw = await get_coworker(coworker_id, tenant_id=tenant_id)
     except asyncpg.DataError:
@@ -183,6 +187,11 @@ async def _ensure_coworker(coworker_id: str, *, tenant_id: str) -> None:
             status_code=404,
             details={"coworker_id": coworker_id},
         )
+    return cw
+
+
+async def _ensure_coworker(coworker_id: str, *, tenant_id: str) -> None:
+    await _get_coworker_or_404(coworker_id, tenant_id=tenant_id)
 
 
 async def _broadcast_skills_changed(
@@ -221,7 +230,7 @@ async def list_skills_endpoint(
 @skills_router.post("", response_model=Skill, status_code=201)
 async def create_skill_endpoint(
     body: SkillCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
 ) -> Skill:
     try:
         validate_skill_name(body.name)
@@ -316,9 +325,14 @@ async def get_skill_endpoint(
 async def update_skill_endpoint(
     skill_id: str,
     body: SkillUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
 ) -> Skill:
     existing = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    # Ownership-escape: a member may edit a skill they created; reaching a
+    # shared/others' skill requires ``skill.manage``.
+    require_manage_or_owner(
+        manage_action="skill.manage", resource=existing, user=user,
+    )
     set_fields = body.model_fields_set
 
     # ``name`` is read-only on PATCH (see SkillUpdate docstring). Accept
@@ -454,9 +468,12 @@ async def update_skill_endpoint(
 @skills_router.delete("/{skill_id}", status_code=204)
 async def delete_skill_endpoint(
     skill_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
 ) -> Response:
-    await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    skill = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    require_manage_or_owner(
+        manage_action="skill.manage", resource=skill, user=user,
+    )
     coworker_ids = await list_coworkers_for_skill(
         skill_id, tenant_id=user.tenant_id,
     )
@@ -517,9 +534,12 @@ async def put_skill_file_endpoint(
     skill_id: str,
     path: str,
     body: SkillFileUpsert,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
 ) -> SkillFile:
-    await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    skill = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    require_manage_or_owner(
+        manage_action="skill.manage", resource=skill, user=user,
+    )
     try:
         validate_skill_file_path(path)
     except SkillValidationError as exc:
@@ -558,9 +578,12 @@ async def put_skill_file_endpoint(
 async def delete_skill_file_endpoint(
     skill_id: str,
     path: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("skill.create")),
 ) -> Response:
-    await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    skill = await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
+    require_manage_or_owner(
+        manage_action="skill.manage", resource=skill, user=user,
+    )
     if path == SKILL_MANIFEST_NAME:
         raise ErrorResponseException(
             status_code=409,
@@ -654,15 +677,21 @@ async def list_coworker_skills_endpoint(
 async def enable_coworker_skill_endpoint(
     coworker_id: str,
     skill_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> CoworkerSkillBinding:
     """Bind a catalog skill to this coworker (idempotent).
 
     Re-enabling an already-enabled binding is a no-op. Re-enabling
     a disabled binding flips the junction flag back to true. Both
     cases publish ``skills_changed``.
+
+    Mutates the coworker's skill set (agent config): the route requires
+    ``agent.use`` and the handler escalates to ``agent.manage``-or-own.
     """
-    await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
+    cw = await _get_coworker_or_404(coworker_id, tenant_id=user.tenant_id)
+    require_manage_or_owner(
+        manage_action="agent.manage", resource=cw, user=user,
+    )
     await _get_skill_or_404(skill_id, tenant_id=user.tenant_id)
     ok = await enable_skill_for_coworker(
         skill_id=skill_id,
@@ -689,14 +718,20 @@ async def enable_coworker_skill_endpoint(
 async def disable_coworker_skill_endpoint(
     coworker_id: str,
     skill_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("agent.use")),
 ) -> Response:
     """Remove the ``coworker_skills`` binding row.
 
     Distinct from "enable=false" — this deletes the binding outright,
     matching the v1 DELETE convention. The catalog skill survives.
+
+    Mutates the coworker's skill set (agent config): route ``agent.use``,
+    handler escalates to ``agent.manage``-or-own.
     """
-    await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
+    cw = await _get_coworker_or_404(coworker_id, tenant_id=user.tenant_id)
+    require_manage_or_owner(
+        manage_action="agent.manage", resource=cw, user=user,
+    )
     removed = await disable_skill_for_coworker(
         skill_id=skill_id,
         coworker_id=coworker_id,

--- a/tests/admin/test_create_admin.py
+++ b/tests/admin/test_create_admin.py
@@ -19,11 +19,12 @@ import pytest
 from rolemesh.admin.cli import _build_parser, _cmd_create_admin
 from rolemesh.admin.core import (
     PLATFORM_ADMIN_ROLE,
+    PLATFORM_TENANT_SLUG,
     AdminProvisionError,
     create_admin,
     ensure_seed_admin,
 )
-from rolemesh.db import DEFAULT_TENANT, get_tenant_by_slug
+from rolemesh.db import get_tenant_by_slug
 from rolemesh.db._pool import admin_conn
 
 pytestmark = pytest.mark.usefixtures("test_db")
@@ -43,17 +44,37 @@ async def _user_count_by_email(email: str) -> int:
 # ---------------------------------------------------------------------------
 
 
-async def test_creates_platform_admin_in_default_tenant() -> None:
+async def test_creates_platform_admin_in_sentinel_tenant() -> None:
     result = await create_admin(email="a@b.com")
 
     assert result.created is True
     assert result.role == PLATFORM_ADMIN_ROLE
-    assert result.tenant_slug == DEFAULT_TENANT
+    assert result.tenant_slug == PLATFORM_TENANT_SLUG
     assert result.email == "a@b.com"
-    default = await get_tenant_by_slug(DEFAULT_TENANT)
-    assert default is not None
-    assert result.tenant_id == default.id
+    sentinel = await get_tenant_by_slug(PLATFORM_TENANT_SLUG)
+    assert sentinel is not None
+    assert result.tenant_id == sentinel.id
     assert await _user_count_by_email("a@b.com") == 1
+
+
+async def test_sentinel_tenant_created_once_and_reused() -> None:
+    """Provisioning two platform_admins must not duplicate the sentinel tenant.
+
+    Regression guard: the anchor tenant is created idempotently. A second
+    platform_admin (distinct email) must land in the SAME ``__platform__``
+    tenant row, not a fresh one.
+    """
+    first = await create_admin(email="one@b.com")
+    second = await create_admin(email="two@b.com")
+
+    assert first.tenant_id == second.tenant_id
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM tenants WHERE slug = $1",
+            PLATFORM_TENANT_SLUG,
+        )
+    assert row is not None
+    assert int(row["n"]) == 1
 
 
 async def test_create_admin_is_idempotent() -> None:

--- a/tests/auth/test_permissions_role_model.py
+++ b/tests/auth/test_permissions_role_model.py
@@ -1,0 +1,115 @@
+"""Role -> action capability table contract (rolemesh.auth.permissions).
+
+These tests pin the AUTHORIZATION SPEC (PLAN.md §4 matrix), not the current
+implementation. They are written to fail if a future edit silently weakens a
+gate (e.g. granting ``credential.byok.manage`` to ``admin``) or breaks the
+fail-closed contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.auth.permissions import (
+    _PLATFORM_ONLY_ACTIONS,
+    _TENANT_ROLE_ACTIONS,
+    _USER_ROLE_ACTIONS,
+    user_can,
+)
+
+# The complete §4 fine-grained action set the v1 surface gates on.
+_V1_ACTIONS = {
+    "agent.create",
+    "agent.manage",
+    "agent.use",
+    "skill.create",
+    "skill.manage",
+    "mcp.configure",
+    "approval_policy.manage",
+    "credential.byok.manage",
+    "safety.read",
+}
+
+
+# ---------------------------------------------------------------------------
+# platform_admin is the superset
+# ---------------------------------------------------------------------------
+
+
+def test_platform_admin_grants_every_v1_action() -> None:
+    for action in _V1_ACTIONS:
+        assert user_can("platform_admin", action), action
+
+
+def test_platform_admin_grants_every_legacy_action() -> None:
+    for action in (
+        "manage_tenant",
+        "manage_agents",
+        "manage_users",
+        "view_all_conversations",
+        "use_agent",
+    ):
+        assert user_can("platform_admin", action), action
+
+
+def test_platform_admin_superset_is_derived_not_hand_copied() -> None:
+    """platform_admin must equal the union of every tenant role + platform-only.
+
+    Catches drift: if someone adds an action to a tenant role but forgets to
+    extend platform_admin, this fails — proving the superset is computed, not
+    a stale copy.
+    """
+    expected = set(_PLATFORM_ONLY_ACTIONS)
+    for actions in _TENANT_ROLE_ACTIONS.values():
+        expected |= actions
+    assert _USER_ROLE_ACTIONS["platform_admin"] == expected
+
+
+# ---------------------------------------------------------------------------
+# §4 matrix: per-role boundaries (negative assertions are the valuable ones)
+# ---------------------------------------------------------------------------
+
+
+def test_member_cannot_manage_shared_resources() -> None:
+    # A member may create/use, but NOT reach the manage/configure capability.
+    assert user_can("member", "agent.create")
+    assert user_can("member", "agent.use")
+    assert user_can("member", "skill.create")
+    assert not user_can("member", "agent.manage")
+    assert not user_can("member", "skill.manage")
+    assert not user_can("member", "mcp.configure")
+    assert not user_can("member", "approval_policy.manage")
+    assert not user_can("member", "credential.byok.manage")
+    assert not user_can("member", "safety.read")
+
+
+def test_admin_has_manage_but_not_byok_credentials() -> None:
+    assert user_can("admin", "agent.manage")
+    assert user_can("admin", "skill.manage")
+    assert user_can("admin", "mcp.configure")
+    assert user_can("admin", "approval_policy.manage")
+    assert user_can("admin", "safety.read")
+    # BYOK credential management is owner+ only (§4 matrix).
+    assert not user_can("admin", "credential.byok.manage")
+
+
+def test_owner_has_byok_credentials() -> None:
+    assert user_can("owner", "credential.byok.manage")
+    for action in _V1_ACTIONS:
+        assert user_can("owner", action), action
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("role", ["", "godmode", "Owner", "PLATFORM_ADMIN"])
+def test_unknown_role_denies_everything(role: str) -> None:
+    for action in _V1_ACTIONS:
+        assert not user_can(role, action)  # type: ignore[arg-type]
+
+
+def test_unknown_action_denies_for_every_role() -> None:
+    for role in ("platform_admin", "owner", "admin", "member"):
+        assert not user_can(role, "nonexistent.action")  # type: ignore[arg-type]

--- a/tests/db/test_rls_enforcement.py
+++ b/tests/db/test_rls_enforcement.py
@@ -233,7 +233,7 @@ async def test_force_rls_keeps_owner_under_policy(
         "safety_rules", "safety_decisions", "safety_rules_audit",
         "scheduled_tasks", "task_run_logs",
         "messages", "conversations", "sessions",
-        "coworkers", "channel_bindings", "user_agent_assignments",
+        "coworkers", "channel_bindings",
         "users", "oidc_user_tokens",
     ]
     pool = _get_pool()

--- a/tests/db/test_visibility_backfill.py
+++ b/tests/db/test_visibility_backfill.py
@@ -1,0 +1,219 @@
+"""DB-layer visibility: backfill ordering + the list predicate's
+three-valued NULL logic.
+
+feat/roles PR3. The trap the plan flagged is the backfill: existing
+rows must end up ``'shared'`` (so they stay visible to members after the
+upgrade) while NEW rows default to ``'private'``. We assert both halves
+against the real schema, and we assert the list predicate does not leak a
+NULL-attributed private row to a member (NULL never equals the user).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from rolemesh.db import (
+    create_coworker,
+    create_skill,
+    create_tenant,
+    create_user,
+    get_coworkers_for_tenant,
+    list_skills_for_tenant,
+)
+from rolemesh.db._pool import admin_conn
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+async def _tenant() -> str:
+    t = await create_tenant(name="T", slug=f"bf-{uuid.uuid4().hex[:8]}")
+    return t.id
+
+
+# ---------------------------------------------------------------------------
+# Column + constraint exist; new rows default private.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_coworker_row_defaults_private_at_db_level() -> None:
+    """An INSERT that omits ``visibility`` lands 'private' — proves the
+    SET DEFAULT 'private' flip won (not the transient ADD ... 'shared').
+
+    Inserts via raw SQL (bypassing ``create_coworker``'s own default) so
+    the assertion is about the COLUMN default, not the Python default."""
+    tid = await _tenant()
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "INSERT INTO coworkers (tenant_id, name, folder) "
+            "VALUES ($1::uuid, $2, $3) RETURNING visibility",
+            tid, "raw", f"raw-{uuid.uuid4().hex[:8]}",
+        )
+    assert row is not None
+    assert row["visibility"] == "private"
+
+
+@pytest.mark.asyncio
+async def test_new_skill_row_defaults_private_at_db_level() -> None:
+    tid = await _tenant()
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "INSERT INTO skills (tenant_id, name) "
+            "VALUES ($1::uuid, $2) RETURNING visibility",
+            tid, f"sk{uuid.uuid4().hex[:6]}",
+        )
+    assert row is not None
+    assert row["visibility"] == "private"
+
+
+@pytest.mark.asyncio
+async def test_visibility_check_constraint_rejects_garbage() -> None:
+    """The CHECK constraint must reject any value outside the domain."""
+    tid = await _tenant()
+    import asyncpg
+
+    async with admin_conn() as conn:
+        with pytest.raises(asyncpg.CheckViolationError):
+            await conn.execute(
+                "INSERT INTO coworkers (tenant_id, name, folder, visibility) "
+                "VALUES ($1::uuid, $2, $3, 'public')",
+                tid, "bad", f"bad-{uuid.uuid4().hex[:8]}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Backfill: a row that existed BEFORE the column was added ends 'shared'.
+# We simulate the pre-migration state by stripping the column, inserting a
+# legacy row, then re-running the migration DDL and asserting it backfilled.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_makes_preexisting_coworker_shared() -> None:
+    """Drop the column (simulate a pre-PR3 row), insert a legacy
+    coworker, then replay the exact two-step migration DDL. The legacy
+    row must come out 'shared' — NOT 'private' (which would hide it from
+    every member). This is the regression the plan called the trap."""
+    tid = await _tenant()
+    folder = f"legacy-{uuid.uuid4().hex[:8]}"
+    async with admin_conn() as conn:
+        # Simulate the pre-migration table shape.
+        await conn.execute(
+            "ALTER TABLE coworkers DROP COLUMN visibility"
+        )
+        await conn.execute(
+            "INSERT INTO coworkers (tenant_id, name, folder) "
+            "VALUES ($1::uuid, $2, $3)",
+            tid, "legacy", folder,
+        )
+        # Replay the migration exactly as schema.py orders it.
+        await conn.execute(
+            "ALTER TABLE coworkers "
+            "ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'shared'"
+        )
+        await conn.execute(
+            "ALTER TABLE coworkers ALTER COLUMN visibility SET DEFAULT 'private'"
+        )
+        legacy_vis = await conn.fetchval(
+            "SELECT visibility FROM coworkers WHERE folder = $1", folder
+        )
+        # A row inserted AFTER the flip must be private.
+        await conn.execute(
+            "INSERT INTO coworkers (tenant_id, name, folder) "
+            "VALUES ($1::uuid, $2, $3)",
+            tid, "fresh", f"fresh-{uuid.uuid4().hex[:8]}",
+        )
+        fresh_vis = await conn.fetchval(
+            "SELECT visibility FROM coworkers WHERE name = 'fresh' "
+            "AND tenant_id = $1::uuid",
+            tid,
+        )
+    assert legacy_vis == "shared", "pre-existing row must backfill to shared"
+    assert fresh_vis == "private", "post-flip row must default private"
+
+
+# ---------------------------------------------------------------------------
+# List predicate NULL three-valued logic (data layer, no HTTP).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_predicate_hides_null_attributed_private_from_member() -> None:
+    tid = await _tenant()
+    me = await create_user(
+        tenant_id=tid, name="U", email=f"u-{uuid.uuid4().hex[:6]}@x.com",
+        role="member",
+    )
+    mine = await create_coworker(
+        tenant_id=tid, name="mine", folder=f"m-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=me.id, visibility="private",
+    )
+    orphan = await create_coworker(
+        tenant_id=tid, name="orphan", folder=f"o-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=None, visibility="private",
+    )
+    shared = await create_coworker(
+        tenant_id=tid, name="shared", folder=f"s-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=None, visibility="shared",
+    )
+
+    filtered = await get_coworkers_for_tenant(
+        tid, requesting_user_id=me.id, include_all=False,
+    )
+    ids = {c.id for c in filtered}
+    assert mine.id in ids
+    assert shared.id in ids
+    # The NULL created_by + private row must NOT leak: ``created_by = $2``
+    # is NULL (not TRUE) for it, so the predicate excludes it.
+    assert orphan.id not in ids
+
+    # include_all (manager path) returns everything, orphan included.
+    all_rows = await get_coworkers_for_tenant(tid, include_all=True)
+    assert orphan.id in {c.id for c in all_rows}
+
+
+@pytest.mark.asyncio
+async def test_skill_list_predicate_hides_null_attributed_private() -> None:
+    from rolemesh.core.types import SkillFile as SkillFileDataclass
+
+    tid = await _tenant()
+    me = await create_user(
+        tenant_id=tid, name="U", email=f"u-{uuid.uuid4().hex[:6]}@x.com",
+        role="member",
+    )
+    files = {"SKILL.md": SkillFileDataclass(path="SKILL.md", content="b")}
+    orphan = await create_skill(
+        tenant_id=tid, name=f"orph{uuid.uuid4().hex[:6]}",
+        frontmatter_common={"description": "x" * 40}, frontmatter_backend={},
+        files=files, created_by_user_id=None, visibility="private",
+    )
+    mine = await create_skill(
+        tenant_id=tid, name=f"mine{uuid.uuid4().hex[:6]}",
+        frontmatter_common={"description": "x" * 40}, frontmatter_backend={},
+        files=files, created_by_user_id=me.id, visibility="private",
+    )
+
+    filtered = await list_skills_for_tenant(
+        tid, requesting_user_id=me.id, include_all=False,
+    )
+    ids = {s.id for s in filtered}
+    assert mine.id in ids
+    assert orphan.id not in ids
+
+
+# ---------------------------------------------------------------------------
+# Validation: the DB helpers reject an out-of-domain visibility value
+# BEFORE the round-trip to Postgres.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_coworker_rejects_bad_visibility() -> None:
+    tid = await _tenant()
+    with pytest.raises(ValueError, match="visibility"):
+        await create_coworker(
+            tenant_id=tid, name="x", folder=f"x-{uuid.uuid4().hex[:8]}",
+            visibility="everyone",
+        )

--- a/tests/test_inv1_tenant_predicate_lint.py
+++ b/tests/test_inv1_tenant_predicate_lint.py
@@ -61,7 +61,6 @@ TENANT_SCOPED_TABLES: frozenset[str] = frozenset({
     "skills",
     "task_run_logs",
     "tenant_model_credentials",
-    "user_agent_assignments",
     "users",
 })
 

--- a/tests/webui/test_assignment_removal_regression.py
+++ b/tests/webui/test_assignment_removal_regression.py
@@ -1,0 +1,211 @@
+"""Regression guard for feat/roles PR4 — removal of user_agent_assignments.
+
+The user-agent assignment mechanism (table + CRUD + admin endpoints + OIDC
+auto-assign) was deleted. The whole point of this file is to prove that the
+removal did NOT regress agent access: access is governed purely by coworker
+``visibility`` + ``created_by_user_id`` ownership, never by an assignment row.
+
+Concretely, after removal:
+  * a ``member`` can create a conversation with / use a SHARED coworker
+    end-to-end (this previously could have depended on an assignment row);
+  * a ``member`` still CANNOT use another member's PRIVATE coworker
+    (visibility still governs, nothing fell open);
+  * the deleted admin assignment routes are gone (404/405);
+  * the ``user_agent_assignments`` table no longer exists in the schema.
+
+DO NOT re-introduce an assignment-style gate: if a future change makes the
+shared-agent case below start failing, the fix is to restore visibility-based
+access, not to add back a per-user assignment table.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db import create_coworker, create_tenant, create_user
+from rolemesh.db._pool import admin_conn
+from webui import admin
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import (
+    get_current_user,
+    require_manage_agents,
+    require_manage_tenant,
+    require_manage_users,
+)
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _authed(tenant_id: str, user_id: str, role: str) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id, tenant_id=tenant_id, role=role,
+        email="x@x.com", name="X",
+    )
+
+
+def _build_v1_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+def _build_admin_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin.router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    app.dependency_overrides[require_manage_agents] = _return_user
+    app.dependency_overrides[require_manage_tenant] = _return_user
+    app.dependency_overrides[require_manage_users] = _return_user
+    return app
+
+
+async def _tenant() -> str:
+    t = await create_tenant(name="T", slug=f"asg-rm-{uuid.uuid4().hex[:8]}")
+    return t.id
+
+
+async def _user(tenant_id: str, role: str) -> str:
+    u = await create_user(
+        tenant_id=tenant_id, name="U",
+        email=f"u-{uuid.uuid4().hex[:8]}@x.com", role=role,
+    )
+    return u.id
+
+
+async def _coworker(tenant_id: str, *, created_by: str | None, visibility: str) -> str:
+    cw = await create_coworker(
+        tenant_id=tenant_id, name=f"CW {uuid.uuid4().hex[:6]}",
+        folder=f"cw-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=created_by,
+        visibility=visibility,
+    )
+    return cw.id
+
+
+# ---------------------------------------------------------------------------
+# Core regression: access survives assignment removal, governed by visibility.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_can_use_shared_agent_without_any_assignment() -> None:
+    """A member who was NEVER assigned the coworker can still open a
+    conversation with a SHARED one. Before PR4 this path could have been
+    gated by an assignment row; it must now work on visibility alone."""
+    tid = await _tenant()
+    creator = await _user(tid, "member")
+    nobody_assigned_me = await _user(tid, "member")
+    shared = await _coworker(tid, created_by=creator, visibility="shared")
+
+    app = _build_v1_app(_authed(tid, nobody_assigned_me, "member"))
+    async with _client(app) as c:
+        resp = await c.post(
+            f"/api/v1/coworkers/{shared}/conversations", json={"name": "hi"}
+        )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_use_other_members_private_agent() -> None:
+    """Visibility still governs after removal: a member cannot open a
+    conversation with another member's PRIVATE coworker (404 — existence
+    hidden). This proves access did not silently fall open when the
+    assignment table was deleted."""
+    tid = await _tenant()
+    creator = await _user(tid, "member")
+    intruder = await _user(tid, "member")
+    private = await _coworker(tid, created_by=creator, visibility="private")
+
+    app = _build_v1_app(_authed(tid, intruder, "member"))
+    async with _client(app) as c:
+        resp = await c.post(
+            f"/api/v1/coworkers/{private}/conversations", json={"name": "hi"}
+        )
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# The deleted admin assignment routes must be gone.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assignment_admin_routes_are_removed() -> None:
+    """The three assignment endpoints were deleted. FastAPI returns 404 for
+    an unknown path and 405 when the path exists with a different method;
+    either proves the assignment route is gone (and not, e.g., accidentally
+    shadowed by another handler that 200s)."""
+    tid = await _tenant()
+    admin_id = await _user(tid, "admin")
+    member_id = await _user(tid, "member")
+    cw = await _coworker(tid, created_by=admin_id, visibility="shared")
+
+    app = _build_admin_app(_authed(tid, admin_id, "admin"))
+    async with _client(app) as c:
+        # POST /agents/{id}/assign  (was: assign_agent)
+        r1 = await c.post(
+            f"/api/admin/agents/{cw}/assign", json={"user_id": member_id}
+        )
+        assert r1.status_code in (404, 405), r1.text
+        # DELETE /agents/{id}/assign/{user_id}  (was: unassign_agent)
+        r2 = await c.delete(f"/api/admin/agents/{cw}/assign/{member_id}")
+        assert r2.status_code in (404, 405), r2.text
+        # GET /agents/{id}/users  (was: list_assigned_users)
+        r3 = await c.get(f"/api/admin/agents/{cw}/users")
+        assert r3.status_code in (404, 405), r3.text
+
+
+@pytest.mark.asyncio
+async def test_user_detail_has_no_assigned_agents_field() -> None:
+    """GET /users/{id} was surgically edited (not deleted). It must still
+    return the user, but the ``assigned_agents`` field is gone from the
+    response contract."""
+    tid = await _tenant()
+    admin_id = await _user(tid, "admin")
+    target = await _user(tid, "member")
+
+    app = _build_admin_app(_authed(tid, admin_id, "admin"))
+    async with _client(app) as c:
+        resp = await c.get(f"/api/admin/users/{target}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == target
+    assert "assigned_agents" not in body, body
+
+
+# ---------------------------------------------------------------------------
+# The table itself must be gone from the schema (idempotent DROP applied).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_agent_assignments_table_does_not_exist() -> None:
+    """After schema init, the table must not exist — neither the CREATE in
+    schema.py nor the test-reset DROP should leave it behind."""
+    async with admin_conn() as conn:
+        exists = await conn.fetchval(
+            "SELECT to_regclass('public.user_agent_assignments') IS NOT NULL"
+        )
+    assert exists is False

--- a/tests/webui/test_v1_default_deny.py
+++ b/tests/webui/test_v1_default_deny.py
@@ -1,0 +1,252 @@
+"""Default-deny meta-test for the ``/api/v1`` surface.
+
+The keystone of the role-gate work: it walks EVERY route registered under
+``/api/v1`` and asserts each one is either
+
+  * capability-gated (a ``require_action(...)`` dependency in its chain, tagged
+    with ``_required_action``), OR
+  * present in the EXPLICIT ``AUTH_ONLY_V1_ROUTES`` allowlist below, with a
+    one-line justification for why "authenticated is enough".
+
+A new ungated mutation route therefore fails CI until someone consciously
+either gates it or adds it (with a reason) to the allowlist. There is no silent
+pass — that is the whole point.
+
+A second test asserts every action string passed to ``require_action`` anywhere
+in ``src/webui`` exists in at least one role's set in ``_USER_ROLE_ACTIONS``,
+catching typos / drift between the gate and the capability table.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
+from rolemesh.auth.permissions import _USER_ROLE_ACTIONS
+from webui.api_v1 import router as api_v1_router
+
+# ---------------------------------------------------------------------------
+# Allowlist: (METHOD, path) tuples that are intentionally "authenticated is
+# enough". Each entry carries a one-line justification. Err toward GATING; only
+# add here when the route genuinely needs no role gate. Reviewed by hand.
+# ---------------------------------------------------------------------------
+AUTH_ONLY_V1_ROUTES: dict[tuple[str, str], str] = {
+    # --- Public / boot-time metadata -------------------------------------
+    ("GET", "/api/v1/backends"):
+        "Static compatibility matrix; design §2.3 marks it public metadata.",
+    ("GET", "/api/v1/auth/config"):
+        "Boot-time auth-mode hint the SPA reads before it has a session.",
+    # --- Identity (the caller's own row) ---------------------------------
+    ("GET", "/api/v1/auth/me"):
+        "Returns the caller's own identity only.",
+    ("GET", "/api/v1/me"):
+        "Returns the caller's own identity only.",
+    ("POST", "/api/v1/auth/ws-ticket"):
+        "Mints a WS ticket for a conversation the caller is verified to own "
+        "(membership checked in-handler); no role escalation.",
+    # --- Per-user IM self-service (DB scopes every row to user_id) --------
+    ("POST", "/api/v1/me/channel-links/telegram"):
+        "User links their OWN Telegram identity; rows are user_id-scoped.",
+    ("GET", "/api/v1/me/channel-links/telegram"):
+        "Lists the caller's OWN linked identities.",
+    ("DELETE", "/api/v1/me/channel-links/{identity_id}"):
+        "Unbinds the caller's OWN identity; DB DELETE filters by user_id.",
+    # --- Reads of tenant-scoped catalog / own data (RLS = tenant scope) ---
+    ("GET", "/api/v1/coworkers"):
+        "Read of the tenant's coworker catalog; a member may use agents.",
+    ("GET", "/api/v1/coworkers/{coworker_id}"):
+        "Read of one tenant coworker.",
+    ("GET", "/api/v1/coworkers/{coworker_id}/conversations"):
+        "Read of a coworker's conversations within the tenant.",
+    ("GET", "/api/v1/coworkers/{coworker_id}/bindings"):
+        "Read of a coworker's channel bindings (write-only creds omitted).",
+    ("GET", "/api/v1/coworkers/{coworker_id}/bindings/{binding_id}"):
+        "Read of one binding (write-only creds omitted from the response).",
+    ("GET", "/api/v1/coworkers/{coworker_id}/mcp-servers"):
+        "Read of a coworker's MCP bindings.",
+    ("GET", "/api/v1/coworkers/{coworker_id}/skills"):
+        "Read of a coworker's skill bindings.",
+    ("GET", "/api/v1/conversations/{conversation_id}"):
+        "Read of one conversation in the caller's tenant.",
+    ("GET", "/api/v1/conversations/{conversation_id}/messages"):
+        "Read of a conversation's message history.",
+    ("GET", "/api/v1/conversations/{conversation_id}/approval-requests"):
+        "Read of a conversation's HITL approval cards for re-render.",
+    ("GET", "/api/v1/skills"):
+        "Read of the tenant's skill catalog.",
+    ("GET", "/api/v1/skills/{skill_id}"):
+        "Read of one skill.",
+    ("GET", "/api/v1/skills/{skill_id}/files"):
+        "Read of a skill's file list.",
+    ("GET", "/api/v1/skills/{skill_id}/files/{path:path}"):
+        "Read of one skill file.",
+    ("GET", "/api/v1/mcp-servers"):
+        "Read of the tenant's MCP server catalog.",
+    ("GET", "/api/v1/mcp-servers/{mcp_id}"):
+        "Read of one MCP server (no secrets in the response shape).",
+    ("GET", "/api/v1/approval-policies"):
+        "Read of the tenant's approval policies.",
+    ("GET", "/api/v1/approval-policies/{policy_id}"):
+        "Read of one approval policy.",
+    ("GET", "/api/v1/approval-requests"):
+        "Read of the tenant's pending approval requests (inbox re-render).",
+    ("GET", "/api/v1/schedules"):
+        "Read-only schedules surface; writes are not exposed on v1.",
+    ("GET", "/api/v1/schedules/{task_id}"):
+        "Read of one scheduled task.",
+    ("GET", "/api/v1/runs/{run_id}"):
+        "Read of one run snapshot (SPA reconnect path).",
+    ("GET", "/api/v1/models"):
+        "Read of the platform model catalog (tenant-agnostic, no secrets).",
+    ("GET", "/api/v1/models/{model_id}"):
+        "Read of one platform model.",
+    # --- Operator-only writes gated IN-HANDLER (not via require_action) ---
+    # admin_models.py gates these with its own ``_require_owner(user)`` call at
+    # the top of each handler (a deliberate audit-locality choice predating
+    # this work). They are NOT ungated; they are simply gated by a mechanism
+    # the route-tag walker can't see, so they are allowlisted with this note.
+    ("POST", "/api/v1/admin/models"):
+        "Owner-gated in-handler via _require_owner (platform catalog write).",
+    ("PATCH", "/api/v1/admin/models/{model_id}"):
+        "Owner-gated in-handler via _require_owner (platform catalog write).",
+    ("DELETE", "/api/v1/admin/models/{model_id}"):
+        "Owner-gated in-handler via _require_owner (platform catalog write).",
+}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_v1_router)
+    return app
+
+
+def _route_required_action(route: APIRoute) -> str | None:
+    """Return the action a route's ``require_action`` gate enforces, if any.
+
+    Walks the FastAPI dependency tree looking for the ``_required_action`` tag
+    that ``require_action`` stamps on its inner callable.
+    """
+    for dep in route.dependant.dependencies:
+        call = getattr(dep, "call", None)
+        action = getattr(call, "_required_action", None)
+        if action is not None:
+            return str(action)
+    return None
+
+
+def _iter_v1_routes() -> list[tuple[str, str, APIRoute]]:
+    app = _build_app()
+    out: list[tuple[str, str, APIRoute]] = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        if not route.path.startswith("/api/v1"):
+            continue
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+            out.append((method, route.path, route))
+    return out
+
+
+def test_every_v1_route_is_gated_or_explicitly_auth_only() -> None:
+    """No silent pass: each /api/v1 route is gated OR allowlisted."""
+    ungated: list[tuple[str, str]] = []
+    for method, path, route in _iter_v1_routes():
+        if _route_required_action(route) is not None:
+            continue
+        if (method, path) in AUTH_ONLY_V1_ROUTES:
+            continue
+        ungated.append((method, path))
+    assert not ungated, (
+        "These /api/v1 routes are neither role-gated nor in the reviewed "
+        f"AUTH_ONLY_V1_ROUTES allowlist: {ungated}"
+    )
+
+
+def test_allowlist_has_no_stale_entries() -> None:
+    """Every allowlisted route must still exist AND still be ungated.
+
+    Guards against an allowlist entry quietly masking a route that later GAINED
+    a gate (entry now dead weight) or was renamed/removed.
+    """
+    live: dict[tuple[str, str], APIRoute] = {
+        (m, p): r for m, p, r in _iter_v1_routes()
+    }
+    stale: list[tuple[str, str]] = []
+    now_gated: list[tuple[str, str]] = []
+    for key in AUTH_ONLY_V1_ROUTES:
+        route = live.get(key)
+        if route is None:
+            stale.append(key)
+        elif _route_required_action(route) is not None:
+            now_gated.append(key)
+    assert not stale, f"Allowlist entries for routes that no longer exist: {stale}"
+    assert not now_gated, (
+        f"Allowlist entries that are now route-gated (remove them): {now_gated}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: every require_action(...) string must exist in the role table.
+# ---------------------------------------------------------------------------
+
+
+def _known_actions() -> set[str]:
+    actions: set[str] = set()
+    for role_actions in _USER_ROLE_ACTIONS.values():
+        actions |= role_actions
+    return actions
+
+
+def _collect_require_action_literals() -> list[tuple[str, str]]:
+    """Static-scan src/webui for ``require_action("...")`` string literals.
+
+    A static scan (not runtime introspection) catches actions on routes that
+    happen not to be imported by this test's app, and is robust to typos that
+    would otherwise only surface as a 403-for-everyone at runtime.
+    """
+    webui_dir = pathlib.Path(__file__).resolve().parents[2] / "src" / "webui"
+    found: list[tuple[str, str]] = []
+    for py in webui_dir.rglob("*.py"):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name != "require_action":
+                continue
+            if node.args and isinstance(node.args[0], ast.Constant):
+                val = node.args[0].value
+                if isinstance(val, str):
+                    found.append((str(py), val))
+    return found
+
+
+def test_every_require_action_string_exists_in_role_table() -> None:
+    literals = _collect_require_action_literals()
+    # Sanity: the scan must actually find gates, else the test is vacuous.
+    assert literals, "No require_action(...) literals found — scan is broken."
+    known = _known_actions()
+    unknown = sorted(
+        {action for _, action in literals if action not in known}
+    )
+    assert not unknown, (
+        f"require_action uses actions absent from _USER_ROLE_ACTIONS "
+        f"(typo or missing table entry): {unknown}"
+    )
+
+
+@pytest.mark.parametrize("key", sorted(AUTH_ONLY_V1_ROUTES))
+def test_allowlist_entries_have_nonempty_justification(
+    key: tuple[str, str],
+) -> None:
+    """Force every allowlist entry to carry a real reason (review hygiene)."""
+    assert AUTH_ONLY_V1_ROUTES[key].strip()

--- a/tests/webui/test_v1_role_gates_403.py
+++ b/tests/webui/test_v1_role_gates_403.py
@@ -1,0 +1,374 @@
+"""403 role-gate + ownership-escape behavior on the /api/v1 surface.
+
+These tests assert the AUTHORIZATION SPEC (PLAN.md §4), not the handler
+internals. For each gated endpoint the valuable assertion is the negative one:
+an under-privileged role is rejected with 403 BEFORE any side effect. The
+boundary role (lowest role that SHOULD pass) is also checked so the gate isn't
+accidentally over-tight.
+
+The ownership-escape cases are the subtle ones: a member CAN update/delete a
+coworker/skill they created, and CANNOT touch one created by someone else (the
+gate falls back to requiring ``agent.manage`` / ``skill.manage``).
+
+Auth is injected by overriding ``get_current_user`` with a fixed role, so the
+role under test is exactly the one the gate sees (``require_action`` resolves
+the user via that same dependency).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.credential_vault import CredentialVault, set_credential_vault
+from rolemesh.auth.encryption import derive_fernet_key
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.core.types import SkillFile as SkillFileDataclass
+from rolemesh.db import (
+    create_coworker,
+    create_skill,
+    create_tenant,
+    create_user,
+)
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import get_current_user
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+def _authed(tenant_id: str, user_id: str, role: str) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id, tenant_id=tenant_id, role=role,
+        email="x@x.com", name="X",
+    )
+
+
+async def _tenant() -> str:
+    t = await create_tenant(
+        name="T", slug=f"gate-{uuid.uuid4().hex[:8]}",
+    )
+    return t.id
+
+
+async def _user(tenant_id: str, role: str) -> str:
+    u = await create_user(
+        tenant_id=tenant_id, name="U",
+        email=f"u-{uuid.uuid4().hex[:8]}@x.com", role=role,
+    )
+    return u.id
+
+
+async def _seed_coworker(tenant_id: str, *, created_by: str | None) -> str:
+    cw = await create_coworker(
+        tenant_id=tenant_id, name=f"CW {uuid.uuid4().hex[:6]}",
+        folder=f"cw-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=created_by,
+    )
+    return cw.id
+
+
+async def _seed_skill(tenant_id: str, *, created_by: str | None) -> str:
+    name = f"skill-{uuid.uuid4().hex[:6]}"
+    skill = await create_skill(
+        tenant_id=tenant_id,
+        name=name,
+        frontmatter_common={"description": "x" * 40},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFileDataclass(path="SKILL.md", content="body")},
+        enabled=True,
+        created_by_user_id=created_by,
+    )
+    return skill.id
+
+
+# ---------------------------------------------------------------------------
+# coworkers: create requires agent.create (all roles); manage gated for member
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_can_create_coworker() -> None:
+    """agent.create is granted to member — the boundary role passes."""
+    tid = await _tenant()
+    uid = await _user(tid, "member")
+    app = _build_app(_authed(tid, uid, "member"))
+    async with _client(app) as c:
+        resp = await c.post(
+            "/api/v1/coworkers",
+            json={
+                "name": "Mine",
+                "folder": f"f-{uuid.uuid4().hex[:8]}",
+                "agent_backend": "claude",
+            },
+        )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_member_can_patch_own_coworker_but_not_others() -> None:
+    """Ownership escape: member edits OWN coworker (200) but not another's (403)."""
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    other_id = await _user(tid, "member")
+
+    own = await _seed_coworker(tid, created_by=member_id)
+    foreign = await _seed_coworker(tid, created_by=other_id)
+
+    app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(app) as c:
+        ok = await c.patch(f"/api/v1/coworkers/{own}", json={"name": "Renamed"})
+        assert ok.status_code == 200, ok.text
+
+        denied = await c.patch(
+            f"/api/v1/coworkers/{foreign}", json={"name": "Hijack"}
+        )
+        assert denied.status_code == 403, denied.text
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_manage_unattributed_coworker() -> None:
+    """Three-valued logic: created_by_user_id IS NULL is NOT 'mine'.
+
+    A member must not be able to claim an un-attributed (legacy/system)
+    coworker as their own; NULL falls through to requiring agent.manage.
+    """
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    orphan = await _seed_coworker(tid, created_by=None)
+
+    app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(app) as c:
+        resp = await c.patch(f"/api/v1/coworkers/{orphan}", json={"name": "X"})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_can_manage_any_coworker() -> None:
+    """agent.manage holder reaches a coworker they did not create."""
+    tid = await _tenant()
+    creator = await _user(tid, "member")
+    admin_id = await _user(tid, "admin")
+    cw = await _seed_coworker(tid, created_by=creator)
+
+    app = _build_app(_authed(tid, admin_id, "admin"))
+    async with _client(app) as c:
+        resp = await c.patch(f"/api/v1/coworkers/{cw}", json={"name": "AdminEdit"})
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_member_can_delete_own_coworker_not_foreign() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    other_id = await _user(tid, "member")
+    own = await _seed_coworker(tid, created_by=member_id)
+    foreign = await _seed_coworker(tid, created_by=other_id)
+
+    app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(app) as c:
+        denied = await c.delete(f"/api/v1/coworkers/{foreign}")
+        assert denied.status_code == 403, denied.text
+        ok = await c.delete(f"/api/v1/coworkers/{own}")
+        assert ok.status_code == 204, ok.text
+
+
+# ---------------------------------------------------------------------------
+# skills: create granted to member; manage gated with ownership escape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_can_patch_own_skill_but_not_foreign() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    other_id = await _user(tid, "member")
+    own = await _seed_skill(tid, created_by=member_id)
+    foreign = await _seed_skill(tid, created_by=other_id)
+
+    app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(app) as c:
+        ok = await c.patch(f"/api/v1/skills/{own}", json={"enabled": False})
+        assert ok.status_code == 200, ok.text
+        denied = await c.patch(f"/api/v1/skills/{foreign}", json={"enabled": False})
+        assert denied.status_code == 403, denied.text
+
+
+@pytest.mark.asyncio
+async def test_member_can_delete_own_skill_not_foreign() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    other_id = await _user(tid, "member")
+    own = await _seed_skill(tid, created_by=member_id)
+    foreign = await _seed_skill(tid, created_by=other_id)
+
+    app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(app) as c:
+        denied = await c.delete(f"/api/v1/skills/{foreign}")
+        assert denied.status_code == 403, denied.text
+        ok = await c.delete(f"/api/v1/skills/{own}")
+        assert ok.status_code == 204, ok.text
+
+
+# ---------------------------------------------------------------------------
+# mcp.configure: member denied, admin allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_create_mcp_server_admin_can() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    admin_id = await _user(tid, "admin")
+    payload = {
+        "name": f"mcp-{uuid.uuid4().hex[:6]}",
+        "type": "http",
+        "url": "https://example.com/mcp",
+        "auth_mode": "service",
+    }
+
+    member_app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(member_app) as c:
+        denied = await c.post("/api/v1/mcp-servers", json=payload)
+    assert denied.status_code == 403, denied.text
+
+    admin_app = _build_app(_authed(tid, admin_id, "admin"))
+    async with _client(admin_app) as c:
+        ok = await c.post("/api/v1/mcp-servers", json=payload)
+    assert ok.status_code == 201, ok.text
+
+
+# ---------------------------------------------------------------------------
+# approval_policy.manage: member denied, admin allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_write_approval_policy_admin_can() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    admin_id = await _user(tid, "admin")
+    payload = {
+        "mcp_server_name": "srv",
+        "tool_name": "do_thing",
+        "condition_expr": {"always": True},
+        "enabled": True,
+        "priority": 10,
+    }
+
+    member_app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(member_app) as c:
+        denied = await c.post("/api/v1/approval-policies", json=payload)
+    assert denied.status_code == 403, denied.text
+
+    admin_app = _build_app(_authed(tid, admin_id, "admin"))
+    async with _client(admin_app) as c:
+        ok = await c.post("/api/v1/approval-policies", json=payload)
+    assert ok.status_code == 201, ok.text
+
+
+# ---------------------------------------------------------------------------
+# credential.byok.manage: owner-only — admin AND member denied, owner allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_owner_can_put_credential() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    admin_id = await _user(tid, "admin")
+    owner_id = await _user(tid, "owner")
+    body = {"api_key": "sk-test"}
+
+    for uid, role in ((member_id, "member"), (admin_id, "admin")):
+        app = _build_app(_authed(tid, uid, role))
+        async with _client(app) as c:
+            denied = await c.put("/api/v1/tenant/credentials/anthropic", json=body)
+        assert denied.status_code == 403, f"{role}: {denied.text}"
+
+    # Owner is the boundary role: the PUT must pass the gate AND succeed.
+    # Install a vault so the encrypt step doesn't 500 (the gate, not the
+    # vault, is under test — but a clean 200 is the strongest signal).
+    set_credential_vault(CredentialVault(derive_fernet_key("test-gate-key")))
+    try:
+        owner_app = _build_app(_authed(tid, owner_id, "owner"))
+        async with _client(owner_app) as c:
+            resp = await c.put("/api/v1/tenant/credentials/anthropic", json=body)
+        assert resp.status_code == 200, resp.text
+    finally:
+        set_credential_vault(None)
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_list_credentials_owner_can() -> None:
+    tid = await _tenant()
+    admin_id = await _user(tid, "admin")
+    owner_id = await _user(tid, "owner")
+
+    admin_app = _build_app(_authed(tid, admin_id, "admin"))
+    async with _client(admin_app) as c:
+        denied = await c.get("/api/v1/tenant/credentials")
+    assert denied.status_code == 403, denied.text
+
+    owner_app = _build_app(_authed(tid, owner_id, "owner"))
+    async with _client(owner_app) as c:
+        ok = await c.get("/api/v1/tenant/credentials")
+    assert ok.status_code == 200, ok.text
+
+
+# ---------------------------------------------------------------------------
+# safety.read: member denied, admin allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_read_safety_rules_admin_can() -> None:
+    tid = await _tenant()
+    member_id = await _user(tid, "member")
+    admin_id = await _user(tid, "admin")
+
+    member_app = _build_app(_authed(tid, member_id, "member"))
+    async with _client(member_app) as c:
+        denied = await c.get("/api/v1/safety/rules")
+    assert denied.status_code == 403, denied.text
+
+    admin_app = _build_app(_authed(tid, admin_id, "admin"))
+    async with _client(admin_app) as c:
+        ok = await c.get("/api/v1/safety/rules")
+    assert ok.status_code == 200, ok.text
+
+
+# ---------------------------------------------------------------------------
+# platform_admin is the superset: passes every gate above
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_admin_passes_owner_only_credential_gate() -> None:
+    tid = await _tenant()
+    pa_id = await _user(tid, "platform_admin")
+    app = _build_app(_authed(tid, pa_id, "platform_admin"))
+    async with _client(app) as c:
+        ok = await c.get("/api/v1/tenant/credentials")
+    assert ok.status_code == 200, ok.text

--- a/tests/webui/test_v1_visibility.py
+++ b/tests/webui/test_v1_visibility.py
@@ -1,0 +1,440 @@
+"""Visibility (private/shared) enforcement on the /api/v1 surface.
+
+feat/roles PR3. These tests assert the AUTHORIZATION SPEC, not handler
+internals, and are deliberately adversarial: the valuable case is the
+negative one — a member must NOT see/use another member's private
+resource, on the LIST, FETCH, USE (conversation-create), and skill-bind
+paths. Owner/admin see everything. Sharing flips the boundary.
+
+Auth is injected by overriding ``get_current_user`` with a fixed role
+(the same dependency ``require_action`` resolves through), so the role
+under test is exactly the one the gates see.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.core.types import SkillFile as SkillFileDataclass
+from rolemesh.db import (
+    create_coworker,
+    create_skill,
+    create_tenant,
+    create_user,
+    get_coworker,
+    get_skill,
+)
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import get_current_user
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+def _authed(tenant_id: str, user_id: str, role: str) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id, tenant_id=tenant_id, role=role,
+        email="x@x.com", name="X",
+    )
+
+
+async def _tenant() -> str:
+    t = await create_tenant(name="T", slug=f"vis-{uuid.uuid4().hex[:8]}")
+    return t.id
+
+
+async def _user(tenant_id: str, role: str) -> str:
+    u = await create_user(
+        tenant_id=tenant_id, name="U",
+        email=f"u-{uuid.uuid4().hex[:8]}@x.com", role=role,
+    )
+    return u.id
+
+
+async def _seed_coworker(
+    tenant_id: str, *, created_by: str | None, visibility: str,
+) -> str:
+    cw = await create_coworker(
+        tenant_id=tenant_id, name=f"CW {uuid.uuid4().hex[:6]}",
+        folder=f"cw-{uuid.uuid4().hex[:8]}",
+        created_by_user_id=created_by,
+        visibility=visibility,
+    )
+    return cw.id
+
+
+async def _seed_skill(
+    tenant_id: str, *, created_by: str | None, visibility: str,
+) -> str:
+    skill = await create_skill(
+        tenant_id=tenant_id,
+        name=f"skill-{uuid.uuid4().hex[:6]}",
+        frontmatter_common={"description": "x" * 40},
+        frontmatter_backend={},
+        files={"SKILL.md": SkillFileDataclass(path="SKILL.md", content="body")},
+        enabled=True,
+        created_by_user_id=created_by,
+        visibility=visibility,
+    )
+    return skill.id
+
+
+# ---------------------------------------------------------------------------
+# Default-on-create: a new coworker / skill is PRIVATE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_created_coworker_defaults_private_and_hidden_from_others() -> None:
+    """A coworker created via v1 defaults to private and is invisible to
+    another member until shared. Guards against a 'shared'-by-default
+    regression (which would leak every draft tenant-wide)."""
+    tid = await _tenant()
+    creator = await _user(tid, "member")
+    other = await _user(tid, "member")
+
+    app = _build_app(_authed(tid, creator, "member"))
+    async with _client(app) as c:
+        resp = await c.post(
+            "/api/v1/coworkers",
+            json={
+                "name": "Draft",
+                "folder": f"f-{uuid.uuid4().hex[:8]}",
+                "agent_backend": "claude",
+            },
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["visibility"] == "private", body
+    cw_id = body["id"]
+
+    # Another member can neither list nor fetch it.
+    other_app = _build_app(_authed(tid, other, "member"))
+    async with _client(other_app) as c:
+        listed = await c.get("/api/v1/coworkers")
+        assert cw_id not in {r["id"] for r in listed.json()}
+        fetched = await c.get(f"/api/v1/coworkers/{cw_id}")
+        assert fetched.status_code == 404, fetched.text
+
+
+@pytest.mark.asyncio
+async def test_created_skill_defaults_private() -> None:
+    tid = await _tenant()
+    creator = await _user(tid, "member")
+    name = f"sk-{uuid.uuid4().hex[:6]}"
+    manifest = f"---\nname: {name}\ndescription: " + "y" * 40 + "\n---\nbody"
+    app = _build_app(_authed(tid, creator, "member"))
+    async with _client(app) as c:
+        resp = await c.post(
+            "/api/v1/skills",
+            json={"name": name, "files": {"SKILL.md": manifest}},
+        )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["visibility"] == "private", resp.text
+
+
+# ---------------------------------------------------------------------------
+# LIST predicate: member sees shared + own private, NOT others' private.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_list_coworkers_scopes_to_visible() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+
+    my_private = await _seed_coworker(tid, created_by=me, visibility="private")
+    shared = await _seed_coworker(tid, created_by=other, visibility="shared")
+    others_private = await _seed_coworker(
+        tid, created_by=other, visibility="private"
+    )
+    orphan_private = await _seed_coworker(
+        tid, created_by=None, visibility="private"
+    )
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        resp = await c.get("/api/v1/coworkers")
+    ids = {r["id"] for r in resp.json()}
+    assert my_private in ids
+    assert shared in ids
+    assert others_private not in ids
+    # NULL three-valued logic: an un-attributed private row is NOT "mine".
+    assert orphan_private not in ids
+
+
+@pytest.mark.asyncio
+async def test_admin_list_coworkers_sees_everything() -> None:
+    tid = await _tenant()
+    member = await _user(tid, "member")
+    admin = await _user(tid, "admin")
+    a = await _seed_coworker(tid, created_by=member, visibility="private")
+    b = await _seed_coworker(tid, created_by=None, visibility="private")
+
+    app = _build_app(_authed(tid, admin, "admin"))
+    async with _client(app) as c:
+        resp = await c.get("/api/v1/coworkers")
+    ids = {r["id"] for r in resp.json()}
+    assert {a, b} <= ids
+
+
+@pytest.mark.asyncio
+async def test_member_list_skills_scopes_to_visible() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    mine = await _seed_skill(tid, created_by=me, visibility="private")
+    shared = await _seed_skill(tid, created_by=other, visibility="shared")
+    foreign = await _seed_skill(tid, created_by=other, visibility="private")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        resp = await c.get("/api/v1/skills")
+    ids = {r["id"] for r in resp.json()}
+    assert mine in ids
+    assert shared in ids
+    assert foreign not in ids
+
+
+# ---------------------------------------------------------------------------
+# FETCH: member 404s on another member's private resource (existence hidden).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_fetch_foreign_private_coworker_404() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    foreign = await _seed_coworker(tid, created_by=other, visibility="private")
+    shared = await _seed_coworker(tid, created_by=other, visibility="shared")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        assert (await c.get(f"/api/v1/coworkers/{foreign}")).status_code == 404
+        assert (await c.get(f"/api/v1/coworkers/{shared}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_member_fetch_orphan_private_coworker_404_admin_200() -> None:
+    """NULL three-valued logic on the FETCH path: a coworker with
+    created_by_user_id IS NULL + private is invisible to a member (404)
+    but visible to an admin (200). No error is raised either way."""
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    admin = await _user(tid, "admin")
+    orphan = await _seed_coworker(tid, created_by=None, visibility="private")
+
+    member_app = _build_app(_authed(tid, me, "member"))
+    async with _client(member_app) as c:
+        assert (await c.get(f"/api/v1/coworkers/{orphan}")).status_code == 404
+
+    admin_app = _build_app(_authed(tid, admin, "admin"))
+    async with _client(admin_app) as c:
+        assert (await c.get(f"/api/v1/coworkers/{orphan}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_member_fetch_foreign_private_skill_404() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    foreign = await _seed_skill(tid, created_by=other, visibility="private")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        assert (await c.get(f"/api/v1/skills/{foreign}")).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# USE path (the feed-forward gap): conversation-create against a private
+# coworker the member doesn't own must 404 — not silently succeed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_open_conversation_on_foreign_private_coworker() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    foreign = await _seed_coworker(tid, created_by=other, visibility="private")
+    shared = await _seed_coworker(tid, created_by=other, visibility="shared")
+    mine = await _seed_coworker(tid, created_by=me, visibility="private")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        blocked = await c.post(
+            f"/api/v1/coworkers/{foreign}/conversations", json={"name": "x"}
+        )
+        assert blocked.status_code == 404, blocked.text
+        # A shared coworker and the member's own private one are usable.
+        ok_shared = await c.post(
+            f"/api/v1/coworkers/{shared}/conversations", json={"name": "x"}
+        )
+        assert ok_shared.status_code == 201, ok_shared.text
+        ok_own = await c.post(
+            f"/api/v1/coworkers/{mine}/conversations", json={"name": "x"}
+        )
+        assert ok_own.status_code == 201, ok_own.text
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_list_conversations_on_foreign_private_coworker() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    foreign = await _seed_coworker(tid, created_by=other, visibility="private")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        resp = await c.get(f"/api/v1/coworkers/{foreign}/conversations")
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Skill-bind path: member may only attach a skill they can see.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_bind_foreign_private_skill() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    my_cw = await _seed_coworker(tid, created_by=me, visibility="private")
+    foreign_skill = await _seed_skill(
+        tid, created_by=other, visibility="private"
+    )
+    shared_skill = await _seed_skill(
+        tid, created_by=other, visibility="shared"
+    )
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        blocked = await c.post(
+            f"/api/v1/coworkers/{my_cw}/skills/{foreign_skill}"
+        )
+        assert blocked.status_code == 404, blocked.text
+        ok = await c.post(f"/api/v1/coworkers/{my_cw}/skills/{shared_skill}")
+        assert ok.status_code == 201, ok.text
+
+
+# ---------------------------------------------------------------------------
+# Share / unshare: own-or-manage gate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_can_share_own_coworker_then_others_see_it() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    cw = await _seed_coworker(tid, created_by=me, visibility="private")
+
+    me_app = _build_app(_authed(tid, me, "member"))
+    async with _client(me_app) as c:
+        shared = await c.post(f"/api/v1/coworkers/{cw}/share")
+        assert shared.status_code == 200, shared.text
+        assert shared.json()["visibility"] == "shared"
+
+    # Now visible + usable to another member.
+    other_app = _build_app(_authed(tid, other, "member"))
+    async with _client(other_app) as c:
+        assert (await c.get(f"/api/v1/coworkers/{cw}")).status_code == 200
+        conv = await c.post(
+            f"/api/v1/coworkers/{cw}/conversations", json={"name": "x"}
+        )
+        assert conv.status_code == 201, conv.text
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_share_foreign_coworker() -> None:
+    """A member sharing someone ELSE's private coworker is a MANAGE
+    attempt → 403 from the ownership gate (not 404), matching PATCH/DELETE."""
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    foreign = await _seed_coworker(tid, created_by=other, visibility="private")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        resp = await c.post(f"/api/v1/coworkers/{foreign}/share")
+    assert resp.status_code == 403, resp.text
+    # And the DB row is unchanged.
+    row = await get_coworker(foreign, tenant_id=tid)
+    assert row is not None and row.visibility == "private"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_share_any_coworker() -> None:
+    tid = await _tenant()
+    member = await _user(tid, "member")
+    admin = await _user(tid, "admin")
+    cw = await _seed_coworker(tid, created_by=member, visibility="private")
+
+    app = _build_app(_authed(tid, admin, "admin"))
+    async with _client(app) as c:
+        resp = await c.post(f"/api/v1/coworkers/{cw}/share")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["visibility"] == "shared"
+
+
+@pytest.mark.asyncio
+async def test_unshare_makes_coworker_private_again() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    cw = await _seed_coworker(tid, created_by=me, visibility="shared")
+
+    me_app = _build_app(_authed(tid, me, "member"))
+    async with _client(me_app) as c:
+        resp = await c.post(f"/api/v1/coworkers/{cw}/unshare")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["visibility"] == "private"
+
+    other_app = _build_app(_authed(tid, other, "member"))
+    async with _client(other_app) as c:
+        assert (await c.get(f"/api/v1/coworkers/{cw}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_member_can_share_own_skill_member_cannot_share_foreign() -> None:
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    mine = await _seed_skill(tid, created_by=me, visibility="private")
+    foreign = await _seed_skill(tid, created_by=other, visibility="private")
+
+    app = _build_app(_authed(tid, me, "member"))
+    async with _client(app) as c:
+        ok = await c.post(f"/api/v1/skills/{mine}/share")
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["visibility"] == "shared"
+        denied = await c.post(f"/api/v1/skills/{foreign}/share")
+        assert denied.status_code == 403, denied.text
+    row = await get_skill(foreign, tenant_id=tid)
+    assert row is not None and row.visibility == "private"

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -197,6 +197,53 @@ export interface paths {
         patch: operations["updateCoworker"];
         trace?: never;
     };
+    "/api/v1/coworkers/{id}/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Make a coworker shared (tenant-wide)
+         * @description Self-serve visibility flip to `shared` (feat/roles). A member
+         *     may share a coworker they created; owner/admin/platform_admin
+         *     may share any. Idempotent. Returns the updated coworker.
+         */
+        post: operations["shareCoworker"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/coworkers/{id}/unshare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Make a coworker private again (creator + managers only)
+         * @description Visibility flip back to `private` (feat/roles). Same own-or-manage
+         *     gate as share. Returns the updated coworker.
+         */
+        post: operations["unshareCoworker"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/coworkers/{id}/conversations": {
         parameters: {
             query?: never;
@@ -492,6 +539,53 @@ export interface paths {
          *     coworker currently bound to this skill.
          */
         patch: operations["updateSkill"];
+        trace?: never;
+    };
+    "/api/v1/skills/{id}/share": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Make a skill shared (tenant-wide)
+         * @description Self-serve visibility flip to `shared` (feat/roles). A member
+         *     may share a skill they created; owner/admin/platform_admin may
+         *     share any. Idempotent. Returns the updated skill.
+         */
+        post: operations["shareSkill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/skills/{id}/unshare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Make a skill private again (creator + managers only)
+         * @description Visibility flip back to `private` (feat/roles). Same
+         *     own-or-manage gate as share. Returns the updated skill.
+         */
+        post: operations["unshareSkill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/v1/skills/{id}/files": {
@@ -1135,6 +1229,15 @@ export interface components {
         };
         /** @enum {string} */
         CoworkerStatus: "active" | "paused" | "disabled";
+        /**
+         * @description Per-resource visibility (feat/roles). `private` — visible only
+         *     to the creator and role-managers (owner/admin/platform_admin);
+         *     `shared` — visible to and usable by every member of the tenant.
+         *     New resources default to `private`; legacy rows were backfilled
+         *     to `shared`.
+         * @enum {string}
+         */
+        Visibility: "private" | "shared";
         Coworker: {
             /** Format: uuid */
             id: string;
@@ -1150,6 +1253,7 @@ export interface components {
             max_concurrent: number;
             /** Format: uuid */
             created_by_user_id?: string | null;
+            visibility: components["schemas"]["Visibility"];
             /** Format: date-time */
             created_at: string;
         };
@@ -1498,6 +1602,7 @@ export interface components {
             updated_at: string;
             /** Format: uuid */
             created_by_user_id?: string | null;
+            visibility: components["schemas"]["Visibility"];
         };
         /**
          * @description List-view projection — drops the file map and frontmatter.
@@ -1517,6 +1622,7 @@ export interface components {
              *     can spot orphaned vs heavily-shared skills.
              */
             bound_coworker_count: number;
+            visibility: components["schemas"]["Visibility"];
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -2458,6 +2564,56 @@ export interface operations {
             422: components["responses"]["Unprocessable"];
         };
     };
+    shareCoworker: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Coworker"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    unshareCoworker: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Coworker"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
     listCoworkerConversations: {
         parameters: {
             query?: never;
@@ -2980,6 +3136,56 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    shareSkill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Skill"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    unshareSkill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Skill"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
         };
     };


### PR DESCRIPTION
## Summary

Replaces the old per-user coworker-assignment mechanism with a proper visibility-based access control model. Every `/api/v1` endpoint is now behind a default-deny gate, coworkers and skills carry a `visibility` field (`private`/`shared`), and the `user_agent_assignments` table is deleted.

| Commit | Change |
|---|---|
| `2d893d3` | Wire `platform_admin` role into role model + sentinel tenant |
| `c2f4b1a` | Gate every `/api/v1` endpoint with default-deny; meta-test asserts full coverage |
| `e7f0f20` | DB: add `visibility` (`private`/`shared`) to coworkers and skills; backfill existing rows as `shared` |
| `3046610` | Enforce visibility on list / fetch / use / share / skill-bind via single `user_can_see_resource` helper |
| `2c7554e` | Add `Visibility` schema + share/unshare routes to `contracts/openapi.yaml`; regen `types.ts` |
| `4d78dde` | Adversarial tests: backfill ordering, NULL three-valued logic, list scoping, use-path, skill-bind, share/unshare |
| `20be3d2` | Delete `user_agent_assignments` table, CRUD, OIDC auto-assign; access is visibility-only now |
| `dedf6bc` | Drop assignment admin endpoints + `assigned_agents` field from `UserDetailResponse` |
| `c438c2a` | Regression test: member without assignment row can access shared coworker, cannot access foreign private |

## Access model

```
member → shared coworker       ✓  (visible to all members)
member → own private coworker  ✓  (created_by_user_id = self)
member → foreign private       ✗  404
admin  → any coworker          ✓  (bypass visibility)
```

Same rules apply to skills. Share/unshare routes let owners promote a private resource to shared.

## Stats

- **9 commits**, backend + contracts (no UI changes needed — frontend already uses the new routes)
- **2505 Python tests passing**, 28 skipped
- **440 frontend tests passing**
- **35 files changed**, ~2,700 net lines (majority tests)

## Test plan

- [x] `tests/webui/test_v1_default_deny.py` — every `/api/v1` path gated; default-deny meta-test
- [x] `tests/webui/test_v1_role_gates_403.py` — member vs admin role separation on admin-privileged paths
- [x] `tests/webui/test_v1_visibility.py` — list scoping, fetch 404, use-path, skill-bind, share/unshare
- [x] `tests/db/test_visibility_backfill.py` — backfill ordering, NULL three-valued logic, CHECK constraint
- [x] `tests/webui/test_assignment_removal_regression.py` — proves assignment table is gone and access still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)