### PR TITLE
feat(platform): tenant lifecycle — provision + suspend/resume

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -756,6 +756,139 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/platform/tenants:
+    get:
+      tags: [Platform]
+      operationId: listPlatformTenants
+      summary: List all tenants (platform lifecycle)
+      description: |
+        Platform-plane only (`platform.tenant.manage`, granted to
+        `platform_admin`). Returns every tenant, including suspended ones
+        and the reserved `__platform__` sentinel, with lifecycle `status`.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/PlatformTenantResponse' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Platform]
+      operationId: provisionPlatformTenant
+      summary: Provision a new tenant
+      description: |
+        Platform-plane only (`platform.tenant.manage`). Creates a tenant in
+        the `active` state. The reserved `__platform__` slug is rejected
+        (`403`); a slug already in use returns `409`.
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PlatformTenantProvision' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformTenantResponse' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/Unprocessable'
+
+  /api/v1/platform/tenants/{tenant_id}:
+    parameters:
+      - in: path
+        name: tenant_id
+        required: true
+        schema: { type: string }
+    get:
+      tags: [Platform]
+      operationId: getPlatformTenant
+      summary: Fetch one tenant (platform lifecycle)
+      description: Platform-plane only (`platform.tenant.manage`).
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformTenantResponse' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/platform/tenants/{tenant_id}/suspend:
+    parameters:
+      - in: path
+        name: tenant_id
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Platform]
+      operationId: suspendPlatformTenant
+      summary: Suspend a tenant
+      description: |
+        Platform-plane only (`platform.tenant.manage`). Sets `status` to
+        `suspended`: the tenant's users can no longer authenticate and its
+        scheduled tasks pause (they are not failed/deleted). Idempotent. The
+        reserved `__platform__` sentinel cannot be suspended (`403`).
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformTenantResponse' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/platform/tenants/{tenant_id}/resume:
+    parameters:
+      - in: path
+        name: tenant_id
+        required: true
+        schema: { type: string }
+    post:
+      tags: [Platform]
+      operationId: resumePlatformTenant
+      summary: Resume a suspended tenant
+      description: |
+        Platform-plane only (`platform.tenant.manage`). Sets `status` back to
+        `active` (suspend is reversible). Idempotent. The reserved
+        `__platform__` sentinel is refused (`403`).
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformTenantResponse' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/coworkers/{id}/mcp-servers:
     parameters:
       - $ref: '#/components/parameters/IdInPath'
@@ -2663,6 +2796,35 @@ components:
         provider: { $ref: '#/components/schemas/ModelProvider' }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+
+    TenantStatus:
+      type: string
+      enum: [active, suspended]
+      description: |
+        Platform tenant lifecycle state. `suspended` tenants cannot
+        authenticate and their scheduled tasks pause until resumed.
+
+    PlatformTenantResponse:
+      type: object
+      required: [id, name, max_concurrent_containers, status, created_at]
+      description: |
+        A tenant on the platform lifecycle plane (carries `status`).
+        Distinct from `TenantResponse` (owner self-service settings).
+      properties:
+        id: { type: string }
+        name: { type: string }
+        slug: { type: string, nullable: true }
+        plan: { type: string, nullable: true }
+        max_concurrent_containers: { type: integer }
+        status: { $ref: '#/components/schemas/TenantStatus' }
+        created_at: { type: string }
+
+    PlatformTenantProvision:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string, minLength: 1, maxLength: 200 }
+        slug: { type: string, nullable: true, maxLength: 60 }
 
     CredentialUpsert:
       type: object

--- a/src/rolemesh/auth/permissions.py
+++ b/src/rolemesh/auth/permissions.py
@@ -78,7 +78,18 @@ _TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
 #     (``/api/v1/platform/models``). Every tenant READS the catalog at
 #     ``/api/v1/models``; only the platform operator may write it (a tenant
 #     owner must not edit a catalog every other tenant sees).
-_PLATFORM_ONLY_ACTIONS: set[str] = {"credential.pool.manage", "model.manage"}
+#   * platform.tenant.manage — run the tenant lifecycle
+#     (``/api/v1/platform/tenants``): provision / list / get / suspend /
+#     resume. A SINGLE action covers the whole surface, mirroring
+#     ``credential.pool.manage``. Deliberately distinct from the tenant-plane
+#     ``tenant.manage`` (an owner editing their OWN tenant's settings): this
+#     one operates a tenant AS a customer across the platform and must never
+#     be reachable by any tenant role.
+_PLATFORM_ONLY_ACTIONS: set[str] = {
+    "credential.pool.manage",
+    "model.manage",
+    "platform.tenant.manage",
+}
 
 
 def _all_known_actions() -> set[str]:

--- a/src/rolemesh/core/types.py
+++ b/src/rolemesh/core/types.py
@@ -112,6 +112,7 @@ class Tenant:
     max_concurrent_containers: int = 5
     last_message_cursor: str | None = None  # TIMESTAMPTZ iso
     created_at: str = ""
+    status: str = "active"  # 'active' | 'suspended' (platform lifecycle)
 
 
 @dataclass

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -185,6 +185,15 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
     await conn.execute(
         "ALTER TABLE tenants DROP COLUMN IF EXISTS approval_default_mode"
     )
+    # Tenant lifecycle status (platform-plane provision/suspend). Idempotent
+    # ADD so existing rows default to 'active' — behaviour unchanged for any
+    # tenant that predates this column. The CHECK pins the only two legal
+    # states; a suspended tenant's users fail authentication and its
+    # scheduled tasks are skipped (not failed) until resumed.
+    await conn.execute(
+        "ALTER TABLE tenants ADD COLUMN IF NOT EXISTS status TEXT NOT NULL "
+        "DEFAULT 'active' CHECK (status IN ('active','suspended'))"
+    )
 
     # ----- Platform model catalog (v1.1 §2.1) -----------------------------
     # Tenant-agnostic; no RLS. ``is_platform`` is reserved for the v2

--- a/src/rolemesh/db/task.py
+++ b/src/rolemesh/db/task.py
@@ -247,6 +247,13 @@ async def get_due_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
     Treats both ``None`` and ``""`` as "global scheduler scan" so an
     empty string from a misconfigured caller doesn't enter
     ``tenant_conn`` and silently filter every row to zero.
+
+    Tasks belonging to a *suspended* tenant are excluded from the
+    cross-tenant scheduler sweep: a suspended tenant's schedules pause
+    (they are neither run nor failed/deleted) and resume on its own once
+    the tenant is reactivated — the rows are untouched, just not picked
+    up. The join lives here, at the single point the scheduler reads from,
+    rather than in the per-tick dispatch loop.
     """
     now = datetime.now(UTC)
     if tenant_id:
@@ -264,14 +271,17 @@ async def get_due_tasks(tenant_id: str | None = None) -> list[ScheduledTask]:
     else:
         # inv-1-ok: cross-tenant scheduler sweep — the tenant_id-less
         # branch is the documented multi-tenant scheduler path; the
-        # caller iterates results to dispatch jobs per-tenant.
+        # caller iterates results to dispatch jobs per-tenant. Runs under
+        # admin_conn (BYPASSRLS) so the join to ``tenants`` is visible.
         async with admin_conn() as conn:
             rows = await conn.fetch(
                 """
-                SELECT * FROM scheduled_tasks
-                WHERE status = 'active' AND next_run IS NOT NULL
-                  AND next_run <= $1
-                ORDER BY next_run
+                SELECT st.* FROM scheduled_tasks st
+                JOIN tenants t ON t.id = st.tenant_id
+                WHERE st.status = 'active' AND t.status = 'active'
+                  AND st.next_run IS NOT NULL
+                  AND st.next_run <= $1
+                ORDER BY st.next_run
                 """,
                 now,
             )

--- a/src/rolemesh/db/tenant.py
+++ b/src/rolemesh/db/tenant.py
@@ -16,6 +16,7 @@ __all__ = [
     "get_all_tenants",
     "get_tenant",
     "get_tenant_by_slug",
+    "get_tenant_status",
     "set_tenant_status",
     "update_tenant",
     "update_tenant_message_cursor",
@@ -115,6 +116,26 @@ async def get_tenant_by_slug(slug: str) -> Tenant | None:
     if row is None:
         return None
     return _record_to_tenant(row)
+
+
+async def get_tenant_status(tenant_id: str) -> str | None:
+    """Return a tenant's lifecycle status, or None if unknown.
+
+    A focused single-column read for the authentication chokepoint, which
+    runs on every authenticated request (see ``webui.dependencies``). A
+    non-UUID id (the dev bootstrap path may carry the literal ``"default"``
+    when no default tenant exists) returns None rather than raising, so the
+    caller treats it as "not suspended" instead of 500-ing.
+    """
+    import uuid as _uuid
+
+    try:
+        _uuid.UUID(tenant_id)
+    except (ValueError, AttributeError, TypeError):
+        return None
+    async with admin_conn() as conn:
+        row = await conn.fetchrow("SELECT status FROM tenants WHERE id = $1::uuid", tenant_id)
+    return row["status"] if row is not None else None
 
 
 async def set_tenant_status(tenant_id: str, status: str) -> Tenant | None:

--- a/src/rolemesh/db/tenant.py
+++ b/src/rolemesh/db/tenant.py
@@ -16,6 +16,7 @@ __all__ = [
     "get_all_tenants",
     "get_tenant",
     "get_tenant_by_slug",
+    "set_tenant_status",
     "update_tenant",
     "update_tenant_message_cursor",
 ]
@@ -38,7 +39,8 @@ async def create_tenant(
             """
             INSERT INTO tenants (slug, name, plan, max_concurrent_containers)
             VALUES ($1, $2, $3, $4)
-            RETURNING id, slug, name, plan, max_concurrent_containers, last_message_cursor, created_at
+            RETURNING id, slug, name, plan, max_concurrent_containers,
+                      last_message_cursor, created_at, status
             """,
             slug,
             name,
@@ -59,6 +61,7 @@ def _record_to_tenant(row: asyncpg.Record) -> Tenant:
         max_concurrent_containers=row["max_concurrent_containers"],
         last_message_cursor=lmc.isoformat() if lmc else None,
         created_at=row["created_at"].isoformat() if row["created_at"] else "",
+        status=row["status"],
     )
 
 
@@ -109,6 +112,25 @@ async def get_tenant_by_slug(slug: str) -> Tenant | None:
     """Get a tenant by slug."""
     async with admin_conn() as conn:
         row = await conn.fetchrow("SELECT * FROM tenants WHERE slug = $1", slug)
+    if row is None:
+        return None
+    return _record_to_tenant(row)
+
+
+async def set_tenant_status(tenant_id: str, status: str) -> Tenant | None:
+    """Set a tenant's lifecycle status ('active' | 'suspended').
+
+    Platform-plane only (provision/suspend/resume). Returns the updated
+    tenant, or None if no such tenant. The DB CHECK constraint rejects any
+    value outside the allowed set, so a bad ``status`` fails loud rather
+    than silently writing garbage.
+    """
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "UPDATE tenants SET status = $1 WHERE id = $2::uuid RETURNING *",
+            status,
+            tenant_id,
+        )
     if row is None:
         return None
     return _record_to_tenant(row)

--- a/src/webui/api_v1.py
+++ b/src/webui/api_v1.py
@@ -37,6 +37,7 @@ from webui.v1.credentials import router as credentials_router
 from webui.v1.mcp_servers import router as mcp_servers_router
 from webui.v1.models import router as models_router
 from webui.v1.platform_credentials import router as platform_credentials_router
+from webui.v1.platform_tenants import router as platform_tenants_router
 from webui.v1.runs import router as runs_router
 from webui.v1.safety import router as safety_router
 from webui.v1.schedules import router as schedules_router
@@ -91,6 +92,9 @@ router.include_router(bindings_router)
 router.include_router(admin_models_router)
 # Credential pool — platform-plane key management (platform_admin only).
 router.include_router(platform_credentials_router)
+# Tenant lifecycle — platform-plane provision/suspend/resume (platform_admin
+# only). Distinct from the owner-only /tenant settings surface below.
+router.include_router(platform_tenants_router)
 # v6.1 §P1.4 — Telegram IM linking surfaces (POST/GET telegram +
 # DELETE by identity).
 router.include_router(channel_links_router)

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING
 from fastapi import Depends, HTTPException, Request
 
 from rolemesh.auth.permissions import user_can
+from rolemesh.db import get_tenant_status
 from webui import auth
+from webui.v1.errors import raise_error_response
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -16,7 +18,19 @@ if TYPE_CHECKING:
 
 
 async def get_current_user(request: Request) -> AuthenticatedUser:
-    """Extract Bearer token and authenticate via AuthProvider or bootstrap token."""
+    """Extract Bearer token and authenticate via AuthProvider or bootstrap token.
+
+    This is the single authentication chokepoint for the whole ``/api/v1``
+    REST surface, so it is also where a *suspended* tenant is enforced: once
+    a user resolves, a suspended ``tenant.status`` rejects the request with a
+    403 ``TENANT_SUSPENDED`` envelope — covering every gated endpoint at once
+    rather than scattering the check across handlers. The OIDC JIT path may
+    re-provision a user row on re-login, but it never resets ``status`` (see
+    ``rolemesh.auth.oidc.provider._provision_tenant``), so a re-login into a
+    suspended tenant still lands here and is denied. (WebSocket connections do
+    not pass through this dependency; they enforce the same check at the ticket
+    handshake — see ``webui.v1.ws_stream``.)
+    """
     header = request.headers.get("Authorization", "")
     if not header.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
@@ -25,6 +39,13 @@ async def get_current_user(request: Request) -> AuthenticatedUser:
     user = await auth.authenticate_ws(token)
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    if await get_tenant_status(user.tenant_id) == "suspended":
+        raise_error_response(
+            "TENANT_SUSPENDED",
+            "This tenant is suspended.",
+            status_code=403,
+        )
     return user
 
 

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -30,6 +30,8 @@ CoworkerStatus = Literal["active", "paused", "disabled"]
 Visibility = Literal["private", "shared"]
 AuthMode = Literal["external", "oidc", "builtin", "bootstrap"]
 UserRole = Literal["owner", "admin", "member"]
+# Platform tenant lifecycle state (mirrors the tenants.status CHECK).
+TenantStatus = Literal["active", "suspended"]
 
 
 class ErrorResponse(BaseModel):
@@ -319,6 +321,41 @@ class PlatformCredentialResponse(BaseModel):
     provider: ModelProvider
     created_at: str
     updated_at: str
+
+
+class PlatformTenantResponse(BaseModel):
+    """A tenant as seen on the platform lifecycle plane.
+
+    Distinct from the tenant-plane ``TenantResponse`` (owner self-service
+    settings, :mod:`webui.schemas`): this carries ``status`` and is surfaced
+    only to platform_admin via ``/api/v1/platform/tenants``. Kept separate so
+    the lifecycle ``status`` field never leaks onto the owner-facing settings
+    contract.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    slug: str | None = None
+    plan: str | None = None
+    max_concurrent_containers: int
+    status: TenantStatus
+    created_at: str
+
+
+class PlatformTenantProvision(BaseModel):
+    """``POST /api/v1/platform/tenants`` body — provision a new tenant.
+
+    A provisioned tenant always starts ``active``; ``status`` is therefore
+    not an accepted input (suspend/resume are separate verbs). ``slug`` is
+    optional — omit it for an auto/unset slug, matching ``create_tenant``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=200)
+    slug: str | None = Field(default=None, max_length=60)
 
 
 class CredentialUpsert(BaseModel):

--- a/src/webui/v1/platform_tenants.py
+++ b/src/webui/v1/platform_tenants.py
@@ -1,0 +1,169 @@
+"""``/api/v1/platform/tenants`` REST surface — tenant lifecycle.
+
+Platform-plane only: every handler is gated on ``platform.tenant.manage``,
+which lives in ``_PLATFORM_ONLY_ACTIONS`` so no tenant role can reach it
+(see :mod:`rolemesh.auth.permissions`). This is where the platform operator
+runs a tenant *as a customer* — provision a new one, list/inspect all, and
+suspend/resume — as opposed to ``/api/v1/tenant`` where a tenant owner edits
+their OWN settings.
+
+All DB access goes through ``admin_conn`` (BYPASSRLS, cross-tenant): the
+caller has no single-tenant auth context here and must see/operate on every
+tenant. Suspending a tenant takes effect at two enforcement points elsewhere
+(a single authentication chokepoint and the scheduler), not in this module —
+here we only flip ``tenants.status``.
+
+The reserved sentinel tenant ``__platform__`` (which anchors platform_admin
+rows, see :mod:`rolemesh.admin.core`) is never a customer: provision cannot
+recreate it and suspend/resume refuse to touch it, so the platform operators'
+own accounts can never be locked out via this surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends
+
+from rolemesh import db
+from rolemesh.admin.core import PLATFORM_TENANT_SLUG
+from rolemesh.core.logger import get_logger
+from webui.dependencies import require_action
+from webui.schemas_v1 import (
+    PlatformTenantProvision,
+    PlatformTenantResponse,
+)
+from webui.v1.errors import raise_error_response
+
+if TYPE_CHECKING:
+    from rolemesh.auth.provider import AuthenticatedUser
+    from rolemesh.core.types import Tenant
+
+logger = get_logger()
+
+router = APIRouter(prefix="/platform/tenants", tags=["Platform"])
+
+
+def _to_response(t: Tenant) -> PlatformTenantResponse:
+    return PlatformTenantResponse(
+        id=t.id,
+        name=t.name,
+        slug=t.slug,
+        plan=t.plan,
+        max_concurrent_containers=t.max_concurrent_containers,
+        status=t.status,  # type: ignore[arg-type]
+        created_at=t.created_at,
+    )
+
+
+def _reject_if_sentinel(tenant: Tenant) -> None:
+    """Refuse lifecycle operations on the reserved ``__platform__`` tenant.
+
+    Matched by slug — the sentinel is created with this exact slug and it is
+    not a legal user-chosen slug, so a real customer can never collide with
+    it. Raises the design §13 envelope (403) rather than silently no-op'ing
+    so the caller learns the operation was refused, not applied.
+    """
+    if tenant.slug == PLATFORM_TENANT_SLUG:
+        raise_error_response(
+            "FORBIDDEN",
+            "The reserved platform tenant cannot be managed as a customer.",
+            status_code=403,
+            details={"slug": PLATFORM_TENANT_SLUG},
+        )
+
+
+async def _get_or_404(tenant_id: str) -> Tenant:
+    tenant = await db.get_tenant(tenant_id)
+    if tenant is None:
+        raise_error_response(
+            "NOT_FOUND",
+            "Tenant not found.",
+            status_code=404,
+            details={"id": tenant_id},
+        )
+    return tenant
+
+
+@router.get("", response_model=list[PlatformTenantResponse])
+async def list_tenants_endpoint(
+    user: AuthenticatedUser = Depends(require_action("platform.tenant.manage")),
+) -> list[PlatformTenantResponse]:
+    """List every tenant (including the sentinel and any suspended ones)."""
+    tenants = await db.get_all_tenants()
+    return [_to_response(t) for t in tenants]
+
+
+@router.post("", response_model=PlatformTenantResponse, status_code=201)
+async def provision_tenant_endpoint(
+    body: PlatformTenantProvision,
+    user: AuthenticatedUser = Depends(require_action("platform.tenant.manage")),
+) -> PlatformTenantResponse:
+    """Provision a new tenant. It starts ``active`` (schema default).
+
+    A caller-supplied slug colliding with the reserved sentinel is rejected
+    before any write; a slug already taken by a real tenant surfaces as a
+    409 rather than a raw uniqueness traceback.
+    """
+    if body.slug == PLATFORM_TENANT_SLUG:
+        raise_error_response(
+            "FORBIDDEN",
+            "The reserved platform slug cannot be provisioned.",
+            status_code=403,
+            details={"slug": PLATFORM_TENANT_SLUG},
+        )
+    if body.slug is not None and await db.get_tenant_by_slug(body.slug) is not None:
+        raise_error_response(
+            "CONFLICT",
+            "A tenant with this slug already exists.",
+            status_code=409,
+            details={"slug": body.slug},
+        )
+    tenant = await db.create_tenant(name=body.name, slug=body.slug)
+    logger.info("Tenant provisioned", tenant_id=tenant.id, slug=tenant.slug)
+    return _to_response(tenant)
+
+
+@router.get("/{tenant_id}", response_model=PlatformTenantResponse)
+async def get_tenant_endpoint(
+    tenant_id: str,
+    user: AuthenticatedUser = Depends(require_action("platform.tenant.manage")),
+) -> PlatformTenantResponse:
+    return _to_response(await _get_or_404(tenant_id))
+
+
+@router.post("/{tenant_id}/suspend", response_model=PlatformTenantResponse)
+async def suspend_tenant_endpoint(
+    tenant_id: str,
+    user: AuthenticatedUser = Depends(require_action("platform.tenant.manage")),
+) -> PlatformTenantResponse:
+    """Suspend a tenant: its users fail auth and its tasks stop running.
+
+    Idempotent — suspending an already-suspended tenant just returns it.
+    The sentinel tenant is refused so platform operators cannot lock
+    themselves out.
+    """
+    tenant = await _get_or_404(tenant_id)
+    _reject_if_sentinel(tenant)
+    updated = await db.set_tenant_status(tenant_id, "suspended")
+    assert updated is not None  # row existed at _get_or_404 a moment ago
+    logger.info("Tenant suspended", tenant_id=tenant_id)
+    return _to_response(updated)
+
+
+@router.post("/{tenant_id}/resume", response_model=PlatformTenantResponse)
+async def resume_tenant_endpoint(
+    tenant_id: str,
+    user: AuthenticatedUser = Depends(require_action("platform.tenant.manage")),
+) -> PlatformTenantResponse:
+    """Resume a suspended tenant back to ``active`` (suspend is reversible).
+
+    Idempotent. The sentinel is never suspended in the first place, so the
+    same refusal applies for symmetry rather than letting it look managed.
+    """
+    tenant = await _get_or_404(tenant_id)
+    _reject_if_sentinel(tenant)
+    updated = await db.set_tenant_status(tenant_id, "active")
+    assert updated is not None
+    logger.info("Tenant resumed", tenant_id=tenant_id)
+    return _to_response(updated)

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -78,6 +78,7 @@ _CLOSE_TICKET_EXPIRED = 4001
 _CLOSE_TICKET_INVALID = 4002
 _CLOSE_TICKET_MISMATCH = 4003
 _CLOSE_NOT_FOUND = 4004
+_CLOSE_TENANT_SUSPENDED = 4005
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +127,20 @@ async def _verify_handshake(
         await ws.close(
             code=_CLOSE_TICKET_MISMATCH,
             reason="ticket conversation mismatch",
+        )
+        return None
+    # Suspended-tenant enforcement for the WS plane. The REST chokepoint
+    # (``webui.dependencies.get_current_user``) cannot cover WS — connections
+    # arrive with a pre-minted ticket, not a Bearer token — so a still-valid
+    # ticket issued before suspension is rejected here. (A suspended tenant
+    # also cannot mint a *new* ticket: ``POST /auth/ws-ticket`` runs through
+    # the REST chokepoint.)
+    from rolemesh.db import get_tenant_status
+
+    if await get_tenant_status(payload.tenant_id) == "suspended":
+        await ws.close(
+            code=_CLOSE_TENANT_SUSPENDED,
+            reason="TENANT_SUSPENDED",
         )
         return None
     return payload

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -52,6 +52,7 @@ from rolemesh.auth.ws_ticket import (
 from rolemesh.core.logger import get_logger
 from rolemesh.db import (
     get_conversation,
+    get_tenant_status,
     store_message,
     tenant_conn,
 )
@@ -134,9 +135,9 @@ async def _verify_handshake(
     # arrive with a pre-minted ticket, not a Bearer token — so a still-valid
     # ticket issued before suspension is rejected here. (A suspended tenant
     # also cannot mint a *new* ticket: ``POST /auth/ws-ticket`` runs through
-    # the REST chokepoint.)
-    from rolemesh.db import get_tenant_status
-
+    # the REST chokepoint.) ``get_tenant_status`` is imported at module level
+    # so the handshake tests can stub it the same way they stub
+    # ``get_conversation`` (avoiding asyncpg's sync-TestClient cross-loop).
     if await get_tenant_status(payload.tenant_id) == "suspended":
         await ws.close(
             code=_CLOSE_TENANT_SUSPENDED,

--- a/tests/db/test_get_due_tasks_suspend.py
+++ b/tests/db/test_get_due_tasks_suspend.py
@@ -1,0 +1,75 @@
+"""``get_due_tasks`` (the cross-tenant scheduler sweep) skips suspended tenants.
+
+A suspended tenant's schedules pause — neither run nor failed/deleted — and
+resume untouched once the tenant is reactivated. Pins both directions:
+suspended tasks drop out of the sweep, and resume brings them back.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from rolemesh.core.types import ScheduledTask
+from rolemesh.db import (
+    create_coworker,
+    create_task,
+    create_tenant,
+    get_due_tasks,
+    get_task_by_id,
+    set_tenant_status,
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+async def _tenant_with_due_task() -> tuple[str, str]:
+    t = await create_tenant(name="Corp", slug=f"corp-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="Bot", folder=f"bot-{uuid.uuid4().hex[:8]}"
+    )
+    task_id = str(uuid.uuid4())
+    await create_task(
+        ScheduledTask(
+            id=task_id,
+            tenant_id=t.id,
+            coworker_id=cw.id,
+            prompt="Past task",
+            schedule_type="once",
+            schedule_value="2020-01-01T00:00:00+00:00",
+            context_mode="isolated",
+            next_run="2020-01-01T00:00:00+00:00",
+            status="active",
+        )
+    )
+    return t.id, task_id
+
+
+async def test_suspended_tenant_task_dropped_then_restored_on_resume():
+    tid, task_id = await _tenant_with_due_task()
+
+    # Active: the due task appears in the sweep.
+    assert any(t.id == task_id for t in await get_due_tasks())
+
+    # Suspended: it drops out — but the row is untouched (still active),
+    # not cancelled/failed.
+    await set_tenant_status(tid, "suspended")
+    assert all(t.id != task_id for t in await get_due_tasks())
+    row = await get_task_by_id(task_id, tenant_id=tid)
+    assert row is not None
+    assert row.status == "active"
+
+    # Resume: it comes back, same row.
+    await set_tenant_status(tid, "active")
+    assert any(t.id == task_id for t in await get_due_tasks())
+
+
+async def test_suspended_one_tenant_does_not_affect_another():
+    tid_a, task_a = await _tenant_with_due_task()
+    _tid_b, task_b = await _tenant_with_due_task()
+
+    await set_tenant_status(tid_a, "suspended")
+    due_ids = {t.id for t in await get_due_tasks()}
+    assert task_a not in due_ids
+    assert task_b in due_ids

--- a/tests/webui/test_v1_platform_tenants.py
+++ b/tests/webui/test_v1_platform_tenants.py
@@ -1,0 +1,243 @@
+"""Integration tests for ``/api/v1/platform/tenants`` (tenant lifecycle).
+
+Pins the platform tenant-lifecycle surface:
+
+- ``platform.tenant.manage`` gating: a tenant ``owner`` is denied 403 on
+  every route; only ``platform_admin`` reaches them.
+- provision → list/get round-trip; new tenants start ``active``.
+- suspend / resume flip ``status`` and are reversible + idempotent.
+- the reserved sentinel ``__platform__`` can be neither provisioned nor
+  suspended/resumed.
+
+The suspend *enforcement* (auth deny / scheduler skip) is covered in
+``test_v1_tenant_suspend_enforcement.py`` and the scheduler tests; here we
+only assert the CRUD/state-flip behaviour of the surface itself.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.admin.core import PLATFORM_TENANT_SLUG
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db import create_tenant, create_user
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import get_current_user
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+async def _make_user(role: str, slug: str = "plat") -> AuthenticatedUser:
+    t = await create_tenant(name=f"T-{slug}", slug=f"{slug}-{uuid.uuid4().hex[:8]}")
+    u = await create_user(
+        tenant_id=t.id,
+        name="Op",
+        email=f"o-{uuid.uuid4().hex[:6]}@x.com",
+        role="owner",
+    )
+    return AuthenticatedUser(
+        user_id=u.id, tenant_id=t.id, role=role, email="x@x.com", name="X"
+    )
+
+
+_H = {"Authorization": "Bearer x"}
+
+
+# ---------------------------------------------------------------------------
+# Role gate
+# ---------------------------------------------------------------------------
+
+
+async def test_owner_is_forbidden_on_all_platform_tenant_routes():
+    """A tenant owner lacks ``platform.tenant.manage`` → 403 everywhere."""
+    user = await _make_user("owner")
+    target = await create_tenant(name="victim", slug=f"v-{uuid.uuid4().hex[:8]}")
+    async with _client(_build_app(user)) as ac:
+        assert (await ac.get("/api/v1/platform/tenants", headers=_H)).status_code == 403
+        assert (
+            await ac.post(
+                "/api/v1/platform/tenants", json={"name": "n"}, headers=_H
+            )
+        ).status_code == 403
+        assert (
+            await ac.get(f"/api/v1/platform/tenants/{target.id}", headers=_H)
+        ).status_code == 403
+        assert (
+            await ac.post(
+                f"/api/v1/platform/tenants/{target.id}/suspend", headers=_H
+            )
+        ).status_code == 403
+        assert (
+            await ac.post(
+                f"/api/v1/platform/tenants/{target.id}/resume", headers=_H
+            )
+        ).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Provision / list / get
+# ---------------------------------------------------------------------------
+
+
+async def test_provision_creates_active_tenant_and_appears_in_list_and_get():
+    admin = await _make_user("platform_admin")
+    async with _client(_build_app(admin)) as ac:
+        slug = f"acme-{uuid.uuid4().hex[:8]}"
+        created = await ac.post(
+            "/api/v1/platform/tenants",
+            json={"name": "Acme", "slug": slug},
+            headers=_H,
+        )
+        assert created.status_code == 201, created.text
+        body = created.json()
+        assert body["name"] == "Acme"
+        assert body["slug"] == slug
+        assert body["status"] == "active"
+        new_id = body["id"]
+
+        got = await ac.get(f"/api/v1/platform/tenants/{new_id}", headers=_H)
+        assert got.status_code == 200
+        assert got.json()["id"] == new_id
+
+        listing = await ac.get("/api/v1/platform/tenants", headers=_H)
+        assert listing.status_code == 200
+        assert new_id in {t["id"] for t in listing.json()}
+
+
+async def test_provision_without_slug_succeeds():
+    admin = await _make_user("platform_admin")
+    async with _client(_build_app(admin)) as ac:
+        created = await ac.post(
+            "/api/v1/platform/tenants", json={"name": "NoSlug"}, headers=_H
+        )
+        assert created.status_code == 201, created.text
+        assert created.json()["status"] == "active"
+
+
+async def test_provision_duplicate_slug_conflicts():
+    admin = await _make_user("platform_admin")
+    slug = f"dup-{uuid.uuid4().hex[:8]}"
+    await create_tenant(name="existing", slug=slug)
+    async with _client(_build_app(admin)) as ac:
+        resp = await ac.post(
+            "/api/v1/platform/tenants",
+            json={"name": "again", "slug": slug},
+            headers=_H,
+        )
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "CONFLICT"
+
+
+async def test_get_unknown_tenant_404():
+    admin = await _make_user("platform_admin")
+    async with _client(_build_app(admin)) as ac:
+        resp = await ac.get(
+            f"/api/v1/platform/tenants/{uuid.uuid4()}", headers=_H
+        )
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Suspend / resume
+# ---------------------------------------------------------------------------
+
+
+async def test_suspend_then_resume_flips_status_and_is_idempotent():
+    admin = await _make_user("platform_admin")
+    target = await create_tenant(name="cust", slug=f"c-{uuid.uuid4().hex[:8]}")
+    async with _client(_build_app(admin)) as ac:
+        s1 = await ac.post(
+            f"/api/v1/platform/tenants/{target.id}/suspend", headers=_H
+        )
+        assert s1.status_code == 200, s1.text
+        assert s1.json()["status"] == "suspended"
+
+        # Idempotent: suspending again still returns suspended.
+        s2 = await ac.post(
+            f"/api/v1/platform/tenants/{target.id}/suspend", headers=_H
+        )
+        assert s2.status_code == 200
+        assert s2.json()["status"] == "suspended"
+
+        r1 = await ac.post(
+            f"/api/v1/platform/tenants/{target.id}/resume", headers=_H
+        )
+        assert r1.status_code == 200
+        assert r1.json()["status"] == "active"
+
+        # The state flip persists through a fresh GET.
+        got = await ac.get(f"/api/v1/platform/tenants/{target.id}", headers=_H)
+        assert got.json()["status"] == "active"
+
+
+async def test_suspend_unknown_tenant_404():
+    admin = await _make_user("platform_admin")
+    async with _client(_build_app(admin)) as ac:
+        resp = await ac.post(
+            f"/api/v1/platform/tenants/{uuid.uuid4()}/suspend", headers=_H
+        )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Sentinel guard
+# ---------------------------------------------------------------------------
+
+
+async def test_sentinel_tenant_cannot_be_suspended_or_resumed():
+    admin = await _make_user("platform_admin")
+    sentinel = await create_tenant(name="platform", slug=PLATFORM_TENANT_SLUG)
+    async with _client(_build_app(admin)) as ac:
+        suspend = await ac.post(
+            f"/api/v1/platform/tenants/{sentinel.id}/suspend", headers=_H
+        )
+        assert suspend.status_code == 403
+        assert suspend.json()["code"] == "FORBIDDEN"
+
+        resume = await ac.post(
+            f"/api/v1/platform/tenants/{sentinel.id}/resume", headers=_H
+        )
+        assert resume.status_code == 403
+
+    # Still active in the DB — the refusal was a no-op, not a silent flip.
+    from rolemesh.db import get_tenant
+
+    again = await get_tenant(sentinel.id)
+    assert again is not None
+    assert again.status == "active"
+
+
+async def test_sentinel_slug_cannot_be_provisioned():
+    admin = await _make_user("platform_admin")
+    async with _client(_build_app(admin)) as ac:
+        resp = await ac.post(
+            "/api/v1/platform/tenants",
+            json={"name": "evil", "slug": PLATFORM_TENANT_SLUG},
+            headers=_H,
+        )
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "FORBIDDEN"

--- a/tests/webui/test_v1_tenant_suspend_enforcement.py
+++ b/tests/webui/test_v1_tenant_suspend_enforcement.py
@@ -1,0 +1,174 @@
+"""Suspend *enforcement* at the authentication chokepoints.
+
+Provisioning/CRUD of the lifecycle surface is covered in
+``test_v1_platform_tenants.py``; this file pins that a suspended tenant is
+actually *locked out*:
+
+- REST: ``get_current_user`` (the single ``/api/v1`` chokepoint) returns 403
+  ``TENANT_SUSPENDED`` once the tenant is suspended, and recovers on resume.
+- WS: ``_verify_handshake`` rejects an already-minted, otherwise-valid ticket
+  with close code 4005 once the tenant is suspended (the REST chokepoint
+  cannot cover the WS plane).
+- JIT no-revival: OIDC re-login machinery never resets ``status`` — a
+  suspended tenant stays suspended across a re-provision.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db import create_tenant, create_user, get_tenant_status, set_tenant_status
+from webui import auth as webui_auth
+from webui.api_v1 import router as api_v1_router
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+_H = {"Authorization": "Bearer tok"}
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _app_without_auth_override() -> FastAPI:
+    """App with the REAL get_current_user (so the suspend check runs)."""
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+    return app
+
+
+async def _make_owner_in_new_tenant() -> AuthenticatedUser:
+    t = await create_tenant(name="cust", slug=f"c-{uuid.uuid4().hex[:8]}")
+    u = await create_user(
+        tenant_id=t.id,
+        name="Owner",
+        email=f"o-{uuid.uuid4().hex[:6]}@x.com",
+        role="owner",
+    )
+    return AuthenticatedUser(
+        user_id=u.id, tenant_id=t.id, role="owner", email="x@x.com", name="X"
+    )
+
+
+# ---------------------------------------------------------------------------
+# REST chokepoint
+# ---------------------------------------------------------------------------
+
+
+async def test_suspended_tenant_user_gets_403_on_v1_request(monkeypatch):
+    """A real gated endpoint returns 403 TENANT_SUSPENDED when suspended."""
+    user = await _make_owner_in_new_tenant()
+
+    async def _fake_auth(_token: str) -> AuthenticatedUser:
+        return user
+
+    monkeypatch.setattr(webui_auth, "authenticate_ws", _fake_auth)
+
+    async with _client(_app_without_auth_override()) as ac:
+        # Active: the tenant settings endpoint (owner-gated) is reachable.
+        ok = await ac.get("/api/v1/tenant", headers=_H)
+        assert ok.status_code == 200, ok.text
+
+        # Suspend -> the SAME request is now blocked at the chokepoint.
+        await set_tenant_status(user.tenant_id, "suspended")
+        blocked = await ac.get("/api/v1/tenant", headers=_H)
+        assert blocked.status_code == 403
+        assert blocked.json()["code"] == "TENANT_SUSPENDED"
+
+        # Resume -> recovers.
+        await set_tenant_status(user.tenant_id, "active")
+        recovered = await ac.get("/api/v1/tenant", headers=_H)
+        assert recovered.status_code == 200, recovered.text
+
+
+async def test_suspended_blocks_every_gated_surface(monkeypatch):
+    """The chokepoint covers the whole surface, not one endpoint."""
+    user = await _make_owner_in_new_tenant()
+
+    async def _fake_auth(_token: str) -> AuthenticatedUser:
+        return user
+
+    monkeypatch.setattr(webui_auth, "authenticate_ws", _fake_auth)
+    await set_tenant_status(user.tenant_id, "suspended")
+
+    async with _client(_app_without_auth_override()) as ac:
+        for path in ("/api/v1/coworkers", "/api/v1/tenant", "/api/v1/credentials"):
+            resp = await ac.get(path, headers=_H)
+            assert resp.status_code == 403, (path, resp.text)
+            assert resp.json()["code"] == "TENANT_SUSPENDED", path
+
+
+# ---------------------------------------------------------------------------
+# WS handshake chokepoint
+# ---------------------------------------------------------------------------
+
+
+class _FakeWS:
+    """Records the close(code, reason) the handshake invokes."""
+
+    def __init__(self) -> None:
+        self.closed_code: int | None = None
+        self.closed_reason: str | None = None
+
+    async def close(self, code: int, reason: str = "") -> None:
+        self.closed_code = code
+        self.closed_reason = reason
+
+
+async def test_ws_handshake_rejects_suspended_tenant(monkeypatch):
+    monkeypatch.setenv("WS_TICKET_SECRET", "test-ws-secret")
+    from rolemesh.auth.ws_ticket import issue_ws_ticket
+    from webui.v1 import ws_stream
+
+    user = await _make_owner_in_new_tenant()
+    conv_id = str(uuid.uuid4())
+    ticket, _ = issue_ws_ticket(
+        user_id=user.user_id, tenant_id=user.tenant_id, conversation_id=conv_id
+    )
+
+    # Active: a valid ticket verifies (returns the payload, no close).
+    ws_ok = _FakeWS()
+    payload = await ws_stream._verify_handshake(ws_ok, conv_id, ticket)
+    assert payload is not None
+    assert ws_ok.closed_code is None
+
+    # Suspended: the same still-valid ticket is now refused with 4005.
+    await set_tenant_status(user.tenant_id, "suspended")
+    ws_susp = _FakeWS()
+    payload2 = await ws_stream._verify_handshake(ws_susp, conv_id, ticket)
+    assert payload2 is None
+    assert ws_susp.closed_code == ws_stream._CLOSE_TENANT_SUSPENDED
+
+
+# ---------------------------------------------------------------------------
+# JIT no-revival invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_status_survives_reprovision_no_revival():
+    """Re-provisioning a tenant by slug must not flip a suspended tenant back.
+
+    Mirrors the OIDC JIT shape: ``_provision_tenant`` returns the existing
+    tenant id on a mapping hit and never writes ``status``. Here we assert the
+    underlying invariant directly: creating/looking a suspended tenant up does
+    not resurrect it; only an explicit resume does.
+    """
+    from rolemesh.db import get_tenant_by_slug
+
+    t = await create_tenant(name="jit", slug=f"jit-{uuid.uuid4().hex[:8]}")
+    await set_tenant_status(t.id, "suspended")
+
+    # A slug lookup (what the JIT hit path does) returns it unchanged.
+    again = await get_tenant_by_slug(t.slug)
+    assert again is not None
+    assert again.status == "suspended"
+    assert await get_tenant_status(t.id) == "suspended"

--- a/tests/webui/test_v1_ws_approval_frame.py
+++ b/tests/webui/test_v1_ws_approval_frame.py
@@ -132,6 +132,13 @@ def conv_stub(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
         return holder.get("conv")
 
     monkeypatch.setattr(ws_stream, "get_conversation", _fake)
+
+    # Handshake also reads tenant status now; stub it active (same
+    # sync-TestClient/asyncpg rationale as the get_conversation stub).
+    async def _fake_status(_tenant_id: str) -> str:
+        return "active"
+
+    monkeypatch.setattr(ws_stream, "get_tenant_status", _fake_status)
     return holder
 
 

--- a/tests/webui/test_v1_ws_side_channel_subs.py
+++ b/tests/webui/test_v1_ws_side_channel_subs.py
@@ -274,6 +274,13 @@ def stub_conv(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
         return holder.get("conv")
 
     monkeypatch.setattr(ws_stream, "get_conversation", _fake)
+
+    # Handshake also reads tenant status now; stub it active (same
+    # sync-TestClient/asyncpg rationale as the get_conversation stub).
+    async def _fake_status(_tenant_id: str) -> str:
+        return "active"
+
+    monkeypatch.setattr(ws_stream, "get_tenant_status", _fake_status)
     return holder
 
 

--- a/tests/webui/test_v1_ws_stop_frame.py
+++ b/tests/webui/test_v1_ws_stop_frame.py
@@ -137,6 +137,13 @@ def stub_conv(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
         return holder.get("conv")
 
     monkeypatch.setattr(ws_stream, "get_conversation", _fake)
+
+    # The handshake also reads tenant lifecycle status now; stub it active
+    # for the same sync-TestClient/asyncpg reason get_conversation is stubbed.
+    async def _fake_status(_tenant_id: str) -> str:
+        return "active"
+
+    monkeypatch.setattr(ws_stream, "get_tenant_status", _fake_status)
     return holder
 
 

--- a/tests/webui/test_ws_v1_handshake.py
+++ b/tests/webui/test_ws_v1_handshake.py
@@ -100,6 +100,16 @@ def stub_get_conversation(
         )
 
     monkeypatch.setattr(ws_stream, "get_conversation", _fake)
+
+    # The handshake now also reads tenant lifecycle status (suspended ->
+    # close 4005). Stub it for the same reason ``get_conversation`` is
+    # stubbed — keep the real asyncpg pool out of the sync TestClient path.
+    # Suspended-tenant rejection is exercised in
+    # ``test_v1_tenant_suspend_enforcement`` against the real DB.
+    async def _fake_status(_tenant_id: str) -> str:
+        return "active"
+
+    monkeypatch.setattr(ws_stream, "get_tenant_status", _fake_status)
     return control
 
 

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -512,6 +512,105 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/platform/tenants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all tenants (platform lifecycle)
+         * @description Platform-plane only (`platform.tenant.manage`, granted to
+         *     `platform_admin`). Returns every tenant, including suspended ones
+         *     and the reserved `__platform__` sentinel, with lifecycle `status`.
+         */
+        get: operations["listPlatformTenants"];
+        put?: never;
+        /**
+         * Provision a new tenant
+         * @description Platform-plane only (`platform.tenant.manage`). Creates a tenant in
+         *     the `active` state. The reserved `__platform__` slug is rejected
+         *     (`403`); a slug already in use returns `409`.
+         */
+        post: operations["provisionPlatformTenant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/platform/tenants/{tenant_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        /**
+         * Fetch one tenant (platform lifecycle)
+         * @description Platform-plane only (`platform.tenant.manage`).
+         */
+        get: operations["getPlatformTenant"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/platform/tenants/{tenant_id}/suspend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Suspend a tenant
+         * @description Platform-plane only (`platform.tenant.manage`). Sets `status` to
+         *     `suspended`: the tenant's users can no longer authenticate and its
+         *     scheduled tasks pause (they are not failed/deleted). Idempotent. The
+         *     reserved `__platform__` sentinel cannot be suspended (`403`).
+         */
+        post: operations["suspendPlatformTenant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/platform/tenants/{tenant_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume a suspended tenant
+         * @description Platform-plane only (`platform.tenant.manage`). Sets `status` back to
+         *     `active` (suspend is reversible). Idempotent. The reserved
+         *     `__platform__` sentinel is refused (`403`).
+         */
+        post: operations["resumePlatformTenant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/coworkers/{id}/mcp-servers": {
         parameters: {
             query?: never;
@@ -1601,6 +1700,29 @@ export interface components {
             created_at: string;
             /** Format: date-time */
             updated_at: string;
+        };
+        /**
+         * @description Platform tenant lifecycle state. `suspended` tenants cannot
+         *     authenticate and their scheduled tasks pause until resumed.
+         * @enum {string}
+         */
+        TenantStatus: "active" | "suspended";
+        /**
+         * @description A tenant on the platform lifecycle plane (carries `status`).
+         *     Distinct from `TenantResponse` (owner self-service settings).
+         */
+        PlatformTenantResponse: {
+            id: string;
+            name: string;
+            slug?: string | null;
+            plan?: string | null;
+            max_concurrent_containers: number;
+            status: components["schemas"]["TenantStatus"];
+            created_at: string;
+        };
+        PlatformTenantProvision: {
+            name: string;
+            slug?: string | null;
         };
         CredentialUpsert: {
             /**
@@ -3451,6 +3573,131 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listPlatformTenants: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponse"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    provisionPlatformTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformTenantProvision"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["Unprocessable"];
+        };
+    };
+    getPlatformTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    suspendPlatformTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    resumePlatformTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformTenantResponse"];
+                };
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];


### PR DESCRIPTION
## Background

RoleMesh had no way to "operate a tenant as a customer": tenants could only come into being naturally (OIDC JIT / create-admin / default bootstrap), the `tenants` table had no status column, and **there was no way to suspend a tenant**. `/api/v1/tenant` is tenant self-service settings (an owner editing their own tenant), not platform operations.

This PR gives `platform_admin` the ability to **provision** and **suspend/resume** tenants, and makes "suspend" actually take effect at both the **authentication** and **scheduler** layers.

## Changes

### 1. schema / db / role
- `tenants.status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended'))`, idempotent ALTER (existing rows default to active — behaviour unchanged).
- `Tenant.status` model field; `create_tenant`'s RETURNING lists status explicitly (it is not a `SELECT *`).
- `db.set_tenant_status()` / `db.get_tenant_status()` (the latter is a single-column read for the auth hot path; a non-UUID id returns None instead of raising).
- `_PLATFORM_ONLY_ACTIONS` gains a **single** `platform.tenant.manage` (mirrors the `credential.pool.manage` style); `platform_admin` receives it via the superset, **no tenant role can reach it**, and it is deliberately distinct from the existing `tenant.manage` (owner self-service).

### 2. REST surface
New `/api/v1/platform/tenants` (all gated on `platform.tenant.manage`, via `admin_conn` cross-tenant):
- `GET /platform/tenants` — list all (incl. status)
- `POST /platform/tenants` — provision (status=active; duplicate slug → 409)
- `GET /platform/tenants/{id}`
- `POST /platform/tenants/{id}/suspend` / `.../resume` (idempotent)

Dedicated `PlatformTenantResponse` / `PlatformTenantProvision` (in schemas_v1) so the lifecycle `status` never leaks onto the owner-facing `TenantResponse` contract.

### 3. Two enforcement points for suspend (key)
- **Auth (REST)**: `get_current_user` is the single chokepoint — after resolving the user it checks tenant.status; suspended → 403 `TENANT_SUSPENDED`, covering every v1 endpoint; resume restores access. OIDC JIT hitting an existing suspended tenant does **not** revive it (`_provision_tenant` never writes status), so it is still blocked here.
- **Auth (WS)**: WS does not pass through `get_current_user` (it uses a pre-minted ticket), so enforcement is added in `_verify_handshake` — an already-minted, still-valid ticket is rejected with close code `4005` once the tenant is suspended.
- **Scheduler**: `get_due_tasks`'s cross-tenant sweep `JOIN tenants` and skips tasks of suspended tenants — **not run, not marked failed/deleted** — and they resume automatically once the tenant is reactivated.

### 4. Guard
The reserved sentinel tenant `__platform__` (which anchors platform_admin) is explicitly refused (403) on provision / suspend / resume, so platform operators cannot lock themselves out.

### 5. Contract
`contracts/openapi.yaml` gains the 5 operations + `TenantStatus` / `PlatformTenant*` schemas; `web/src/api/generated/types.ts` is regenerated via `openapi-typescript` (`openapi:check` is clean).

## Out of scope
usage / billing / quota; tenant offboard/delete; plan/limit editing; frontend UI; the `platform_support` role.

## Tests
- Platform CRUD / provision / suspend·resume idempotency / non-platform_admin always 403 / duplicate slug 409 / 404 / sentinel cannot be operated on.
- Suspend auth enforcement: 403 across multiple REST endpoints + resume recovery; **WS handshake 4005**; **OIDC re-login does not revive**.
- Scheduler: suspended tasks drop out of the due list (row stays active), resume restores them, one tenant's suspension does not affect another's.
- The default-deny meta-test automatically covers the new action.
- Incidental fix: the new DB query in `_verify_handshake` tripped asyncpg's cross-loop issue under the sync TestClient (the existing WS handshake tests already stub `get_conversation` for this reason) — `get_tenant_status` is now a module-level patchable import, and the four WS test stub fixtures were extended.

### Verification status
- `ruff check .` clean; mypy reports no new errors (only 4 pre-existing errors, confirmed identical against main).
- Local PostgreSQL (no Docker) full webui+db run: 481 passed; 15 failed are **all cross-tenant RLS isolation tests**. Running the same 15 against main with the same local PG yields the **same 15 failures** — the root cause is the local PG connecting as a superuser (which bypasses RLS; CI's testcontainers two-role setup enforces it), unrelated to this PR. All tests added by this PR pass.

https://claude.ai/code/session_017WsotXB9AxtuwKdtjqDvSL