### PR TITLE
API pagination: bound every unbounded v1 list endpoint (offset/limit + cursor for messages)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -392,14 +392,15 @@ paths:
       tags: [Conversations]
       operationId: listCoworkerConversations
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/Conversation' }
+              schema: { $ref: '#/components/schemas/ConversationPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -468,14 +469,21 @@ paths:
       tags: [Conversations]
       operationId: listConversationMessages
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - name: before
+          in: query
+          required: false
+          description: >-
+            Opaque cursor from a previous page's next_cursor; returns the
+            page of messages immediately older than it.
+          schema: { type: string }
+        - { $ref: '#/components/parameters/LimitParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/Message' }
+              schema: { $ref: '#/components/schemas/MessagePage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -1637,14 +1645,13 @@ paths:
           in: query
           required: false
           schema: { type: integer, minimum: 1, maximum: 500, default: 200 }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/SafetyRuleAuditEntry' }
+              schema: { $ref: '#/components/schemas/SafetyRuleAuditPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -3469,6 +3476,43 @@ components:
         total: { type: integer, minimum: 0 }
         limit: { type: integer, minimum: 1 }
         offset: { type: integer, minimum: 0 }
+
+    ConversationPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Conversation' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    SafetyRuleAuditPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/SafetyRuleAuditEntry' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    MessagePage:
+      type: object
+      required: [items, has_more]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Message' }
+        has_more: { type: boolean }
+        next_cursor:
+          type: string
+          nullable: true
+          description: >-
+            Opaque cursor for the next OLDER page; pass back as the
+            `before` query param. Null when there are no older messages.
 
     SafetyRuleAuditEntry:
       type: object

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -1302,14 +1302,15 @@ paths:
         tiebreak order). Tenant-scoped via RLS — never returns another
         tenant's policies.
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/ApprovalPolicy' }
+              schema: { $ref: '#/components/schemas/ApprovalPolicyPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
     post:
@@ -1406,6 +1407,8 @@ paths:
         surface another tenant's request.
       security: [ { bearerAuth: [] } ]
       parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
         - name: conversation_id
           in: query
           required: false
@@ -1416,9 +1419,7 @@ paths:
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/ApprovalRequest' }
+              schema: { $ref: '#/components/schemas/ApprovalRequestPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -1493,6 +1494,8 @@ paths:
         `safety.read`.
       security: [ { bearerAuth: [] } ]
       parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
         - name: coworker_id
           in: query
           required: false
@@ -1510,9 +1513,7 @@ paths:
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/SafetyRule' }
+              schema: { $ref: '#/components/schemas/SafetyRulePage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
     post:
@@ -1813,6 +1814,8 @@ paths:
         IPC. A coworker filter is exposed for the per-coworker view.
       security: [ { bearerAuth: [] } ]
       parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
         - name: coworker_id
           in: query
           required: false
@@ -1823,9 +1826,7 @@ paths:
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/ScheduledTask' }
+              schema: { $ref: '#/components/schemas/ScheduledTaskPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -2093,14 +2094,15 @@ paths:
         Gated by `user.manage` (owner + admin). Returns every user in
         the caller's tenant.
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/UserResponse' }
+              schema: { $ref: '#/components/schemas/UserPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2266,6 +2268,25 @@ components:
       schema:
         type: string
         format: uuid
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      description: Maximum number of items to return (default 50, max 200).
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+    OffsetParam:
+      name: offset
+      in: query
+      required: false
+      description: Number of items to skip from the start of the ordered set.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
 
   responses:
     BadRequest:
@@ -3355,6 +3376,63 @@ components:
         offset:
           type: integer
           minimum: 0
+
+    # Offset/limit page envelopes. One named schema per resource (clean TS
+    # type names); all share {items, total, limit, offset}.
+    UserPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/UserResponse' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    SafetyRulePage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/SafetyRule' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    ScheduledTaskPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/ScheduledTask' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    ApprovalPolicyPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/ApprovalPolicy' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    ApprovalRequestPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/ApprovalRequest' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
 
     SafetyRuleAuditEntry:
       type: object

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -224,14 +224,15 @@ paths:
       operationId: listCoworkers
       summary: List coworkers visible to the caller
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/Coworker' }
+              schema: { $ref: '#/components/schemas/CoworkerPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
     post:
@@ -852,14 +853,15 @@ paths:
       operationId: listSkills
       summary: List the tenant's catalog skills
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/SkillSummary' }
+              schema: { $ref: '#/components/schemas/SkillSummaryPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
     post:
@@ -1182,14 +1184,15 @@ paths:
       operationId: listMCPServers
       summary: List the tenant's MCP servers
       security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
       responses:
         '200':
           description: OK
           content:
             application/json:
-              schema:
-                type: array
-                items: { $ref: '#/components/schemas/MCPServer' }
+              schema: { $ref: '#/components/schemas/MCPServerPage' }
         '401':
           $ref: '#/components/responses/Unauthorized'
     post:
@@ -3430,6 +3433,39 @@ components:
         items:
           type: array
           items: { $ref: '#/components/schemas/ApprovalRequest' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    CoworkerPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Coworker' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    SkillSummaryPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/SkillSummary' }
+        total: { type: integer, minimum: 0 }
+        limit: { type: integer, minimum: 1 }
+        offset: { type: integer, minimum: 0 }
+
+    MCPServerPage:
+      type: object
+      required: [items, total, limit, offset]
+      properties:
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/MCPServer' }
         total: { type: integer, minimum: 0 }
         limit: { type: integer, minimum: 1 }
         offset: { type: integer, minimum: 0 }

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -3341,14 +3341,20 @@ components:
 
     SafetyDecisionPage:
       type: object
-      required: [total]
+      required: [items, total, limit, offset]
       properties:
-        total:
-          type: integer
-          minimum: 0
         items:
           type: array
           items: { $ref: '#/components/schemas/SafetyDecision' }
+        total:
+          type: integer
+          minimum: 0
+        limit:
+          type: integer
+          minimum: 1
+        offset:
+          type: integer
+          minimum: 0
 
     SafetyRuleAuditEntry:
       type: object

--- a/src/rolemesh/db/approval.py
+++ b/src/rolemesh/db/approval.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ApprovalRequest",
+    "count_approval_policies",
+    "count_pending_requests_for_tenant",
     "create_approval_policy",
     "create_approval_request",
     "delete_approval_policy",
@@ -185,22 +187,43 @@ async def get_approval_policy(
 
 
 async def list_approval_policies(
-    tenant_id: str, *, enabled_only: bool = False
+    tenant_id: str,
+    *,
+    enabled_only: bool = False,
+    limit: int | None = None,
+    offset: int = 0,
 ) -> list[ApprovalPolicy]:
-    """List a tenant's policies.
+    """List a tenant's policies, optionally paginated.
 
     ``enabled_only=True`` returns the snapshot the matcher consumes
-    (``find_matching_policy``). Order is the matcher's tiebreak order
-    (priority desc, then newest) so callers that take the first match get
-    the same answer as the matcher — but the matcher does not rely on it.
+    (``find_matching_policy``) — internal callers leave ``limit`` unset to
+    get the full set. Order is the matcher's tiebreak order (priority desc,
+    then newest) so callers that take the first match get the same answer
+    as the matcher — but the matcher does not rely on it.
     """
     sql = "SELECT * FROM approval_policies WHERE tenant_id = $1::uuid"
     if enabled_only:
         sql += " AND enabled = TRUE"
     sql += " ORDER BY priority DESC, updated_at DESC"
+    params: list[object] = [tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(sql, tenant_id)
+        rows = await conn.fetch(sql, *params)
     return [_record_to_policy(r) for r in rows]
+
+
+async def count_approval_policies(
+    tenant_id: str, *, enabled_only: bool = False
+) -> int:
+    """Total policy count for a tenant (matching ``enabled_only``)."""
+    sql = "SELECT COUNT(*) AS n FROM approval_policies WHERE tenant_id = $1::uuid"
+    if enabled_only:
+        sql += " AND enabled = TRUE"
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(sql, tenant_id)
+    return int(row["n"]) if row else 0
 
 
 async def update_approval_policy(
@@ -378,18 +401,63 @@ async def get_approval_request(
     return _record_to_request(row) if row else None
 
 
+def _pending_requests_filter_sql(
+    tenant_id: str, *, conversation_id: str | None,
+) -> tuple[str, list[object]]:
+    """Shared WHERE clause for pending-request list/count.
+
+    The optional ``conversation_id`` is pushed into SQL (not filtered in
+    process) so pagination counts and slices the same scoped set.
+    """
+    sql = "tenant_id = $1::uuid AND status = 'pending'"
+    params: list[object] = [tenant_id]
+    if conversation_id is not None:
+        params.append(conversation_id)
+        sql += f" AND conversation_id = ${len(params)}::uuid"
+    return sql, params
+
+
 async def list_pending_requests_for_tenant(
     tenant_id: str,
+    *,
+    conversation_id: str | None = None,
+    limit: int | None = None,
+    offset: int = 0,
 ) -> list[ApprovalRequest]:
-    """Pending requests for one tenant (oldest first)."""
+    """Pending requests for one tenant (oldest first), optionally paginated.
+
+    ``conversation_id`` narrows to one conversation's in-flight cards (the
+    SPA reconnect path). Internal callers leave ``limit`` unset.
+    """
+    where, params = _pending_requests_filter_sql(
+        tenant_id, conversation_id=conversation_id,
+    )
+    sql = (
+        "SELECT * FROM approval_requests WHERE "
+        + where
+        + " ORDER BY requested_at ASC"
+    )
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            "SELECT * FROM approval_requests "
-            "WHERE tenant_id = $1::uuid AND status = 'pending' "
-            "ORDER BY requested_at ASC",
-            tenant_id,
-        )
+        rows = await conn.fetch(sql, *params)
     return [_record_to_request(r) for r in rows]
+
+
+async def count_pending_requests_for_tenant(
+    tenant_id: str, *, conversation_id: str | None = None,
+) -> int:
+    """Total pending-request count for a tenant (matching the filter)."""
+    where, params = _pending_requests_filter_sql(
+        tenant_id, conversation_id=conversation_id,
+    )
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM approval_requests WHERE " + where,
+            *params,
+        )
+    return int(row["n"]) if row else 0
 
 
 async def list_requests_for_conversation(

--- a/src/rolemesh/db/chat.py
+++ b/src/rolemesh/db/chat.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
+    "count_conversations_for_coworker",
     "create_channel_binding",
     "create_conversation",
     "delete_channel_binding",
@@ -396,18 +397,35 @@ async def get_conversation_for_notification(conversation_id: str) -> Conversatio
 
 
 async def get_conversations_for_coworker(
-    coworker_id: str, *, tenant_id: str
+    coworker_id: str, *, tenant_id: str, limit: int | None = None, offset: int = 0,
 ) -> list[Conversation]:
-    """Get all conversations for a coworker."""
+    """Get conversations for a coworker (oldest first), optionally paginated."""
+    sql = (
+        "SELECT * FROM conversations "
+        "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid "
+        "ORDER BY created_at"
+    )
+    params: list[object] = [coworker_id, tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            "SELECT * FROM conversations "
-            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid "
-            "ORDER BY created_at",
+        rows = await conn.fetch(sql, *params)
+    return [_record_to_conversation(row) for row in rows]
+
+
+async def count_conversations_for_coworker(
+    coworker_id: str, *, tenant_id: str,
+) -> int:
+    """Total conversation count for a coworker (for the pagination envelope)."""
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM conversations "
+            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid",
             coworker_id,
             tenant_id,
         )
-    return [_record_to_conversation(row) for row in rows]
+    return int(row["n"]) if row else 0
 
 
 async def get_all_conversations() -> list[Conversation]:

--- a/src/rolemesh/db/coworker.py
+++ b/src/rolemesh/db/coworker.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
+    "count_coworkers_for_tenant",
     "create_coworker",
     "delete_coworker",
     "get_all_coworkers",
@@ -188,48 +189,72 @@ async def get_coworker_by_folder(tenant_id: str, folder: str) -> Coworker | None
     return _record_to_coworker(row)
 
 
+def _coworker_visibility_sql(
+    tenant_id: str,
+    *,
+    requesting_user_id: str | None,
+    include_all: bool,
+) -> tuple[str, list[object]]:
+    """WHERE clause + params shared by the visibility-scoped list/count.
+
+    ``created_by_user_id = $2`` is three-valued-logic safe: a row with
+    ``created_by_user_id IS NULL`` yields ``NULL`` (not TRUE), so an
+    un-attributed private row never leaks to a member. Managers pass
+    ``include_all=True`` so no predicate is added.
+    """
+    where = "tenant_id = $1::uuid"
+    params: list[object] = [tenant_id]
+    if not include_all:
+        params.append(requesting_user_id)
+        where += " AND (visibility = 'shared' OR created_by_user_id = $2::uuid)"
+    return where, params
+
+
 async def get_coworkers_for_tenant(
     tenant_id: str,
     *,
     requesting_user_id: str | None = None,
     include_all: bool = True,
+    limit: int | None = None,
+    offset: int = 0,
 ) -> list[Coworker]:
-    """Get coworkers for a tenant.
+    """Get coworkers for a tenant, optionally visibility-scoped and paginated.
 
     ``include_all`` (the DEFAULT) preserves the historical unfiltered
     behavior: every internal caller (orchestrator load paths, OIDC
-    auto-assign, the legacy admin surface) needs ALL rows and must NOT
-    be visibility-scoped. Only the v1 list endpoint opts in to filtering
-    by passing ``include_all=False`` together with ``requesting_user_id``.
-
-    When filtering, the visibility predicate is exactly the SQL mirror of
-    :func:`webui.dependencies.user_can_see_resource`'s SEE rule for a
-    non-manager caller:
-
-        visibility = 'shared' OR created_by_user_id = :requesting_user_id
-
-    ``created_by_user_id = $2`` is three-valued-logic safe: a row with
-    ``created_by_user_id IS NULL`` yields ``NULL`` (not TRUE) for that
-    comparison, so an un-attributed private row never leaks to a member.
-    Managers (owner/admin/platform_admin) call with ``include_all=True``
-    so no predicate is added and they see every row.
+    auto-assign) needs ALL rows and must NOT be visibility-scoped. Only
+    the v1 list endpoint opts in to filtering by passing
+    ``include_all=False`` together with ``requesting_user_id`` (the
+    predicate is the SQL mirror of
+    :func:`webui.dependencies.user_can_see_resource`'s SEE rule).
     """
+    where, params = _coworker_visibility_sql(
+        tenant_id, requesting_user_id=requesting_user_id, include_all=include_all,
+    )
+    sql = f"SELECT * FROM coworkers WHERE {where} ORDER BY name"
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        if include_all:
-            rows = await conn.fetch(
-                "SELECT * FROM coworkers WHERE tenant_id = $1::uuid "
-                "ORDER BY name",
-                tenant_id,
-            )
-        else:
-            rows = await conn.fetch(
-                "SELECT * FROM coworkers WHERE tenant_id = $1::uuid "
-                "AND (visibility = 'shared' OR created_by_user_id = $2::uuid) "
-                "ORDER BY name",
-                tenant_id,
-                requesting_user_id,
-            )
+        rows = await conn.fetch(sql, *params)
     return [_record_to_coworker(row) for row in rows]
+
+
+async def count_coworkers_for_tenant(
+    tenant_id: str,
+    *,
+    requesting_user_id: str | None = None,
+    include_all: bool = True,
+) -> int:
+    """Count coworkers visible to the caller (same predicate as the list)."""
+    where, params = _coworker_visibility_sql(
+        tenant_id, requesting_user_id=requesting_user_id, include_all=include_all,
+    )
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            f"SELECT COUNT(*) AS n FROM coworkers WHERE {where}", *params,
+        )
+    return int(row["n"]) if row else 0
 
 
 async def set_coworker_visibility(

--- a/src/rolemesh/db/mcp_server.py
+++ b/src/rolemesh/db/mcp_server.py
@@ -26,6 +26,7 @@ __all__ = [
     "CoworkerMCPBinding",
     "MCPServerRow",
     "bind_coworker_mcp_server",
+    "count_mcp_servers",
     "create_mcp_server",
     "delete_mcp_server",
     "get_mcp_server",
@@ -101,14 +102,30 @@ _SELECT_COLUMNS = (
 )
 
 
-async def list_mcp_servers(tenant_id: str) -> list[MCPServerRow]:
+async def list_mcp_servers(
+    tenant_id: str, *, limit: int | None = None, offset: int = 0,
+) -> list[MCPServerRow]:
+    sql = (
+        f"SELECT {_SELECT_COLUMNS} FROM mcp_servers "
+        "WHERE tenant_id = $1::uuid ORDER BY name"
+    )
+    params: list[object] = [tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            f"SELECT {_SELECT_COLUMNS} FROM mcp_servers "
-            "WHERE tenant_id = $1::uuid ORDER BY name",
+        rows = await conn.fetch(sql, *params)
+    return [_row_to_dataclass(r) for r in rows]
+
+
+async def count_mcp_servers(tenant_id: str) -> int:
+    """Total MCP server count for a tenant (for the pagination envelope)."""
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM mcp_servers WHERE tenant_id = $1::uuid",
             tenant_id,
         )
-    return [_row_to_dataclass(r) for r in rows]
+    return int(row["n"]) if row else 0
 
 
 async def get_mcp_server(

--- a/src/rolemesh/db/safety.py
+++ b/src/rolemesh/db/safety.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 __all__ = [
     "count_safety_decisions",
     "count_safety_rules",
+    "count_safety_rules_audit",
     "create_safety_rule",
     "delete_safety_rule",
     "get_safety_decision",
@@ -321,29 +322,52 @@ async def delete_safety_rule(
     return result.endswith(" 1")
 
 
-async def list_safety_rules_audit(
-    *,
-    tenant_id: str,
-    rule_id: str | None = None,
-    limit: int = 200,
-) -> list[dict[str, Any]]:
-    """List rule-change audit rows, newest first.
-
-    Filtered by tenant_id (never cross-tenant). ``rule_id`` optional
-    to narrow to a specific rule's history. Returns plain dicts; the
-    V2 admin UI will surface this as a timeline. Test fixture uses it
-    to pin actor/action correctness.
-    """
+def _safety_audit_filter_sql(
+    tenant_id: str, *, rule_id: str | None,
+) -> tuple[str, list[Any]]:
+    """Shared WHERE clause for the audit list/count."""
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if rule_id is not None:
         params.append(rule_id)
         clauses.append(f"rule_id = ${len(params)}::uuid")
+    return " AND ".join(clauses), params
+
+
+async def count_safety_rules_audit(
+    *, tenant_id: str, rule_id: str | None = None,
+) -> int:
+    """Total audit-row count matching the same filters as the list."""
+    where, params = _safety_audit_filter_sql(tenant_id, rule_id=rule_id)
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM safety_rules_audit WHERE " + where,
+            *params,
+        )
+    return int(row["n"]) if row else 0
+
+
+async def list_safety_rules_audit(
+    *,
+    tenant_id: str,
+    rule_id: str | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """List rule-change audit rows, newest first (paginated).
+
+    Filtered by tenant_id (never cross-tenant). ``rule_id`` optional
+    to narrow to a specific rule's history. Returns plain dicts; the
+    admin UI surfaces this as a timeline.
+    """
+    where, params = _safety_audit_filter_sql(tenant_id, rule_id=rule_id)
     params.append(limit)
+    limit_pos = len(params)
+    params.append(offset)
     sql = (
         "SELECT * FROM safety_rules_audit WHERE "
-        + " AND ".join(clauses)
-        + f" ORDER BY created_at DESC LIMIT ${len(params)}"
+        + where
+        + f" ORDER BY created_at DESC LIMIT ${limit_pos} OFFSET ${len(params)}"
     )
     async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)

--- a/src/rolemesh/db/safety.py
+++ b/src/rolemesh/db/safety.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "count_safety_decisions",
+    "count_safety_rules",
     "create_safety_rule",
     "delete_safety_rule",
     "get_safety_decision",
@@ -140,14 +141,14 @@ async def get_safety_rule(
     return _record_to_safety_rule(row)
 
 
-async def list_safety_rules(
+def _safety_rule_filter_sql(
     tenant_id: str,
     *,
-    coworker_id: str | None = None,
-    stage: str | None = None,
-    enabled: bool | None = None,
-) -> list[SafetyRule]:
-    """List rules for a tenant, optionally filtered."""
+    coworker_id: str | None,
+    stage: str | None,
+    enabled: bool | None,
+) -> tuple[str, list[Any]]:
+    """Build the shared WHERE clause for list/count of safety rules."""
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
     if coworker_id is not None:
@@ -159,14 +160,51 @@ async def list_safety_rules(
     if enabled is not None:
         params.append(enabled)
         clauses.append(f"enabled = ${len(params)}")
+    return " AND ".join(clauses), params
+
+
+async def list_safety_rules(
+    tenant_id: str,
+    *,
+    coworker_id: str | None = None,
+    stage: str | None = None,
+    enabled: bool | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+) -> list[SafetyRule]:
+    """List rules for a tenant, optionally filtered and paginated."""
+    where, params = _safety_rule_filter_sql(
+        tenant_id, coworker_id=coworker_id, stage=stage, enabled=enabled,
+    )
     sql = (
         "SELECT * FROM safety_rules WHERE "
-        + " AND ".join(clauses)
+        + where
         + " ORDER BY priority DESC, updated_at DESC"
     )
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
         rows = await conn.fetch(sql, *params)
     return [_record_to_safety_rule(r) for r in rows]
+
+
+async def count_safety_rules(
+    tenant_id: str,
+    *,
+    coworker_id: str | None = None,
+    stage: str | None = None,
+    enabled: bool | None = None,
+) -> int:
+    """Total tenant rule count matching the same filters as the list."""
+    where, params = _safety_rule_filter_sql(
+        tenant_id, coworker_id=coworker_id, stage=stage, enabled=enabled,
+    )
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM safety_rules WHERE " + where, *params,
+        )
+    return int(row["n"]) if row else 0
 
 
 async def list_safety_rules_for_coworker(

--- a/src/rolemesh/db/skill.py
+++ b/src/rolemesh/db/skill.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
+    "count_skills_for_tenant",
     "create_skill",
     "create_skill_for_coworker",
     "delete_skill",
@@ -283,42 +284,72 @@ async def get_skill(
     return _record_to_skill(row, files)
 
 
+def _skill_visibility_sql(
+    tenant_id: str,
+    *,
+    requesting_user_id: str | None,
+    include_all: bool,
+) -> tuple[str, list[object]]:
+    """WHERE clause + params shared by the visibility-scoped list/count.
+
+    NULL-safe mirror of ``user_can_see_resource`` for a non-manager:
+    ``visibility = 'shared' OR created_by_user_id = :requesting_user_id``.
+    """
+    where = "tenant_id = $1::uuid"
+    params: list[object] = [tenant_id]
+    if not include_all:
+        params.append(requesting_user_id)
+        where += " AND (visibility = 'shared' OR created_by_user_id = $2::uuid)"
+    return where, params
+
+
+async def count_skills_for_tenant(
+    tenant_id: str,
+    *,
+    requesting_user_id: str | None = None,
+    include_all: bool = True,
+) -> int:
+    """Count catalog skills visible to the caller (same predicate as list)."""
+    where, params = _skill_visibility_sql(
+        tenant_id, requesting_user_id=requesting_user_id, include_all=include_all,
+    )
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            f"SELECT COUNT(*) AS n FROM skills WHERE {where}", *params,
+        )
+    return int(row["n"]) if row else 0
+
+
 async def list_skills_for_tenant(
     tenant_id: str,
     *,
     with_files: bool = False,
     requesting_user_id: str | None = None,
     include_all: bool = True,
+    limit: int | None = None,
+    offset: int = 0,
 ) -> list[Skill]:
-    """List catalog skills for ``tenant_id``.
+    """List catalog skills for ``tenant_id``, optionally scoped/paginated.
 
     Backs the v1 flat ``GET /api/v1/skills``. ``with_files`` defaults
     False because the list shape drops body content; the per-skill
     detail endpoint passes True.
 
     ``include_all`` (the DEFAULT) preserves the historical unfiltered
-    behavior for internal/admin callers. The v1 list endpoint opts into
+    behavior for internal callers. The v1 list endpoint opts into
     visibility scoping by passing ``include_all=False`` +
-    ``requesting_user_id``; the predicate is the SQL mirror of
-    :func:`webui.dependencies.user_can_see_resource` for a non-manager
-    (``visibility = 'shared' OR created_by_user_id = :requesting_user_id``)
-    and is NULL-safe (a NULL ``created_by_user_id`` never equals the
-    caller, so an un-attributed private skill stays hidden).
+    ``requesting_user_id`` (SQL mirror of ``user_can_see_resource`` for a
+    non-manager; NULL-safe so an un-attributed private skill stays hidden).
     """
+    where, params = _skill_visibility_sql(
+        tenant_id, requesting_user_id=requesting_user_id, include_all=include_all,
+    )
+    sql = f"SELECT * FROM skills WHERE {where} ORDER BY name"
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        if include_all:
-            rows = await conn.fetch(
-                "SELECT * FROM skills WHERE tenant_id = $1::uuid ORDER BY name",
-                tenant_id,
-            )
-        else:
-            rows = await conn.fetch(
-                "SELECT * FROM skills WHERE tenant_id = $1::uuid "
-                "AND (visibility = 'shared' OR created_by_user_id = $2::uuid) "
-                "ORDER BY name",
-                tenant_id,
-                requesting_user_id,
-            )
+        rows = await conn.fetch(sql, *params)
         result: list[Skill] = []
         if with_files and rows:
             ids = [r["id"] for r in rows]

--- a/src/rolemesh/db/task.py
+++ b/src/rolemesh/db/task.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "cancel_tasks_for_user",
+    "count_tasks",
     "create_task",
     "delete_task",
     "get_all_tasks",
@@ -107,22 +108,41 @@ async def get_task_by_id(task_id: str, *, tenant_id: str) -> ScheduledTask | Non
 
 
 async def get_tasks_for_coworker(
-    coworker_id: str, *, tenant_id: str
+    coworker_id: str, *, tenant_id: str, limit: int | None = None, offset: int = 0,
 ) -> list[ScheduledTask]:
-    """Get all tasks for a specific coworker."""
+    """Get tasks for a specific coworker (newest first), optionally paginated."""
+    sql = (
+        "SELECT * FROM scheduled_tasks "
+        "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid "
+        "ORDER BY created_at DESC"
+    )
+    params: list[object] = [coworker_id, tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            "SELECT * FROM scheduled_tasks "
-            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid "
-            "ORDER BY created_at DESC",
-            coworker_id,
-            tenant_id,
-        )
+        rows = await conn.fetch(sql, *params)
     return [_record_to_scheduled_task(row) for row in rows]
 
 
-async def get_all_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
-    """Get all scheduled tasks, optionally filtered by tenant.
+async def count_tasks(
+    tenant_id: str, *, coworker_id: str | None = None,
+) -> int:
+    """Total scheduled-task count for a tenant (optionally one coworker)."""
+    sql = "SELECT COUNT(*) AS n FROM scheduled_tasks WHERE tenant_id = $1::uuid"
+    params: list[object] = [tenant_id]
+    if coworker_id is not None:
+        params.append(coworker_id)
+        sql += f" AND coworker_id = ${len(params)}::uuid"
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(sql, *params)
+    return int(row["n"]) if row else 0
+
+
+async def get_all_tasks(
+    tenant_id: str | None = None, *, limit: int | None = None, offset: int = 0,
+) -> list[ScheduledTask]:
+    """Get all scheduled tasks, optionally filtered by tenant and paginated.
 
     Treats both ``None`` and ``""`` as "no tenant scope" so callers
     that build the parameter from an admin REST query string don't
@@ -130,17 +150,24 @@ async def get_all_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
     fail-closed (current_tenant_id = NULL → RLS drops every row).
     """
     if tenant_id:
+        sql = (
+            "SELECT * FROM scheduled_tasks "
+            "WHERE tenant_id = $1::uuid ORDER BY created_at DESC"
+        )
+        params: list[object] = [tenant_id]
+        if limit is not None:
+            params.extend((limit, offset))
+            sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
         async with tenant_conn(tenant_id) as conn:
-            rows = await conn.fetch(
-                "SELECT * FROM scheduled_tasks "
-                "WHERE tenant_id = $1::uuid ORDER BY created_at DESC",
-                tenant_id,
-            )
+            rows = await conn.fetch(sql, *params)
     else:
+        sql = "SELECT * FROM scheduled_tasks ORDER BY created_at DESC"
+        params = []
+        if limit is not None:
+            params.extend((limit, offset))
+            sql += " LIMIT $1 OFFSET $2"
         async with admin_conn() as conn:
-            rows = await conn.fetch(
-                "SELECT * FROM scheduled_tasks ORDER BY created_at DESC"
-            )
+            rows = await conn.fetch(sql, *params)
     return [_record_to_scheduled_task(row) for row in rows]
 
 

--- a/src/rolemesh/db/user.py
+++ b/src/rolemesh/db/user.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
+    "count_users_for_tenant",
     "create_external_tenant_mapping",
     "create_user",
     "create_user_with_external_sub",
@@ -309,14 +310,32 @@ async def resolve_user_for_auth(user_id: str) -> tuple[str, str] | None:
     return (str(row["tenant_id"]), str(row["role"]))
 
 
-async def get_users_for_tenant(tenant_id: str) -> list[User]:
-    """Get all users for a tenant."""
+async def get_users_for_tenant(
+    tenant_id: str, *, limit: int | None = None, offset: int = 0,
+) -> list[User]:
+    """Get users for a tenant, ordered by name.
+
+    ``limit`` bounds the page (``None`` means no bound, for internal
+    callers); ``offset`` skips from the start of the ordered set.
+    """
+    sql = "SELECT * FROM users WHERE tenant_id = $1::uuid ORDER BY name"
+    params: list[object] = [tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
     async with tenant_conn(tenant_id) as conn:
-        rows = await conn.fetch(
-            "SELECT * FROM users WHERE tenant_id = $1::uuid ORDER BY name",
+        rows = await conn.fetch(sql, *params)
+    return [_record_to_user(row) for row in rows]
+
+
+async def count_users_for_tenant(tenant_id: str) -> int:
+    """Total user count for a tenant (for the pagination envelope)."""
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM users WHERE tenant_id = $1::uuid",
             tenant_id,
         )
-    return [_record_to_user(row) for row in rows]
+    return int(row["n"]) if row else 0
 
 
 async def update_user(

--- a/src/webui/schemas.py
+++ b/src/webui/schemas.py
@@ -61,6 +61,22 @@ class UserDetailResponse(UserResponse):
     mechanism (access is governed by coworker visibility + ownership)."""
 
 
+class UserPage(BaseModel):
+    """Offset/limit page of users.
+
+    Defined here (next to ``UserResponse``) rather than in
+    ``schemas_v1`` because that module would otherwise have to import
+    ``UserResponse`` from here, and ``schemas`` already imports from
+    ``schemas_v1`` — keeping the page on this side avoids the cycle.
+    Same ``{items, total, limit, offset}`` shape as the v1 envelopes.
+    """
+
+    items: list[UserResponse]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
 # ---------------------------------------------------------------------------
 # Agent (Coworker)
 # ---------------------------------------------------------------------------

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -918,16 +918,18 @@ class SafetyDecision(BaseModel):
 class SafetyDecisionPage(BaseModel):
     """``GET /api/v1/safety/decisions`` response envelope.
 
-    Mirrors the admin shape ``{total, items}`` so the SPA renders
-    pagination without a second count call. The two-field envelope
-    is intentional even when ``total == len(items)`` — keeps the
-    list and count concerns coupled in one round-trip.
+    The standard offset/limit page shape shared across the v1 list
+    surface: ``items`` plus ``total`` (so the SPA renders pagination
+    without a second count call) and an echo of the effective
+    ``limit``/``offset`` (so the caller doesn't have to track them).
     """
 
     model_config = ConfigDict(extra="forbid")
 
+    items: list[SafetyDecision]
     total: int = Field(ge=0)
-    items: list[SafetyDecision] = Field(default_factory=list)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
 
 
 class SafetyRuleAuditEntry(BaseModel):

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1352,3 +1352,44 @@ class MCPServerPage(BaseModel):
     total: int = Field(ge=0)
     limit: int = Field(ge=1)
     offset: int = Field(ge=0)
+
+
+class ConversationPage(BaseModel):
+    """Offset/limit page of conversations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[Conversation]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class SafetyRuleAuditPage(BaseModel):
+    """Offset/limit page of safety rule audit entries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[SafetyRuleAuditEntry]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class MessagePage(BaseModel):
+    """Cursor page of conversation messages.
+
+    Messages use cursor pagination, NOT offset/limit like the other
+    collections: chat history is append-only and read newest-first
+    ("load older"), so offset paging would shift or duplicate rows as
+    new messages arrive mid-scroll. The server seeks on ``(timestamp,
+    id)``. ``items`` are returned oldest-first (natural display order);
+    when ``has_more`` is true, ``next_cursor`` is passed back as the
+    ``before`` query param to fetch the next older page.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[Message]
+    has_more: bool
+    next_cursor: str | None = None

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1268,3 +1268,54 @@ class ModelUpdate(BaseModel):
 
     display_name: str | None = Field(default=None, min_length=1, max_length=200)
     is_active: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pagination envelopes (offset/limit). One named class per resource keeps the
+# generated TS type names clean; all share the {items, total, limit, offset}
+# shape established by SafetyDecisionPage. See webui.v1._pagination.
+# ---------------------------------------------------------------------------
+
+
+class SafetyRulePage(BaseModel):
+    """Offset/limit page of safety rules."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[SafetyRule]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class ScheduledTaskPage(BaseModel):
+    """Offset/limit page of scheduled tasks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ScheduledTask]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class ApprovalPolicyPage(BaseModel):
+    """Offset/limit page of approval policies."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ApprovalPolicy]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class ApprovalRequestPage(BaseModel):
+    """Offset/limit page of approval requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[ApprovalRequest]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1319,3 +1319,36 @@ class ApprovalRequestPage(BaseModel):
     total: int = Field(ge=0)
     limit: int = Field(ge=1)
     offset: int = Field(ge=0)
+
+
+class CoworkerPage(BaseModel):
+    """Offset/limit page of coworkers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[Coworker]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class SkillSummaryPage(BaseModel):
+    """Offset/limit page of skill summaries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[SkillSummary]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+
+
+class MCPServerPage(BaseModel):
+    """Offset/limit page of MCP servers."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[MCPServer]
+    total: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)

--- a/src/webui/v1/_pagination.py
+++ b/src/webui/v1/_pagination.py
@@ -1,0 +1,42 @@
+"""Shared pagination conventions for ``/api/v1`` list endpoints.
+
+Every unbounded tenant-scoped collection pages with offset/limit and
+returns a named ``XPage`` envelope ``{items, total, limit, offset}``
+(the concrete envelopes live in :mod:`webui.schemas_v1`). The
+query-parameter types here keep the default and the hard cap in one
+place so every list handler agrees — a client can never pull an
+unbounded array, and the response echoes ``limit``/``offset`` so the
+caller doesn't have to track them itself.
+
+Bounded sub-resources (e.g. a skill's files, a coworker's bindings)
+stay as bare arrays — they don't grow with tenant size. Append-only
+high-growth histories (conversation messages) use cursor pagination
+instead; see the ``*Page`` cursor envelopes in :mod:`webui.schemas_v1`.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Query
+
+# One source of truth for the offset/limit window. 200 matches the cap the
+# safety-decisions endpoint shipped with; 50 is a sensible default page.
+DEFAULT_PAGE_LIMIT = 50
+MAX_PAGE_LIMIT = 200
+
+LimitParam = Annotated[
+    int,
+    Query(
+        ge=1,
+        le=MAX_PAGE_LIMIT,
+        description="Maximum number of items to return (default 50, max 200).",
+    ),
+]
+OffsetParam = Annotated[
+    int,
+    Query(
+        ge=0,
+        description="Number of items to skip from the start of the ordered set.",
+    ),
+]

--- a/src/webui/v1/approvals.py
+++ b/src/webui/v1/approvals.py
@@ -23,6 +23,8 @@ from rolemesh.db.approval import (
     ApprovalRequest as ApprovalRequestRow,
 )
 from rolemesh.db.approval import (
+    count_approval_policies,
+    count_pending_requests_for_tenant,
     create_approval_policy,
     delete_approval_policy,
     get_approval_policy,
@@ -34,10 +36,13 @@ from webui.dependencies import get_current_user, require_action
 from webui.schemas_v1 import (
     ApprovalPolicy,
     ApprovalPolicyCreate,
+    ApprovalPolicyPage,
     ApprovalPolicyUpdate,
     ApprovalRequest,
+    ApprovalRequestPage,
     ApprovalTriggeredBy,
 )
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import raise_error_response
 
 if TYPE_CHECKING:
@@ -137,13 +142,23 @@ async def _get_policy_or_404(policy_id: str, *, tenant_id: str) -> ApprovalPolic
 # ---------------------------------------------------------------------------
 
 
-@policies_router.get("", response_model=list[ApprovalPolicy])
+@policies_router.get("", response_model=ApprovalPolicyPage)
 async def list_policies_endpoint(
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[ApprovalPolicy]:
+) -> ApprovalPolicyPage:
     """List the tenant's approval policies (priority desc, then newest)."""
-    policies = await list_approval_policies(user.tenant_id)
-    return [_policy_to_response(p) for p in policies]
+    policies = await list_approval_policies(
+        user.tenant_id, limit=limit, offset=offset,
+    )
+    total = await count_approval_policies(user.tenant_id)
+    return ApprovalPolicyPage(
+        items=[_policy_to_response(p) for p in policies],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @policies_router.post("", response_model=ApprovalPolicy, status_code=201)
@@ -232,7 +247,7 @@ async def delete_policy_endpoint(
 # ---------------------------------------------------------------------------
 
 
-@requests_router.get("", response_model=list[ApprovalRequest])
+@requests_router.get("", response_model=ApprovalRequestPage)
 async def list_pending_requests_endpoint(
     conversation_id: str | None = Query(
         default=None,
@@ -242,17 +257,30 @@ async def list_pending_requests_endpoint(
             "re-renders just that conversation's in-flight cards."
         ),
     ),
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[ApprovalRequest]:
+) -> ApprovalRequestPage:
     """Pending approval requests for the caller's tenant (oldest first).
 
-    Authoritative source for re-rendering ✅/❌ cards after a socket drop. The
-    optional ``conversation_id`` filter is applied in-process after the
-    tenant-scoped read — both the read and the filter stay inside the tenant
-    boundary, so it can never surface another tenant's request even if a
-    foreign ``conversation_id`` is supplied.
+    Authoritative source for re-rendering approval cards after a socket
+    drop. The optional ``conversation_id`` filter is pushed into the DB
+    query (not applied in-process) so the page count and slice cover the
+    same scoped set; either way the read stays inside the tenant boundary,
+    so a foreign ``conversation_id`` can never surface another tenant's row.
     """
-    pending = await list_pending_requests_for_tenant(user.tenant_id)
-    if conversation_id is not None:
-        pending = [r for r in pending if r.conversation_id == conversation_id]
-    return [_request_to_response(r) for r in pending]
+    pending = await list_pending_requests_for_tenant(
+        user.tenant_id,
+        conversation_id=conversation_id,
+        limit=limit,
+        offset=offset,
+    )
+    total = await count_pending_requests_for_tenant(
+        user.tenant_id, conversation_id=conversation_id,
+    )
+    return ApprovalRequestPage(
+        items=[_request_to_response(r) for r in pending],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -15,13 +15,15 @@ no second filter; instead it asks the DB helper to scope, and
 
 from __future__ import annotations
 
+import base64
 import uuid
 from typing import TYPE_CHECKING
 
 import asyncpg
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 
 from rolemesh.db import (
+    count_conversations_for_coworker,
     create_channel_binding,
     create_conversation,
     delete_conversation,
@@ -36,8 +38,11 @@ from webui.schemas_v1 import (
     ApprovalRequest,
     Conversation,
     ConversationCreate,
+    ConversationPage,
     Message,
+    MessagePage,
 )
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.approvals import _request_to_response
 from webui.v1.coworkers import _get_coworker_or_404
 from webui.v1.errors import raise_error_response
@@ -111,20 +116,30 @@ async def _get_conversation_or_404(
 
 @coworker_conversations_router.get(
     "/{coworker_id}/conversations",
-    response_model=list[Conversation],
+    response_model=ConversationPage,
 )
 async def list_coworker_conversations(
     coworker_id: str,
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[Conversation]:
-    """List conversations for a coworker, ordered by ``created_at``."""
+) -> ConversationPage:
+    """List conversations for a coworker, ordered by ``created_at`` (paged)."""
     # USE/SEE enforcement: a member may not enumerate conversations of a
     # coworker they cannot see (another member's private one) — 404.
     await _get_coworker_or_404(coworker_id, user.tenant_id, user=user)
     convs = await get_conversations_for_coworker(
-        coworker_id, tenant_id=user.tenant_id
+        coworker_id, tenant_id=user.tenant_id, limit=limit, offset=offset,
     )
-    return [_conversation_to_response(c) for c in convs]
+    total = await count_conversations_for_coworker(
+        coworker_id, tenant_id=user.tenant_id,
+    )
+    return ConversationPage(
+        items=[_conversation_to_response(c) for c in convs],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @coworker_conversations_router.post(
@@ -199,44 +214,99 @@ async def delete_conversation_endpoint(
     return Response(status_code=204)
 
 
+def _encode_message_cursor(ts_iso: str, msg_id: str) -> str:
+    """Opaque cursor = base64("<timestamp_iso>|<message_id>")."""
+    return base64.urlsafe_b64encode(f"{ts_iso}|{msg_id}".encode()).decode()
+
+
+def _decode_message_cursor(cursor: str) -> tuple[str, str]:
+    """Inverse of :func:`_encode_message_cursor`. Raises ValueError on junk."""
+    raw = base64.urlsafe_b64decode(cursor.encode()).decode()
+    ts_iso, sep, msg_id = raw.partition("|")
+    if not sep or not ts_iso or not msg_id:
+        raise ValueError("malformed cursor")
+    return ts_iso, msg_id
+
+
 @conversations_router.get(
     "/{conversation_id}/messages",
-    response_model=list[Message],
+    response_model=MessagePage,
 )
 async def list_conversation_messages(
     conversation_id: str,
+    before: str | None = Query(
+        default=None,
+        description=(
+            "Opaque cursor from a previous page's next_cursor; returns the "
+            "page of messages immediately OLDER than it."
+        ),
+    ),
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[Message]:
-    """Return persisted messages for a conversation, ordered by timestamp.
+) -> MessagePage:
+    """Return persisted messages for a conversation (cursor-paginated).
+
+    Messages page with a ``(timestamp, id)`` cursor rather than
+    offset/limit — chat history is append-only and read "load older",
+    so an offset would shift or duplicate rows as new messages arrive
+    mid-scroll. ``items`` come back oldest-first (display order); when
+    ``has_more`` is true, pass ``next_cursor`` as ``before`` to fetch the
+    next older page.
 
     The wire-level ``role`` projects ``is_from_me`` / ``is_bot_message``
     onto ``user`` / ``assistant``. Token usage and sender metadata are
-    intentionally omitted from the wire schema — the WS event stream
-    surfaces live usage; persisted history only needs role / content /
-    timestamp for re-render.
+    intentionally omitted — the WS event stream surfaces live usage;
+    persisted history only needs role / content / timestamp for re-render.
     """
     await _get_conversation_or_404(conversation_id, user.tenant_id)
-    async with tenant_conn(user.tenant_id) as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id,
-                   content,
-                   timestamp,
-                   is_from_me,
-                   is_bot_message,
-                   run_id::text AS run_id
-              FROM messages
-             WHERE conversation_id = $1::uuid
-               AND tenant_id       = $2::uuid
-             ORDER BY timestamp
-            """,
-            conversation_id,
-            user.tenant_id,
+
+    where = "conversation_id = $1::uuid AND tenant_id = $2::uuid"
+    params: list[object] = [conversation_id, user.tenant_id]
+    if before is not None:
+        try:
+            cur_ts, cur_id = _decode_message_cursor(before)
+        except ValueError:
+            raise_error_response(
+                "INVALID_CURSOR",
+                "Malformed pagination cursor.",
+                status_code=400,
+            )
+        # messages.id is TEXT (client-supplied ids), so the cursor tiebreak
+        # compares it as text — no ::uuid cast.
+        params.extend((cur_ts, cur_id))
+        where += " AND (timestamp, id) < ($3::timestamptz, $4)"
+    params.append(limit + 1)  # over-fetch one to detect has_more
+    sql = (
+        "SELECT id, content, timestamp, is_from_me, is_bot_message, "
+        "run_id::text AS run_id FROM messages WHERE "
+        + where
+        + f" ORDER BY timestamp DESC, id DESC LIMIT ${len(params)}"
+    )
+    try:
+        async with tenant_conn(user.tenant_id) as conn:
+            rows_desc = await conn.fetch(sql, *params)
+    except asyncpg.DataError:
+        # A cursor that decodes but carries a non-UUID / bad timestamp.
+        raise_error_response(
+            "INVALID_CURSOR",
+            "Malformed pagination cursor.",
+            status_code=400,
         )
-    out: list[Message] = []
-    for row in rows:
+
+    has_more = len(rows_desc) > limit
+    rows_desc = rows_desc[:limit]
+    next_cursor: str | None = None
+    if has_more and rows_desc:
+        oldest = rows_desc[-1]
+        next_cursor = _encode_message_cursor(
+            oldest["timestamp"].isoformat() if oldest["timestamp"] else "",
+            str(oldest["id"]),
+        )
+
+    items: list[Message] = []
+    for row in reversed(rows_desc):  # oldest-first for display
         role = "assistant" if (row["is_from_me"] or row["is_bot_message"]) else "user"
-        out.append(
+        items.append(
             Message(
                 id=row["id"],
                 role=role,  # type: ignore[arg-type]
@@ -245,7 +315,7 @@ async def list_conversation_messages(
                 run_id=row["run_id"],
             )
         )
-    return out
+    return MessagePage(items=items, has_more=has_more, next_cursor=next_cursor)
 
 
 @conversations_router.get(

--- a/src/webui/v1/coworkers.py
+++ b/src/webui/v1/coworkers.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from rolemesh.auth.permissions import user_can
 from rolemesh.core.backend_capabilities import BackendCompatError, validate_combo
 from rolemesh.db import (
+    count_coworkers_for_tenant,
     create_coworker,
     delete_coworker,
     get_coworker,
@@ -45,8 +46,9 @@ from webui.dependencies import (
     require_manage_or_owner,
     user_can_see_resource,
 )
-from webui.schemas_v1 import Coworker, CoworkerCreate, CoworkerUpdate
+from webui.schemas_v1 import Coworker, CoworkerCreate, CoworkerPage, CoworkerUpdate
 from webui.v1 import coworker_events
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import ErrorResponseException, raise_error_response
 
 if TYPE_CHECKING:
@@ -125,10 +127,12 @@ async def _validate_model_and_credential(
         )
 
 
-@router.get("", response_model=list[Coworker])
+@router.get("", response_model=CoworkerPage)
 async def list_coworkers(
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[Coworker]:
+) -> CoworkerPage:
     """List coworkers visible to the caller (feat/roles PR3 visibility).
 
     A manager (``agent.manage``: owner/admin/platform_admin) sees every
@@ -137,15 +141,28 @@ async def list_coworkers(
     :func:`rolemesh.db.get_coworkers_for_tenant`; it is the SQL mirror of
     :func:`webui.dependencies.user_can_see_resource`. This is NOT a new
     capability gate — the route stays auth-only (in the meta-test
-    allowlist); only the result SET narrows.
+    allowlist); only the result SET narrows. ``total`` reflects the
+    visible set, not the whole tenant.
     """
     can_manage = user_can(user.role, "agent.manage")  # type: ignore[arg-type]
     cws = await get_coworkers_for_tenant(
         user.tenant_id,
         requesting_user_id=user.user_id,
         include_all=can_manage,
+        limit=limit,
+        offset=offset,
     )
-    return [_coworker_to_response(c) for c in cws]
+    total = await count_coworkers_for_tenant(
+        user.tenant_id,
+        requesting_user_id=user.user_id,
+        include_all=can_manage,
+    )
+    return CoworkerPage(
+        items=[_coworker_to_response(c) for c in cws],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.post("", response_model=Coworker, status_code=201)

--- a/src/webui/v1/mcp_servers.py
+++ b/src/webui/v1/mcp_servers.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, Response
 
 from rolemesh.db import (
     MCPServerRow,
+    count_mcp_servers,
     create_mcp_server,
     delete_mcp_server,
     get_mcp_server,
@@ -27,8 +28,14 @@ from rolemesh.db import (
     update_mcp_server,
 )
 from webui.dependencies import get_current_user, require_action
-from webui.schemas_v1 import MCPServer, MCPServerCreate, MCPServerUpdate
+from webui.schemas_v1 import (
+    MCPServer,
+    MCPServerCreate,
+    MCPServerPage,
+    MCPServerUpdate,
+)
 from webui.v1 import mcp_events
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import ErrorResponseException, raise_error_response
 
 if TYPE_CHECKING:
@@ -70,12 +77,20 @@ async def _get_or_404(mcp_id: str, *, tenant_id: str) -> MCPServerRow:
     return row
 
 
-@router.get("", response_model=list[MCPServer])
+@router.get("", response_model=MCPServerPage)
 async def list_endpoint(
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[MCPServer]:
-    rows = await list_mcp_servers(user.tenant_id)
-    return [_row_to_response(r) for r in rows]
+) -> MCPServerPage:
+    rows = await list_mcp_servers(user.tenant_id, limit=limit, offset=offset)
+    total = await count_mcp_servers(user.tenant_id)
+    return MCPServerPage(
+        items=[_row_to_response(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.post("", response_model=MCPServer, status_code=201)

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -30,6 +30,7 @@ from rolemesh import db
 from rolemesh.auth.bootstrap_actor import resolve_actor_user_id
 from rolemesh.db import (
     count_safety_decisions,
+    count_safety_rules,
     create_safety_rule,
     delete_safety_rule,
     get_safety_decision,
@@ -54,6 +55,7 @@ from webui.schemas_v1 import (
     SafetyFinding,
     SafetyRule,
     SafetyRuleAuditEntry,
+    SafetyRulePage,
     SafetyStage,
     SafetyVerdictAction,
 )
@@ -398,14 +400,16 @@ async def _publish_rule_changed(action: str, rule: SafetyRuleDataclass) -> None:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/rules", response_model=list[SafetyRule])
+@router.get("/rules", response_model=SafetyRulePage)
 async def list_rules(
     coworker_id: str | None = None,
     stage: SafetyStage | None = None,
     enabled: bool | None = None,
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(require_action("safety.read")),
-) -> list[SafetyRule]:
-    """List safety rules for the caller's tenant.
+) -> SafetyRulePage:
+    """List safety rules for the caller's tenant (offset/limit paged).
 
     Returns the tenant's own rules PLUS the platform-owned rules that
     apply across all tenants. Platform rules are read-only
@@ -414,29 +418,43 @@ async def list_rules(
     enforce but are never shown. They honor the ``stage`` / ``enabled``
     filters. Like tenant-wide (``coworker_id IS NULL``) rules, platform
     rules are excluded when the caller filters by a specific
-    ``coworker_id`` — that filter is an exact-match narrowing, and
-    platform rules are not bound to any single coworker.
+    ``coworker_id``.
 
-    Tenant-rule filters mirror the admin endpoint exactly. Ordering
-    (``priority DESC, updated_at DESC``) lives in the helper; platform
-    rules are appended after, so the list groups tenant rules first.
+    Only the tenant rows are paginated at the DB. Platform rules are a
+    small read-only reference set, so they ride on the FIRST page only
+    (``offset == 0``), after the tenant slice; ``total`` counts them so
+    the SPA's pagination math stays correct.
     """
     rows = await list_safety_rules(
         user.tenant_id,
         coworker_id=coworker_id,
         stage=stage,
         enabled=enabled,
+        limit=limit,
+        offset=offset,
     )
-    out = [_rule_to_response(r) for r in rows]
+    items = [_rule_to_response(r) for r in rows]
+    total = await count_safety_rules(
+        user.tenant_id,
+        coworker_id=coworker_id,
+        stage=stage,
+        enabled=enabled,
+    )
 
     if coworker_id is None:
-        for prow in await list_visible_platform_rules(user.tenant_id):
-            if stage is not None and prow["stage"] != stage:
-                continue
-            if enabled is not None and bool(prow["enabled"]) != enabled:
-                continue
-            out.append(_platform_rule_to_response(prow))
-    return out
+        platform = [
+            _platform_rule_to_response(prow)
+            for prow in await list_visible_platform_rules(user.tenant_id)
+            if (stage is None or prow["stage"] == stage)
+            and (enabled is None or bool(prow["enabled"]) == enabled)
+        ]
+        total += len(platform)
+        if offset == 0:
+            items.extend(platform)
+
+    return SafetyRulePage(
+        items=items, total=total, limit=limit, offset=offset,
+    )
 
 
 @router.get("/rules/{rule_id}", response_model=SafetyRule)

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -31,6 +31,7 @@ from rolemesh.auth.bootstrap_actor import resolve_actor_user_id
 from rolemesh.db import (
     count_safety_decisions,
     count_safety_rules,
+    count_safety_rules_audit,
     create_safety_rule,
     delete_safety_rule,
     get_safety_decision,
@@ -55,6 +56,7 @@ from webui.schemas_v1 import (
     SafetyFinding,
     SafetyRule,
     SafetyRuleAuditEntry,
+    SafetyRuleAuditPage,
     SafetyRulePage,
     SafetyStage,
     SafetyVerdictAction,
@@ -491,27 +493,40 @@ async def get_rule(
 
 @router.get(
     "/rules/{rule_id}/audit",
-    response_model=list[SafetyRuleAuditEntry],
+    response_model=SafetyRuleAuditPage,
 )
 async def list_rule_audit(
     rule_id: str,
     limit: int = Query(default=200, ge=1, le=500),
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(require_action("safety.read")),
-) -> list[SafetyRuleAuditEntry]:
-    """Change-history timeline for one rule, newest first.
+) -> SafetyRuleAuditPage:
+    """Change-history timeline for one rule, newest first (offset/limit paged).
 
     Probes the parent rule via :func:`_get_rule_or_404` before
     reading audit rows — without this guard, a cross-tenant rule_id
     would return an empty 200 (because the audit table is RLS-
     scoped) which is itself a weak signal of "wrong tenant".
+
+    Keeps its own ``limit`` cap (max 500, vs the shared 200) because a
+    compliance timeline is occasionally read in larger pulls.
     """
     await _get_rule_or_404(rule_id, tenant_id=user.tenant_id)
     rows = await list_safety_rules_audit(
         tenant_id=user.tenant_id,
         rule_id=rule_id,
         limit=limit,
+        offset=offset,
     )
-    return [_audit_row_to_response(r) for r in rows]
+    total = await count_safety_rules_audit(
+        tenant_id=user.tenant_id, rule_id=rule_id,
+    )
+    return SafetyRuleAuditPage(
+        items=[_audit_row_to_response(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.get("/checks", response_model=list[SafetyCheck])

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -57,6 +57,7 @@ from webui.schemas_v1 import (
     SafetyStage,
     SafetyVerdictAction,
 )
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import raise_error_response
 
 if TYPE_CHECKING:
@@ -546,8 +547,8 @@ async def list_decisions(
     rule_id: str | None = None,
     from_ts: str | None = None,
     to_ts: str | None = None,
-    limit: int = Query(default=50, ge=1, le=200),
-    offset: int = Query(default=0, ge=0),
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(require_action("safety.read")),
 ) -> SafetyDecisionPage:
     """Paginated decisions list with a total-count envelope.
@@ -585,8 +586,10 @@ async def list_decisions(
         offset=offset,
     )
     return SafetyDecisionPage(
-        total=total,
         items=[_decision_row_to_response(r) for r in items],
+        total=total,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/src/webui/v1/schedules.py
+++ b/src/webui/v1/schedules.py
@@ -22,13 +22,15 @@ import asyncpg
 from fastapi import APIRouter, Depends, Query, Response
 
 from rolemesh.db import (
+    count_tasks,
     delete_task,
     get_all_tasks,
     get_task_by_id,
     get_tasks_for_coworker,
 )
 from webui.dependencies import get_current_user, require_action
-from webui.schemas_v1 import ScheduledTask
+from webui.schemas_v1 import ScheduledTask, ScheduledTaskPage
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import raise_error_response
 
 if TYPE_CHECKING:
@@ -56,16 +58,28 @@ def _to_response(t: ScheduledTaskDataclass) -> ScheduledTask:
     )
 
 
-@router.get("", response_model=list[ScheduledTask])
+@router.get("", response_model=ScheduledTaskPage)
 async def list_schedules_endpoint(
     coworker_id: str | None = Query(default=None),
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[ScheduledTask]:
+) -> ScheduledTaskPage:
     if coworker_id is not None:
-        rows = await get_tasks_for_coworker(coworker_id, tenant_id=user.tenant_id)
+        rows = await get_tasks_for_coworker(
+            coworker_id, tenant_id=user.tenant_id, limit=limit, offset=offset,
+        )
     else:
-        rows = await get_all_tasks(tenant_id=user.tenant_id)
-    return [_to_response(r) for r in rows]
+        rows = await get_all_tasks(
+            tenant_id=user.tenant_id, limit=limit, offset=offset,
+        )
+    total = await count_tasks(user.tenant_id, coworker_id=coworker_id)
+    return ScheduledTaskPage(
+        items=[_to_response(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.get("/{task_id}", response_model=ScheduledTask)

--- a/src/webui/v1/skills.py
+++ b/src/webui/v1/skills.py
@@ -32,6 +32,7 @@ from rolemesh.core.skills import (
 from rolemesh.core.types import Skill as SkillDataclass
 from rolemesh.core.types import SkillFile as SkillFileDataclass
 from rolemesh.db import (
+    count_skills_for_tenant,
     create_skill,
     delete_skill,
     delete_skill_file,
@@ -59,9 +60,11 @@ from webui.schemas_v1 import (
     SkillFile,
     SkillFileUpsert,
     SkillSummary,
+    SkillSummaryPage,
     SkillUpdate,
 )
 from webui.v1 import coworker_events
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import ErrorResponseException, raise_error_response
 
 if TYPE_CHECKING:
@@ -240,16 +243,26 @@ async def _broadcast_skills_changed(
 # ---------------------------------------------------------------------------
 
 
-@skills_router.get("", response_model=list[SkillSummary])
+@skills_router.get("", response_model=SkillSummaryPage)
 async def list_skills_endpoint(
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
-) -> list[SkillSummary]:
+) -> SkillSummaryPage:
     # feat/roles PR3 visibility: a manager (skill.manage) sees every
     # catalog skill; a member sees shared + their own private. Row-level
     # predicate lives in ``list_skills_for_tenant`` (SQL mirror of
     # ``user_can_see_resource``); the route stays auth-only (allowlisted).
+    # ``total`` reflects the visible set, not the whole catalog.
     can_manage = user_can(user.role, "skill.manage")  # type: ignore[arg-type]
     skills = await list_skills_for_tenant(
+        user.tenant_id,
+        requesting_user_id=user.user_id,
+        include_all=can_manage,
+        limit=limit,
+        offset=offset,
+    )
+    total = await count_skills_for_tenant(
         user.tenant_id,
         requesting_user_id=user.user_id,
         include_all=can_manage,
@@ -258,7 +271,9 @@ async def list_skills_endpoint(
     for s in skills:
         bound = await list_coworkers_for_skill(s.id, tenant_id=user.tenant_id)
         summaries.append(_skill_to_summary(s, bound_count=len(bound)))
-    return summaries
+    return SkillSummaryPage(
+        items=summaries, total=total, limit=limit, offset=offset,
+    )
 
 
 @skills_router.post("", response_model=Skill, status_code=201)

--- a/src/webui/v1/users.py
+++ b/src/webui/v1/users.py
@@ -22,9 +22,11 @@ from webui.dependencies import require_action
 from webui.schemas import (
     UserCreate,
     UserDetailResponse,
+    UserPage,
     UserResponse,
     UserUpdate,
 )
+from webui.v1._pagination import DEFAULT_PAGE_LIMIT, LimitParam, OffsetParam
 from webui.v1.errors import raise_error_response
 
 if TYPE_CHECKING:
@@ -46,12 +48,22 @@ def _user_to_response(u: User) -> UserResponse:
     )
 
 
-@router.get("", response_model=list[UserResponse])
+@router.get("", response_model=UserPage)
 async def list_users(
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(require_action("user.manage")),
-) -> list[UserResponse]:
-    users = await db.get_users_for_tenant(user.tenant_id)
-    return [_user_to_response(u) for u in users]
+) -> UserPage:
+    users = await db.get_users_for_tenant(
+        user.tenant_id, limit=limit, offset=offset,
+    )
+    total = await db.count_users_for_tenant(user.tenant_id)
+    return UserPage(
+        items=[_user_to_response(u) for u in users],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.post("", response_model=UserResponse, status_code=201)

--- a/tests/safety/e2e/test_rest_to_audit.py
+++ b/tests/safety/e2e/test_rest_to_audit.py
@@ -198,7 +198,7 @@ class TestRestCreateToAudit:
             # TestCrossTenantListing below.
             r = await client.get("/api/v1/safety/rules")
             assert r.status_code == 200
-            assert any(row["id"] == rule_id for row in r.json())
+            assert any(row["id"] == rule_id for row in r.json()["items"])
 
         # 2. Container side: loads snapshot exactly as
         #    container_executor would. If the REST layer quietly
@@ -401,7 +401,7 @@ class TestCrossTenantListing:
             # B's list must be empty.
             r = await c_b.get("/api/v1/safety/rules")
             assert r.status_code == 200
-            assert r.json() == []
+            assert r.json()["items"] == []
 
             # B's direct GET by id must 404 (not 403 — avoids
             # existence leakage).

--- a/tests/webui/test_v1_approval_policies.py
+++ b/tests/webui/test_v1_approval_policies.py
@@ -104,7 +104,7 @@ async def test_create_list_get_patch_delete_round_trip() -> None:
 
         listing = await ac.get("/api/v1/approval-policies", headers=_AUTH)
         assert listing.status_code == 200
-        assert [p["id"] for p in listing.json()] == [pid]
+        assert [p["id"] for p in listing.json()["items"]] == [pid]
 
         got = await ac.get(f"/api/v1/approval-policies/{pid}", headers=_AUTH)
         assert got.status_code == 200
@@ -312,13 +312,13 @@ async def test_pending_requests_returns_own_tenant_only() -> None:
     async with _client(_build_app(a)) as ac:
         resp = await ac.get("/api/v1/approval-requests", headers=_AUTH)
     assert resp.status_code == 200
-    ids = {r["request_id"] for r in resp.json()}
+    ids = {r["request_id"] for r in resp.json()["items"]}
     assert a_req in ids
     assert b_req not in ids
     # §1.2: the projection now carries the decision-relevant payload — the raw
     # params (the decision input), the requesting coworker, and the rationale —
     # flattened out of the internal ``action`` wrapper.
-    row = next(r for r in resp.json() if r["request_id"] == a_req)
+    row = next(r for r in resp.json()["items"] if r["request_id"] == a_req)
     assert row["tool_name"] == "charge"
     assert row["action_summary"] == "charge $500"
     assert row["params"] == {"amount": 500}

--- a/tests/webui/test_v1_conversations.py
+++ b/tests/webui/test_v1_conversations.py
@@ -122,7 +122,7 @@ async def test_create_then_list_conversation() -> None:
         # List
         resp = await c.get(f"/api/v1/coworkers/{cw_id}/conversations")
         assert resp.status_code == 200
-        items = resp.json()
+        items = resp.json()["items"]
         assert len(items) == 1
         assert items[0]["id"] == conv_id
 
@@ -260,7 +260,7 @@ async def test_delete_conversation_cascades_messages() -> None:
     async with _client(app) as c:
         r = await c.get(f"/api/v1/conversations/{conv_id}/messages")
     assert r.status_code == 200
-    msgs = r.json()
+    msgs = r.json()["items"]
     assert len(msgs) == 2
     roles = {m["role"] for m in msgs}
     assert roles == {"user", "assistant"}, msgs
@@ -307,7 +307,7 @@ async def test_bot_message_with_only_is_bot_message_surfaces_as_assistant() -> N
     async with _client(app) as c:
         r = await c.get(f"/api/v1/conversations/{conv_id}/messages")
     assert r.status_code == 200
-    msgs = r.json()
+    msgs = r.json()["items"]
     assert len(msgs) == 1
     assert msgs[0]["role"] == "assistant"
 
@@ -471,3 +471,63 @@ async def test_conversation_approvals_cross_tenant_is_404() -> None:
         r = await c.get(f"/api/v1/conversations/{b_conv}/approval-requests")
     assert r.status_code == 404
     assert r.json()["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_messages_cursor_pagination_walks_older() -> None:
+    """Cursor paging returns the newest page first, then walks older via
+    next_cursor. Items come back oldest-first (display order); the cursor
+    is opaque and seeks on (timestamp, id)."""
+    tid, uid, cw_id = await _make_tenant_user_coworker("curs")
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        conv_id = (
+            await c.post(f"/api/v1/coworkers/{cw_id}/conversations", json={})
+        ).json()["id"]
+
+    base = datetime.now(UTC)
+    for i in range(3):  # m0 < m1 < m2 in time
+        await store_message(
+            tenant_id=tid,
+            conversation_id=conv_id,
+            msg_id=f"m-{i}",
+            sender="user",
+            sender_name="U",
+            content=f"msg{i}",
+            timestamp=(base + timedelta(seconds=i)).isoformat(),
+            is_from_me=False,
+        )
+
+    async with _client(app) as c:
+        # Page 1: newest 2 (m1, m2), oldest-first; more remain.
+        p1 = (
+            await c.get(f"/api/v1/conversations/{conv_id}/messages?limit=2")
+        ).json()
+        assert [m["content"] for m in p1["items"]] == ["msg1", "msg2"]
+        assert p1["has_more"] is True
+        assert p1["next_cursor"]
+        # Page 2: the one older message (m0); no more.
+        p2 = (
+            await c.get(
+                f"/api/v1/conversations/{conv_id}/messages"
+                f"?limit=2&before={p1['next_cursor']}"
+            )
+        ).json()
+        assert [m["content"] for m in p2["items"]] == ["msg0"]
+        assert p2["has_more"] is False
+        assert p2["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_messages_malformed_cursor_is_400() -> None:
+    tid, uid, cw_id = await _make_tenant_user_coworker("badc")
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        conv_id = (
+            await c.post(f"/api/v1/coworkers/{cw_id}/conversations", json={})
+        ).json()["id"]
+        resp = await c.get(
+            f"/api/v1/conversations/{conv_id}/messages?before=not-a-cursor"
+        )
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_CURSOR"

--- a/tests/webui/test_v1_coworkers_create.py
+++ b/tests/webui/test_v1_coworkers_create.py
@@ -369,11 +369,11 @@ async def test_list_coworkers_does_not_leak_across_tenants() -> None:
 
         list_a = await c_a.get("/api/v1/coworkers")
         assert list_a.status_code == 200
-        names_a = {c["name"] for c in list_a.json()}
+        names_a = {c["name"] for c in list_a.json()["items"]}
         assert "secret-helper" in names_a
 
     async with _client(app_b) as c_b:
         list_b = await c_b.get("/api/v1/coworkers")
         assert list_b.status_code == 200
-        names_b = {c["name"] for c in list_b.json()}
+        names_b = {c["name"] for c in list_b.json()["items"]}
         assert "secret-helper" not in names_b

--- a/tests/webui/test_v1_safety.py
+++ b/tests/webui/test_v1_safety.py
@@ -125,7 +125,7 @@ async def test_list_rules_returns_only_caller_tenant() -> None:
     async with _client(_build_app(a)) as ac:
         resp = await ac.get("/api/v1/safety/rules", headers=_HDRS)
     assert resp.status_code == 200, resp.text
-    rows = resp.json()
+    rows = resp.json()["items"]
     rule_ids = {r["id"] for r in rows}
     assert rule_a.id in rule_ids
     assert rule_b.id not in rule_ids
@@ -153,7 +153,7 @@ async def test_list_rules_orders_by_priority_then_updated_desc() -> None:
     async with _client(_build_app(user)) as ac:
         resp = await ac.get("/api/v1/safety/rules", headers=_HDRS)
     assert resp.status_code == 200
-    ids = [r["id"] for r in resp.json()]
+    ids = [r["id"] for r in resp.json()["items"]]
     assert ids.index(high.id) < ids.index(mid.id) < ids.index(low.id)
 
 
@@ -179,7 +179,7 @@ async def test_list_rules_filters_by_coworker_id() -> None:
             f"/api/v1/safety/rules?coworker_id={cw}", headers=_HDRS,
         )
     assert resp.status_code == 200
-    ids = {r["id"] for r in resp.json()}
+    ids = {r["id"] for r in resp.json()["items"]}
     assert bound.id in ids
     assert tenant_wide.id not in ids
 
@@ -205,7 +205,7 @@ async def test_list_rules_filters_by_stage_and_enabled() -> None:
             headers=_HDRS,
         )
     assert resp.status_code == 200
-    rows = resp.json()
+    rows = resp.json()["items"]
     # Tenant-owned rows respect the exact filter.
     tenant_ids = {r["id"] for r in rows if r["source"] == "tenant"}
     assert tenant_ids == {on.id}
@@ -235,7 +235,7 @@ async def test_list_rules_surfaces_platform_rules_read_only() -> None:
     async with _client(_build_app(user)) as ac:
         resp = await ac.get("/api/v1/safety/rules", headers=_HDRS)
     assert resp.status_code == 200, resp.text
-    rows = resp.json()
+    rows = resp.json()["items"]
     platform = [r for r in rows if r["source"] == "platform"]
     assert len(platform) == 5  # the 5 default-tier rules
     assert all(r["editable"] is False for r in platform)

--- a/tests/webui/test_v1_safety.py
+++ b/tests/webui/test_v1_safety.py
@@ -375,7 +375,7 @@ async def test_rule_audit_timeline_newest_first() -> None:
             f"/api/v1/safety/rules/{rule.id}/audit", headers=_HDRS,
         )
     assert resp.status_code == 200, resp.text
-    rows = resp.json()
+    rows = resp.json()["items"]
     assert len(rows) >= 2
     # Ordering: most recent first
     timestamps = [r["created_at"] for r in rows]

--- a/tests/webui/test_v1_schedules.py
+++ b/tests/webui/test_v1_schedules.py
@@ -98,7 +98,7 @@ async def test_list_schedules_returns_tenant_tasks() -> None:
     async with _client(_build_app(user)) as ac:
         resp = await ac.get("/api/v1/schedules", headers=_HDRS)
     assert resp.status_code == 200
-    ids = {row["id"] for row in resp.json()}
+    ids = {row["id"] for row in resp.json()["items"]}
     assert a in ids and b in ids
 
 
@@ -122,7 +122,7 @@ async def test_list_schedules_filters_by_coworker() -> None:
             f"/api/v1/schedules?coworker_id={cw_a}", headers=_HDRS,
         )
     assert resp.status_code == 200
-    ids = {row["id"] for row in resp.json()}
+    ids = {row["id"] for row in resp.json()["items"]}
     assert task_a in ids
     assert task_b not in ids
 
@@ -140,7 +140,7 @@ async def test_list_schedules_excludes_other_tenants() -> None:
     async with _client(_build_app(user_a)) as ac:
         resp = await ac.get("/api/v1/schedules", headers=_HDRS)
     assert resp.status_code == 200
-    ids = {row["id"] for row in resp.json()}
+    ids = {row["id"] for row in resp.json()["items"]}
     assert other not in ids
 
 

--- a/tests/webui/test_v1_skills.py
+++ b/tests/webui/test_v1_skills.py
@@ -177,7 +177,7 @@ async def test_list_skills_returns_summary_with_zero_bound_count() -> None:
         )
         resp = await ac.get("/api/v1/skills", headers=_HDRS)
     assert resp.status_code == 200
-    rows = resp.json()
+    rows = resp.json()["items"]
     assert any(s["name"] == "a" and s["bound_coworker_count"] == 0 for s in rows)
 
 
@@ -472,7 +472,7 @@ async def test_cross_tenant_list_excludes_other_tenant() -> None:
         )
     async with _client(_build_app(user_a)) as ac:
         resp = await ac.get("/api/v1/skills", headers=_HDRS)
-    names = {s["name"] for s in resp.json()}
+    names = {s["name"] for s in resp.json()["items"]}
     assert "secret-b" not in names
 
 
@@ -737,5 +737,5 @@ async def test_patch_files_refreshes_frontmatter_description() -> None:
             headers=_HDRS,
         )
         listing = await ac.get("/api/v1/skills", headers=_HDRS)
-    summaries = {s["name"]: s for s in listing.json()}
+    summaries = {s["name"]: s for s in listing.json()["items"]}
     assert summaries["rdesc"]["description"] == new_desc

--- a/tests/webui/test_v1_users.py
+++ b/tests/webui/test_v1_users.py
@@ -71,7 +71,7 @@ async def test_list_users_owner_ok() -> None:
     async with _client(_build_app(user)) as ac:
         resp = await ac.get("/api/v1/users", headers=_HDRS)
     assert resp.status_code == 200, resp.text
-    ids = {u["id"] for u in resp.json()}
+    ids = {u["id"] for u in resp.json()["items"]}
     assert user.user_id in ids
 
 
@@ -80,6 +80,36 @@ async def test_list_users_admin_ok() -> None:
     async with _client(_build_app(user)) as ac:
         resp = await ac.get("/api/v1/users", headers=_HDRS)
     assert resp.status_code == 200, resp.text
+
+
+async def test_list_users_pagination_envelope_and_window() -> None:
+    # Seed enough users that a small limit forces two pages; assert the
+    # {items, total, limit, offset} envelope and that limit/offset slice
+    # without overlap and total reflects the full set (not the page).
+    owner = await _make_tenant_user("owner")
+    for _ in range(4):  # owner + 4 = 5 users in the tenant
+        await create_user(
+            tenant_id=owner.tenant_id, name="U",
+            email=f"u-{uuid.uuid4().hex[:6]}@x.com", role="member",
+        )
+    async with _client(_build_app(owner)) as ac:
+        p1 = (await ac.get("/api/v1/users?limit=2&offset=0", headers=_HDRS)).json()
+        p2 = (await ac.get("/api/v1/users?limit=2&offset=2", headers=_HDRS)).json()
+    assert p1["total"] == 5
+    assert p1["limit"] == 2 and p1["offset"] == 0
+    assert len(p1["items"]) == 2
+    assert p2["offset"] == 2 and len(p2["items"]) == 2
+    # No overlap between consecutive pages.
+    assert {u["id"] for u in p1["items"]}.isdisjoint(
+        {u["id"] for u in p2["items"]}
+    )
+
+
+async def test_list_users_limit_over_max_is_rejected() -> None:
+    owner = await _make_tenant_user("owner")
+    async with _client(_build_app(owner)) as ac:
+        resp = await ac.get("/api/v1/users?limit=999", headers=_HDRS)
+    assert resp.status_code == 422  # exceeds MAX_PAGE_LIMIT (200)
 
 
 async def test_list_users_member_forbidden() -> None:

--- a/tests/webui/test_v1_visibility.py
+++ b/tests/webui/test_v1_visibility.py
@@ -135,7 +135,7 @@ async def test_created_coworker_defaults_private_and_hidden_from_others() -> Non
     other_app = _build_app(_authed(tid, other, "member"))
     async with _client(other_app) as c:
         listed = await c.get("/api/v1/coworkers")
-        assert cw_id not in {r["id"] for r in listed.json()}
+        assert cw_id not in {r["id"] for r in listed.json()["items"]}
         fetched = await c.get(f"/api/v1/coworkers/{cw_id}")
         assert fetched.status_code == 404, fetched.text
 
@@ -179,7 +179,7 @@ async def test_member_list_coworkers_scopes_to_visible() -> None:
     app = _build_app(_authed(tid, me, "member"))
     async with _client(app) as c:
         resp = await c.get("/api/v1/coworkers")
-    ids = {r["id"] for r in resp.json()}
+    ids = {r["id"] for r in resp.json()["items"]}
     assert my_private in ids
     assert shared in ids
     assert others_private not in ids
@@ -198,8 +198,32 @@ async def test_admin_list_coworkers_sees_everything() -> None:
     app = _build_app(_authed(tid, admin, "admin"))
     async with _client(app) as c:
         resp = await c.get("/api/v1/coworkers")
-    ids = {r["id"] for r in resp.json()}
+    ids = {r["id"] for r in resp.json()["items"]}
     assert {a, b} <= ids
+
+
+@pytest.mark.asyncio
+async def test_list_coworkers_pagination_total_respects_visibility() -> None:
+    # The page envelope's total must reflect the VISIBLE set, not the
+    # whole tenant: a member who can see fewer rows gets a smaller total
+    # than an admin over the same data (the count mirrors the list's
+    # visibility predicate).
+    tid = await _tenant()
+    me = await _user(tid, "member")
+    other = await _user(tid, "member")
+    await _seed_coworker(tid, created_by=me, visibility="private")
+    await _seed_coworker(tid, created_by=other, visibility="shared")
+    await _seed_coworker(tid, created_by=other, visibility="private")
+
+    async with _client(_build_app(_authed(tid, me, "member"))) as c:
+        member_page = (await c.get("/api/v1/coworkers")).json()
+    async with _client(_build_app(_authed(tid, me, "admin"))) as c:
+        admin_page = (await c.get("/api/v1/coworkers")).json()
+
+    # Member sees own-private + shared (2); admin sees all 3.
+    assert member_page["total"] == 2
+    assert admin_page["total"] == 3
+    assert member_page["limit"] == 50 and member_page["offset"] == 0
 
 
 @pytest.mark.asyncio
@@ -214,7 +238,7 @@ async def test_member_list_skills_scopes_to_visible() -> None:
     app = _build_app(_authed(tid, me, "member"))
     async with _client(app) as c:
         resp = await c.get("/api/v1/skills")
-    ids = {r["id"] for r in resp.json()}
+    ids = {r["id"] for r in resp.json()["items"]}
     assert mine in ids
     assert shared in ids
     assert foreign not in ids

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -261,12 +261,15 @@ export class ApiClient {
   }
 
   async listCoworkerConversations(coworkerId: string): Promise<Conversation[]> {
+    // Paged endpoint; request the max window and return items (array shape
+    // preserved for callers; full page-through UI is a follow-up).
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/conversations`,
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/conversations?limit=200`,
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as Conversation[];
+    return ((await resp.json()) as components['schemas']['ConversationPage'])
+      .items;
   }
 
   /** Create a fresh web-channel conversation for a coworker. The
@@ -290,12 +293,16 @@ export class ApiClient {
   }
 
   async listMessages(conversationId: string): Promise<Message[]> {
+    // Cursor-paginated endpoint. Request the max window and return the
+    // (oldest-first) items so existing callers keep their array shape; this
+    // shows the newest 200 messages. "Load older" via next_cursor is a
+    // follow-up once the chat UI grows a scrollback control.
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/conversations/${encodeURIComponent(conversationId)}/messages`,
+      `${this.baseUrl}/api/v1/conversations/${encodeURIComponent(conversationId)}/messages?limit=200`,
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as Message[];
+    return ((await resp.json()) as components['schemas']['MessagePage']).items;
   }
 
   async getRun(runId: string): Promise<Run | null> {
@@ -661,12 +668,14 @@ export class ApiClient {
     ruleId: string,
     limit = 200,
   ): Promise<SafetyRuleAuditEntry[]> {
+    // Paged endpoint; return items so callers keep their array shape.
     const resp = await fetch(
       `${this.baseUrl}/api/v1/safety/rules/${encodeURIComponent(ruleId)}/audit?limit=${limit}`,
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as SafetyRuleAuditEntry[];
+    return ((await resp.json()) as components['schemas']['SafetyRuleAuditPage'])
+      .items;
   }
 
   async listSafetyChecks(): Promise<SafetyCheck[]> {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -415,12 +415,15 @@ export class ApiClient {
   // ------------------------------------------------------------------
 
   async listApprovalPolicies(): Promise<ApprovalPolicy[]> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/approval-policies`, {
-      method: 'GET',
-      headers: this.headers(),
-    });
+    // Paged endpoint; request the max window and return the items so
+    // callers keep their array shape (page-through UI is a follow-up).
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/approval-policies?limit=200`,
+      { method: 'GET', headers: this.headers() },
+    );
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as ApprovalPolicy[];
+    return ((await resp.json()) as components['schemas']['ApprovalPolicyPage'])
+      .items;
   }
 
   async createApprovalPolicy(
@@ -465,15 +468,15 @@ export class ApiClient {
   async listPendingApprovals(
     conversationId?: string,
   ): Promise<ApprovalRequest[]> {
-    const qs = conversationId
-      ? `?conversation_id=${encodeURIComponent(conversationId)}`
-      : '';
+    const qs = new URLSearchParams({ limit: '200' });
+    if (conversationId) qs.set('conversation_id', conversationId);
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/approval-requests${qs}`,
+      `${this.baseUrl}/api/v1/approval-requests?${qs}`,
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as ApprovalRequest[];
+    return ((await resp.json()) as components['schemas']['ApprovalRequestPage'])
+      .items;
   }
 
   /** A conversation's full HITL approval record — pending AND resolved,
@@ -629,10 +632,15 @@ export class ApiClient {
     if (filters?.enabled !== undefined && filters.enabled !== null) {
       qs.set('enabled', String(filters.enabled));
     }
-    const url = `${this.baseUrl}/api/v1/safety/rules${qs.size ? `?${qs}` : ''}`;
+    // List endpoints are paged; request the max window and return the
+    // items so existing callers keep their array shape. Real page-through
+    // UI is a follow-up (see the pagination rollout).
+    qs.set('limit', '200');
+    const url = `${this.baseUrl}/api/v1/safety/rules?${qs}`;
     const resp = await fetch(url, { method: 'GET', headers: this.headers() });
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as SafetyRule[];
+    return ((await resp.json()) as components['schemas']['SafetyRulePage'])
+      .items;
   }
 
   async getSafetyRule(id: string): Promise<SafetyRule> {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -224,12 +224,14 @@ export class ApiClient {
   }
 
   async listCoworkers(): Promise<Coworker[]> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/coworkers`, {
+    // Paged endpoint; request the max window and return items so callers
+    // keep their array shape (full page-through UI is a follow-up).
+    const resp = await fetch(`${this.baseUrl}/api/v1/coworkers?limit=200`, {
       method: 'GET',
       headers: this.headers(),
     });
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as Coworker[];
+    return ((await resp.json()) as components['schemas']['CoworkerPage']).items;
   }
 
   /** Patch selected fields on a coworker. Backend treats ABSENT keys
@@ -368,12 +370,13 @@ export class ApiClient {
   // ------------------------------------------------------------------
 
   async listMCPServers(): Promise<MCPServer[]> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/mcp-servers`, {
+    // Paged endpoint; request the max window and return items (see above).
+    const resp = await fetch(`${this.baseUrl}/api/v1/mcp-servers?limit=200`, {
       method: 'GET',
       headers: this.headers(),
     });
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as MCPServer[];
+    return ((await resp.json()) as components['schemas']['MCPServerPage']).items;
   }
 
   async createMCPServer(body: MCPServerCreate): Promise<MCPServer> {
@@ -503,12 +506,14 @@ export class ApiClient {
   // ------------------------------------------------------------------
 
   async listSkills(): Promise<SkillSummary[]> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/skills`, {
+    // Paged endpoint; request the max window and return items (see above).
+    const resp = await fetch(`${this.baseUrl}/api/v1/skills?limit=200`, {
       method: 'GET',
       headers: this.headers(),
     });
     if (!resp.ok) throw await this.parseError(resp);
-    return (await resp.json()) as SkillSummary[];
+    return ((await resp.json()) as components['schemas']['SkillSummaryPage'])
+      .items;
   }
 
   async getSkill(id: string): Promise<Skill> {

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2081,8 +2081,10 @@ export interface components {
             created_at: string;
         };
         SafetyDecisionPage: {
+            items: components["schemas"]["SafetyDecision"][];
             total: number;
-            items?: components["schemas"]["SafetyDecision"][];
+            limit: number;
+            offset: number;
         };
         SafetyRuleAuditEntry: {
             /** Format: uuid */

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2134,6 +2134,24 @@ export interface components {
             limit: number;
             offset: number;
         };
+        ConversationPage: {
+            items: components["schemas"]["Conversation"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        SafetyRuleAuditPage: {
+            items: components["schemas"]["SafetyRuleAuditEntry"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        MessagePage: {
+            items: components["schemas"]["Message"][];
+            has_more: boolean;
+            /** @description Opaque cursor for the next OLDER page; pass back as the `before` query param. Null when there are no older messages. */
+            next_cursor?: string | null;
+        };
         SafetyRuleAuditEntry: {
             /** Format: uuid */
             id: string;
@@ -3051,7 +3069,12 @@ export interface operations {
     };
     listCoworkerConversations: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
             header?: never;
             path: {
                 id: components["parameters"]["IdInPath"];
@@ -3066,7 +3089,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Conversation"][];
+                    "application/json": components["schemas"]["ConversationPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -3151,7 +3174,12 @@ export interface operations {
     };
     listConversationMessages: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Opaque cursor from a previous page's next_cursor; returns the page of messages immediately older than it. */
+                before?: string;
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+            };
             header?: never;
             path: {
                 id: components["parameters"]["IdInPath"];
@@ -3166,7 +3194,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Message"][];
+                    "application/json": components["schemas"]["MessagePage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -4426,6 +4454,8 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: number;
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
             };
             header?: never;
             path: {
@@ -4441,7 +4471,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SafetyRuleAuditEntry"][];
+                    "application/json": components["schemas"]["SafetyRuleAuditPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2086,6 +2086,36 @@ export interface components {
             limit: number;
             offset: number;
         };
+        UserPage: {
+            items: components["schemas"]["UserResponse"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        SafetyRulePage: {
+            items: components["schemas"]["SafetyRule"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        ScheduledTaskPage: {
+            items: components["schemas"]["ScheduledTask"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        ApprovalPolicyPage: {
+            items: components["schemas"]["ApprovalPolicy"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        ApprovalRequestPage: {
+            items: components["schemas"]["ApprovalRequest"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
         SafetyRuleAuditEntry: {
             /** Format: uuid */
             id: string;
@@ -2644,6 +2674,10 @@ export interface components {
     };
     parameters: {
         IdInPath: string;
+        /** @description Maximum number of items to return (default 50, max 200). */
+        LimitParam: number;
+        /** @description Number of items to skip from the start of the ordered set. */
+        OffsetParam: number;
     };
     requestBodies: never;
     headers: never;
@@ -4006,7 +4040,12 @@ export interface operations {
     };
     listApprovalPolicies: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -4019,7 +4058,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ApprovalPolicy"][];
+                    "application/json": components["schemas"]["ApprovalPolicyPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -4129,6 +4168,10 @@ export interface operations {
     listPendingApprovalRequests: {
         parameters: {
             query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
                 /** @description Only return pending requests for this conversation. */
                 conversation_id?: string;
             };
@@ -4144,7 +4187,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ApprovalRequest"][];
+                    "application/json": components["schemas"]["ApprovalRequestPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -4213,6 +4256,10 @@ export interface operations {
     listSafetyRules: {
         parameters: {
             query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
                 coworker_id?: string;
                 stage?: components["schemas"]["SafetyStage"];
                 enabled?: boolean;
@@ -4229,7 +4276,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SafetyRule"][];
+                    "application/json": components["schemas"]["SafetyRulePage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -4485,6 +4532,10 @@ export interface operations {
     schedulesList: {
         parameters: {
             query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
                 /** @description When set, only tasks bound to this coworker. */
                 coworker_id?: string;
             };
@@ -4500,7 +4551,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ScheduledTask"][];
+                    "application/json": components["schemas"]["ScheduledTaskPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -4769,7 +4820,12 @@ export interface operations {
     };
     listUsers: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -4782,7 +4838,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserResponse"][];
+                    "application/json": components["schemas"]["UserPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2116,6 +2116,24 @@ export interface components {
             limit: number;
             offset: number;
         };
+        CoworkerPage: {
+            items: components["schemas"]["Coworker"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        SkillSummaryPage: {
+            items: components["schemas"]["SkillSummary"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
+        MCPServerPage: {
+            items: components["schemas"]["MCPServer"][];
+            total: number;
+            limit: number;
+            offset: number;
+        };
         SafetyRuleAuditEntry: {
             /** Format: uuid */
             id: string;
@@ -2850,7 +2868,12 @@ export interface operations {
     };
     listCoworkers: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -2863,7 +2886,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Coworker"][];
+                    "application/json": components["schemas"]["CoworkerPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -3514,7 +3537,12 @@ export interface operations {
     };
     listSkills: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3527,7 +3555,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SkillSummary"][];
+                    "application/json": components["schemas"]["SkillSummaryPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];
@@ -3903,7 +3931,12 @@ export interface operations {
     };
     listMCPServers: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3916,7 +3949,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MCPServer"][];
+                    "application/json": components["schemas"]["MCPServerPage"];
                 };
             };
             401: components["responses"]["Unauthorized"];

--- a/web/src/components/coworker-wizard.test.ts
+++ b/web/src/components/coworker-wizard.test.ts
@@ -23,6 +23,8 @@ import {
 } from './coworker-wizard.js';
 import type { Backend, Coworker, CredentialResponse, Model } from '../api/client.js';
 
+const pageOf = <T,>(items: T[]) => ({ items, total: items.length, limit: 200, offset: 0 });
+
 // ---------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------
@@ -202,12 +204,12 @@ describe('<rm-coworker-wizard>', () => {
         respond: () => jsonResp(CREDS_ANT),
       },
       {
-        match: (u) => u === '/api/v1/mcp-servers',
-        respond: () => jsonResp([]),
+        match: (u) => u.split('?')[0] === '/api/v1/mcp-servers',
+        respond: () => jsonResp(pageOf([])),
       },
       {
-        match: (u) => u === '/api/v1/skills',
-        respond: () => jsonResp([]),
+        match: (u) => u.split('?')[0] === '/api/v1/skills',
+        respond: () => jsonResp(pageOf([])),
       },
       {
         match: (u, i) => u === '/api/v1/coworkers' && i?.method === 'POST',
@@ -456,8 +458,8 @@ describe('<rm-coworker-wizard>', () => {
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
       { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
       {
-        match: (u) => u === '/api/v1/mcp-servers',
-        respond: () => jsonResp([
+        match: (u) => u.split('?')[0] === '/api/v1/mcp-servers',
+        respond: () => jsonResp(pageOf([
           {
             id: 'mmmmmmmm-0000-0000-0000-000000000001',
             tenant_id: 't',
@@ -468,9 +470,9 @@ describe('<rm-coworker-wizard>', () => {
             created_at: '2026-05-20T00:00:00Z',
             updated_at: '2026-05-20T00:00:00Z',
           },
-        ]),
+        ])),
       },
-      { match: (u) => u === '/api/v1/skills', respond: () => jsonResp([]) },
+      { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
       {
         match: (u, i) => u === '/api/v1/coworkers' && i?.method === 'POST',
         respond: () => jsonResp(CREATED_COWORKER, 201),
@@ -545,8 +547,8 @@ describe('<rm-coworker-wizard>', () => {
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
       { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
-      { match: (u) => u === '/api/v1/mcp-servers', respond: () => jsonResp([]) },
-      { match: (u) => u === '/api/v1/skills', respond: () => jsonResp([]) },
+      { match: (u) => u.split('?')[0] === '/api/v1/mcp-servers', respond: () => jsonResp(pageOf([])) },
+      { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
       // Existing MCP bindings: seed the wizard with one already-bound
       // server so we can verify it ends up in originalMcpServerIds.
       {
@@ -654,8 +656,8 @@ describe('<rm-coworker-wizard>', () => {
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
       { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
-      { match: (u) => u === '/api/v1/mcp-servers', respond: () => jsonResp([]) },
-      { match: (u) => u === '/api/v1/skills', respond: () => jsonResp([]) },
+      { match: (u) => u.split('?')[0] === '/api/v1/mcp-servers', respond: () => jsonResp(pageOf([])) },
+      { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
     ]);
     const el = mount();
     el.open = true;
@@ -693,8 +695,8 @@ describe('<rm-coworker-wizard>', () => {
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
       { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
-      { match: (u) => u === '/api/v1/mcp-servers', respond: () => jsonResp(MCP_LIST) },
-      { match: (u) => u === '/api/v1/skills', respond: () => jsonResp(SKILL_LIST) },
+      { match: (u) => u.split('?')[0] === '/api/v1/mcp-servers', respond: () => jsonResp(pageOf(MCP_LIST)) },
+      { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf(SKILL_LIST)) },
     ]);
     const el = mount();
     el.open = true;
@@ -768,12 +770,12 @@ describe('<rm-coworker-wizard>', () => {
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
       { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
       {
-        match: (u) => u === '/api/v1/mcp-servers',
-        respond: () => jsonResp([
+        match: (u) => u.split('?')[0] === '/api/v1/mcp-servers',
+        respond: () => jsonResp(pageOf([
           { id: 'm1', name: 'a', tenant_id: 't', config: {}, created_at: '', updated_at: '' },
-        ]),
+        ])),
       },
-      { match: (u) => u === '/api/v1/skills', respond: () => jsonResp([]) },
+      { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
     ]);
     const el = mount();
     el.open = true;

--- a/web/src/components/safety-decisions-page.ts
+++ b/web/src/components/safety-decisions-page.ts
@@ -66,7 +66,12 @@ export class SafetyDecisionsPage extends LitElement {
   // Cached so the admin CSV endpoint (not on v1) gets the tenant in its URL.
   // Decisions reads themselves derive tenant from auth.
   @state() private tenantId: string | null = null;
-  @state() private decisions: SafetyDecisionPage = { total: 0, items: [] };
+  @state() private decisions: SafetyDecisionPage = {
+    items: [],
+    total: 0,
+    limit: 0,
+    offset: 0,
+  };
   @state() private coworkers: CoworkerSummary[] = [];
   @state() private checks: SafetyCheck[] = [];
   // rule_id → check label, for the detail modal's "triggered rule" cell.

--- a/web/src/services/safety-admin-client.ts
+++ b/web/src/services/safety-admin-client.ts
@@ -341,8 +341,12 @@ export interface CoworkerSummary {
 }
 
 export async function listCoworkers(): Promise<CoworkerSummary[]> {
-  const res = await apiFetch('/api/v1/coworkers');
+  // Paged endpoint; request the max window and read items (the decisions
+  // filter only needs id/name for the dropdown).
+  const res = await apiFetch('/api/v1/coworkers?limit=200');
   if (!res.ok) return [];
-  const body = (await res.json()) as Array<{ id: string; name: string }>;
-  return body.map((c) => ({ id: c.id, name: c.name }));
+  const body = (await res.json()) as {
+    items: Array<{ id: string; name: string }>;
+  };
+  return body.items.map((c) => ({ id: c.id, name: c.name }));
 }

--- a/web/src/services/safety-admin-client.ts
+++ b/web/src/services/safety-admin-client.ts
@@ -253,15 +253,23 @@ export async function deleteRule(ruleId: string): Promise<void> {
   }
 }
 
+interface SafetyRuleAuditPage {
+  items: SafetyRuleAuditEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export async function listRuleAudit(
   ruleId: string,
   limit = 200,
 ): Promise<SafetyRuleAuditEntry[]> {
   // Tenant is derived from the session server-side (no tenant id in path).
+  // Paged endpoint; return items so callers keep the array shape.
   const res = await apiFetch(
     `/api/v1/safety/rules/${encodeURIComponent(ruleId)}/audit?limit=${limit}`,
   );
-  return jsonOrThrow<SafetyRuleAuditEntry[]>(res);
+  return (await jsonOrThrow<SafetyRuleAuditPage>(res)).items;
 }
 
 export async function listDecisions(

--- a/web/src/services/safety-admin-client.ts
+++ b/web/src/services/safety-admin-client.ts
@@ -201,6 +201,13 @@ export async function listChecks(): Promise<SafetyCheckMeta[]> {
   return jsonOrThrow<SafetyCheckMeta[]>(res);
 }
 
+interface SafetyRulePage {
+  items: SafetyRule[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export async function listRules(filters: {
   coworker_id?: string;
   stage?: SafetyStage;
@@ -210,9 +217,12 @@ export async function listRules(filters: {
     coworker_id: filters.coworker_id,
     stage: filters.stage,
     enabled: filters.enabled === undefined ? undefined : String(filters.enabled),
+    // Paged endpoint; request the max window and return items so callers
+    // keep the array shape (full page-through UI is a follow-up).
+    limit: 200,
   });
   const res = await apiFetch(`/api/v1/safety/rules${qs}`);
-  return jsonOrThrow<SafetyRule[]>(res);
+  return (await jsonOrThrow<SafetyRulePage>(res)).items;
 }
 
 export async function createRule(body: SafetyRuleCreateBody): Promise<SafetyRule> {


### PR DESCRIPTION
## Summary

Implements review point **A (pagination)** from the API-cleanup review: every unbounded `/api/v1` list endpoint now returns a bounded page envelope instead of a naked, unbounded array. Before this, only `/safety/decisions` was paginated; the other ~12 tenant collections could return arrays that grow without limit as a tenant adds users / coworkers / rules / messages.

This is a **breaking contract change** on the listed endpoints, rolled out as 4 self-contained commits (one per batch). Decisions locked with the maintainer up front:

1. **Mechanism:** offset/limit for all tenant collections; **cursor** for conversation messages.
2. **Envelope:** one shape everywhere — `{ items, total, limit, offset }` (and decisions upgraded to it).
3. **Messages → cursor** (`{ items, has_more, next_cursor }`) with an in-code comment explaining why (chat history is append-only / "load older"; offset would shift/duplicate rows mid-scroll).
4. **Named `*Page` schemas** (not a generic `Page[T]`) for clean generated TS type names.

## Commits

1. **`establish convention; upgrade safety decisions`** — `webui/v1/_pagination.py` (`LimitParam`/`OffsetParam`, default 50 / max 200) + the `{items,total,limit,offset}` envelope, applied to `/safety/decisions`.
2. **`paginate management lists`** — `/users`, `/safety/rules`, `/schedules`, `/approval-policies`, `/approval-requests`. (Safety rules: tenant rows page at the DB; the small read-only platform-rule set rides on the first page only, and `total` counts it. Approval-requests: the `conversation_id` filter is pushed into SQL so count and page cover the same set.)
3. **`paginate core catalog lists`** — `/coworkers`, `/skills`, `/mcp-servers`. The coworker/skill counts reuse the same visibility WHERE clause as their list, so `total` reflects exactly the rows the caller may see.
4. **`paginate sub-collections; cursor messages`** — `/coworkers/{id}/conversations` and `/safety/rules/{id}/audit` (offset/limit; audit keeps its 500 cap); `/conversations/{id}/messages` (cursor; `messages.id` is TEXT so the tiebreak compares as text; malformed cursor → `400 INVALID_CURSOR`).

Each commit covers the full stack: DB (`limit`/`offset` + `count_*` helpers), Pydantic `*Page` schemas, handlers, `contracts/openapi.yaml` (shared `LimitParam`/`OffsetParam` params + `*Page` responses), regenerated `types.ts`, the SPA client, and tests.

## Frontend rollout (approach A, no UX regression)

The SPA client methods request `limit=200` and return `.items`, so **every existing array-shaped caller is untouched** and behavior is preserved up to 200 rows. Real page-through / "load older" UI is a deliberate follow-up — this PR makes the API correct (bounded), not the UI fancier.

## Verification (local, no Docker)

- `ruff check src tests` clean; **mypy zero new errors** (compared file-by-file against the base).
- Contract gates green: `test_openapi_codegen_freshness` + `test_openapi_contract`; default-deny meta-test green. `types.ts` regenerated each batch.
- Frontend: `tsc` at baseline (no new errors); **vitest 553 passing** (incl. updated `coworker-wizard` raw-fetch mocks → page envelopes).
- New pagination tests added: users window + over-max (422), coworkers `total` respecting the visibility predicate, messages cursor-walk + malformed-cursor 400.
- Repo-wide scan: zero non-English text in the diff.

DB-backed integration tests run in CI (Postgres testcontainers need Docker, unavailable in the dev sandbox); the suite collects cleanly aside from a pre-existing missing `filelock` dep in `tests/test_agent_runner/`.

## Follow-ups (intentionally out of scope)

- Real pagination / "load older" UI in the SPA (the client currently caps at `limit=200`).
- `/conversations/{id}/approval-requests` (a per-conversation sub-list) was left as a bare array — not part of the A scope; can be paginated later if it proves unbounded in practice.

https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom

---
_Generated by [Claude Code](https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom)_