### PR TITLE
API cleanup v2: remove dead legacy endpoints, refresh OpenAPI hygiene, de-Chinese comments

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -3,10 +3,11 @@ info:
   title: RoleMesh API
   version: 1.1.0
   description: |
-    REST contract for the `/api/v1/*` surface introduced by the
-    webui-backend v1.1 design. Only `/api/v1/backends` is implemented
-    in Phase 0; the rest are listed as forward contracts so frontend
-    work can compile against typed types from day one.
+    REST contract for the `/api/v1/*` surface (webui-backend v1.1
+    design). This YAML is the hand-maintained source of truth; the
+    typed client `web/src/api/generated/types.ts` is generated from it
+    (`npm run openapi:gen`) and CI guards both directions against drift
+    (`test_openapi_codegen_freshness`, `test_openapi_contract`).
 
     The companion WebSocket endpoint `/api/v1/conversations/{id}/stream`
     is documented in design §4 (event-driven JSON protocol); OpenAPI 3
@@ -32,6 +33,10 @@ tags:
   - name: ApprovalPolicies
   - name: Users
   - name: Tenant
+  - name: Safety
+  - name: Schedules
+  - name: Admin
+  - name: Platform
 
 paths:
   # ===================================================================
@@ -318,7 +323,7 @@ paths:
       summary: Delete a coworker (cascades conversations / runs / messages)
       description: |
         Cascading delete — conversations, runs and messages owned by
-        this coworker are removed. Design §3 "DELETE 语义" table.
+        this coworker are removed. Design §3 "DELETE semantics" table.
       security: [ { bearerAuth: [] } ]
       responses:
         '204':
@@ -442,7 +447,7 @@ paths:
       operationId: deleteConversation
       summary: Delete a conversation (cascades messages and runs)
       description: |
-        Cascading delete — design §3 "DELETE 语义" treats
+        Cascading delete — design §3 "DELETE semantics" treats
         conversations as owned children of coworkers.
       security: [ { bearerAuth: [] } ]
       responses:
@@ -1427,7 +1432,7 @@ paths:
       description: |
         Clients reconnecting to a stream first GET the run snapshot
         to decide whether the run is already terminal — design §4
-        "重连" flow.
+        "reconnect" flow.
       security: [ { bearerAuth: [] } ]
       responses:
         '200':

--- a/src/rolemesh/channels/admission.py
+++ b/src/rolemesh/channels/admission.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
-# v6.1 §P1.5 "引导文本统一一处" — every Telegram wire string the
+# v6.1 §P1.5 "onboarding text in one place" — every Telegram wire string the
 # user can see during the link / admission flow lives here, even
 # the ones whose physical reply happens inside
 # ``telegram_gateway._handle_start_command``. The two modules then

--- a/src/rolemesh/channels/telegram_gateway.py
+++ b/src/rolemesh/channels/telegram_gateway.py
@@ -89,7 +89,7 @@ async def _short_circuit_group(update: Update) -> bool:
 
 # v6.1 §P1.4 link guidance — wire strings live in
 # ``rolemesh.channels.admission`` so admission + link flows share a
-# single source of truth (see F2 / "引导文本统一一处").
+# single source of truth (see F2 / "onboarding text in one place").
 
 
 async def _handle_start_command(

--- a/src/rolemesh/db/channel_identity.py
+++ b/src/rolemesh/db/channel_identity.py
@@ -228,7 +228,7 @@ async def delete_channel_identity(
 ) -> bool:
     """Unbind one identity row; returns True iff a row was deleted.
 
-    v6.1 §P1.4 contract (边界 table, row 3): same-transaction NULL of
+    v6.1 §P1.4 contract (boundary table, row 3): same-transaction NULL of
     ``conv.user_id`` on every 1:1 conversation the deleted identity
     was the sole authorising binding for. Without that, a different
     RoleMesh user who later re-links the same channel (the

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -923,7 +923,7 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
             )
         """)
         # ``conversation_id`` FK uses ON DELETE CASCADE so a DELETE
-        # on conversations (design §3 "DELETE 语义") propagates to the
+        # on conversations (design §3 "DELETE semantics") propagates to the
         # message log. Without the cascade a v1 DELETE on a busy
         # conversation would 500 on a FK violation — the schema, not
         # the handler, is the right place to enforce the policy.

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -635,7 +635,7 @@ async def _auto_create_telegram_1on1_conversation(
     for an *already admitted* sender.
 
     Counterpart of ``_auto_create_web_conversation``: the design's
-    "已关联→建 conv" implicit case. ``admission_user_id`` is the
+    "already-linked -> create conv" implicit case. ``admission_user_id`` is the
     resolved RoleMesh user_id from ``admit_telegram_1on1`` — passed
     in so the row lands with ``user_id`` populated on first write
     instead of needing the lazy-backfill UPDATE later.

--- a/src/rolemesh/runs/lifecycle.py
+++ b/src/rolemesh/runs/lifecycle.py
@@ -15,7 +15,7 @@ Two operations:
   application-level promise.
 
 A separate :func:`get_run` exists so 01b's reconnect path (design
-§4 "重连") doesn't have to construct ad-hoc SELECTs.
+§4 "reconnect") doesn't have to construct ad-hoc SELECTs.
 
 Why ``conn`` is parameter-injected rather than acquired per-call:
 ``create_run`` is the first step in a transaction that also writes

--- a/src/webui/main.py
+++ b/src/webui/main.py
@@ -13,14 +13,12 @@ from __future__ import annotations
 import rolemesh.bootstrap  # noqa: F401
 
 import os
-import re
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import asyncpg
 import nats
-from fastapi import FastAPI, Query
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -30,10 +28,7 @@ from rolemesh.auth.bootstrap_users import init_bootstrap_users
 from rolemesh.db import (
     _get_pool,
     close_database,
-    get_channel_binding_for_coworker,
-    get_coworker,
     init_database,
-    tenant_conn,
 )
 from webui import auth
 from webui.config import (
@@ -201,105 +196,6 @@ if CORS_ORIGINS:
 @app.get("/api/health")
 async def health() -> JSONResponse:
     return JSONResponse({"status": "ok"})
-
-
-async def _resolve_web_agent(agent_id: str, token: str) -> tuple[str, str] | JSONResponse:
-    """Authenticate and resolve the web binding for an agent.
-
-    Returns (binding_id, tenant_id) on success, or a JSONResponse error.
-    """
-    if not agent_id or not token:
-        return JSONResponse({"error": "Unauthorized"}, status_code=401)
-    user = await auth.authenticate_ws(token)
-    if user is None:
-        return JSONResponse({"error": "Unauthorized"}, status_code=401)
-    try:
-        coworker = await get_coworker(agent_id, tenant_id=user.tenant_id)
-    except asyncpg.DataError:
-        coworker = None
-    if coworker is None:
-        return JSONResponse({"error": "Agent not found"}, status_code=404)
-    binding = await get_channel_binding_for_coworker(agent_id, "web", tenant_id=user.tenant_id)
-    if binding is None:
-        return JSONResponse({"error": "Web binding not found"}, status_code=404)
-    return binding.id, user.tenant_id
-
-
-@app.get("/api/conversations")
-async def list_conversations(
-    agent_id: str = Query(""),
-    token: str = Query(""),
-) -> JSONResponse:
-    """Return conversation list for a web binding."""
-    result_or_error = await _resolve_web_agent(agent_id, token)
-    if isinstance(result_or_error, JSONResponse):
-        return result_or_error
-    binding_id, tenant_id = result_or_error
-
-    async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            """
-            SELECT c.channel_chat_id as chat_id,
-                   (SELECT content FROM messages m
-                    WHERE m.conversation_id = c.id AND m.is_from_me = FALSE
-                    ORDER BY m.timestamp LIMIT 1) as first_msg,
-                   (SELECT MAX(m.timestamp) FROM messages m
-                    WHERE m.conversation_id = c.id) as updated_at
-            FROM conversations c
-            WHERE c.channel_binding_id = $1::uuid
-              AND EXISTS (SELECT 1 FROM messages m WHERE m.conversation_id = c.id)
-            ORDER BY updated_at DESC NULLS LAST
-            """,
-            binding_id,
-        )
-
-    result = []
-    for row in rows:
-        first_msg = row["first_msg"] or ""
-        title = first_msg[:30] + ("..." if len(first_msg) > 30 else "") if first_msg else "New conversation"
-        updated_at = row["updated_at"].isoformat() if row["updated_at"] else ""
-        result.append({"chatId": row["chat_id"], "title": title, "updatedAt": updated_at})
-
-    return JSONResponse(result)
-
-
-@app.get("/api/conversations/{chat_id}/messages")
-async def get_messages(
-    chat_id: str,
-    agent_id: str = Query(""),
-    token: str = Query(""),
-) -> JSONResponse:
-    """Return message history for a conversation."""
-    result_or_error = await _resolve_web_agent(agent_id, token)
-    if isinstance(result_or_error, JSONResponse):
-        return result_or_error
-    binding_id, tenant_id = result_or_error
-
-    async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            """
-            SELECT m.content, m.timestamp, m.is_from_me, m.is_bot_message
-            FROM messages m
-            JOIN conversations c ON c.id = m.conversation_id
-            WHERE c.channel_binding_id = $1::uuid
-              AND c.channel_chat_id = $2
-            ORDER BY m.timestamp
-            """,
-            binding_id,
-            chat_id,
-        )
-
-    result = []
-    for row in rows:
-        role = "assistant" if row["is_from_me"] or row["is_bot_message"] else "user"
-        content = row["content"] or ""
-        # Strip internal tags from assistant messages
-        if role == "assistant":
-            content = re.sub(r"<internal>[\s\S]*?</internal>", "", content).strip()
-        ts = row["timestamp"].isoformat() if row["timestamp"] else ""
-        result.append({"role": role, "content": content, "timestamp": ts})
-
-    return JSONResponse(result)
 
 
 # v1 router: new prefixed surface introduced by webui-backend v1.1.

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -779,7 +779,7 @@ class Run(BaseModel):
     Matches the lifecycle helper's snapshot shape (id /
     conversation_id / status / started_at / completed_at / usage /
     error). The SPA's reconnect path calls ``GET /api/v1/runs/{id}``
-    to decide whether to re-subscribe — see design §4 "重连".
+    to decide whether to re-subscribe — see design §4 "reconnect".
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -188,7 +188,7 @@ async def delete_conversation_endpoint(
 ) -> Response:
     """Delete a conversation; FK ON DELETE CASCADE removes messages and runs.
 
-    Per design §3 "DELETE 语义" table, conversations are owned by
+    Per design §3 "DELETE semantics" table, conversations are owned by
     coworkers and their children (messages, runs) cascade. The
     pre-check 404 keeps the response idempotent — a second DELETE
     of the same id surfaces as 404 rather than 204, which matches

--- a/src/webui/v1/coworkers.py
+++ b/src/webui/v1/coworkers.py
@@ -361,7 +361,7 @@ async def delete_coworker_endpoint(
 ) -> Response:
     """Delete a coworker. DB FK ON DELETE CASCADE handles dependents.
 
-    Per design §3 "DELETE 语义" table, a coworker DELETE cascades to
+    Per design §3 "DELETE semantics" table, a coworker DELETE cascades to
     conversations / runs / messages. No 409 path on this endpoint —
     the design treats coworkers as roots of their own subtree.
 

--- a/src/webui/v1/idempotency.py
+++ b/src/webui/v1/idempotency.py
@@ -18,7 +18,7 @@ Design intent (01b Open Question 3, locked):
   short-circuit publish-throttling.
 
 Why in-memory and not a KV / DB row: the design pin says
-"in-memory dict or KV-cache, not落 DB". The window is short
+"in-memory dict or KV-cache, not persisted to DB". The window is short
 enough that a webui restart simply loses dedup for a minute, which
 is acceptable: a redelivered ``request.run`` after a restart would
 re-INSERT and re-publish, and the second run's INSERT either

--- a/src/webui/v1/runs.py
+++ b/src/webui/v1/runs.py
@@ -1,7 +1,7 @@
 """``/api/v1/runs/{id}`` and ``/api/v1/runs/{id}/cancel``.
 
 GET surfaces the lifecycle helper's snapshot — used by the SPA's
-reconnect path (design §4 "重连"). POST cancel is fire-and-forget:
+reconnect path (design §4 "reconnect"). POST cancel is fire-and-forget:
 it publishes a JetStream event for the orchestrator and returns
 202 immediately. The orchestrator stops the agent container and
 the lifecycle helper writes ``status='cancelled'`` once the

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -180,7 +180,7 @@ export interface paths {
         /**
          * Delete a coworker (cascades conversations / runs / messages)
          * @description Cascading delete — conversations, runs and messages owned by
-         *     this coworker are removed. Design §3 "DELETE 语义" table.
+         *     this coworker are removed. Design §3 "DELETE semantics" table.
          */
         delete: operations["deleteCoworker"];
         options?: never;
@@ -276,7 +276,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a conversation (cascades messages and runs)
-         * @description Cascading delete — design §3 "DELETE 语义" treats
+         * @description Cascading delete — design §3 "DELETE semantics" treats
          *     conversations as owned children of coworkers.
          */
         delete: operations["deleteConversation"];
@@ -920,7 +920,7 @@ export interface paths {
          * Fetch authoritative run state (used by WS reconnect)
          * @description Clients reconnecting to a stream first GET the run snapshot
          *     to decide whether the run is already terminal — design §4
-         *     "重连" flow.
+         *     "reconnect" flow.
          */
         get: operations["getRun"];
         put?: never;

--- a/web/src/components/mcp-servers-page.ts
+++ b/web/src/components/mcp-servers-page.ts
@@ -4,7 +4,7 @@
 // editor stay out for now — design §6.3 D names the affordances
 // but the form here is intentionally narrow to keep the diff
 // reviewable. ``auth_mode=user`` shows a "requires user session"
-// hint per design ("e2e 验收 pending — OIDC 分支合入后启用").
+// hint per design ("e2e acceptance pending — enable after the OIDC branch lands").
 
 import { LitElement, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';

--- a/web/src/ws/v1_client.ts
+++ b/web/src/ws/v1_client.ts
@@ -17,7 +17,7 @@
 // adding a new event type requires editing the yaml first; the
 // freshness drift test catches forgetting to regenerate.
 //
-// Reconnect contract (design §4 "重连" flow + 01b Open Question 1):
+// Reconnect contract (design §4 "reconnect" flow + 01b Open Question 1):
 // every reconnect first does `GET /api/v1/runs/{id}` to learn the
 // authoritative status. If `completed/failed/cancelled/awaiting_reauth`
 // we skip the reconnect entirely so the UI doesn't subscribe to a


### PR DESCRIPTION
## Summary

Follow-up to the `/api/admin` → `/api/v1` migration (#62). This is the **safe set** from the API-cleanup review — no breaking changes to the live `/api/v1` contract. (The pagination work — adding bounds to unbounded list endpoints — is a deliberate breaking change and will come as a separate, coordinated proposal.)

## Changes

**1. Remove dead legacy `/api/conversations*` endpoints** (`c598880`)
`GET /api/conversations` and `GET /api/conversations/{chat_id}/messages` were the pre-v1 web-chat read API (query-token auth, `chat_id`-based, non-v1 `{"error": ...}` shape). They have **zero consumers** in the repo — the SPA reads conversations via the Bearer-authed `/api/v1/conversations/*` surface. Removed both handlers, the now-unused `_resolve_web_agent` helper, and the imports they exclusively used (`re`, `asyncpg`, `Query`, `get_coworker`, `get_channel_binding_for_coworker`, `tenant_conn`).
`GET /api/health` stays — it's an intentionally unversioned liveness probe. After this, the only non-`/api/v1` route is `/api/health`.

**2. OpenAPI contract hygiene** (`d8733b4`)
- `info.description` claimed *"only `/api/v1/backends` is implemented in Phase 0; the rest are forward contracts"* — long obsolete (the whole surface is live). Replaced with an accurate note that the YAML is the hand-maintained source of truth guarded by the codegen/contract tests.
- Declared the tags used by operations but missing from the top-level `tags:` list (`Safety`, `Schedules`, `Admin`, `Platform`) so Swagger UI groups them.
- Regenerated `types.ts` (no structural change).

**3. Translate remaining non-English comments** (`04a327b`)
Translated all pre-existing Chinese fragments in code comments/docstrings (design-doc section names like "reconnect", "DELETE semantics", "onboarding text in one place", "boundary") to English across 11 files. Comment/docstring only — no behavior, wire-shape, or generated-client change. The repo is now zero non-English text in `src/` and `web/src/`.

## Notes on the review points NOT in this PR

- **A (pagination)** — highest priority but a breaking contract change; deferred to its own proposal (shape decision + SPA/contract coordination).
- **B's "auto-export OpenAPI from FastAPI"** — declined: it fights the deliberate, test-guarded design-first model. The actual drift it cited (stale description + missing tags) is fixed here.
- **D/E (resource modeling, idempotency)** — design opinions / medium-priority hardening; documented for later, not built here.

## Verification (local, no Docker)
- `ruff` + `mypy` clean on touched files.
- App imports; only non-v1 `/api/*` route is `/api/health`; no references to the removed endpoints anywhere.
- OpenAPI gates green: `test_openapi_codegen_freshness`, `test_openapi_contract` (36 passed). `types.ts` and `openapi.yaml` are CJK-free.
- Repo-wide scan: 0 Chinese characters in `src/` and `web/src/`.

DB-backed integration tests run in CI (Postgres testcontainers need Docker, unavailable here); the suite collects cleanly aside from a pre-existing missing `filelock` dep in `tests/test_agent_runner/`.

https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom

---
_Generated by [Claude Code](https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom)_