### PR TITLE
API naming cleanup: coworker.* actions, /platform/* plane, /tasks, /approvals/*, /credentials

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -565,7 +565,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/tenant/credentials:
+  /api/v1/credentials:
     get:
       tags: [Credentials]
       operationId: listTenantCredentials
@@ -586,7 +586,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /api/v1/tenant/credentials/{provider}:
+  /api/v1/credentials/{provider}:
     parameters:
       - in: path
         name: provider
@@ -647,7 +647,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
 
-  /api/v1/tenant/credentials/{provider}/pool:
+  /api/v1/credentials/{provider}/pool:
     parameters:
       - in: path
         name: provider

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -34,7 +34,7 @@ tags:
   - name: Users
   - name: Tenant
   - name: Safety
-  - name: Schedules
+  - name: Tasks
   - name: Platform
 
 paths:
@@ -1809,10 +1809,10 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
-  /api/v1/schedules:
+  /api/v1/tasks:
     get:
-      tags: [Schedules]
-      operationId: schedulesList
+      tags: [Tasks]
+      operationId: tasksList
       summary: List scheduled tasks for the tenant
       description: |
         Read-only listing of the `scheduled_tasks` table for the
@@ -1839,10 +1839,10 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /api/v1/schedules/{id}:
+  /api/v1/tasks/{id}:
     get:
-      tags: [Schedules]
-      operationId: schedulesGet
+      tags: [Tasks]
+      operationId: tasksGet
       summary: Fetch one scheduled task
       security: [ { bearerAuth: [] } ]
       parameters:
@@ -1858,8 +1858,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
     delete:
-      tags: [Schedules]
-      operationId: schedulesDelete
+      tags: [Tasks]
+      operationId: tasksDelete
       summary: Delete a scheduled task
       description: |
         Removes a scheduled task. Gated by `task.manage` (owner +

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -35,7 +35,6 @@ tags:
   - name: Tenant
   - name: Safety
   - name: Schedules
-  - name: Admin
   - name: Platform
 
 paths:
@@ -2015,15 +2014,16 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/admin/models:
+  /api/v1/platform/models:
     post:
-      tags: [Admin]
-      operationId: adminModelsCreate
-      summary: Register a new platform model (admin only)
+      tags: [Platform]
+      operationId: platformModelsCreate
+      summary: Register a new platform model (platform operator only)
       description: |
-        The `models` catalog is platform-managed — tenants pick from
-        it but only operators add rows. POST/PATCH/DELETE require
-        the `owner` role (design §13 role check).
+        The `models` catalog is platform-global — every tenant reads
+        it at `/api/v1/models`, but only the platform operator writes
+        it. POST/PATCH/DELETE require the platform-only `model.manage`
+        capability (platform_admin).
       security: [ { bearerAuth: [] } ]
       requestBody:
         required: true
@@ -2045,11 +2045,11 @@ paths:
         '422':
           $ref: '#/components/responses/Unprocessable'
 
-  /api/v1/admin/models/{id}:
+  /api/v1/platform/models/{id}:
     patch:
-      tags: [Admin]
-      operationId: adminModelsUpdate
-      summary: Update a platform model (admin only)
+      tags: [Platform]
+      operationId: platformModelsUpdate
+      summary: Update a platform model (platform operator only)
       security: [ { bearerAuth: [] } ]
       parameters:
         - { $ref: '#/components/parameters/IdInPath' }
@@ -2073,9 +2073,9 @@ paths:
         '422':
           $ref: '#/components/responses/Unprocessable'
     delete:
-      tags: [Admin]
-      operationId: adminModelsDelete
-      summary: Retire a platform model (admin only)
+      tags: [Platform]
+      operationId: platformModelsDelete
+      summary: Retire a platform model (platform operator only)
       description: |
         Soft delete — sets `active = false` rather than dropping the
         row so existing coworkers that point at the model keep

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -30,7 +30,7 @@ tags:
   - name: Models
   - name: Runs
   - name: Skills
-  - name: ApprovalPolicies
+  - name: Approvals
   - name: Users
   - name: Tenant
   - name: Safety
@@ -1302,9 +1302,9 @@ paths:
   # ===================================================================
   # HITL tool approval (docs/21-hitl-approval-plan.md §10 S5)
   # ===================================================================
-  /api/v1/approval-policies:
+  /api/v1/approvals/policies:
     get:
-      tags: [ApprovalPolicies]
+      tags: [Approvals]
       operationId: listApprovalPolicies
       summary: List the tenant's HITL approval policies
       description: |
@@ -1324,7 +1324,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
     post:
-      tags: [ApprovalPolicies]
+      tags: [Approvals]
       operationId: createApprovalPolicy
       summary: Create an approval policy
       description: |
@@ -1351,11 +1351,11 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /api/v1/approval-policies/{id}:
+  /api/v1/approvals/policies/{id}:
     parameters:
       - $ref: '#/components/parameters/IdInPath'
     get:
-      tags: [ApprovalPolicies]
+      tags: [Approvals]
       operationId: getApprovalPolicy
       security: [ { bearerAuth: [] } ]
       responses:
@@ -1369,7 +1369,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
     patch:
-      tags: [ApprovalPolicies]
+      tags: [Approvals]
       operationId: updateApprovalPolicy
       summary: Partially update an approval policy
       security: [ { bearerAuth: [] } ]
@@ -1391,7 +1391,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
     delete:
-      tags: [ApprovalPolicies]
+      tags: [Approvals]
       operationId: deleteApprovalPolicy
       summary: Delete an approval policy
       security: [ { bearerAuth: [] } ]
@@ -1403,9 +1403,9 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /api/v1/approval-requests:
+  /api/v1/approvals/requests:
     get:
-      tags: [ApprovalPolicies]
+      tags: [Approvals]
       operationId: listPendingApprovalRequests
       summary: List in-flight pending approval requests (web reconnect)
       description: |
@@ -2963,7 +2963,7 @@ components:
           enum: [pending, approved, rejected, expired, cancelled]
           description: |
             Lifecycle status. Always `pending` on the tenant-wide inbox read
-            (`GET /approval-requests`); the conversation sub-resource
+            (`GET /approvals/requests`); the conversation sub-resource
             (`GET /conversations/{id}/approval-requests`) returns every state so
             resolved cards re-render inline in chat history.
         decided_at:

--- a/src/rolemesh/auth/credential_vault.py
+++ b/src/rolemesh/auth/credential_vault.py
@@ -1,7 +1,7 @@
 """LLM provider credential vault.
 
 Encrypts the JSON payload (``{"api_key": "sk-...", ...}``) tenants
-PUT through ``/api/v1/tenant/credentials/{provider}``. The ciphertext
+PUT through ``/api/v1/credentials/{provider}``. The ciphertext
 lands in ``tenant_model_credentials.credential_data`` (BYTEA); the API
 list/get surface never re-derives plaintext from this column — design
 §8.1 envelope encryption model.

--- a/src/rolemesh/auth/permissions.py
+++ b/src/rolemesh/auth/permissions.py
@@ -27,9 +27,9 @@ UserRole = Literal["platform_admin", "owner", "admin", "member"]
 # new action is added to any tenant role.
 _TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
     "owner": {
-        "agent.create",
-        "agent.manage",
-        "agent.use",
+        "coworker.create",
+        "coworker.manage",
+        "coworker.use",
         "skill.create",
         "skill.manage",
         "mcp.configure",
@@ -44,9 +44,9 @@ _TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
     "admin": {
         # Admin lacks BYOK credential management and tenant settings (both
         # owner-only) per the §3 role matrix.
-        "agent.create",
-        "agent.manage",
-        "agent.use",
+        "coworker.create",
+        "coworker.manage",
+        "coworker.use",
         "skill.create",
         "skill.manage",
         "mcp.configure",
@@ -61,8 +61,8 @@ _TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
         # ownership-escape helper) manage the ones they created — but the
         # ``*.manage`` capability that reaches others'/shared resources is
         # withheld here.
-        "agent.create",
-        "agent.use",
+        "coworker.create",
+        "coworker.use",
         "skill.create",
     },
 }

--- a/src/rolemesh/auth/permissions.py
+++ b/src/rolemesh/auth/permissions.py
@@ -74,7 +74,11 @@ _TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
 #     (``platform_provider_credentials``). Tenants elect the pool via their
 #     own ``credential.byok.manage``-gated route; only the platform operator
 #     configures the underlying keys.
-_PLATFORM_ONLY_ACTIONS: set[str] = {"credential.pool.manage"}
+#   * model.manage — mutate the platform-global model catalog
+#     (``/api/v1/platform/models``). Every tenant READS the catalog at
+#     ``/api/v1/models``; only the platform operator may write it (a tenant
+#     owner must not edit a catalog every other tenant sees).
+_PLATFORM_ONLY_ACTIONS: set[str] = {"credential.pool.manage", "model.manage"}
 
 
 def _all_known_actions() -> set[str]:

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -68,7 +68,7 @@ def require_manage_or_owner(
 
     Called from *inside* a handler (it needs the loaded row), as the complement
     to the route-level capability gate. The route should carry the lowest
-    sensible capability (e.g. ``agent.use``); this helper then lets a member
+    sensible capability (e.g. ``coworker.use``); this helper then lets a member
     who created the resource manage their OWN copy while still blocking them
     from others'/shared ones.
 

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1247,9 +1247,9 @@ class ChannelBindingUpdate(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Admin model writes (PR24). The /api/v1/models GET path stays
-# tenant-readable; the /api/v1/admin/models writes require role check
-# at the handler layer.
+# Platform model-catalog writes. The /api/v1/models GET path stays
+# tenant-readable; the /api/v1/platform/models writes require the
+# platform-only model.manage capability (platform_admin).
 # ---------------------------------------------------------------------------
 
 

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -322,7 +322,7 @@ class PlatformCredentialResponse(BaseModel):
 
 
 class CredentialUpsert(BaseModel):
-    """``PUT /api/v1/tenant/credentials/{provider}`` body.
+    """``PUT /api/v1/credentials/{provider}`` body.
 
     Today only ``api_key`` is recognised. Provider-specific extras
     (``api_base``, ``region``, ...) ride on top via ``extras`` so

--- a/src/webui/v1/admin_models.py
+++ b/src/webui/v1/admin_models.py
@@ -1,16 +1,14 @@
-"""``/api/v1/admin/models`` REST surface (PR24).
+"""``/api/v1/platform/models`` write surface (platform model catalog).
 
-The platform model catalog is read-everyone, write-operator-only. The
-read surface lives at ``/api/v1/models`` and is open to any
-authenticated user; this module owns the writes (POST / PATCH /
-DELETE) behind a role check.
-
-Why split read and write paths under different prefixes? The frontend
-calls the read endpoints on every coworker-create dialog open; an
-RBAC denial there would break the happy path for everyone. Keeping
-the writes on a separate `/admin/models` path lets the SPA gate the
-admin UI behind `me.role == "owner"` without having to special-case
-403 responses on the read path.
+The model catalog is platform-global (no tenant scoping) and read by
+every authenticated user — the read surface lives at ``/api/v1/models``
+and is open so the coworker-create dialog never hits an RBAC denial on
+its happy path. This module owns the writes (POST / PATCH / DELETE),
+which mutate that shared catalog and so are gated to the platform
+operator via the platform-only ``model.manage`` capability
+(``platform_admin`` only — a tenant ``owner`` must NOT be able to edit a
+catalog every other tenant sees). Writes live on the ``/platform/*``
+plane to keep that "operator-only, cross-tenant" boundary obvious.
 """
 
 from __future__ import annotations
@@ -28,14 +26,14 @@ from rolemesh.db import (
     soft_delete_model,
     update_model,
 )
-from webui.dependencies import get_current_user
+from webui.dependencies import require_action
 from webui.schemas_v1 import Model, ModelCreate, ModelUpdate
 from webui.v1.errors import ErrorResponseException, raise_error_response
 
 if TYPE_CHECKING:
     from rolemesh.auth.provider import AuthenticatedUser
 
-router = APIRouter(prefix="/admin/models", tags=["Admin"])
+router = APIRouter(prefix="/platform/models", tags=["Platform"])
 
 
 def _to_response(m: ModelRow) -> Model:
@@ -50,28 +48,11 @@ def _to_response(m: ModelRow) -> Model:
     )
 
 
-def _require_owner(user: AuthenticatedUser) -> None:
-    """Enforce the role gate for write operations.
-
-    Spelled out at the top of every write handler rather than via a
-    FastAPI dependency so the role rule reads next to the operation it
-    guards — easier to audit when a future PR adds a new write
-    endpoint and forgets to wire the dependency.
-    """
-    if user.role != "owner":
-        raise ErrorResponseException(
-            status_code=403,
-            code="FORBIDDEN",
-            message="Only tenant owners may mutate the platform model catalog.",
-        )
-
-
 @router.post("", response_model=Model, status_code=201)
 async def create_model_endpoint(
     body: ModelCreate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("model.manage")),
 ) -> Model:
-    _require_owner(user)
     try:
         row = await create_model(
             provider=body.provider,
@@ -97,9 +78,8 @@ async def create_model_endpoint(
 async def update_model_endpoint(
     model_id: str,
     body: ModelUpdate,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("model.manage")),
 ) -> Model:
-    _require_owner(user)
     try:
         updated = await update_model(
             model_id,
@@ -121,9 +101,8 @@ async def update_model_endpoint(
 @router.delete("/{model_id}", status_code=204)
 async def delete_model_endpoint(
     model_id: str,
-    user: AuthenticatedUser = Depends(get_current_user),
+    user: AuthenticatedUser = Depends(require_action("model.manage")),
 ) -> Response:
-    _require_owner(user)
     # Confirm the model exists before checking usage — that gives a
     # distinct 404 vs 409 path so the SPA can tell "this model is
     # gone" from "this model is still in use".

--- a/src/webui/v1/approvals.py
+++ b/src/webui/v1/approvals.py
@@ -49,8 +49,8 @@ if TYPE_CHECKING:
     from agent_runner.approval.policy import ApprovalPolicy as ApprovalPolicyValue
     from rolemesh.auth.provider import AuthenticatedUser
 
-policies_router = APIRouter(prefix="/approval-policies", tags=["ApprovalPolicies"])
-requests_router = APIRouter(prefix="/approval-requests", tags=["ApprovalPolicies"])
+policies_router = APIRouter(prefix="/approvals/policies", tags=["Approvals"])
+requests_router = APIRouter(prefix="/approvals/requests", tags=["Approvals"])
 
 
 def _policy_to_response(p: ApprovalPolicyValue) -> ApprovalPolicy:

--- a/src/webui/v1/auth.py
+++ b/src/webui/v1/auth.py
@@ -133,20 +133,6 @@ async def post_ws_ticket(
     return WsTicket(ticket=token, expires_in_s=exp)
 
 
-@router.get("/me", response_model=Me, include_in_schema=False)
-async def get_me_auth_alias(
-    user: AuthenticatedUser = Depends(get_current_user),
-) -> Me:
-    """Convenience alias under ``/auth/me`` — same body as ``/me``.
-
-    The yaml only documents ``/api/v1/me``; this alias exists so a
-    typo in the SPA path doesn't 404 silently. Kept out of the
-    OpenAPI schema (``include_in_schema=False``) so it doesn't
-    drift the freshness check.
-    """
-    return _user_to_me(user)
-
-
 me_router = APIRouter(tags=["Auth"])
 
 

--- a/src/webui/v1/bindings.py
+++ b/src/webui/v1/bindings.py
@@ -107,7 +107,7 @@ async def list_bindings_endpoint(
 async def create_binding_endpoint(
     coworker_id: str,
     body: ChannelBindingCreate,
-    user: AuthenticatedUser = Depends(require_action("agent.manage")),
+    user: AuthenticatedUser = Depends(require_action("coworker.manage")),
 ) -> ChannelBinding:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     try:
@@ -153,7 +153,7 @@ async def update_binding_endpoint(
     coworker_id: str,
     binding_id: str,
     body: ChannelBindingUpdate,
-    user: AuthenticatedUser = Depends(require_action("agent.manage")),
+    user: AuthenticatedUser = Depends(require_action("coworker.manage")),
 ) -> ChannelBinding:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     await _get_binding_for_coworker(
@@ -183,7 +183,7 @@ async def update_binding_endpoint(
 async def delete_binding_endpoint(
     coworker_id: str,
     binding_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.manage")),
+    user: AuthenticatedUser = Depends(require_action("coworker.manage")),
 ) -> Response:
     await _ensure_coworker(coworker_id, tenant_id=user.tenant_id)
     await _get_binding_for_coworker(

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -150,7 +150,7 @@ async def list_coworker_conversations(
 async def create_coworker_conversation(
     coworker_id: str,
     body: ConversationCreate,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Conversation:
     """Create a new web conversation under a coworker.
 
@@ -199,7 +199,7 @@ async def get_conversation_endpoint(
 @conversations_router.delete("/{conversation_id}", status_code=204)
 async def delete_conversation_endpoint(
     conversation_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Response:
     """Delete a conversation; FK ON DELETE CASCADE removes messages and runs.
 

--- a/src/webui/v1/coworkers.py
+++ b/src/webui/v1/coworkers.py
@@ -135,7 +135,7 @@ async def list_coworkers(
 ) -> CoworkerPage:
     """List coworkers visible to the caller (feat/roles PR3 visibility).
 
-    A manager (``agent.manage``: owner/admin/platform_admin) sees every
+    A manager (``coworker.manage``: owner/admin/platform_admin) sees every
     coworker in the tenant; a member sees only ``shared`` coworkers plus
     the private ones they created. The row-level predicate lives in
     :func:`rolemesh.db.get_coworkers_for_tenant`; it is the SQL mirror of
@@ -144,7 +144,7 @@ async def list_coworkers(
     allowlist); only the result SET narrows. ``total`` reflects the
     visible set, not the whole tenant.
     """
-    can_manage = user_can(user.role, "agent.manage")  # type: ignore[arg-type]
+    can_manage = user_can(user.role, "coworker.manage")  # type: ignore[arg-type]
     cws = await get_coworkers_for_tenant(
         user.tenant_id,
         requesting_user_id=user.user_id,
@@ -168,7 +168,7 @@ async def list_coworkers(
 @router.post("", response_model=Coworker, status_code=201)
 async def create_coworker_endpoint(
     body: CoworkerCreate,
-    user: AuthenticatedUser = Depends(require_action("agent.create")),
+    user: AuthenticatedUser = Depends(require_action("coworker.create")),
 ) -> Coworker:
     if body.model_id is not None:
         await _validate_model_and_credential(
@@ -258,7 +258,7 @@ async def _get_coworker_or_404(
     feat/roles PR3 USE/SEE enforcement: when ``user`` is supplied this
     helper additionally hides a coworker the caller may not see/use
     (a private coworker created by someone else, with the caller lacking
-    ``agent.manage``). It collapses "exists but not visible" to the SAME
+    ``coworker.manage``). It collapses "exists but not visible" to the SAME
     404 as "does not exist" so the endpoint never leaks the existence of
     another member's private draft. Read-only catalog reads that are
     intentionally tenant-wide (and already allowlisted) pass ``user=None``
@@ -271,7 +271,7 @@ async def _get_coworker_or_404(
     if cw is None or (
         user is not None
         and not user_can_see_resource(
-            manage_action="agent.manage", resource=cw, user=user,
+            manage_action="coworker.manage", resource=cw, user=user,
         )
     ):
         raise_error_response(
@@ -298,7 +298,7 @@ async def get_coworker_endpoint(
 async def patch_coworker_endpoint(
     coworker_id: str,
     body: CoworkerUpdate,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Coworker:
     """Update selected fields on a coworker.
 
@@ -311,11 +311,11 @@ async def patch_coworker_endpoint(
     even if the broadcast misses.
     """
     cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
-    # Ownership-escape gate: the route requires only ``agent.use`` (member-
+    # Ownership-escape gate: the route requires only ``coworker.use`` (member-
     # reachable); a member may PATCH a coworker they created, but reaching
-    # someone else's / a shared one requires ``agent.manage``.
+    # someone else's / a shared one requires ``coworker.manage``.
     require_manage_or_owner(
-        manage_action="agent.manage", resource=cw, user=user,
+        manage_action="coworker.manage", resource=cw, user=user,
     )
     model_changed = body.model_id is not None and body.model_id != cw.model_id
 
@@ -374,7 +374,7 @@ async def patch_coworker_endpoint(
 @router.delete("/{coworker_id}", status_code=204)
 async def delete_coworker_endpoint(
     coworker_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Response:
     """Delete a coworker. DB FK ON DELETE CASCADE handles dependents.
 
@@ -382,13 +382,13 @@ async def delete_coworker_endpoint(
     conversations / runs / messages. No 409 path on this endpoint —
     the design treats coworkers as roots of their own subtree.
 
-    Ownership-escape gate: the route requires only ``agent.use``; a member
+    Ownership-escape gate: the route requires only ``coworker.use``; a member
     may delete their OWN coworker, others'/shared ones require
-    ``agent.manage``.
+    ``coworker.manage``.
     """
     cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
     require_manage_or_owner(
-        manage_action="agent.manage", resource=cw, user=user,
+        manage_action="coworker.manage", resource=cw, user=user,
     )
     await delete_coworker(coworker_id, tenant_id=user.tenant_id)
     return Response(status_code=204)
@@ -399,7 +399,7 @@ async def _set_visibility_or_404(
 ) -> Coworker:
     """Shared body for share / unshare: own-or-manage gate then flip.
 
-    The route already carries the low ``agent.use`` capability; this
+    The route already carries the low ``coworker.use`` capability; this
     helper escalates to ``require_manage_or_owner`` so a member may flip
     their OWN coworker's visibility while a manager may flip any. The
     initial fetch passes ``user=None`` so a member trying to share a
@@ -409,7 +409,7 @@ async def _set_visibility_or_404(
     """
     cw = await _get_coworker_or_404(coworker_id, user.tenant_id)
     require_manage_or_owner(
-        manage_action="agent.manage", resource=cw, user=user,
+        manage_action="coworker.manage", resource=cw, user=user,
     )
     updated = await set_coworker_visibility(
         coworker_id, visibility=visibility, tenant_id=user.tenant_id,
@@ -427,13 +427,13 @@ async def _set_visibility_or_404(
 @router.post("/{coworker_id}/share", response_model=Coworker)
 async def share_coworker_endpoint(
     coworker_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Coworker:
     """Make a coworker ``shared`` (visible to the whole tenant).
 
     Self-serve, no review: a member shares their OWN draft; a manager
     may share any. Idempotent — sharing an already-shared coworker is a
-    no-op flip. Gated by the ``agent.use`` route capability + the
+    no-op flip. Gated by the ``coworker.use`` route capability + the
     in-handler ``require_manage_or_owner`` escalation (so this mutation
     is NOT in the auth-only allowlist).
     """
@@ -445,7 +445,7 @@ async def share_coworker_endpoint(
 @router.post("/{coworker_id}/unshare", response_model=Coworker)
 async def unshare_coworker_endpoint(
     coworker_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Coworker:
     """Make a coworker ``private`` again (creator + managers only).
 

--- a/src/webui/v1/credentials.py
+++ b/src/webui/v1/credentials.py
@@ -1,4 +1,8 @@
-"""``/api/v1/tenant/credentials`` REST surface (design §3 Phase 2, §8.1).
+"""``/api/v1/credentials`` REST surface (design §3 Phase 2, §8.1).
+
+Tenant-plane resource (tenant is implicit, derived from the session —
+no ``/tenant/`` path prefix; cf. the platform-plane counterpart at
+``/api/v1/platform/credentials``).
 
 Stores tenant-scoped LLM provider API keys behind envelope
 encryption. ``GET`` returns metadata only — the encrypted payload
@@ -35,7 +39,7 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-router = APIRouter(prefix="/tenant/credentials", tags=["Credentials"])
+router = APIRouter(prefix="/credentials", tags=["Credentials"])
 
 
 def _credential_to_response(row: CredentialRow) -> CredentialResponse:

--- a/src/webui/v1/runs.py
+++ b/src/webui/v1/runs.py
@@ -106,7 +106,7 @@ async def get_run_endpoint(
 async def cancel_run_endpoint(
     run_id: str,
     response: Response,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Run:
     """Request cancellation of an in-flight run.
 

--- a/src/webui/v1/schedules.py
+++ b/src/webui/v1/schedules.py
@@ -1,17 +1,21 @@
-"""``/api/v1/schedules`` REST surface (PR24 reads + admin delete migration).
+"""``/api/v1/tasks`` REST surface — scheduled tasks.
 
-The orchestrator owns scheduled-task creation and *schedule* mutation:
-cron / interval / once triggers fire from inside the agent process and
-the helper functions in :mod:`rolemesh.db.task` are how it persists
-state. Letting the SPA edit a trigger schedule independent of the
-orchestrator's runtime view would create a stale-cache race the design
-hasn't worked through yet, so trigger create/update stay off v1.
+The path is ``/tasks`` to match the rest of the stack — the table is
+``scheduled_tasks``, the type ``ScheduledTask``, the capability
+``task.manage`` — leaving "schedule" only as the trigger-config
+vocabulary (``schedule_type`` / ``schedule_value``).
+
+The orchestrator owns task creation and trigger mutation: cron /
+interval / once triggers fire from inside the agent process and the
+helper functions in :mod:`rolemesh.db.task` persist state. Letting the
+SPA edit a trigger independent of the orchestrator's runtime view would
+create a stale-cache race the design hasn't worked through yet, so
+trigger create/update stay off v1.
 
 Reads (``get_current_user`` only — allowlisted in the default-deny
 meta-test) answer "what tasks does this coworker have scheduled". The
 ``DELETE`` was migrated off the legacy ``/api/admin/tasks/{id}`` face:
-task removal is a tenant-management operation gated by ``task.manage``
-(admin+), with cross-tenant ids reading as 404.
+task removal is gated by ``task.manage`` (admin+), cross-tenant ids 404.
 """
 
 from __future__ import annotations
@@ -37,7 +41,7 @@ if TYPE_CHECKING:
     from rolemesh.auth.provider import AuthenticatedUser
     from rolemesh.core.types import ScheduledTask as ScheduledTaskDataclass
 
-router = APIRouter(prefix="/schedules", tags=["Schedules"])
+router = APIRouter(prefix="/tasks", tags=["Tasks"])
 
 
 def _to_response(t: ScheduledTaskDataclass) -> ScheduledTask:

--- a/src/webui/v1/skills.py
+++ b/src/webui/v1/skills.py
@@ -788,7 +788,7 @@ async def list_coworker_skills_endpoint(
 async def enable_coworker_skill_endpoint(
     coworker_id: str,
     skill_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> CoworkerSkillBinding:
     """Bind a catalog skill to this coworker (idempotent).
 
@@ -797,11 +797,11 @@ async def enable_coworker_skill_endpoint(
     cases publish ``skills_changed``.
 
     Mutates the coworker's skill set (agent config): the route requires
-    ``agent.use`` and the handler escalates to ``agent.manage``-or-own.
+    ``coworker.use`` and the handler escalates to ``coworker.manage``-or-own.
     """
     cw = await _get_coworker_or_404(coworker_id, tenant_id=user.tenant_id)
     require_manage_or_owner(
-        manage_action="agent.manage", resource=cw, user=user,
+        manage_action="coworker.manage", resource=cw, user=user,
     )
     # USE enforcement on the SKILL being attached: a member may only bind
     # a skill they can see (shared, or their own private one). Binding a
@@ -834,19 +834,19 @@ async def enable_coworker_skill_endpoint(
 async def disable_coworker_skill_endpoint(
     coworker_id: str,
     skill_id: str,
-    user: AuthenticatedUser = Depends(require_action("agent.use")),
+    user: AuthenticatedUser = Depends(require_action("coworker.use")),
 ) -> Response:
     """Remove the ``coworker_skills`` binding row.
 
     Distinct from "enable=false" — this deletes the binding outright,
     matching the v1 DELETE convention. The catalog skill survives.
 
-    Mutates the coworker's skill set (agent config): route ``agent.use``,
-    handler escalates to ``agent.manage``-or-own.
+    Mutates the coworker's skill set (agent config): route ``coworker.use``,
+    handler escalates to ``coworker.manage``-or-own.
     """
     cw = await _get_coworker_or_404(coworker_id, tenant_id=user.tenant_id)
     require_manage_or_owner(
-        manage_action="agent.manage", resource=cw, user=user,
+        manage_action="coworker.manage", resource=cw, user=user,
     )
     removed = await disable_skill_for_coworker(
         skill_id=skill_id,

--- a/src/webui/v1/tenant.py
+++ b/src/webui/v1/tenant.py
@@ -5,9 +5,9 @@ Equivalence migration of the legacy ``/api/admin/tenant`` GET/PATCH
 response shape, gated by the owner-only ``tenant.manage`` capability,
 returning the design §13 error envelope.
 
-The ``/tenant`` prefix sits alongside (not in conflict with) the
-``/tenant/credentials`` sub-surface served by :mod:`webui.v1.credentials`
-— FastAPI matches the more specific path first.
+This resource only carries tenant *settings*; per-tenant credentials are
+a separate top-level resource at ``/api/v1/credentials``
+(:mod:`webui.v1.credentials`).
 """
 
 from __future__ import annotations

--- a/tests/auth/test_permissions_role_model.py
+++ b/tests/auth/test_permissions_role_model.py
@@ -104,6 +104,16 @@ def test_owner_has_byok_credentials_and_tenant_settings() -> None:
         assert user_can("owner", action), action
 
 
+def test_platform_only_actions_denied_to_every_tenant_role() -> None:
+    # Platform-plane capabilities (e.g. the global model catalog,
+    # credential pool) must be platform_admin-only — NOT even a tenant
+    # owner may hold them.
+    for action in _PLATFORM_ONLY_ACTIONS:
+        assert user_can("platform_admin", action), action
+        for role in ("owner", "admin", "member"):
+            assert not user_can(role, action), f"{role} must not hold {action}"
+
+
 # ---------------------------------------------------------------------------
 # Fail-closed
 # ---------------------------------------------------------------------------

--- a/tests/auth/test_permissions_role_model.py
+++ b/tests/auth/test_permissions_role_model.py
@@ -19,9 +19,9 @@ from rolemesh.auth.permissions import (
 
 # The complete §3 fine-grained action set the v1 surface gates on.
 _V1_ACTIONS = {
-    "agent.create",
-    "agent.manage",
-    "agent.use",
+    "coworker.create",
+    "coworker.manage",
+    "coworker.use",
     "skill.create",
     "skill.manage",
     "mcp.configure",
@@ -65,10 +65,10 @@ def test_platform_admin_superset_is_derived_not_hand_copied() -> None:
 
 def test_member_cannot_manage_shared_resources() -> None:
     # A member may create/use, but NOT reach the manage/configure capability.
-    assert user_can("member", "agent.create")
-    assert user_can("member", "agent.use")
+    assert user_can("member", "coworker.create")
+    assert user_can("member", "coworker.use")
     assert user_can("member", "skill.create")
-    assert not user_can("member", "agent.manage")
+    assert not user_can("member", "coworker.manage")
     assert not user_can("member", "skill.manage")
     assert not user_can("member", "mcp.configure")
     assert not user_can("member", "approval_policy.manage")
@@ -83,7 +83,7 @@ def test_member_cannot_manage_shared_resources() -> None:
 
 
 def test_admin_has_manage_but_not_byok_credentials_or_tenant() -> None:
-    assert user_can("admin", "agent.manage")
+    assert user_can("admin", "coworker.manage")
     assert user_can("admin", "skill.manage")
     assert user_can("admin", "mcp.configure")
     assert user_can("admin", "approval_policy.manage")

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -88,8 +88,8 @@ def test_phase_1_endpoints_listed_in_design_are_present_in_yaml() -> None:
         "/api/v1/mcp-servers/{id}",
         "/api/v1/models",
         "/api/v1/models/{id}",
-        "/api/v1/tenant/credentials",
-        "/api/v1/tenant/credentials/{provider}",
+        "/api/v1/credentials",
+        "/api/v1/credentials/{provider}",
         "/api/v1/runs/{id}",
         "/api/v1/runs/{id}/cancel",
     }

--- a/tests/webui/test_v1_approval_policies.py
+++ b/tests/webui/test_v1_approval_policies.py
@@ -1,4 +1,4 @@
-"""REST attack-sim for ``/api/v1/approval-policies`` + ``/approval-requests``.
+"""REST attack-sim for ``/api/v1/approvals/policies`` + ``/approval-requests``.
 
 Hits the FastAPI app via httpx ASGI transport against a real Postgres
 testcontainer. The DB-layer scoping is already proven in
@@ -86,7 +86,7 @@ async def test_create_list_get_patch_delete_round_trip() -> None:
     user = await _make_actor("crud")
     async with _client(_build_app(user)) as ac:
         created = await ac.post(
-            "/api/v1/approval-policies",
+            "/api/v1/approvals/policies",
             json=_policy_body(
                 tool_name="*",
                 condition_expr={"field": "amount", "op": ">", "value": 100},
@@ -102,16 +102,16 @@ async def test_create_list_get_patch_delete_round_trip() -> None:
         assert created.json()["priority"] == 5
         assert created.json()["enabled"] is True
 
-        listing = await ac.get("/api/v1/approval-policies", headers=_AUTH)
+        listing = await ac.get("/api/v1/approvals/policies", headers=_AUTH)
         assert listing.status_code == 200
         assert [p["id"] for p in listing.json()["items"]] == [pid]
 
-        got = await ac.get(f"/api/v1/approval-policies/{pid}", headers=_AUTH)
+        got = await ac.get(f"/api/v1/approvals/policies/{pid}", headers=_AUTH)
         assert got.status_code == 200
         assert got.json()["tool_name"] == "*"
 
         patched = await ac.patch(
-            f"/api/v1/approval-policies/{pid}",
+            f"/api/v1/approvals/policies/{pid}",
             json={"enabled": False, "priority": 9},
             headers=_AUTH,
         )
@@ -123,9 +123,9 @@ async def test_create_list_get_patch_delete_round_trip() -> None:
             "field": "amount", "op": ">", "value": 100,
         }
 
-        deleted = await ac.delete(f"/api/v1/approval-policies/{pid}", headers=_AUTH)
+        deleted = await ac.delete(f"/api/v1/approvals/policies/{pid}", headers=_AUTH)
         assert deleted.status_code == 204
-        gone = await ac.get(f"/api/v1/approval-policies/{pid}", headers=_AUTH)
+        gone = await ac.get(f"/api/v1/approvals/policies/{pid}", headers=_AUTH)
         assert gone.status_code == 404
 
 
@@ -133,7 +133,7 @@ async def test_create_defaults_condition_to_always_true() -> None:
     user = await _make_actor("dflt")
     async with _client(_build_app(user)) as ac:
         created = await ac.post(
-            "/api/v1/approval-policies", json=_policy_body(), headers=_AUTH,
+            "/api/v1/approvals/policies", json=_policy_body(), headers=_AUTH,
         )
     assert created.status_code == 201
     assert created.json()["condition_expr"] == {"always": True}
@@ -160,7 +160,7 @@ async def test_create_rejects_malformed_condition(bad_expr: dict) -> None:
     user = await _make_actor("badc")
     async with _client(_build_app(user)) as ac:
         resp = await ac.post(
-            "/api/v1/approval-policies",
+            "/api/v1/approvals/policies",
             json=_policy_body(condition_expr=bad_expr),
             headers=_AUTH,
         )
@@ -171,11 +171,11 @@ async def test_patch_rejects_malformed_condition() -> None:
     user = await _make_actor("badp")
     async with _client(_build_app(user)) as ac:
         created = await ac.post(
-            "/api/v1/approval-policies", json=_policy_body(), headers=_AUTH,
+            "/api/v1/approvals/policies", json=_policy_body(), headers=_AUTH,
         )
         pid = created.json()["id"]
         resp = await ac.patch(
-            f"/api/v1/approval-policies/{pid}",
+            f"/api/v1/approvals/policies/{pid}",
             json={"condition_expr": {"op": "bogus"}},
             headers=_AUTH,
         )
@@ -188,7 +188,7 @@ async def test_body_cannot_smuggle_tenant_or_id() -> None:
     user = await _make_actor("smug")
     async with _client(_build_app(user)) as ac:
         resp = await ac.post(
-            "/api/v1/approval-policies",
+            "/api/v1/approvals/policies",
             json=_policy_body(tenant_id=str(uuid.uuid4()), id=str(uuid.uuid4())),
             headers=_AUTH,
         )
@@ -204,7 +204,7 @@ async def test_body_cannot_smuggle_tenant_or_id() -> None:
 async def _seed_policy_in(actor: AuthenticatedUser) -> str:
     async with _client(_build_app(actor)) as ac:
         created = await ac.post(
-            "/api/v1/approval-policies",
+            "/api/v1/approvals/policies",
             json=_policy_body(mcp_server_name="victim-srv", tool_name="secret"),
             headers=_AUTH,
         )
@@ -217,7 +217,7 @@ async def test_get_cross_tenant_policy_is_404() -> None:
     b = await _make_actor("b")
     victim = await _seed_policy_in(b)
     async with _client(_build_app(a)) as ac:
-        resp = await ac.get(f"/api/v1/approval-policies/{victim}", headers=_AUTH)
+        resp = await ac.get(f"/api/v1/approvals/policies/{victim}", headers=_AUTH)
     assert resp.status_code == 404
     assert resp.json()["code"] == "NOT_FOUND"
 
@@ -227,7 +227,7 @@ async def test_list_does_not_leak_other_tenant_policies() -> None:
     b = await _make_actor("b")
     await _seed_policy_in(b)
     async with _client(_build_app(a)) as ac:
-        listing = await ac.get("/api/v1/approval-policies", headers=_AUTH)
+        listing = await ac.get("/api/v1/approvals/policies", headers=_AUTH)
     assert listing.status_code == 200
     assert listing.json() == []
 
@@ -238,14 +238,14 @@ async def test_patch_cross_tenant_policy_is_404_and_leaves_victim_intact() -> No
     victim = await _seed_policy_in(b)
     async with _client(_build_app(a)) as ac:
         resp = await ac.patch(
-            f"/api/v1/approval-policies/{victim}",
+            f"/api/v1/approvals/policies/{victim}",
             json={"enabled": False, "priority": 999},
             headers=_AUTH,
         )
     assert resp.status_code == 404
     # B's policy is untouched — the cross-tenant PATCH wrote nothing.
     async with _client(_build_app(b)) as ac:
-        got = await ac.get(f"/api/v1/approval-policies/{victim}", headers=_AUTH)
+        got = await ac.get(f"/api/v1/approvals/policies/{victim}", headers=_AUTH)
     assert got.status_code == 200
     assert got.json()["enabled"] is True
     assert got.json()["priority"] == 0
@@ -257,12 +257,12 @@ async def test_delete_cross_tenant_policy_is_404_and_does_not_delete() -> None:
     victim = await _seed_policy_in(b)
     async with _client(_build_app(a)) as ac:
         resp = await ac.delete(
-            f"/api/v1/approval-policies/{victim}", headers=_AUTH,
+            f"/api/v1/approvals/policies/{victim}", headers=_AUTH,
         )
     assert resp.status_code == 404
     # Victim still exists for its owner.
     async with _client(_build_app(b)) as ac:
-        got = await ac.get(f"/api/v1/approval-policies/{victim}", headers=_AUTH)
+        got = await ac.get(f"/api/v1/approvals/policies/{victim}", headers=_AUTH)
     assert got.status_code == 200
 
 
@@ -271,9 +271,9 @@ async def test_garbage_uuid_collapses_to_same_404() -> None:
     well-formed-but-absent id — otherwise it's a uuid-shape oracle."""
     user = await _make_actor("garb")
     async with _client(_build_app(user)) as ac:
-        bad = await ac.get("/api/v1/approval-policies/not-a-uuid", headers=_AUTH)
+        bad = await ac.get("/api/v1/approvals/policies/not-a-uuid", headers=_AUTH)
         absent = await ac.get(
-            f"/api/v1/approval-policies/{uuid.uuid4()}", headers=_AUTH,
+            f"/api/v1/approvals/policies/{uuid.uuid4()}", headers=_AUTH,
         )
     assert bad.status_code == 404
     assert absent.status_code == 404
@@ -310,7 +310,7 @@ async def test_pending_requests_returns_own_tenant_only() -> None:
     a_req, a_cw = await _seed_pending_request(a)
     b_req, _ = await _seed_pending_request(b)
     async with _client(_build_app(a)) as ac:
-        resp = await ac.get("/api/v1/approval-requests", headers=_AUTH)
+        resp = await ac.get("/api/v1/approvals/requests", headers=_AUTH)
     assert resp.status_code == 200
     ids = {r["request_id"] for r in resp.json()["items"]}
     assert a_req in ids
@@ -337,7 +337,7 @@ async def test_pending_requests_conversation_filter_cannot_cross_tenant() -> Non
     await _seed_pending_request(b)
     async with _client(_build_app(a)) as ac:
         resp = await ac.get(
-            "/api/v1/approval-requests",
+            "/api/v1/approvals/requests",
             params={"conversation_id": str(uuid.uuid4())},
             headers=_AUTH,
         )

--- a/tests/webui/test_v1_credentials.py
+++ b/tests/webui/test_v1_credentials.py
@@ -1,4 +1,4 @@
-"""Integration tests for ``/api/v1/tenant/credentials``.
+"""Integration tests for ``/api/v1/credentials``.
 
 Pins design §8.1 invariants from the HTTP layer:
 
@@ -90,7 +90,7 @@ async def test_put_credential_creates_then_get_lists_metadata_only(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         put = await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "sk-ant-test-1234"},
             headers={"Authorization": "Bearer x"},
         )
@@ -103,7 +103,7 @@ async def test_put_credential_creates_then_get_lists_metadata_only(vault):
         assert "sk-ant-test-1234" not in put.text
 
         listing = await ac.get(
-            "/api/v1/tenant/credentials",
+            "/api/v1/credentials",
             headers={"Authorization": "Bearer x"},
         )
         assert listing.status_code == 200
@@ -129,7 +129,7 @@ async def test_put_credential_writes_fernet_ciphertext_not_plaintext(vault):
     sentinel = f"SENTINEL_LEAK_{uuid.uuid4().hex}"
     async with _client(_build_app(user)) as ac:
         put = await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": sentinel},
             headers={"Authorization": "Bearer x"},
         )
@@ -161,12 +161,12 @@ async def test_put_credential_overwrites_existing(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         first = await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "first"},
             headers={"Authorization": "Bearer x"},
         )
         second = await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "second"},
             headers={"Authorization": "Bearer x"},
         )
@@ -191,7 +191,7 @@ async def test_put_credential_with_extras_roundtrips(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         resp = await ac.put(
-            "/api/v1/tenant/credentials/bedrock",
+            "/api/v1/credentials/bedrock",
             json={"api_key": "akia-test", "extras": {"region": "us-east-1"}},
             headers={"Authorization": "Bearer x"},
         )
@@ -231,12 +231,12 @@ async def test_delete_credential_returns_409_when_in_use(vault):
 
     async with _client(_build_app(user)) as ac:
         await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "sk-test"},
             headers={"Authorization": "Bearer x"},
         )
         resp = await ac.delete(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             headers={"Authorization": "Bearer x"},
         )
     assert resp.status_code == 409
@@ -249,19 +249,19 @@ async def test_delete_credential_succeeds_when_no_references(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "sk-test"},
             headers={"Authorization": "Bearer x"},
         )
         resp = await ac.delete(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             headers={"Authorization": "Bearer x"},
         )
     assert resp.status_code == 204
     # Subsequent GET shows the row is gone.
     async with _client(_build_app(user)) as ac:
         listing = await ac.get(
-            "/api/v1/tenant/credentials",
+            "/api/v1/credentials",
             headers={"Authorization": "Bearer x"},
         )
     assert listing.json() == []
@@ -271,7 +271,7 @@ async def test_delete_credential_returns_404_when_unknown(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         resp = await ac.delete(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             headers={"Authorization": "Bearer x"},
         )
     assert resp.status_code == 404
@@ -332,7 +332,7 @@ async def test_put_credential_publishes_restart_per_affected_coworker(
 
     async with _client(_build_app(user)) as ac:
         resp = await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "sk-test"},
             headers={"Authorization": "Bearer x"},
         )
@@ -360,7 +360,7 @@ async def test_put_credential_does_not_publish_for_unused_provider(
 
     async with _client(_build_app(user)) as ac:
         resp = await ac.put(
-            "/api/v1/tenant/credentials/openai",
+            "/api/v1/credentials/openai",
             json={"api_key": "sk-test"},
             headers={"Authorization": "Bearer x"},
         )
@@ -378,7 +378,7 @@ async def test_put_credential_reports_byok_mode(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         put = await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "sk-ant-test"},
             headers={"Authorization": "Bearer x"},
         )
@@ -386,7 +386,7 @@ async def test_put_credential_reports_byok_mode(vault):
         assert put.json()["mode"] == "byok"
 
         listing = await ac.get(
-            "/api/v1/tenant/credentials",
+            "/api/v1/credentials",
             headers={"Authorization": "Bearer x"},
         )
     assert listing.json()[0]["mode"] == "byok"
@@ -397,7 +397,7 @@ async def test_elect_pool_sets_pool_mode(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         resp = await ac.put(
-            "/api/v1/tenant/credentials/anthropic/pool",
+            "/api/v1/credentials/anthropic/pool",
             headers={"Authorization": "Bearer x"},
         )
         assert resp.status_code == 200, resp.text
@@ -405,7 +405,7 @@ async def test_elect_pool_sets_pool_mode(vault):
         assert resp.json()["mode"] == "pool"
 
         listing = await ac.get(
-            "/api/v1/tenant/credentials",
+            "/api/v1/credentials",
             headers={"Authorization": "Bearer x"},
         )
     body = listing.json()
@@ -423,12 +423,12 @@ async def test_elect_pool_retains_dormant_byok_key(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "sk-original"},
             headers={"Authorization": "Bearer x"},
         )
         await ac.put(
-            "/api/v1/tenant/credentials/anthropic/pool",
+            "/api/v1/credentials/anthropic/pool",
             headers={"Authorization": "Bearer x"},
         )
 
@@ -450,7 +450,7 @@ async def test_elect_pool_first_time_has_null_key(vault):
     user = await _make_user()
     async with _client(_build_app(user)) as ac:
         resp = await ac.put(
-            "/api/v1/tenant/credentials/openai/pool",
+            "/api/v1/credentials/openai/pool",
             headers={"Authorization": "Bearer x"},
         )
     assert resp.status_code == 200, resp.text
@@ -495,7 +495,7 @@ async def test_elect_pool_publishes_restart_per_affected_coworker(
 
     async with _client(_build_app(user)) as ac:
         resp = await ac.put(
-            "/api/v1/tenant/credentials/anthropic/pool",
+            "/api/v1/credentials/anthropic/pool",
             headers={"Authorization": "Bearer x"},
         )
     assert resp.status_code == 200
@@ -540,13 +540,13 @@ async def test_get_credentials_isolated_per_tenant(vault):
     b = await _make_user("b")
     async with _client(_build_app(a)) as ac:
         await ac.put(
-            "/api/v1/tenant/credentials/anthropic",
+            "/api/v1/credentials/anthropic",
             json={"api_key": "for-a"},
             headers={"Authorization": "Bearer x"},
         )
     async with _client(_build_app(b)) as ac:
         listing = await ac.get(
-            "/api/v1/tenant/credentials",
+            "/api/v1/credentials",
             headers={"Authorization": "Bearer x"},
         )
     assert listing.status_code == 200

--- a/tests/webui/test_v1_default_deny.py
+++ b/tests/webui/test_v1_default_deny.py
@@ -86,11 +86,11 @@ AUTH_ONLY_V1_ROUTES: dict[tuple[str, str], str] = {
         "Read of the tenant's MCP server catalog.",
     ("GET", "/api/v1/mcp-servers/{mcp_id}"):
         "Read of one MCP server (no secrets in the response shape).",
-    ("GET", "/api/v1/approval-policies"):
+    ("GET", "/api/v1/approvals/policies"):
         "Read of the tenant's approval policies.",
-    ("GET", "/api/v1/approval-policies/{policy_id}"):
+    ("GET", "/api/v1/approvals/policies/{policy_id}"):
         "Read of one approval policy.",
-    ("GET", "/api/v1/approval-requests"):
+    ("GET", "/api/v1/approvals/requests"):
         "Read of the tenant's pending approval requests (inbox re-render).",
     ("GET", "/api/v1/schedules"):
         "Read-only schedules surface; writes are not exposed on v1.",

--- a/tests/webui/test_v1_default_deny.py
+++ b/tests/webui/test_v1_default_deny.py
@@ -102,17 +102,9 @@ AUTH_ONLY_V1_ROUTES: dict[tuple[str, str], str] = {
         "Read of the platform model catalog (tenant-agnostic, no secrets).",
     ("GET", "/api/v1/models/{model_id}"):
         "Read of one platform model.",
-    # --- Operator-only writes gated IN-HANDLER (not via require_action) ---
-    # admin_models.py gates these with its own ``_require_owner(user)`` call at
-    # the top of each handler (a deliberate audit-locality choice predating
-    # this work). They are NOT ungated; they are simply gated by a mechanism
-    # the route-tag walker can't see, so they are allowlisted with this note.
-    ("POST", "/api/v1/admin/models"):
-        "Owner-gated in-handler via _require_owner (platform catalog write).",
-    ("PATCH", "/api/v1/admin/models/{model_id}"):
-        "Owner-gated in-handler via _require_owner (platform catalog write).",
-    ("DELETE", "/api/v1/admin/models/{model_id}"):
-        "Owner-gated in-handler via _require_owner (platform catalog write).",
+    # NOTE: the platform model-catalog WRITES (/api/v1/platform/models) are no
+    # longer here — they are now declaratively gated by
+    # require_action("model.manage") and so are covered by the route-tag walker.
 }
 
 

--- a/tests/webui/test_v1_default_deny.py
+++ b/tests/webui/test_v1_default_deny.py
@@ -41,8 +41,6 @@ AUTH_ONLY_V1_ROUTES: dict[tuple[str, str], str] = {
     ("GET", "/api/v1/auth/config"):
         "Boot-time auth-mode hint the SPA reads before it has a session.",
     # --- Identity (the caller's own row) ---------------------------------
-    ("GET", "/api/v1/auth/me"):
-        "Returns the caller's own identity only.",
     ("GET", "/api/v1/me"):
         "Returns the caller's own identity only.",
     ("POST", "/api/v1/auth/ws-ticket"):

--- a/tests/webui/test_v1_default_deny.py
+++ b/tests/webui/test_v1_default_deny.py
@@ -92,9 +92,9 @@ AUTH_ONLY_V1_ROUTES: dict[tuple[str, str], str] = {
         "Read of one approval policy.",
     ("GET", "/api/v1/approvals/requests"):
         "Read of the tenant's pending approval requests (inbox re-render).",
-    ("GET", "/api/v1/schedules"):
+    ("GET", "/api/v1/tasks"):
         "Read-only schedules surface; writes are not exposed on v1.",
-    ("GET", "/api/v1/schedules/{task_id}"):
+    ("GET", "/api/v1/tasks/{task_id}"):
         "Read of one scheduled task.",
     ("GET", "/api/v1/runs/{run_id}"):
         "Read of one run snapshot (SPA reconnect path).",

--- a/tests/webui/test_v1_platform_credentials.py
+++ b/tests/webui/test_v1_platform_credentials.py
@@ -206,7 +206,7 @@ async def test_platform_credentials_not_visible_to_tenant_credentials_list(vault
         )
     async with _client(_build_app(tenant)) as ac:
         listing = await ac.get(
-            "/api/v1/tenant/credentials",
+            "/api/v1/credentials",
             headers={"Authorization": "Bearer x"},
         )
     assert listing.status_code == 200

--- a/tests/webui/test_v1_platform_models.py
+++ b/tests/webui/test_v1_platform_models.py
@@ -1,7 +1,7 @@
-"""Integration tests for ``/api/v1/admin/models`` (PR24).
+"""Integration tests for ``/api/v1/platform/models`` (PR24).
 
 Platform model catalog writes. Three big behaviors to pin:
-  1. Role gate — only owners may mutate the catalog
+  1. Role gate — only platform_admin may mutate the catalog (model.manage)
   2. Soft-delete semantics — in-use rows return 409, not destruction
   3. (provider, model_id) uniqueness
 """
@@ -49,7 +49,7 @@ def _build_app(user: AuthenticatedUser) -> FastAPI:
     return app
 
 
-async def _make_user(role: str = "owner") -> AuthenticatedUser:
+async def _make_user(role: str = "platform_admin") -> AuthenticatedUser:
     t = await create_tenant(
         name="T", slug=f"adm-{uuid.uuid4().hex[:8]}",
     )
@@ -65,10 +65,10 @@ async def _make_user(role: str = "owner") -> AuthenticatedUser:
 
 
 async def test_create_model_happy_path() -> None:
-    user = await _make_user("owner")
+    user = await _make_user("platform_admin")
     async with _client(_build_app(user)) as ac:
         resp = await ac.post(
-            "/api/v1/admin/models",
+            "/api/v1/platform/models",
             json={
                 "provider": "anthropic",
                 "model_id": f"claude-opus-{uuid.uuid4().hex[:6]}",
@@ -83,14 +83,15 @@ async def test_create_model_happy_path() -> None:
     assert body["is_active"] is True
 
 
-async def test_create_model_rejected_for_non_owner() -> None:
-    # Role gate: members get 403 with a FORBIDDEN code. Pins the
-    # specific code so the SPA can branch on it (e.g. hide the
-    # admin UI for non-owners rather than show a generic error).
-    user = await _make_user("member")
+@pytest.mark.parametrize("role", ["member", "admin", "owner"])
+async def test_create_model_rejected_for_non_platform_admin(role: str) -> None:
+    # model.manage is platform-only: NO tenant role (not even owner) may
+    # mutate the global catalog. The route-level require_action gate returns
+    # a plain 403 (not the {code: FORBIDDEN} envelope).
+    user = await _make_user(role)
     async with _client(_build_app(user)) as ac:
         resp = await ac.post(
-            "/api/v1/admin/models",
+            "/api/v1/platform/models",
             json={
                 "provider": "anthropic",
                 "model_id": "x",
@@ -100,15 +101,14 @@ async def test_create_model_rejected_for_non_owner() -> None:
             headers=_HDRS,
         )
     assert resp.status_code == 403
-    assert resp.json()["code"] == "FORBIDDEN"
 
 
 async def test_create_model_duplicate_returns_409() -> None:
-    user = await _make_user("owner")
+    user = await _make_user("platform_admin")
     model_id_str = f"dup-{uuid.uuid4().hex[:6]}"
     async with _client(_build_app(user)) as ac:
         first = await ac.post(
-            "/api/v1/admin/models",
+            "/api/v1/platform/models",
             json={
                 "provider": "anthropic",
                 "model_id": model_id_str,
@@ -119,7 +119,7 @@ async def test_create_model_duplicate_returns_409() -> None:
         )
         assert first.status_code == 201
         second = await ac.post(
-            "/api/v1/admin/models",
+            "/api/v1/platform/models",
             json={
                 "provider": "anthropic",
                 "model_id": model_id_str,
@@ -132,7 +132,7 @@ async def test_create_model_duplicate_returns_409() -> None:
 
 
 async def test_patch_model_updates_display_name_and_is_active() -> None:
-    user = await _make_user("owner")
+    user = await _make_user("platform_admin")
     row = await create_model(
         provider="anthropic",
         model_id=f"patch-{uuid.uuid4().hex[:6]}",
@@ -141,7 +141,7 @@ async def test_patch_model_updates_display_name_and_is_active() -> None:
     )
     async with _client(_build_app(user)) as ac:
         resp = await ac.patch(
-            f"/api/v1/admin/models/{row.id}",
+            f"/api/v1/platform/models/{row.id}",
             json={"display_name": "After", "is_active": False},
             headers=_HDRS,
         )
@@ -154,7 +154,7 @@ async def test_patch_model_updates_display_name_and_is_active() -> None:
 async def test_delete_unused_model_succeeds_with_soft_delete() -> None:
     # No coworker bindings → DELETE returns 204 and flips
     # is_active=false (not a row drop).
-    user = await _make_user("owner")
+    user = await _make_user("platform_admin")
     row = await create_model(
         provider="anthropic",
         model_id=f"un-{uuid.uuid4().hex[:6]}",
@@ -163,7 +163,7 @@ async def test_delete_unused_model_succeeds_with_soft_delete() -> None:
     )
     async with _client(_build_app(user)) as ac:
         resp = await ac.delete(
-            f"/api/v1/admin/models/{row.id}", headers=_HDRS,
+            f"/api/v1/platform/models/{row.id}", headers=_HDRS,
         )
     assert resp.status_code == 204
     after = await get_model_by_id(row.id)
@@ -175,7 +175,7 @@ async def test_delete_in_use_model_returns_409() -> None:
     # Bind a coworker to the model first, then DELETE — 409 with
     # the bound count surfaced so the UI can show "N coworkers
     # depend on this".
-    user = await _make_user("owner")
+    user = await _make_user("platform_admin")
     row = await create_model(
         provider="anthropic",
         model_id=f"used-{uuid.uuid4().hex[:6]}",
@@ -190,7 +190,7 @@ async def test_delete_in_use_model_returns_409() -> None:
     )
     async with _client(_build_app(user)) as ac:
         resp = await ac.delete(
-            f"/api/v1/admin/models/{row.id}", headers=_HDRS,
+            f"/api/v1/platform/models/{row.id}", headers=_HDRS,
         )
     assert resp.status_code == 409
     body = resp.json()
@@ -203,16 +203,16 @@ async def test_delete_in_use_model_returns_409() -> None:
 
 
 async def test_delete_missing_model_returns_404() -> None:
-    user = await _make_user("owner")
+    user = await _make_user("platform_admin")
     async with _client(_build_app(user)) as ac:
         resp = await ac.delete(
-            f"/api/v1/admin/models/{uuid.uuid4()}", headers=_HDRS,
+            f"/api/v1/platform/models/{uuid.uuid4()}", headers=_HDRS,
         )
     assert resp.status_code == 404
 
 
-async def test_patch_non_owner_rejected() -> None:
-    # Both PATCH and DELETE need the role gate; pin the PATCH path
+async def test_patch_non_platform_admin_rejected() -> None:
+    # Both PATCH and DELETE need the model.manage gate; pin the PATCH path
     # separately so a future refactor that re-wires only POST
     # doesn't open a hole.
     user = await _make_user("member")
@@ -224,7 +224,7 @@ async def test_patch_non_owner_rejected() -> None:
     )
     async with _client(_build_app(user)) as ac:
         resp = await ac.patch(
-            f"/api/v1/admin/models/{row.id}",
+            f"/api/v1/platform/models/{row.id}",
             json={"display_name": "should-fail"},
             headers=_HDRS,
         )

--- a/tests/webui/test_v1_role_gates_403.py
+++ b/tests/webui/test_v1_role_gates_403.py
@@ -304,7 +304,7 @@ async def test_only_owner_can_put_credential() -> None:
     for uid, role in ((member_id, "member"), (admin_id, "admin")):
         app = _build_app(_authed(tid, uid, role))
         async with _client(app) as c:
-            denied = await c.put("/api/v1/tenant/credentials/anthropic", json=body)
+            denied = await c.put("/api/v1/credentials/anthropic", json=body)
         assert denied.status_code == 403, f"{role}: {denied.text}"
 
     # Owner is the boundary role: the PUT must pass the gate AND succeed.
@@ -314,7 +314,7 @@ async def test_only_owner_can_put_credential() -> None:
     try:
         owner_app = _build_app(_authed(tid, owner_id, "owner"))
         async with _client(owner_app) as c:
-            resp = await c.put("/api/v1/tenant/credentials/anthropic", json=body)
+            resp = await c.put("/api/v1/credentials/anthropic", json=body)
         assert resp.status_code == 200, resp.text
     finally:
         set_credential_vault(None)
@@ -328,12 +328,12 @@ async def test_admin_cannot_list_credentials_owner_can() -> None:
 
     admin_app = _build_app(_authed(tid, admin_id, "admin"))
     async with _client(admin_app) as c:
-        denied = await c.get("/api/v1/tenant/credentials")
+        denied = await c.get("/api/v1/credentials")
     assert denied.status_code == 403, denied.text
 
     owner_app = _build_app(_authed(tid, owner_id, "owner"))
     async with _client(owner_app) as c:
-        ok = await c.get("/api/v1/tenant/credentials")
+        ok = await c.get("/api/v1/credentials")
     assert ok.status_code == 200, ok.text
 
 
@@ -370,5 +370,5 @@ async def test_platform_admin_passes_owner_only_credential_gate() -> None:
     pa_id = await _user(tid, "platform_admin")
     app = _build_app(_authed(tid, pa_id, "platform_admin"))
     async with _client(app) as c:
-        ok = await c.get("/api/v1/tenant/credentials")
+        ok = await c.get("/api/v1/credentials")
     assert ok.status_code == 200, ok.text

--- a/tests/webui/test_v1_role_gates_403.py
+++ b/tests/webui/test_v1_role_gates_403.py
@@ -279,12 +279,12 @@ async def test_member_cannot_write_approval_policy_admin_can() -> None:
 
     member_app = _build_app(_authed(tid, member_id, "member"))
     async with _client(member_app) as c:
-        denied = await c.post("/api/v1/approval-policies", json=payload)
+        denied = await c.post("/api/v1/approvals/policies", json=payload)
     assert denied.status_code == 403, denied.text
 
     admin_app = _build_app(_authed(tid, admin_id, "admin"))
     async with _client(admin_app) as c:
-        ok = await c.post("/api/v1/approval-policies", json=payload)
+        ok = await c.post("/api/v1/approvals/policies", json=payload)
     assert ok.status_code == 201, ok.text
 
 

--- a/tests/webui/test_v1_role_gates_403.py
+++ b/tests/webui/test_v1_role_gates_403.py
@@ -8,7 +8,7 @@ accidentally over-tight.
 
 The ownership-escape cases are the subtle ones: a member CAN update/delete a
 coworker/skill they created, and CANNOT touch one created by someone else (the
-gate falls back to requiring ``agent.manage`` / ``skill.manage``).
+gate falls back to requiring ``coworker.manage`` / ``skill.manage``).
 
 Auth is injected by overriding ``get_current_user`` with a fixed role, so the
 role under test is exactly the one the gate sees (``require_action`` resolves
@@ -104,13 +104,13 @@ async def _seed_skill(tenant_id: str, *, created_by: str | None) -> str:
 
 
 # ---------------------------------------------------------------------------
-# coworkers: create requires agent.create (all roles); manage gated for member
+# coworkers: create requires coworker.create (all roles); manage gated for member
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_member_can_create_coworker() -> None:
-    """agent.create is granted to member — the boundary role passes."""
+    """coworker.create is granted to member — the boundary role passes."""
     tid = await _tenant()
     uid = await _user(tid, "member")
     app = _build_app(_authed(tid, uid, "member"))
@@ -152,7 +152,7 @@ async def test_member_cannot_manage_unattributed_coworker() -> None:
     """Three-valued logic: created_by_user_id IS NULL is NOT 'mine'.
 
     A member must not be able to claim an un-attributed (legacy/system)
-    coworker as their own; NULL falls through to requiring agent.manage.
+    coworker as their own; NULL falls through to requiring coworker.manage.
     """
     tid = await _tenant()
     member_id = await _user(tid, "member")
@@ -166,7 +166,7 @@ async def test_member_cannot_manage_unattributed_coworker() -> None:
 
 @pytest.mark.asyncio
 async def test_admin_can_manage_any_coworker() -> None:
-    """agent.manage holder reaches a coworker they did not create."""
+    """coworker.manage holder reaches a coworker they did not create."""
     tid = await _tenant()
     creator = await _user(tid, "member")
     admin_id = await _user(tid, "admin")

--- a/tests/webui/test_v1_tasks.py
+++ b/tests/webui/test_v1_tasks.py
@@ -1,4 +1,4 @@
-"""Integration tests for ``/api/v1/schedules`` (PR24 read-only surface).
+"""Integration tests for ``/api/v1/tasks`` (PR24 read-only surface).
 
 Hits the FastAPI app via httpx ASGI transport against the testcontainer
 postgres. Catches contract drift between the read-only endpoint and
@@ -96,7 +96,7 @@ async def test_list_schedules_returns_tenant_tasks() -> None:
         tenant_id=user.tenant_id, coworker_id=cw_id, prompt="beta",
     )
     async with _client(_build_app(user)) as ac:
-        resp = await ac.get("/api/v1/schedules", headers=_HDRS)
+        resp = await ac.get("/api/v1/tasks", headers=_HDRS)
     assert resp.status_code == 200
     ids = {row["id"] for row in resp.json()["items"]}
     assert a in ids and b in ids
@@ -119,7 +119,7 @@ async def test_list_schedules_filters_by_coworker() -> None:
     )
     async with _client(_build_app(user)) as ac:
         resp = await ac.get(
-            f"/api/v1/schedules?coworker_id={cw_a}", headers=_HDRS,
+            f"/api/v1/tasks?coworker_id={cw_a}", headers=_HDRS,
         )
     assert resp.status_code == 200
     ids = {row["id"] for row in resp.json()["items"]}
@@ -138,7 +138,7 @@ async def test_list_schedules_excludes_other_tenants() -> None:
         tenant_id=user_b.tenant_id, coworker_id=cw_b, prompt="other",
     )
     async with _client(_build_app(user_a)) as ac:
-        resp = await ac.get("/api/v1/schedules", headers=_HDRS)
+        resp = await ac.get("/api/v1/tasks", headers=_HDRS)
     assert resp.status_code == 200
     ids = {row["id"] for row in resp.json()["items"]}
     assert other not in ids
@@ -150,7 +150,7 @@ async def test_get_schedule_returns_one() -> None:
         tenant_id=user.tenant_id, coworker_id=cw, prompt="probe",
     )
     async with _client(_build_app(user)) as ac:
-        resp = await ac.get(f"/api/v1/schedules/{tid}", headers=_HDRS)
+        resp = await ac.get(f"/api/v1/tasks/{tid}", headers=_HDRS)
     assert resp.status_code == 200
     body = resp.json()
     assert body["id"] == tid
@@ -161,7 +161,7 @@ async def test_get_schedule_404_on_missing() -> None:
     user, _ = await _make_user_and_coworker("g404")
     bogus = str(uuid.uuid4())
     async with _client(_build_app(user)) as ac:
-        resp = await ac.get(f"/api/v1/schedules/{bogus}", headers=_HDRS)
+        resp = await ac.get(f"/api/v1/tasks/{bogus}", headers=_HDRS)
     assert resp.status_code == 404
     assert resp.json()["code"] == "NOT_FOUND"
 
@@ -177,7 +177,7 @@ async def test_get_schedule_404_on_cross_tenant() -> None:
         tenant_id=user_b.tenant_id, coworker_id=cw_b, prompt="b-only",
     )
     async with _client(_build_app(user_a)) as ac:
-        resp = await ac.get(f"/api/v1/schedules/{tid_b}", headers=_HDRS)
+        resp = await ac.get(f"/api/v1/tasks/{tid_b}", headers=_HDRS)
     assert resp.status_code == 404
 
 
@@ -186,7 +186,7 @@ async def test_get_schedule_404_on_malformed_uuid() -> None:
     # 404, not 500. Pattern matches skills + coworkers handling.
     user, _ = await _make_user_and_coworker("mu")
     async with _client(_build_app(user)) as ac:
-        resp = await ac.get("/api/v1/schedules/not-a-uuid", headers=_HDRS)
+        resp = await ac.get("/api/v1/tasks/not-a-uuid", headers=_HDRS)
     assert resp.status_code == 404
 
 
@@ -214,10 +214,10 @@ async def test_delete_schedule_owner_ok() -> None:
         tenant_id=user.tenant_id, coworker_id=cw, prompt="doomed",
     )
     async with _client(_build_app(user)) as ac:
-        resp = await ac.delete(f"/api/v1/schedules/{tid}", headers=_HDRS)
+        resp = await ac.delete(f"/api/v1/tasks/{tid}", headers=_HDRS)
         assert resp.status_code == 204
         # Confirm it's gone.
-        after = await ac.get(f"/api/v1/schedules/{tid}", headers=_HDRS)
+        after = await ac.get(f"/api/v1/tasks/{tid}", headers=_HDRS)
     assert after.status_code == 404
 
 
@@ -228,7 +228,7 @@ async def test_delete_schedule_admin_ok() -> None:
         tenant_id=owner.tenant_id, coworker_id=cw, prompt="x",
     )
     async with _client(_build_app(admin)) as ac:
-        resp = await ac.delete(f"/api/v1/schedules/{tid}", headers=_HDRS)
+        resp = await ac.delete(f"/api/v1/tasks/{tid}", headers=_HDRS)
     assert resp.status_code == 204
 
 
@@ -239,7 +239,7 @@ async def test_delete_schedule_member_forbidden() -> None:
         tenant_id=owner.tenant_id, coworker_id=cw, prompt="x",
     )
     async with _client(_build_app(member)) as ac:
-        resp = await ac.delete(f"/api/v1/schedules/{tid}", headers=_HDRS)
+        resp = await ac.delete(f"/api/v1/tasks/{tid}", headers=_HDRS)
     assert resp.status_code == 403
 
 
@@ -247,7 +247,7 @@ async def test_delete_schedule_unknown_404() -> None:
     user, _ = await _make_user_and_coworker("d404")
     async with _client(_build_app(user)) as ac:
         resp = await ac.delete(
-            f"/api/v1/schedules/{uuid.uuid4()}", headers=_HDRS,
+            f"/api/v1/tasks/{uuid.uuid4()}", headers=_HDRS,
         )
     assert resp.status_code == 404
 
@@ -259,5 +259,5 @@ async def test_delete_schedule_cross_tenant_404() -> None:
         tenant_id=user_b.tenant_id, coworker_id=cw_b, prompt="b-only",
     )
     async with _client(_build_app(user_a)) as ac:
-        resp = await ac.delete(f"/api/v1/schedules/{tid_b}", headers=_HDRS)
+        resp = await ac.delete(f"/api/v1/tasks/{tid_b}", headers=_HDRS)
     assert resp.status_code == 404

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -337,7 +337,7 @@ export class ApiClient {
   // ------------------------------------------------------------------
 
   async listCredentials(): Promise<CredentialResponse[]> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/tenant/credentials`, {
+    const resp = await fetch(`${this.baseUrl}/api/v1/credentials`, {
       method: 'GET',
       headers: this.headers(),
     });
@@ -353,7 +353,7 @@ export class ApiClient {
     body: CredentialUpsert,
   ): Promise<CredentialResponse> {
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/tenant/credentials/${encodeURIComponent(provider)}`,
+      `${this.baseUrl}/api/v1/credentials/${encodeURIComponent(provider)}`,
       {
         method: 'PUT',
         headers: this.headers({ 'Content-Type': 'application/json' }),
@@ -366,7 +366,7 @@ export class ApiClient {
 
   async deleteCredential(provider: ModelProvider): Promise<void> {
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/tenant/credentials/${encodeURIComponent(provider)}`,
+      `${this.baseUrl}/api/v1/credentials/${encodeURIComponent(provider)}`,
       { method: 'DELETE', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -428,7 +428,7 @@ export class ApiClient {
     // Paged endpoint; request the max window and return the items so
     // callers keep their array shape (page-through UI is a follow-up).
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/approval-policies?limit=200`,
+      `${this.baseUrl}/api/v1/approvals/policies?limit=200`,
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
@@ -439,7 +439,7 @@ export class ApiClient {
   async createApprovalPolicy(
     body: ApprovalPolicyCreate,
   ): Promise<ApprovalPolicy> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/approval-policies`, {
+    const resp = await fetch(`${this.baseUrl}/api/v1/approvals/policies`, {
       method: 'POST',
       headers: this.headers({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
@@ -453,7 +453,7 @@ export class ApiClient {
     body: ApprovalPolicyUpdate,
   ): Promise<ApprovalPolicy> {
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/approval-policies/${encodeURIComponent(id)}`,
+      `${this.baseUrl}/api/v1/approvals/policies/${encodeURIComponent(id)}`,
       {
         method: 'PATCH',
         headers: this.headers({ 'Content-Type': 'application/json' }),
@@ -466,7 +466,7 @@ export class ApiClient {
 
   async deleteApprovalPolicy(id: string): Promise<void> {
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/approval-policies/${encodeURIComponent(id)}`,
+      `${this.baseUrl}/api/v1/approvals/policies/${encodeURIComponent(id)}`,
       { method: 'DELETE', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
@@ -481,7 +481,7 @@ export class ApiClient {
     const qs = new URLSearchParams({ limit: '200' });
     if (conversationId) qs.set('conversation_id', conversationId);
     const resp = await fetch(
-      `${this.baseUrl}/api/v1/approval-requests?${qs}`,
+      `${this.baseUrl}/api/v1/approvals/requests?${qs}`,
       { method: 'GET', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1140,7 +1140,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/schedules": {
+    "/api/v1/tasks": {
         parameters: {
             query?: never;
             header?: never;
@@ -1156,7 +1156,7 @@ export interface paths {
          *     scheduled" without round-tripping through the orchestrator
          *     IPC. A coworker filter is exposed for the per-coworker view.
          */
-        get: operations["schedulesList"];
+        get: operations["tasksList"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1165,7 +1165,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/schedules/{id}": {
+    "/api/v1/tasks/{id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1173,7 +1173,7 @@ export interface paths {
             cookie?: never;
         };
         /** Fetch one scheduled task */
-        get: operations["schedulesGet"];
+        get: operations["tasksGet"];
         put?: never;
         post?: never;
         /**
@@ -1182,7 +1182,7 @@ export interface paths {
          *     admin); reads on this surface stay auth-only. A cross-tenant /
          *     unknown id returns 404.
          */
-        delete: operations["schedulesDelete"];
+        delete: operations["tasksDelete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -4593,7 +4593,7 @@ export interface operations {
             403: components["responses"]["Forbidden"];
         };
     };
-    schedulesList: {
+    tasksList: {
         parameters: {
             query?: {
                 /** @description Maximum number of items to return (default 50, max 200). */
@@ -4621,7 +4621,7 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
         };
     };
-    schedulesGet: {
+    tasksGet: {
         parameters: {
             query?: never;
             header?: never;
@@ -4645,7 +4645,7 @@ export interface operations {
             404: components["responses"]["NotFound"];
         };
     };
-    schedulesDelete: {
+    tasksDelete: {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -831,7 +831,7 @@ export interface paths {
         patch: operations["updateMCPServer"];
         trace?: never;
     };
-    "/api/v1/approval-policies": {
+    "/api/v1/approvals/policies": {
         parameters: {
             query?: never;
             header?: never;
@@ -862,7 +862,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/approval-policies/{id}": {
+    "/api/v1/approvals/policies/{id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -882,7 +882,7 @@ export interface paths {
         patch: operations["updateApprovalPolicy"];
         trace?: never;
     };
-    "/api/v1/approval-requests": {
+    "/api/v1/approvals/requests": {
         parameters: {
             query?: never;
             header?: never;
@@ -1798,7 +1798,7 @@ export interface components {
             rationale?: string | null;
             /**
              * @description Lifecycle status. Always `pending` on the tenant-wide inbox read
-             *     (`GET /approval-requests`); the conversation sub-resource
+             *     (`GET /approvals/requests`); the conversation sub-resource
              *     (`GET /conversations/{id}/approval-requests`) returns every state so
              *     resolved cards re-render inline in chat history.
              * @enum {string}

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -371,7 +371,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/tenant/credentials": {
+    "/api/v1/credentials": {
         parameters: {
             query?: never;
             header?: never;
@@ -393,7 +393,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/tenant/credentials/{provider}": {
+    "/api/v1/credentials/{provider}": {
         parameters: {
             query?: never;
             header?: never;
@@ -427,7 +427,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/tenant/credentials/{provider}/pool": {
+    "/api/v1/credentials/{provider}/pool": {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1249,7 +1249,7 @@ export interface paths {
         patch: operations["bindingsUpdate"];
         trace?: never;
     };
-    "/api/v1/admin/models": {
+    "/api/v1/platform/models": {
         parameters: {
             query?: never;
             header?: never;
@@ -1259,19 +1259,20 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Register a new platform model (admin only)
-         * @description The `models` catalog is platform-managed — tenants pick from
-         *     it but only operators add rows. POST/PATCH/DELETE require
-         *     the `owner` role (design §13 role check).
+         * Register a new platform model (platform operator only)
+         * @description The `models` catalog is platform-global — every tenant reads
+         *     it at `/api/v1/models`, but only the platform operator writes
+         *     it. POST/PATCH/DELETE require the platform-only `model.manage`
+         *     capability (platform_admin).
          */
-        post: operations["adminModelsCreate"];
+        post: operations["platformModelsCreate"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/api/v1/admin/models/{id}": {
+    "/api/v1/platform/models/{id}": {
         parameters: {
             query?: never;
             header?: never;
@@ -1282,16 +1283,16 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Retire a platform model (admin only)
+         * Retire a platform model (platform operator only)
          * @description Soft delete — sets `active = false` rather than dropping the
          *     row so existing coworkers that point at the model keep
          *     rendering. Returns 409 if any coworker is still bound.
          */
-        delete: operations["adminModelsDelete"];
+        delete: operations["platformModelsDelete"];
         options?: never;
         head?: never;
-        /** Update a platform model (admin only) */
-        patch: operations["adminModelsUpdate"];
+        /** Update a platform model (platform operator only) */
+        patch: operations["platformModelsUpdate"];
         trace?: never;
     };
     "/api/v1/users": {
@@ -4799,7 +4800,7 @@ export interface operations {
             422: components["responses"]["Unprocessable"];
         };
     };
-    adminModelsCreate: {
+    platformModelsCreate: {
         parameters: {
             query?: never;
             header?: never;
@@ -4827,7 +4828,7 @@ export interface operations {
             422: components["responses"]["Unprocessable"];
         };
     };
-    adminModelsDelete: {
+    platformModelsDelete: {
         parameters: {
             query?: never;
             header?: never;
@@ -4851,7 +4852,7 @@ export interface operations {
             409: components["responses"]["Conflict"];
         };
     };
-    adminModelsUpdate: {
+    platformModelsUpdate: {
         parameters: {
             query?: never;
             header?: never;

--- a/web/src/components/approval-store.ts
+++ b/web/src/components/approval-store.ts
@@ -7,7 +7,7 @@
 // conversation. Three inputs feed it:
 //   - `event.approval.requested`  → a new pending card (idempotent on id)
 //   - `event.approval.resolved`   → an existing card flips to its terminal state
-//   - `GET /api/v1/approval-requests` (reconnect) → the authoritative pending set
+//   - `GET /api/v1/approvals/requests` (reconnect) → the authoritative pending set
 //
 // Every function is pure and returns a fresh array (Lit `@state` change
 // detection is reference-based), never mutating the input. The one exception to

--- a/web/src/components/approvals-inbox.ts
+++ b/web/src/components/approvals-inbox.ts
@@ -6,7 +6,7 @@
 // reject controls.
 //
 // State scope: the component self-holds its own `ApprovalRequest[]`
-// fetched from `GET /api/v1/approval-requests` WITHOUT a conversation_id
+// fetched from `GET /api/v1/approvals/requests` WITHOUT a conversation_id
 // filter (tenant-wide; RLS scopes to the user's tenant server-side). The
 // approval-store is deliberately NOT lifted to the shell — the inbox and
 // the chat panel each keep their own view; the inbox is fed by explicit

--- a/web/src/components/coworker-wizard.test.ts
+++ b/web/src/components/coworker-wizard.test.ts
@@ -200,7 +200,7 @@ describe('<rm-coworker-wizard>', () => {
       },
       {
         match: (u, i) =>
-          u === '/api/v1/tenant/credentials' && (i?.method ?? 'GET') === 'GET',
+          u === '/api/v1/credentials' && (i?.method ?? 'GET') === 'GET',
         respond: () => jsonResp(CREDS_ANT),
       },
       {
@@ -456,7 +456,7 @@ describe('<rm-coworker-wizard>', () => {
     fetchStub = installFetch([
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
-      { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
+      { match: (u) => u === '/api/v1/credentials', respond: () => jsonResp(CREDS_ANT) },
       {
         match: (u) => u.split('?')[0] === '/api/v1/mcp-servers',
         respond: () => jsonResp(pageOf([
@@ -546,7 +546,7 @@ describe('<rm-coworker-wizard>', () => {
     fetchStub = installFetch([
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
-      { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
+      { match: (u) => u === '/api/v1/credentials', respond: () => jsonResp(CREDS_ANT) },
       { match: (u) => u.split('?')[0] === '/api/v1/mcp-servers', respond: () => jsonResp(pageOf([])) },
       { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
       // Existing MCP bindings: seed the wizard with one already-bound
@@ -655,7 +655,7 @@ describe('<rm-coworker-wizard>', () => {
     fetchStub = installFetch([
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
-      { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
+      { match: (u) => u === '/api/v1/credentials', respond: () => jsonResp(CREDS_ANT) },
       { match: (u) => u.split('?')[0] === '/api/v1/mcp-servers', respond: () => jsonResp(pageOf([])) },
       { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
     ]);
@@ -694,7 +694,7 @@ describe('<rm-coworker-wizard>', () => {
     fetchStub = installFetch([
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
-      { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
+      { match: (u) => u === '/api/v1/credentials', respond: () => jsonResp(CREDS_ANT) },
       { match: (u) => u.split('?')[0] === '/api/v1/mcp-servers', respond: () => jsonResp(pageOf(MCP_LIST)) },
       { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf(SKILL_LIST)) },
     ]);
@@ -768,7 +768,7 @@ describe('<rm-coworker-wizard>', () => {
     fetchStub = installFetch([
       { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
       { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
-      { match: (u) => u === '/api/v1/tenant/credentials', respond: () => jsonResp(CREDS_ANT) },
+      { match: (u) => u === '/api/v1/credentials', respond: () => jsonResp(CREDS_ANT) },
       {
         match: (u) => u.split('?')[0] === '/api/v1/mcp-servers',
         respond: () => jsonResp(pageOf([

--- a/web/src/components/credential-dialog.test.ts
+++ b/web/src/components/credential-dialog.test.ts
@@ -8,7 +8,7 @@
 //   - Bedrock specifically renders 4 fields (per locked decision):
 //     access key id (api_key slot), secret, region (default us-west-2),
 //     and optional session token.
-//   - Save → PUT /tenant/credentials/{provider} with the right body
+//   - Save → PUT /credentials/{provider} with the right body
 //     shape `{api_key, extras: {...}}` (or `extras: null` when no
 //     extras are needed).
 //   - Save success fires `credential-saved` AND clears the form
@@ -37,7 +37,7 @@ function installFetch(): Stub {
   const stub: Stub = { restore: () => {}, calls: [], shouldFail: null };
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString();
-    const m = /\/api\/v1\/tenant\/credentials\/(\w+)$/.exec(url);
+    const m = /\/api\/v1\/credentials\/(\w+)$/.exec(url);
     if (m && init?.method === 'PUT') {
       const body = JSON.parse(init.body as string);
       stub.calls.push({ url, body });
@@ -169,7 +169,7 @@ describe('<rm-credential-dialog>', () => {
 
     expect(stub!.calls).toHaveLength(1);
     expect(stub!.calls[0]).toMatchObject({
-      url: expect.stringContaining('/tenant/credentials/openai'),
+      url: expect.stringContaining('/credentials/openai'),
       body: {
         api_key: 'sk-fake',
         extras: { api_base: 'https://gateway.example.com/v1' },

--- a/web/src/components/credential-dialog.ts
+++ b/web/src/components/credential-dialog.ts
@@ -3,7 +3,7 @@
 // Wraps <rm-dialog> (v2-A primitive). Knows which provider the user
 // is configuring; renders the right set of fields (anthropic = one
 // API key, bedrock = AWS quartet, etc.) and writes via PUT
-// /api/v1/tenant/credentials/{provider} with the open-shape
+// /api/v1/credentials/{provider} with the open-shape
 // `extras: { ... }` map per OpenAPI.
 //
 // Invariants:

--- a/web/src/components/models-page.ts
+++ b/web/src/components/models-page.ts
@@ -1,7 +1,7 @@
 // Read-only Models catalog (#/models).
 //
 // Lists `GET /api/v1/models` grouped by provider, augmented with
-// the tenant's `GET /tenant/credentials` so each provider header
+// the tenant's `GET /credentials` so each provider header
 // shows ready / needs-credential status. The grouping logic is in
 // `services/models-grouping.ts` so the v2-B coworker wizard and
 // this page share one source of truth.


### PR DESCRIPTION
## Summary

Greenfield API naming/structure cleanup from the review — done now, before any external consumer exists, since breaking renames only get more expensive later. Six self-contained commits, one per change. Everything (contract + generated `types.ts` + SPA + backend + tests) is changed atomically so the in-repo app stays consistent.

## What changed

| # | Commit | Change | Breaking? |
|---|---|---|---|
| 1 | `agent.* → coworker.*` actions | the 3 capability actions were the lone "agent" holdouts; everything else (path/table/type) says coworker | **No** — action strings are internal authz, not on the wire |
| 2 | drop hidden `/auth/me` | it was an `include_in_schema=False` alias of `/me` with no consumers | No (hidden alias) |
| 3 | `/admin/models → /platform/models` + platform_admin gate | confusing "admin" segment; **and** it was owner-gated on a platform-global catalog (any tenant owner could edit a catalog every tenant reads) | **Yes — path + authz** |
| 4 | `/approval-policies` + `/approval-requests` → `/approvals/{policies,requests}` | one feature, one namespace | **Yes — path** |
| 5 | `/schedules → /tasks` | table/type/action/param/db all said "task"; path was the outlier | **Yes — path** |
| 6 | `/tenant/credentials → /credentials` | tenant is the implicit plane (cf. `/users`, `/coworkers`); platform counterpart stays `/platform/credentials` | **Yes — path** |

### Functional surfaces touched by the breaking renames
- **HITL approvals** (policy CRUD + pending-request inbox) — path only.
- **Tenant BYOK credentials** (CRUD + pool election) — path only.
- **Scheduled tasks** (list/get/delete) — path only; no SPA consumer.
- **Platform model catalog writes** — path **and** authz: now `platform_admin`-only via a new platform-only `model.manage` capability; a tenant `owner` can no longer edit the global catalog. Catalog **read** (`/api/v1/models`) is unchanged. No SPA consumer.

The per-conversation sub-resource `/conversations/{id}/approval-requests` is intentionally left unchanged (different context).

## Resulting conventions
- **Tenant plane = implicit, unprefixed** (`/users`, `/coworkers`, `/credentials`, `/tasks`, …); `/tenant` carries only tenant settings.
- **Platform plane = `/platform/*`** (`/platform/models`, `/platform/credentials`), gated by platform-only capabilities.
- **One vocabulary per resource** across path / table / type / action.

## Verification (local, no Docker)
- `ruff check src tests` clean; **zero new mypy errors** (file-by-file vs base).
- Gate tests green: OpenAPI codegen-freshness + contract, default-deny meta-test (incl. the AST "action must exist in role table" check), permissions role-model (added a negative test: no tenant role — incl. owner — holds a platform-only action).
- Frontend: `tsc` at baseline (no new errors); **vitest 553 passing** (updated the raw-fetch mocks / escaped-slash matchers in coworker-wizard + credential-dialog).
- Repo-wide: zero non-English text in the diff; runtime route check confirms all legacy names are gone except the intentional conversation sub-resource.

DB-backed integration tests run in CI (testcontainers Postgres needs Docker, unavailable in the dev sandbox); the suite collects cleanly aside from a pre-existing missing `filelock` dep in `tests/test_agent_runner/`.

## Note for external consumers
This is a breaking contract change on the four surfaces above. No external codegen clients are known (the whole point of doing it pre-launch). The model-catalog write also requires `platform_admin` now, not tenant `owner`.

https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom

---
_Generated by [Claude Code](https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom)_