### PR TITLE
feat(platform-safety): platform_admin safety rule management API

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -889,6 +889,184 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/platform/safety/rules:
+    get:
+      tags: [Platform]
+      operationId: listPlatformSafetyRules
+      summary: List all platform safety rules (every tier, incl. floor)
+      description: |
+        Platform-plane only (`safety.platform.manage`, granted to
+        `platform_admin`). Unlike the tenant-facing `/api/v1/safety/rules`
+        read — which surfaces only the visible tiers — this returns ALL
+        tiers including `floor`, plus the `is_seeded` flag.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/PlatformSafetyRule' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+    post:
+      tags: [Platform]
+      operationId: createPlatformSafetyRule
+      summary: Create a platform safety rule
+      description: |
+        Platform-plane only (`safety.platform.manage`). The body is
+        validated against the safety check registry — an unknown
+        `check_id`, an unsupported `stage`, or an invalid `action_override`
+        returns `400 INVALID_RULE`. A duplicate `(tier, check_id, stage)`
+        identity returns `409`. Created rules carry `is_seeded=false` and
+        allow full CRUD.
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PlatformSafetyRuleCreate' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformSafetyRule' }
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          $ref: '#/components/responses/Unprocessable'
+
+  /api/v1/platform/safety/rules/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    get:
+      tags: [Platform]
+      operationId: getPlatformSafetyRule
+      summary: Get one platform safety rule (any tier)
+      description: Platform-plane only (`safety.platform.manage`).
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformSafetyRule' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Platform]
+      operationId: updatePlatformSafetyRule
+      summary: Update a platform safety rule
+      description: |
+        Platform-plane only (`safety.platform.manage`). Patches the mutable
+        fields — `config` / `priority` / `description` / `enabled`. The
+        identity (`tier` / `stage` / `check_id`) is immutable. A changed
+        `config` is re-validated (`400 INVALID_RULE`) when the check is in
+        the orchestrator registry. Seeded defaults are editable here.
+      security: [ { bearerAuth: [] } ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PlatformSafetyRuleUpdate' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformSafetyRule' }
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/Unprocessable'
+    delete:
+      tags: [Platform]
+      operationId: deletePlatformSafetyRule
+      summary: Delete a platform safety rule
+      description: |
+        Platform-plane only (`safety.platform.manage`). A seeded factory
+        default (`is_seeded=true`) cannot be hard-deleted (`409`
+        `SEEDED_RULE_IMMUTABLE`) — the next build-time seed would recreate
+        it; disable it instead. Unknown id → 404.
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '204':
+          description: No content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /api/v1/platform/safety/rules/{id}/enable:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    post:
+      tags: [Platform]
+      operationId: enablePlatformSafetyRule
+      summary: Enable a platform safety rule
+      description: Platform-plane only (`safety.platform.manage`).
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformSafetyRule' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/platform/safety/rules/{id}/disable:
+    parameters:
+      - $ref: '#/components/parameters/IdInPath'
+    post:
+      tags: [Platform]
+      operationId: disablePlatformSafetyRule
+      summary: Disable a platform safety rule
+      description: |
+        Platform-plane only (`safety.platform.manage`). Also the sanctioned
+        way to suppress a seeded factory default (which cannot be deleted).
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlatformSafetyRule' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/coworkers/{id}/mcp-servers:
     parameters:
       - $ref: '#/components/parameters/IdInPath'
@@ -4338,3 +4516,64 @@ components:
         priority: { type: integer, minimum: -1000, maximum: 1000 }
         enabled: { type: boolean }
         description: { type: string, maxLength: 500 }
+
+    PlatformSafetyTier:
+      type: string
+      enum: [floor, transparent_floor, default]
+
+    PlatformSafetyRule:
+      type: object
+      required:
+        - id
+        - tier
+        - stage
+        - check_id
+        - priority
+        - enabled
+        - description
+        - is_seeded
+        - created_at
+        - updated_at
+      properties:
+        id: { type: string, format: uuid }
+        tier: { $ref: '#/components/schemas/PlatformSafetyTier' }
+        stage: { $ref: '#/components/schemas/SafetyStage' }
+        check_id: { type: string }
+        config:
+          type: object
+          additionalProperties: true
+        priority: { type: integer }
+        enabled: { type: boolean }
+        description: { type: string }
+        is_seeded:
+          type: boolean
+          description: |
+            True for the shipped factory defaults (seeded at build time).
+            These are managed disable-only: editable and disablable, but a
+            hard DELETE is refused (`409`) since the next seed would
+            recreate them. Platform-admin-created rules carry `false`.
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    PlatformSafetyRuleCreate:
+      type: object
+      required: [tier, stage, check_id]
+      properties:
+        tier: { $ref: '#/components/schemas/PlatformSafetyTier' }
+        stage: { $ref: '#/components/schemas/SafetyStage' }
+        check_id: { type: string, minLength: 1, maxLength: 128 }
+        config:
+          type: object
+          additionalProperties: true
+        priority: { type: integer, minimum: -1000, maximum: 1000, default: 1000 }
+        description: { type: string, maxLength: 500, default: "" }
+
+    PlatformSafetyRuleUpdate:
+      type: object
+      properties:
+        config:
+          type: object
+          additionalProperties: true
+        priority: { type: integer, minimum: -1000, maximum: 1000 }
+        description: { type: string, maxLength: 500 }
+        enabled: { type: boolean }

--- a/src/rolemesh/auth/permissions.py
+++ b/src/rolemesh/auth/permissions.py
@@ -85,10 +85,15 @@ _TENANT_ROLE_ACTIONS: dict[str, set[str]] = {
 #     ``tenant.manage`` (an owner editing their OWN tenant's settings): this
 #     one operates a tenant AS a customer across the platform and must never
 #     be reachable by any tenant role.
+#   * safety.platform.manage — mutate the cross-tenant platform safety rule
+#     catalog (``platform_safety_rules`` via ``/api/v1/platform/safety/rules``).
+#     Tenants READ the visible tiers through ``safety.read``; only the platform
+#     operator writes them, since one platform rule enforces on every tenant.
 _PLATFORM_ONLY_ACTIONS: set[str] = {
     "credential.pool.manage",
     "model.manage",
     "platform.tenant.manage",
+    "safety.platform.manage",
 }
 
 

--- a/src/rolemesh/db/platform_safety.py
+++ b/src/rolemesh/db/platform_safety.py
@@ -22,9 +22,20 @@ Two read paths, deliberately on different pools:
     Floor-tier rows are filtered out here — that is where the three-tier
     visibility contract lives.
 
-This phase exposes no write helpers: the 5 default-tier rules are seeded
-via schema seeding (:func:`rolemesh.db.schema._seed_platform_safety_rules`)
-and there is no platform-admin write REST yet.
+Write helpers (:func:`create_platform_rule`, :func:`update_platform_rule`,
+:func:`set_platform_rule_enabled`, :func:`delete_platform_rule`) and the
+all-tiers reads (:func:`list_all_platform_rules`, :func:`get_platform_rule`)
+back the platform-admin REST surface (``/api/v1/platform/safety/rules``).
+They run on **admin_conn**: ``rolemesh_app`` holds SELECT but never
+INSERT/UPDATE/DELETE on this catalog (see schema GRANTs), so writes MUST
+use the cross-tenant maintenance pool. Unlike the tenant-facing read,
+these surface ALL tiers (floor included) — the platform operator manages
+floor; only its *visibility* is suppressed for tenants.
+
+The 5 default-tier rules are still seeded at build time
+(:func:`rolemesh.db.schema._seed_platform_safety_rules`) and carry
+``is_seeded = TRUE``; they are managed disable-only (the write API
+forbids hard-deleting them — a delete would be undone by the next seed).
 """
 
 from __future__ import annotations
@@ -39,8 +50,14 @@ if TYPE_CHECKING:
 
 __all__ = [
     "VISIBLE_TIERS",
+    "create_platform_rule",
+    "delete_platform_rule",
     "fetch_platform_rule_snapshots",
+    "get_platform_rule",
+    "list_all_platform_rules",
     "list_visible_platform_rules",
+    "set_platform_rule_enabled",
+    "update_platform_rule",
 ]
 
 # Tiers a tenant is allowed to SEE. ``floor`` is intentionally absent —
@@ -86,6 +103,7 @@ def _row_to_dict(row: asyncpg.Record) -> dict[str, Any]:
         "priority": int(row["priority"]),
         "enabled": bool(row["enabled"]),
         "description": row["description"] or "",
+        "is_seeded": bool(row["is_seeded"]),
         "created_at": row["created_at"].isoformat() if row["created_at"] else "",
         "updated_at": row["updated_at"].isoformat() if row["updated_at"] else "",
     }
@@ -131,3 +149,149 @@ async def list_visible_platform_rules(tenant_id: str) -> list[dict[str, Any]]:
             list(VISIBLE_TIERS),
         )
     return [_row_to_dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Platform-admin management (admin_conn) — all tiers, including floor.
+# ---------------------------------------------------------------------------
+
+
+async def list_all_platform_rules() -> list[dict[str, Any]]:
+    """Every platform rule across ALL tiers (floor included).
+
+    For the platform-admin surface — the operator manages floor too, so
+    (unlike :func:`list_visible_platform_rules`) nothing is filtered.
+    Runs on ``admin_conn``: this is platform-plane management, not a
+    tenant read.
+    """
+    async with admin_conn() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT * FROM platform_safety_rules
+            ORDER BY tier, priority DESC, created_at
+            """
+        )
+    return [_row_to_dict(r) for r in rows]
+
+
+async def get_platform_rule(rule_id: str) -> dict[str, Any] | None:
+    """One platform rule by id, any tier (or None). ``admin_conn``."""
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM platform_safety_rules WHERE id = $1", rule_id
+        )
+    return _row_to_dict(row) if row is not None else None
+
+
+async def create_platform_rule(
+    *,
+    tier: str,
+    stage: str,
+    check_id: str,
+    config: dict[str, Any],
+    priority: int,
+    description: str,
+) -> dict[str, Any]:
+    """Insert a platform-admin-created rule (``is_seeded = FALSE``).
+
+    ``admin_conn`` — the business role cannot write this catalog. The
+    UNIQUE ``(tier, check_id, stage)`` identity is enforced by the DB; a
+    duplicate raises ``asyncpg.UniqueViolationError`` for the caller to
+    map to a 409.
+    """
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO platform_safety_rules
+                (tier, stage, check_id, config, priority, description,
+                 is_seeded)
+            VALUES ($1, $2, $3, $4::jsonb, $5, $6, FALSE)
+            RETURNING *
+            """,
+            tier,
+            stage,
+            check_id,
+            json.dumps(config),
+            priority,
+            description,
+        )
+    # INSERT ... RETURNING always yields a row; the assert narrows the
+    # asyncpg ``Record | None`` type for the projector.
+    assert row is not None
+    return _row_to_dict(row)
+
+
+async def update_platform_rule(
+    rule_id: str,
+    *,
+    config: dict[str, Any] | None = None,
+    priority: int | None = None,
+    description: str | None = None,
+    enabled: bool | None = None,
+) -> dict[str, Any] | None:
+    """Patch a platform rule's mutable fields (or None if no such id).
+
+    Only ``config`` / ``priority`` / ``description`` / ``enabled`` are
+    mutable — ``tier`` / ``stage`` / ``check_id`` form the rule identity
+    and are immutable (change = create a new rule). Each ``None`` argument
+    leaves its column untouched via ``COALESCE``. Seeded defaults are
+    editable here; ``is_seeded`` only gates DELETE, not edits. ``admin_conn``.
+    """
+    config_json = json.dumps(config) if config is not None else None
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            """
+            UPDATE platform_safety_rules
+            SET config      = COALESCE($2::jsonb, config),
+                priority    = COALESCE($3, priority),
+                description = COALESCE($4, description),
+                enabled     = COALESCE($5, enabled),
+                updated_at  = now()
+            WHERE id = $1
+            RETURNING *
+            """,
+            rule_id,
+            config_json,
+            priority,
+            description,
+            enabled,
+        )
+    return _row_to_dict(row) if row is not None else None
+
+
+async def set_platform_rule_enabled(
+    rule_id: str, *, enabled: bool
+) -> dict[str, Any] | None:
+    """Toggle a platform rule's ``enabled`` flag (or None if no such id).
+
+    Backs the dedicated enable/disable endpoints; disable is also the
+    sanctioned way to suppress a seeded default. ``admin_conn``.
+    """
+    async with admin_conn() as conn:
+        row = await conn.fetchrow(
+            """
+            UPDATE platform_safety_rules
+            SET enabled = $2, updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            """,
+            rule_id,
+            enabled,
+        )
+    return _row_to_dict(row) if row is not None else None
+
+
+async def delete_platform_rule(rule_id: str) -> bool:
+    """Hard-delete a platform rule; True if a row was removed.
+
+    Does NOT itself enforce the seeded-default guard — the REST layer
+    fetches first and refuses (409) when ``is_seeded`` so it can return a
+    clear "disable instead" message rather than a silent miss. ``admin_conn``.
+    """
+    async with admin_conn() as conn:
+        result = await conn.execute(
+            "DELETE FROM platform_safety_rules WHERE id = $1", rule_id
+        )
+    # asyncpg returns the command tag, e.g. "DELETE 1" / "DELETE 0";
+    # the id is a PK so at most one row is ever affected.
+    return result == "DELETE 1"

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -141,6 +141,15 @@ async def _seed_platform_safety_rules(
     and post-``TRUNCATE`` re-seeds (``_reset_test_data``) are safe. Only
     the ``default`` tier is seeded this phase; ``floor`` /
     ``transparent_floor`` are carried in the schema for future use.
+
+    Each row is stamped ``is_seeded = TRUE`` so the platform-admin write
+    API can enforce disable-only on the factory defaults. The ON CONFLICT
+    branch is a deliberate DO UPDATE (not DO NOTHING) that touches ONLY
+    ``is_seeded``: it backfills the flag on a DB created before the column
+    existed, while leaving a platform-admin's config / enabled / priority /
+    description edits untouched — those survive every re-seed. Only the
+    five shipped identities can conflict here; a PA-created rule has a
+    different (tier, check_id, stage) and is never stamped.
     """
     import json
 
@@ -148,9 +157,10 @@ async def _seed_platform_safety_rules(
         await conn.execute(
             """
             INSERT INTO platform_safety_rules
-                (tier, stage, check_id, config, priority, description)
-            VALUES ('default', $1, $2, $3::jsonb, $4, $5)
-            ON CONFLICT (tier, check_id, stage) DO NOTHING
+                (tier, stage, check_id, config, priority, description, is_seeded)
+            VALUES ('default', $1, $2, $3::jsonb, $4, $5, TRUE)
+            ON CONFLICT (tier, check_id, stage)
+                DO UPDATE SET is_seeded = TRUE
             """,
             stage,
             check_id,
@@ -1239,10 +1249,25 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
             priority        INTEGER NOT NULL DEFAULT 1000,
             enabled         BOOLEAN NOT NULL DEFAULT TRUE,
             description     TEXT NOT NULL DEFAULT '',
+            -- ``is_seeded`` marks the shipped factory defaults (seeded at
+            -- build time, insert-if-absent). They are managed disable-only:
+            -- the platform-admin write API forbids hard-deleting them
+            -- (a delete would be undone by the next seed on a fresh DB),
+            -- but config / enabled edits ARE allowed and survive re-seed
+            -- (the seed is ON CONFLICT DO NOTHING). PA-created rules carry
+            -- FALSE and allow full CRUD.
+            is_seeded       BOOLEAN NOT NULL DEFAULT FALSE,
             created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
             updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
         )
     """)
+    # Backfill for a pre-existing DB created before the is_seeded column.
+    # Idempotent ADD COLUMN IF NOT EXISTS; the column defaults FALSE, then
+    # the seed below stamps TRUE on the rows it owns (its UPDATE branch).
+    await conn.execute(
+        "ALTER TABLE platform_safety_rules "
+        "ADD COLUMN IF NOT EXISTS is_seeded BOOLEAN NOT NULL DEFAULT FALSE"
+    )
     # Identity for the idempotent seed: one platform rule per
     # (tier, check_id, stage). The seed's ON CONFLICT keys on this.
     await conn.execute(

--- a/src/webui/api_v1.py
+++ b/src/webui/api_v1.py
@@ -37,6 +37,7 @@ from webui.v1.credentials import router as credentials_router
 from webui.v1.mcp_servers import router as mcp_servers_router
 from webui.v1.models import router as models_router
 from webui.v1.platform_credentials import router as platform_credentials_router
+from webui.v1.platform_safety import router as platform_safety_router
 from webui.v1.platform_tenants import router as platform_tenants_router
 from webui.v1.runs import router as runs_router
 from webui.v1.safety import router as safety_router
@@ -92,6 +93,8 @@ router.include_router(bindings_router)
 router.include_router(admin_models_router)
 # Credential pool — platform-plane key management (platform_admin only).
 router.include_router(platform_credentials_router)
+# Platform safety rules — cross-tenant rule catalog (platform_admin only).
+router.include_router(platform_safety_router)
 # Tenant lifecycle — platform-plane provision/suspend/resume (platform_admin
 # only). Distinct from the owner-only /tenant settings surface below.
 router.include_router(platform_tenants_router)

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1413,6 +1413,72 @@ class SafetyRuleAuditPage(BaseModel):
     offset: int = Field(ge=0)
 
 
+# ---------------------------------------------------------------------------
+# Platform safety rules (cross-tenant, platform_admin only)
+# ---------------------------------------------------------------------------
+
+
+PlatformSafetyTier = Literal["floor", "transparent_floor", "default"]
+
+
+class PlatformSafetyRule(BaseModel):
+    """Wire projection of a ``platform_safety_rules`` row (all tiers).
+
+    The platform-admin surface, unlike the tenant read, exposes ALL tiers
+    (floor included) and the ``is_seeded`` flag. ``is_seeded`` rules are the
+    shipped factory defaults: editable / disablable but never hard-deletable
+    (a delete would be undone by the next build-time seed).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    tier: PlatformSafetyTier
+    stage: SafetyStage
+    check_id: str
+    config: dict[str, object] = Field(default_factory=dict)
+    priority: int
+    enabled: bool
+    description: str
+    is_seeded: bool
+    created_at: str
+    updated_at: str
+
+
+class PlatformSafetyRuleCreate(BaseModel):
+    """``POST /api/v1/platform/safety/rules`` body.
+
+    ``tier`` / ``stage`` / ``check_id`` form the rule identity. The handler
+    additionally validates ``check_id`` against the safety check registry and
+    that the check supports ``stage`` (400 ``INVALID_RULE`` otherwise).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tier: PlatformSafetyTier
+    stage: SafetyStage
+    check_id: str = Field(min_length=1, max_length=128)
+    config: dict[str, object] = Field(default_factory=dict)
+    priority: int = Field(1000, ge=-1000, le=1000)
+    description: str = Field("", max_length=500)
+
+
+class PlatformSafetyRuleUpdate(BaseModel):
+    """``PATCH /api/v1/platform/safety/rules/{id}`` body.
+
+    Only the mutable fields — ``tier`` / ``stage`` / ``check_id`` are the
+    immutable identity and cannot be patched (create a new rule instead).
+    Every field is optional; omitted fields are left untouched.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    config: dict[str, object] | None = None
+    priority: int | None = Field(None, ge=-1000, le=1000)
+    description: str | None = Field(None, max_length=500)
+    enabled: bool | None = None
+
+
 class MessagePage(BaseModel):
     """Cursor page of conversation messages.
 

--- a/src/webui/v1/platform_safety.py
+++ b/src/webui/v1/platform_safety.py
@@ -240,7 +240,15 @@ async def update_platform_rule_endpoint(
     so the effective rule stays runnable.
     """
     existing = await _get_rule_or_404(rule_id)
-    if body.config is not None:
+    # Re-validate a changed config against the rule's (immutable) check +
+    # stage — but ONLY when the check lives in the orchestrator registry.
+    # Seeded defaults often target container-side checks (secret_scanner,
+    # llm_guard.*) that are absent from this registry; rejecting their
+    # config edits would make seeded defaults uneditable. The runtime is
+    # permissive on such checks, so the admin edit is too.
+    if body.config is not None and get_orchestrator_registry().has(
+        existing["check_id"]
+    ):
         _validate_rule(existing["check_id"], existing["stage"], dict(body.config))
     updated = await update_platform_rule(
         rule_id,

--- a/src/webui/v1/platform_safety.py
+++ b/src/webui/v1/platform_safety.py
@@ -1,0 +1,341 @@
+"""``/api/v1/platform/safety/rules`` REST surface (platform safety rules).
+
+The platform safety rule catalog (``platform_safety_rules``) is
+cross-tenant: every rule enforces on EVERY tenant's agents. This surface
+is platform-plane only — every handler is gated on
+``safety.platform.manage``, which lives in ``_PLATFORM_ONLY_ACTIONS`` so no
+tenant role (not even an owner) can reach it (see
+:mod:`rolemesh.auth.permissions`).
+
+Contrast with the tenant-facing ``/api/v1/safety/rules``:
+
+  * It surfaces a tenant's OWN rules plus the *visible* platform tiers
+    (default / transparent_floor), read-only. This surface exposes ALL
+    tiers including ``floor`` — the platform operator manages floor too;
+    only its *visibility* is suppressed for tenants.
+  * Writes go through ``admin_conn`` (the business role has no
+    INSERT/UPDATE/DELETE on this catalog), via the helpers in
+    :mod:`rolemesh.db.platform_safety`.
+
+Seeded factory defaults (``is_seeded = TRUE``) are managed disable-only:
+config / enabled edits are allowed, but a hard DELETE is refused (409) —
+the next build-time seed would resurrect the row, so disabling is the
+sanctioned way to suppress one.
+
+No live reload is published here: platform rules are loaded into a fresh
+agent's safety pipeline at spawn (``fetch_platform_rule_snapshots``), so a
+change takes effect for newly spawned agents automatically; already-running
+agents keep the rules they booted with, matching the existing container-
+side rule lifecycle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import asyncpg
+from fastapi import APIRouter, Depends, Response
+
+from rolemesh.core.logger import get_logger
+from rolemesh.db import (
+    create_platform_rule,
+    delete_platform_rule,
+    get_platform_rule,
+    list_all_platform_rules,
+    set_platform_rule_enabled,
+    update_platform_rule,
+)
+from rolemesh.safety.registry import get_orchestrator_registry
+from webui.dependencies import require_action
+from webui.schemas_v1 import (
+    PlatformSafetyRule,
+    PlatformSafetyRuleCreate,
+    PlatformSafetyRuleUpdate,
+)
+from webui.v1.errors import raise_error_response
+
+if TYPE_CHECKING:
+    from rolemesh.auth.provider import AuthenticatedUser
+
+logger = get_logger()
+
+router = APIRouter(prefix="/platform/safety/rules", tags=["Platform"])
+
+
+def _to_response(row: dict[str, Any]) -> PlatformSafetyRule:
+    """Project a ``rolemesh.db.platform_safety`` row dict onto the wire shape."""
+    config = row.get("config")
+    return PlatformSafetyRule(
+        id=str(row["id"]),
+        tier=row["tier"],
+        stage=row["stage"],
+        check_id=str(row["check_id"]),
+        config=config if isinstance(config, dict) else {},
+        priority=int(row["priority"]),
+        enabled=bool(row["enabled"]),
+        description=str(row["description"]),
+        is_seeded=bool(row["is_seeded"]),
+        created_at=str(row.get("created_at", "")),
+        updated_at=str(row.get("updated_at", "")),
+    )
+
+
+def _validate_rule(check_id: str, stage: str, config: dict[str, object]) -> None:
+    """Reject (400 ``INVALID_RULE``) a platform rule that cannot run.
+
+    Same registry-backed validation as tenant rule creation — the check must
+    exist, support the stage, and its declared ``config_model`` (if any) must
+    accept the config; the ``action_override`` whitelist is enforced too.
+
+    The tenant path's PRE_TOOL_CALL reversibility guard is intentionally NOT
+    applied: it is scoped to a single tenant's coworker MCP bindings, which
+    has no meaning for a cross-tenant platform rule.
+    """
+    from pydantic import ValidationError
+
+    from rolemesh.safety.types import Stage
+
+    registry = get_orchestrator_registry()
+    if not registry.has(check_id):
+        raise_error_response(
+            "INVALID_RULE",
+            f"Unknown safety check_id: {check_id}",
+            status_code=400,
+        )
+    check = registry.get(check_id)
+    try:
+        stage_enum = Stage(stage)
+    except ValueError:
+        raise_error_response(
+            "INVALID_RULE", f"Unknown stage: {stage}", status_code=400,
+        )
+    if stage_enum not in check.stages:
+        raise_error_response(
+            "INVALID_RULE",
+            (
+                f"Check {check_id} does not support stage {stage}; "
+                f"valid stages: {sorted(s.value for s in check.stages)}"
+            ),
+            status_code=400,
+        )
+    if not isinstance(config, dict):
+        raise_error_response(
+            "INVALID_RULE", "config must be a JSON object", status_code=400,
+        )
+    config_model = getattr(check, "config_model", None)
+    if config_model is not None:
+        try:
+            config_model.model_validate(config)
+        except ValidationError as exc:
+            raise_error_response(
+                "INVALID_RULE",
+                f"Invalid config for {check_id}: {exc.errors()}",
+                status_code=400,
+            )
+    override = config.get("action_override")
+    if override is not None:
+        valid = {"block", "warn", "require_approval"}
+        if override not in valid:
+            raise_error_response(
+                "INVALID_RULE",
+                (
+                    f"Invalid action_override {override!r}; "
+                    f"must be one of {sorted(valid)} "
+                    f"(redact cannot be synthesized via override)"
+                ),
+                status_code=400,
+            )
+
+
+async def _get_rule_or_404(rule_id: str) -> dict[str, Any]:
+    """Fetch a platform rule or raise the 404 envelope (bad UUID → 404 too)."""
+    try:
+        row = await get_platform_rule(rule_id)
+    except asyncpg.DataError:
+        row = None
+    if row is None:
+        raise_error_response(
+            "NOT_FOUND",
+            "Platform safety rule not found.",
+            status_code=404,
+            details={"rule_id": rule_id},
+        )
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=list[PlatformSafetyRule])
+async def list_platform_rules(
+    _user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> list[PlatformSafetyRule]:
+    """List every platform safety rule across ALL tiers (floor included)."""
+    rows = await list_all_platform_rules()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=PlatformSafetyRule, status_code=201)
+async def create_platform_rule_endpoint(
+    body: PlatformSafetyRuleCreate,
+    user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> PlatformSafetyRule:
+    """Create a platform safety rule (``is_seeded=False``).
+
+    The body is validated against the check registry before the write. A
+    duplicate ``(tier, check_id, stage)`` identity returns 409 ``CONFLICT``.
+    """
+    _validate_rule(body.check_id, body.stage, dict(body.config))
+    try:
+        row = await create_platform_rule(
+            tier=body.tier,
+            stage=body.stage,
+            check_id=body.check_id,
+            config=dict(body.config),
+            priority=body.priority,
+            description=body.description,
+        )
+    except asyncpg.UniqueViolationError:
+        raise_error_response(
+            "CONFLICT",
+            (
+                f"A platform rule already exists for tier={body.tier}, "
+                f"check_id={body.check_id}, stage={body.stage}."
+            ),
+            status_code=409,
+        )
+    logger.info(
+        "platform safety rule created",
+        actor_user_id=user.user_id,
+        rule_id=row["id"],
+        tier=row["tier"],
+        check_id=row["check_id"],
+        stage=row["stage"],
+    )
+    return _to_response(row)
+
+
+@router.get("/{rule_id}", response_model=PlatformSafetyRule)
+async def get_platform_rule_endpoint(
+    rule_id: str,
+    _user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> PlatformSafetyRule:
+    """One platform safety rule by id (any tier). Unknown id → 404."""
+    row = await _get_rule_or_404(rule_id)
+    return _to_response(row)
+
+
+@router.patch("/{rule_id}", response_model=PlatformSafetyRule)
+async def update_platform_rule_endpoint(
+    rule_id: str,
+    body: PlatformSafetyRuleUpdate,
+    user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> PlatformSafetyRule:
+    """Patch a rule's config / priority / description / enabled.
+
+    ``tier`` / ``stage`` / ``check_id`` are immutable. When ``config``
+    changes it is re-validated against the rule's (unchanged) check + stage
+    so the effective rule stays runnable.
+    """
+    existing = await _get_rule_or_404(rule_id)
+    if body.config is not None:
+        _validate_rule(existing["check_id"], existing["stage"], dict(body.config))
+    updated = await update_platform_rule(
+        rule_id,
+        config=body.config,
+        priority=body.priority,
+        description=body.description,
+        enabled=body.enabled,
+    )
+    if updated is None:
+        raise_error_response(
+            "NOT_FOUND",
+            "Platform safety rule not found.",
+            status_code=404,
+            details={"rule_id": rule_id},
+        )
+    logger.info(
+        "platform safety rule updated",
+        actor_user_id=user.user_id,
+        rule_id=rule_id,
+        before={"config": existing["config"], "enabled": existing["enabled"],
+                "priority": existing["priority"]},
+        after={"config": updated["config"], "enabled": updated["enabled"],
+               "priority": updated["priority"]},
+    )
+    return _to_response(updated)
+
+
+@router.post("/{rule_id}/enable", response_model=PlatformSafetyRule)
+async def enable_platform_rule_endpoint(
+    rule_id: str,
+    user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> PlatformSafetyRule:
+    """Enable a platform safety rule. Unknown id → 404."""
+    await _get_rule_or_404(rule_id)
+    updated = await set_platform_rule_enabled(rule_id, enabled=True)
+    if updated is None:  # raced delete
+        raise_error_response(
+            "NOT_FOUND", "Platform safety rule not found.",
+            status_code=404, details={"rule_id": rule_id},
+        )
+    logger.info(
+        "platform safety rule enabled",
+        actor_user_id=user.user_id, rule_id=rule_id,
+    )
+    return _to_response(updated)
+
+
+@router.post("/{rule_id}/disable", response_model=PlatformSafetyRule)
+async def disable_platform_rule_endpoint(
+    rule_id: str,
+    user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> PlatformSafetyRule:
+    """Disable a platform safety rule. Also the sanctioned way to suppress a
+    seeded default (which cannot be hard-deleted). Unknown id → 404."""
+    await _get_rule_or_404(rule_id)
+    updated = await set_platform_rule_enabled(rule_id, enabled=False)
+    if updated is None:  # raced delete
+        raise_error_response(
+            "NOT_FOUND", "Platform safety rule not found.",
+            status_code=404, details={"rule_id": rule_id},
+        )
+    logger.info(
+        "platform safety rule disabled",
+        actor_user_id=user.user_id, rule_id=rule_id,
+    )
+    return _to_response(updated)
+
+
+@router.delete("/{rule_id}", status_code=204)
+async def delete_platform_rule_endpoint(
+    rule_id: str,
+    user: AuthenticatedUser = Depends(require_action("safety.platform.manage")),
+) -> Response:
+    """Hard-delete a platform safety rule.
+
+    A seeded factory default (``is_seeded=True``) cannot be deleted (409
+    ``SEEDED_RULE_IMMUTABLE``) — the next build-time seed would resurrect it;
+    disable it instead. Unknown id → 404.
+    """
+    existing = await _get_rule_or_404(rule_id)
+    if existing["is_seeded"]:
+        raise_error_response(
+            "SEEDED_RULE_IMMUTABLE",
+            (
+                "Seeded factory-default platform rules cannot be deleted "
+                "(the next seed would recreate them). Disable it instead."
+            ),
+            status_code=409,
+            details={"rule_id": rule_id},
+        )
+    await delete_platform_rule(rule_id)
+    logger.info(
+        "platform safety rule deleted",
+        actor_user_id=user.user_id, rule_id=rule_id,
+        tier=existing["tier"], check_id=existing["check_id"],
+        stage=existing["stage"],
+    )
+    return Response(status_code=204)

--- a/tests/safety/test_platform_rules_db.py
+++ b/tests/safety/test_platform_rules_db.py
@@ -22,14 +22,21 @@ import pytest
 from rolemesh.db import (
     admin_conn,
     create_coworker,
+    create_platform_rule,
     create_safety_rule,
     create_tenant,
+    delete_platform_rule,
     fetch_platform_rule_snapshots,
+    get_platform_rule,
     insert_safety_decision,
+    list_all_platform_rules,
     list_safety_decisions,
     list_visible_platform_rules,
+    set_platform_rule_enabled,
+    update_platform_rule,
 )
 from rolemesh.db.platform_safety import VISIBLE_TIERS
+from rolemesh.db.schema import _seed_platform_safety_rules
 from rolemesh.safety import loader
 
 pytestmark = pytest.mark.usefixtures("test_db")
@@ -52,7 +59,7 @@ async def _tenant_and_coworker(slug: str) -> tuple[str, str]:
 
 
 async def _insert_floor_rule() -> None:
-    """Seed one floor-tier rule directly (no write helper this phase)."""
+    """Insert one floor-tier rule directly (bypassing the write API)."""
     async with admin_conn() as conn:
         await conn.execute(
             "INSERT INTO platform_safety_rules (tier, stage, check_id) "
@@ -171,3 +178,80 @@ class TestDecisionSource:
         rows = await list_safety_decisions(tid)
         row = next(r for r in rows if r["id"] == decision_id)
         assert row["source"] == "tenant"
+
+
+class TestWriteHelpers:
+    @pytest.mark.asyncio
+    async def test_create_sets_is_seeded_false_and_full_crud(self) -> None:
+        await _tenant_and_coworker("crud")
+        created = await create_platform_rule(
+            tier="transparent_floor",
+            stage="model_output",
+            check_id="pii.regex",
+            config={"patterns": {"EMAIL": True}},
+            priority=200,
+            description="pa rule",
+        )
+        assert created["is_seeded"] is False
+        rid = created["id"]
+
+        fetched = await get_platform_rule(rid)
+        assert fetched is not None
+        assert fetched["check_id"] == "pii.regex"
+
+        updated = await update_platform_rule(
+            rid, priority=5, enabled=False, description="edited",
+        )
+        assert updated is not None
+        assert updated["priority"] == 5
+        assert updated["enabled"] is False
+        assert updated["description"] == "edited"
+
+        toggled = await set_platform_rule_enabled(rid, enabled=True)
+        assert toggled is not None and toggled["enabled"] is True
+
+        assert await delete_platform_rule(rid) is True
+        assert await get_platform_rule(rid) is None
+        # Deleting a now-absent id is a no-op (False).
+        assert await delete_platform_rule(rid) is False
+
+    @pytest.mark.asyncio
+    async def test_list_all_returns_floor_tier(self) -> None:
+        await _tenant_and_coworker("listall")
+        await _insert_floor_rule()
+        rows = await list_all_platform_rules()
+        # Unlike list_visible_platform_rules, floor IS surfaced here.
+        assert any(r["tier"] == "floor" for r in rows)
+        # The 5 seeded defaults are present and flagged.
+        seeded = {r["check_id"] for r in rows if r["is_seeded"]}
+        assert seeded >= _EXPECTED_DEFAULT_CHECKS
+
+
+class TestSeedSurvival:
+    @pytest.mark.asyncio
+    async def test_seed_does_not_overwrite_pa_edits(self) -> None:
+        """A re-seed (fresh-DB rebuild) must not clobber a PA's edits.
+
+        The seed is ON CONFLICT DO UPDATE that touches ONLY is_seeded, so a
+        disabled / re-configured factory default keeps the operator's state
+        across the next seed run.
+        """
+        await _tenant_and_coworker("survive")
+        rows = await list_all_platform_rules()
+        seeded = next(r for r in rows if r["is_seeded"])
+        rid = seeded["id"]
+
+        await update_platform_rule(
+            rid, config={"sentinel": True}, enabled=False, priority=42,
+        )
+
+        # Re-run the build-time seed (simulates a fresh-DB rebuild / reseed).
+        async with admin_conn() as conn:
+            await _seed_platform_safety_rules(conn)
+
+        after = await get_platform_rule(rid)
+        assert after is not None
+        assert after["enabled"] is False  # disable survives
+        assert after["config"] == {"sentinel": True}  # config edit survives
+        assert after["priority"] == 42  # priority edit survives
+        assert after["is_seeded"] is True  # still a managed default

--- a/tests/webui/test_v1_platform_safety.py
+++ b/tests/webui/test_v1_platform_safety.py
@@ -1,0 +1,294 @@
+"""Integration tests for ``/api/v1/platform/safety/rules`` (platform rules).
+
+Pins the platform-admin safety-rule surface:
+
+- ``safety.platform.manage`` gating: a tenant ``owner`` is denied 403 on
+  every endpoint; only ``platform_admin`` reaches them.
+- list returns ALL tiers — including ``floor`` (which the tenant-facing
+  read hides) — plus the 5 seeded factory defaults.
+- create / get / patch / enable / disable round-trips; ``check_id`` is
+  validated against the orchestrator registry (unknown / unsupported-stage
+  / bad action_override → 400) and a duplicate identity → 409.
+- seeded factory defaults (``is_seeded=True``) are disable-only: a hard
+  DELETE is refused (409) but disable + config edits are allowed.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db import admin_conn, create_tenant, create_user
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import get_current_user
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+_H = {"Authorization": "Bearer x"}
+_BASE = "/api/v1/platform/safety/rules"
+
+# check_ids that exist in the ORCHESTRATOR registry (the validation
+# authority). Seeded defaults reference container-side checks
+# (secret_scanner / llm_guard.*) that are absent from it, so creates use
+# these instead.
+_PII = "pii.regex"  # stages: input_prompt, model_output, post_tool_result, pre_tool_call
+_DOMAIN = "domain_allowlist"  # stage: pre_tool_call only
+
+_EXPECTED_SEEDED_CHECKS = {
+    "secret_scanner",
+    "pii.regex",
+    "llm_guard.prompt_injection",
+    "llm_guard.jailbreak",
+    "llm_guard.toxicity",
+}
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+async def _make_user(role: str, slug: str = "plat") -> AuthenticatedUser:
+    t = await create_tenant(name=f"T-{slug}", slug=f"{slug}-{uuid.uuid4().hex[:8]}")
+    u = await create_user(
+        tenant_id=t.id, name="Op",
+        email=f"o-{uuid.uuid4().hex[:6]}@x.com", role="owner",
+    )
+    return AuthenticatedUser(
+        user_id=u.id, tenant_id=t.id, role=role, email="x@x.com", name="X",
+    )
+
+
+async def _create(ac: httpx.AsyncClient, **body: object) -> httpx.Response:
+    payload: dict[str, object] = {
+        "tier": "transparent_floor",
+        "stage": "input_prompt",
+        "check_id": _PII,
+        "config": {},
+        "priority": 500,
+        "description": "test rule",
+    }
+    payload.update(body)
+    return await ac.post(_BASE, json=payload, headers=_H)
+
+
+# ---------------------------------------------------------------------------
+# Role gate — only platform_admin
+# ---------------------------------------------------------------------------
+
+
+async def test_owner_is_forbidden_on_every_endpoint() -> None:
+    user = await _make_user("owner")
+    rid = str(uuid.uuid4())
+    async with _client(_build_app(user)) as ac:
+        assert (await ac.get(_BASE, headers=_H)).status_code == 403
+        assert (await _create(ac)).status_code == 403
+        assert (await ac.get(f"{_BASE}/{rid}", headers=_H)).status_code == 403
+        assert (
+            await ac.patch(f"{_BASE}/{rid}", json={"enabled": False}, headers=_H)
+        ).status_code == 403
+        assert (
+            await ac.post(f"{_BASE}/{rid}/enable", headers=_H)
+        ).status_code == 403
+        assert (
+            await ac.post(f"{_BASE}/{rid}/disable", headers=_H)
+        ).status_code == 403
+        assert (await ac.delete(f"{_BASE}/{rid}", headers=_H)).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# List — all tiers (incl floor) + seeded defaults
+# ---------------------------------------------------------------------------
+
+
+async def test_list_includes_seeded_defaults_and_floor_tier() -> None:
+    user = await _make_user("platform_admin")
+    # Inject a floor-tier rule directly — the tenant read hides floor; the
+    # platform list must surface it.
+    async with admin_conn() as conn:
+        await conn.execute(
+            "INSERT INTO platform_safety_rules (tier, stage, check_id) "
+            "VALUES ('floor', 'input_prompt', 'pii.regex') "
+            "ON CONFLICT (tier, check_id, stage) DO NOTHING"
+        )
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get(_BASE, headers=_H)
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    seeded = {r["check_id"] for r in rows if r["is_seeded"]}
+    assert seeded >= _EXPECTED_SEEDED_CHECKS
+    assert all(r["is_seeded"] for r in rows if r["tier"] == "default" and
+               r["check_id"] in _EXPECTED_SEEDED_CHECKS)
+    # floor tier is visible to the platform admin (unlike the tenant read).
+    assert any(r["tier"] == "floor" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Create / get / validation
+# ---------------------------------------------------------------------------
+
+
+async def test_create_then_get_roundtrip() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        created = await _create(
+            ac, config={"patterns": {"EMAIL": True}}, priority=300,
+        )
+        assert created.status_code == 201, created.text
+        body = created.json()
+        assert body["tier"] == "transparent_floor"
+        assert body["check_id"] == _PII
+        assert body["is_seeded"] is False
+        assert body["config"] == {"patterns": {"EMAIL": True}}
+        assert body["priority"] == 300
+        rid = body["id"]
+
+        got = await ac.get(f"{_BASE}/{rid}", headers=_H)
+        assert got.status_code == 200
+        assert got.json()["id"] == rid
+
+
+async def test_get_unknown_id_is_404() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get(f"{_BASE}/{uuid.uuid4()}", headers=_H)
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "NOT_FOUND"
+
+
+async def test_create_unknown_check_id_rejected() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        resp = await _create(ac, check_id="nope.not_a_check")
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_RULE"
+
+
+async def test_create_unsupported_stage_rejected() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        # domain_allowlist only supports pre_tool_call.
+        resp = await _create(ac, check_id=_DOMAIN, stage="input_prompt")
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_RULE"
+
+
+async def test_create_bad_action_override_rejected() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        resp = await _create(ac, config={"action_override": "redact"})
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_RULE"
+
+
+async def test_create_duplicate_identity_conflict() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        # tier=default + pii.regex + input_prompt is a seeded identity.
+        resp = await _create(ac, tier="default", check_id=_PII, stage="input_prompt")
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "CONFLICT"
+
+
+# ---------------------------------------------------------------------------
+# Patch / enable / disable
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_updates_mutable_fields() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        rid = (await _create(ac)).json()["id"]
+        patched = await ac.patch(
+            f"{_BASE}/{rid}",
+            json={
+                "config": {"patterns": {"SSN": True}},
+                "priority": 10,
+                "description": "edited",
+                "enabled": False,
+            },
+            headers=_H,
+        )
+    assert patched.status_code == 200, patched.text
+    body = patched.json()
+    assert body["config"] == {"patterns": {"SSN": True}}
+    assert body["priority"] == 10
+    assert body["description"] == "edited"
+    assert body["enabled"] is False
+
+
+async def test_patch_invalid_config_rejected() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        rid = (await _create(ac)).json()["id"]
+        resp = await ac.patch(
+            f"{_BASE}/{rid}",
+            json={"config": {"action_override": "redact"}},
+            headers=_H,
+        )
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_RULE"
+
+
+async def test_enable_disable_toggles_flag() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        rid = (await _create(ac)).json()["id"]
+        disabled = await ac.post(f"{_BASE}/{rid}/disable", headers=_H)
+        assert disabled.status_code == 200
+        assert disabled.json()["enabled"] is False
+        enabled = await ac.post(f"{_BASE}/{rid}/enable", headers=_H)
+        assert enabled.status_code == 200
+        assert enabled.json()["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Delete — PA-created deletable, seeded defaults disable-only
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_pa_created_rule_then_404() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        rid = (await _create(ac)).json()["id"]
+        first = await ac.delete(f"{_BASE}/{rid}", headers=_H)
+        assert first.status_code == 204
+        assert (await ac.get(f"{_BASE}/{rid}", headers=_H)).status_code == 404
+
+
+async def test_seeded_default_cannot_be_deleted_but_can_be_disabled() -> None:
+    user = await _make_user("platform_admin")
+    async with _client(_build_app(user)) as ac:
+        rows = (await ac.get(_BASE, headers=_H)).json()
+        seeded = next(r for r in rows if r["is_seeded"])
+        rid = seeded["id"]
+
+        # Hard delete is refused.
+        deleted = await ac.delete(f"{_BASE}/{rid}", headers=_H)
+        assert deleted.status_code == 409
+        assert deleted.json()["code"] == "SEEDED_RULE_IMMUTABLE"
+
+        # Disable IS allowed (the sanctioned suppression path).
+        disabled = await ac.post(f"{_BASE}/{rid}/disable", headers=_H)
+        assert disabled.status_code == 200
+        assert disabled.json()["enabled"] is False
+        # Still present (not deleted), just disabled.
+        assert (await ac.get(f"{_BASE}/{rid}", headers=_H)).status_code == 200

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -611,6 +611,120 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/platform/safety/rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all platform safety rules (every tier, incl. floor)
+         * @description Platform-plane only (`safety.platform.manage`, granted to
+         *     `platform_admin`). Unlike the tenant-facing `/api/v1/safety/rules`
+         *     read — which surfaces only the visible tiers — this returns ALL
+         *     tiers including `floor`, plus the `is_seeded` flag.
+         */
+        get: operations["listPlatformSafetyRules"];
+        put?: never;
+        /**
+         * Create a platform safety rule
+         * @description Platform-plane only (`safety.platform.manage`). The body is
+         *     validated against the safety check registry — an unknown
+         *     `check_id`, an unsupported `stage`, or an invalid `action_override`
+         *     returns `400 INVALID_RULE`. A duplicate `(tier, check_id, stage)`
+         *     identity returns `409`. Created rules carry `is_seeded=false` and
+         *     allow full CRUD.
+         */
+        post: operations["createPlatformSafetyRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/platform/safety/rules/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        /**
+         * Get one platform safety rule (any tier)
+         * @description Platform-plane only (`safety.platform.manage`).
+         */
+        get: operations["getPlatformSafetyRule"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a platform safety rule
+         * @description Platform-plane only (`safety.platform.manage`). A seeded factory
+         *     default (`is_seeded=true`) cannot be hard-deleted (`409`
+         *     `SEEDED_RULE_IMMUTABLE`) — the next build-time seed would recreate
+         *     it; disable it instead. Unknown id → 404.
+         */
+        delete: operations["deletePlatformSafetyRule"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a platform safety rule
+         * @description Platform-plane only (`safety.platform.manage`). Patches the mutable
+         *     fields — `config` / `priority` / `description` / `enabled`. The
+         *     identity (`tier` / `stage` / `check_id`) is immutable. A changed
+         *     `config` is re-validated (`400 INVALID_RULE`) when the check is in
+         *     the orchestrator registry. Seeded defaults are editable here.
+         */
+        patch: operations["updatePlatformSafetyRule"];
+        trace?: never;
+    };
+    "/api/v1/platform/safety/rules/{id}/enable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Enable a platform safety rule
+         * @description Platform-plane only (`safety.platform.manage`).
+         */
+        post: operations["enablePlatformSafetyRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/platform/safety/rules/{id}/disable": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Disable a platform safety rule
+         * @description Platform-plane only (`safety.platform.manage`). Also the sanctioned
+         *     way to suppress a seeded factory default (which cannot be deleted).
+         */
+        post: operations["disablePlatformSafetyRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/coworkers/{id}/mcp-servers": {
         parameters: {
             query?: never;
@@ -2768,6 +2882,52 @@ export interface components {
             enabled?: boolean;
             description?: string;
         };
+        /** @enum {string} */
+        PlatformSafetyTier: "floor" | "transparent_floor" | "default";
+        PlatformSafetyRule: {
+            /** Format: uuid */
+            id: string;
+            tier: components["schemas"]["PlatformSafetyTier"];
+            stage: components["schemas"]["SafetyStage"];
+            check_id: string;
+            config?: {
+                [key: string]: unknown;
+            };
+            priority: number;
+            enabled: boolean;
+            description: string;
+            /**
+             * @description True for the shipped factory defaults (seeded at build time).
+             *     These are managed disable-only: editable and disablable, but a
+             *     hard DELETE is refused (`409`) since the next seed would
+             *     recreate them. Platform-admin-created rules carry `false`.
+             */
+            is_seeded: boolean;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        PlatformSafetyRuleCreate: {
+            tier: components["schemas"]["PlatformSafetyTier"];
+            stage: components["schemas"]["SafetyStage"];
+            check_id: string;
+            config?: {
+                [key: string]: unknown;
+            };
+            /** @default 1000 */
+            priority: number;
+            /** @default  */
+            description: string;
+        };
+        PlatformSafetyRuleUpdate: {
+            config?: {
+                [key: string]: unknown;
+            };
+            priority?: number;
+            description?: string;
+            enabled?: boolean;
+        };
     };
     responses: {
         /** @description Malformed request. */
@@ -3697,6 +3857,187 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PlatformTenantResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listPlatformSafetyRules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformSafetyRule"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createPlatformSafetyRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformSafetyRuleCreate"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformSafetyRule"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            409: components["responses"]["Conflict"];
+            422: components["responses"]["Unprocessable"];
+        };
+    };
+    getPlatformSafetyRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformSafetyRule"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deletePlatformSafetyRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+        };
+    };
+    updatePlatformSafetyRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformSafetyRuleUpdate"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformSafetyRule"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["Unprocessable"];
+        };
+    };
+    enablePlatformSafetyRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformSafetyRule"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    disablePlatformSafetyRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: components["parameters"]["IdInPath"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformSafetyRule"];
                 };
             };
             401: components["responses"]["Unauthorized"];


### PR DESCRIPTION
## Background

Platform rules (`platform_safety_rules`, cross-tenant, enforced on every tenant) previously had **read-only access + build-time seed injection** only — they could not be created, edited, or removed at runtime. This PR gives `platform_admin` a write REST surface to manage platform safety rules (the `safety.platform.manage` capability in the role matrix), mirroring the existing `/api/v1/platform/credentials` platform-write pattern.

## Changes

- **action**: `safety.platform.manage` added to `_PLATFORM_ONLY_ACTIONS` (platform_admin-only via the derived superset; every tenant role hits default-deny).
- **db write helpers** (`db/platform_safety.py`, on `admin_conn`): `create / update / set_enabled / delete` plus all-tier `list_all` / `get`.
- **REST** (new `webui/v1/platform_safety.py`, `prefix=/platform/safety/rules`, every endpoint gated on `safety.platform.manage`):
  - `GET ""` lists **all tiers including `floor`** — unlike the tenant read path, which hides floor.
  - `POST ""` / `GET /{id}` / `PATCH /{id}` / `POST /{id}/enable` / `POST /{id}/disable` / `DELETE /{id}`.
- **validation**: `check_id` must exist in the safety check registry, the stage must be supported by that check, and the `action_override` whitelist is enforced (reusing the same validation as tenant rule creation; the tenant-scoped reversibility guard does not apply cross-tenant and is dropped).
- **schema**: new `is_seeded` column. The seed now uses `ON CONFLICT DO UPDATE SET is_seeded=TRUE` — it only backfills the flag and **never overwrites** a platform admin's config/enabled edits; an idempotent `ADD COLUMN IF NOT EXISTS` upgrades pre-existing DBs.
- **openapi.yaml + types.ts** kept in sync (types.ts regenerated via `openapi-typescript`).

## Two key design decisions

1. **Keep the seed, disable-only for shipped defaults**: factory defaults are still inserted at build time (a security product must work out of the box). Seeded defaults (`is_seeded=true`) **cannot be hard-deleted** (the next seed would resurrect them) — a hard DELETE returns `409 SEEDED_RULE_IMMUTABLE`; suppression goes through disable. Platform-admin-created rules allow full CRUD.
2. **No reload**: platform rules are loaded into an agent's safety pipeline at spawn (`fetch_platform_rule_snapshots`), so a change takes effect for newly spawned agents automatically; no event is published and running agents are not hot-reloaded (consistent with the existing container-side rule lifecycle). The existing `safety.rule.changed` event only feeds the egress gateway and does not carry platform rules, so reusing it would create snapshot/delta inconsistency — deliberately avoided.

## Pitfall found and handled during implementation

The orchestrator registry only contains 3 checks (`pii.regex` / `domain_allowlist` / `egress.domain_rule`); the seeded defaults reference container-side checks (`secret_scanner` / `llm_guard.*`) that are absent from it (the seed INSERTs directly, bypassing validation). So **PATCH only re-validates config when the check is in the registry** — otherwise a platform admin could not edit a seeded default's config — matching the runtime's permissive contract for container-side checks.

## Acceptance / testing

Run locally against a real Postgres + Docker:

- ✅ Platform safety DB + route tests **23/23 passing** (403 for non-PA, list includes floor, create/update/enable/disable, seeded disable-only / no-delete, check_id validation, seed does not overwrite PA edits).
- ✅ Regression (auth / safety / webui / openapi): **538 passed, 30 skipped, 0 failed**.
- ✅ `ruff` clean repo-wide; `mypy` no new errors (the only error is the pre-existing baseline one at `schemas_v1.py:462`).
- ✅ openapi/types.ts freshness test passes.

## Footprint

10 files, +1581 / −8 (net hand-written ~1240; generated types.ts +341).

https://claude.ai/code/session_01CcKxZJgEDU6EiDnHbAntW3