### PR TITLE
Pagination hardening: fix stale list assertions + cursor page-2 bug, add list-shape guard

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -16,6 +16,15 @@ info:
     Error responses use the shape declared in design §13:
     `{code, message, details?}`.
 
+    List endpoints follow one pagination convention (enforced by
+    `tests/webui/test_v1_list_pagination_shape.py`): a growable collection
+    returns a named `*Page` envelope — `{items, total, limit, offset}` for
+    offset/limit, or `{items, has_more, next_cursor}` for append-only
+    cursor paging (conversation messages). A collection that is
+    intrinsically bounded (a fixed enum, a static registry, or a small
+    per-parent set) may return a bare array; the test holds the reviewed
+    allowlist of those.
+
 servers:
   - url: /
     description: Same-origin (FastAPI serves both the SPA and the API).

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -271,10 +271,19 @@ async def list_conversation_messages(
                 "Malformed pagination cursor.",
                 status_code=400,
             )
-        # messages.id is TEXT (client-supplied ids), so the cursor tiebreak
-        # compares it as text — no ::uuid cast.
+        # Keyset seek on (timestamp, id), newest-first. Written as an
+        # explicit OR rather than a row-constructor comparison
+        # ``(timestamp, id) < ($3, $4)`` so BOTH bound params carry an
+        # explicit cast ($3 timestamptz, $4 text — messages.id is TEXT). A
+        # bare param inside a row constructor left Postgres unable to resolve
+        # its type, which surfaced as a query error on the second page (the
+        # only path that binds the cursor) — a page's own next_cursor came
+        # back looking "invalid".
         params.extend((cur_ts, cur_id))
-        where += " AND (timestamp, id) < ($3::timestamptz, $4)"
+        where += (
+            " AND (timestamp < $3::timestamptz"
+            " OR (timestamp = $3::timestamptz AND id < $4::text))"
+        )
     params.append(limit + 1)  # over-fetch one to detect has_more
     sql = (
         "SELECT id, content, timestamp, is_from_me, is_bot_message, "
@@ -286,7 +295,8 @@ async def list_conversation_messages(
         async with tenant_conn(user.tenant_id) as conn:
             rows_desc = await conn.fetch(sql, *params)
     except asyncpg.DataError:
-        # A cursor that decodes but carries a non-UUID / bad timestamp.
+        # A cursor that base64-decodes but carries a bad timestamp (the
+        # ``$3::timestamptz`` cast then fails) — still a malformed cursor.
         raise_error_response(
             "INVALID_CURSOR",
             "Malformed pagination cursor.",

--- a/tests/webui/test_v1_approval_policies.py
+++ b/tests/webui/test_v1_approval_policies.py
@@ -229,7 +229,7 @@ async def test_list_does_not_leak_other_tenant_policies() -> None:
     async with _client(_build_app(a)) as ac:
         listing = await ac.get("/api/v1/approvals/policies", headers=_AUTH)
     assert listing.status_code == 200
-    assert listing.json() == []
+    assert listing.json()["items"] == []
 
 
 async def test_patch_cross_tenant_policy_is_404_and_leaves_victim_intact() -> None:
@@ -342,4 +342,4 @@ async def test_pending_requests_conversation_filter_cannot_cross_tenant() -> Non
             headers=_AUTH,
         )
     assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.json()["items"] == []

--- a/tests/webui/test_v1_list_pagination_shape.py
+++ b/tests/webui/test_v1_list_pagination_shape.py
@@ -1,0 +1,164 @@
+"""Pagination-shape meta-test for the ``/api/v1`` list surface.
+
+THE RULE (the one this test enforces, so it can't rot):
+
+  Every ``/api/v1`` GET that returns a *collection* must declare its
+  response shape deliberately:
+
+    * Growable collection  -> a named ``*Page`` ENVELOPE
+      ``{items, total, limit, offset}`` (offset/limit) or, for
+      append-only/time-series data, ``{items, has_more, next_cursor}``
+      (cursor). Both are "envelopes" — a Pydantic model with an
+      ``items`` field — and that is what this test recognises.
+
+    * Bounded collection (fixed enum, static registry, or a small
+      per-parent set that can't grow with tenant size) MAY stay a bare
+      ``list[X]`` — but only if it is listed in ``BARE_LIST_ALLOWLIST``
+      below with a one-line justification.
+
+A new bare-array list endpoint therefore fails CI until someone either
+wraps it in a ``*Page`` or consciously allowlists it (with a reason).
+There is no silent "half-migrated" state — that is the whole point
+(this guard exists because four list endpoints were moved to envelopes
+while their tests, and nearly a fifth endpoint, were left on the old
+bare-array convention).
+
+Single-resource GETs (``response_model`` is one model, not a list) and
+non-JSON responses (e.g. the CSV export) are not collections and are
+skipped.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from pydantic import BaseModel
+
+from webui.api_v1 import router as api_v1_router
+
+# ---------------------------------------------------------------------------
+# Bare ``list[X]`` GETs that are intentionally NOT paginated, each with a
+# one-line justification. Err toward an envelope; only add here when the
+# collection genuinely cannot grow with tenant/usage size. Reviewed by hand.
+# ---------------------------------------------------------------------------
+BARE_LIST_ALLOWLIST: dict[tuple[str, str], str] = {
+    ("GET", "/api/v1/backends"):
+        "Static backend×provider×family matrix; fixed at build time.",
+    ("GET", "/api/v1/models"):
+        "Curated platform model catalog (reference data, operator-managed).",
+    ("GET", "/api/v1/safety/checks"):
+        "Static in-process safety-check registry.",
+    ("GET", "/api/v1/credentials"):
+        "At most one row per provider — bounded by the provider enum (~4).",
+    ("GET", "/api/v1/platform/credentials"):
+        "At most one row per provider — bounded by the provider enum.",
+    ("GET", "/api/v1/platform/safety/rules"):
+        "Curated platform safety-rule catalog; small, operator-managed.",
+    ("GET", "/api/v1/me/channel-links/telegram"):
+        "The caller's own linked Telegram identities; small per-user set.",
+    ("GET", "/api/v1/coworkers/{coworker_id}/bindings"):
+        "One coworker's channel bindings; bounded (a few channels).",
+    ("GET", "/api/v1/coworkers/{coworker_id}/mcp-servers"):
+        "One coworker's MCP bindings; bounded per coworker.",
+    ("GET", "/api/v1/coworkers/{coworker_id}/skills"):
+        "One coworker's skill bindings; bounded per coworker.",
+    ("GET", "/api/v1/skills/{skill_id}/files"):
+        "One skill's files; bounded per skill.",
+    ("GET", "/api/v1/conversations/{conversation_id}/approval-requests"):
+        "A single conversation's in-flight approvals; bounded per conversation.",
+    ("GET", "/api/v1/platform/tenants"):
+        "Platform tenant list. NOTE: this grows with tenant count — the one "
+        "allowlisted collection that is not intrinsically bounded. Candidate "
+        "to convert to a *Page envelope; allowlisted for now (platform_admin "
+        "only, and deployments are small today).",
+}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(api_v1_router)
+    return app
+
+
+def _is_envelope(model: object) -> bool:
+    """An ``*Page`` envelope is a Pydantic model carrying an ``items`` field.
+
+    Recognises both offset (``{items,total,limit,offset}``) and cursor
+    (``{items,has_more,next_cursor}``) envelopes — the distinction between
+    the two is a per-endpoint choice this guard does not police.
+    """
+    return (
+        isinstance(model, type)
+        and issubclass(model, BaseModel)
+        and "items" in model.model_fields
+    )
+
+
+def _is_bare_list(model: object) -> bool:
+    return typing.get_origin(model) is list
+
+
+def _list_get_routes() -> list[tuple[str, APIRoute]]:
+    """Every ``/api/v1`` GET whose response_model is a collection."""
+    out: list[tuple[str, APIRoute]] = []
+    for route in _build_app().routes:
+        if not isinstance(route, APIRoute):
+            continue
+        if not route.path.startswith("/api/v1"):
+            continue
+        if "GET" not in (route.methods or set()):
+            continue
+        rm = route.response_model
+        if _is_envelope(rm) or _is_bare_list(rm):
+            out.append((route.path, route))
+    return out
+
+
+def test_every_list_endpoint_is_enveloped_or_allowlisted_bare() -> None:
+    """No silent bare array: each list GET is a *Page OR allowlisted."""
+    offenders: list[str] = []
+    for path, route in _list_get_routes():
+        if _is_envelope(route.response_model):
+            continue
+        if ("GET", path) in BARE_LIST_ALLOWLIST:
+            continue
+        offenders.append(path)
+    assert not offenders, (
+        "These /api/v1 list GETs return a bare array but are neither a "
+        f"*Page envelope nor in BARE_LIST_ALLOWLIST: {offenders}"
+    )
+
+
+def test_bare_list_allowlist_has_no_stale_entries() -> None:
+    """Every allowlist entry must still be a live bare-array list GET.
+
+    Guards against an entry quietly masking an endpoint that since gained a
+    *Page envelope (entry now dead weight) or was renamed/removed.
+    """
+    live = {
+        ("GET", path): route
+        for path, route in _list_get_routes()
+    }
+    stale: list[tuple[str, str]] = []
+    now_enveloped: list[tuple[str, str]] = []
+    for key in BARE_LIST_ALLOWLIST:
+        route = live.get(key)
+        if route is None:
+            stale.append(key)
+        elif _is_envelope(route.response_model):
+            now_enveloped.append(key)
+    assert not stale, f"Allowlist entries for routes that no longer exist: {stale}"
+    assert not now_enveloped, (
+        f"Allowlist entries that are now *Page-enveloped (remove them): "
+        f"{now_enveloped}"
+    )
+
+
+@pytest.mark.parametrize("key", sorted(BARE_LIST_ALLOWLIST))
+def test_bare_list_allowlist_entries_have_justification(
+    key: tuple[str, str],
+) -> None:
+    assert BARE_LIST_ALLOWLIST[key].strip()

--- a/tests/webui/test_v1_mcp_servers.py
+++ b/tests/webui/test_v1_mcp_servers.py
@@ -89,7 +89,7 @@ async def test_create_then_list_then_get_round_trip() -> None:
             "/api/v1/mcp-servers", headers={"Authorization": "Bearer x"},
         )
         assert listing.status_code == 200
-        names = [r["name"] for r in listing.json()]
+        names = [r["name"] for r in listing.json()["items"]]
         assert "primary" in names
 
         detail = await ac.get(
@@ -388,4 +388,4 @@ async def test_mcp_servers_isolated_per_tenant() -> None:
             "/api/v1/mcp-servers", headers={"Authorization": "Bearer x"},
         )
     assert listing.status_code == 200
-    assert listing.json() == []
+    assert listing.json()["items"] == []


### PR DESCRIPTION
## Summary

Hardens the v1 list/pagination surface: fixes the stale test assertions and a real cursor bug left over from the pagination migration, and adds a self-enforcing rule so "half-migrated" list endpoints can't slip through again.

## Commits

**1. Fix 4 list assertions stuck on the bare-array convention**
Four endpoints return `*Page` envelopes (`{items,total,limit,offset}`) but their tests still read the body as a bare array — a left-over from the pagination migration (the endpoints, OpenAPI contract, and `types.ts` were all correct; only these assertions lagged, so they fail under the DB-backed CI):
- `test_v1_mcp_servers`: `GET /mcp-servers` round-trip + tenant isolation
- `test_v1_approval_policies`: `GET /approvals/policies` and `/approvals/requests`

They now read `.items`. The remaining `== []` assertions in the credentials / platform-credentials / channel-links / coworker-skills / conversation-approval-requests suites are left untouched — those endpoints are genuinely bare arrays.

**2. Add a pagination-shape guard + document the convention**
`tests/webui/test_v1_list_pagination_shape.py` walks every `/api/v1` GET that returns a collection and asserts it is either a named `*Page` envelope OR is in an explicit `BARE_LIST_ALLOWLIST` with a one-line justification (same shape as the default-deny meta-test; cursor and offset envelopes both count as enveloped; single-resource GETs and the CSV stream are skipped). The allowlist captures today's 13 intrinsically-bounded bare lists and flags `/platform/tenants` as the one that grows with tenant count — a future candidate to envelope, surfaced rather than silently bare. The rule is also written into the OpenAPI `info.description` for contract consumers.

**3. Fix the message-cursor page-2 bug**
`GET /conversations/{id}/messages` page 1 returned a `next_cursor`, but fetching page 2 with `?before=<that cursor>` returned `400 INVALID_CURSOR` — the endpoint rejecting a cursor it just minted. Root cause was the keyset predicate, not the codec: the WHERE used a row-constructor comparison `(timestamp, id) < ($3::timestamptz, $4)` with a bare, uncast `$4`. Postgres can't resolve a parameter's type inside a row constructor, so the second page (the only path that binds the cursor) errored into the malformed-cursor branch. Page 1 never bound it and the malformed-cursor test fails earlier at decode, so both masked the bug. Rewritten to the canonical keyset form with explicit casts on both bound params:

```
timestamp < $3::timestamptz OR (timestamp = $3::timestamptz AND id < $4::text)
```

The base64 cursor codec was fine (round-trips through the URL unchanged); the `DataError` branch is kept for a tampered cursor carrying a bad timestamp.

## Why both a guard and a fix

The shape guard (commit 2) catches *structural* drift without a DB — had it existed, the 4 stale assertions and the nearly-bare fifth endpoint would have been caught immediately. The cursor bug (commit 3) is a *runtime* logic error that only a DB-backed test can catch (`test_messages_cursor_pagination_walks_older`). Both layers are needed.

## Verification (local, no Docker)
- `ruff check src tests` clean; no new mypy errors.
- Gate suite green: OpenAPI codegen-freshness + contract, default-deny, and the new pagination-shape guard (15 cases). The cursor decode round-trips correctly through URL parsing.
- Repo-wide: zero non-English text in the diff.

The two DB-backed checks this PR targets (the 4 assertions and `test_messages_cursor_pagination_walks_older`) run in CI (testcontainers Postgres needs Docker, unavailable in the dev sandbox); the assertions now read the correct envelope shape and the cursor query no longer has the untyped-param error.

## Follow-up (not in this PR)
- `/platform/tenants` is bare but grows with tenant count — allowlisted with a note; convert to a `*Page` envelope later.
- Error-code catalog drift guard (analogous to this guard, for the `ErrorResponse.code` set) — proposed earlier, still open.

https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom

---
_Generated by [Claude Code](https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom)_