### PR TITLE
Error-code drift guard + accurate ErrorResponse catalog

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -2662,11 +2662,28 @@ components:
         code:
           type: string
           description: |
-            Stable, machine-readable code. Known values include
-            `RESOURCE_IN_USE`, `BACKEND_INCOMPAT`, `MISSING_CREDENTIAL`,
-            `BOOTSTRAP_NEEDS_TENANT_OWNER`, `NEEDS_USER_PRESENCE`,
-            `WS_TICKET_EXPIRED`, `SKILL_MANIFEST_PROTECTED`,
-            `REAUTH_REQUIRED` (design §13).
+            Stable, machine-readable error code (design §13). The catalog is
+            kept in sync with the backend by a drift guard
+            (`tests/webui/test_v1_error_codes.py`); the complete set is:
+
+            Transport / CRUD: `NOT_FOUND`, `FORBIDDEN`, `CONFLICT`,
+            `INVALID_REQUEST`, `RESOURCE_IN_USE`, `RESOURCE_NOT_AVAILABLE`,
+            `ALREADY_TERMINAL`, `TENANT_SUSPENDED`.
+
+            Coworker / model / credential: `MODEL_NOT_FOUND`,
+            `MISSING_CREDENTIAL`, `BACKEND_INCOMPAT`.
+
+            Skills: `INVALID_NAME`, `INVALID_PATH`, `INVALID_PAYLOAD`,
+            `INVALID_MANIFEST`, `SKILL_MANIFEST_REQUIRED`,
+            `SKILL_MANIFEST_PROTECTED`.
+
+            Safety rules: `INVALID_RULE`, `SEEDED_RULE_IMMUTABLE`.
+
+            Pagination / channel links / WS ticket: `INVALID_CURSOR`,
+            `ACTOR_NOT_LINKABLE`, `WS_TICKET_SECRET_UNSET`.
+
+            (This is the HTTP error vocabulary; safety-check *finding*
+            codes live on `SafetyFinding`, not here.)
         message:
           type: string
         details:

--- a/src/webui/v1/errors.py
+++ b/src/webui/v1/errors.py
@@ -32,10 +32,54 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 __all__ = [
+    "KNOWN_ERROR_CODES",
     "ErrorResponseException",
     "install_error_handler",
     "raise_error_response",
 ]
+
+
+# Authoritative catalog of every ``code`` that can appear in an
+# ``ErrorResponse`` on the ``/api/v1`` surface. This is the HTTP error
+# vocabulary ONLY — safety-check *finding* codes (JAILBREAK, TOXICITY,
+# PROMPT_INJECTION, DOMAIN_NOT_ALLOWED, …) are a separate vocabulary that
+# lives on the ``SafetyFinding`` model, not on ``ErrorResponse.code``, and
+# is intentionally not listed here.
+#
+# A drift guard (``tests/webui/test_v1_error_codes.py``) keeps this honest:
+# every ``code`` literal raised under ``src/webui`` must be in this set, the
+# set must have no dead entries, and the OpenAPI ``ErrorResponse`` doc must
+# mention each one. When you introduce a new error code: add it here, raise
+# it, and list it in ``contracts/openapi.yaml``'s ``ErrorResponse`` schema.
+KNOWN_ERROR_CODES: frozenset[str] = frozenset({
+    # Generic transport / CRUD.
+    "NOT_FOUND",
+    "FORBIDDEN",
+    "CONFLICT",
+    "INVALID_REQUEST",
+    "RESOURCE_IN_USE",
+    "RESOURCE_NOT_AVAILABLE",
+    "ALREADY_TERMINAL",
+    "TENANT_SUSPENDED",
+    # Coworker / model / credential validation.
+    "MODEL_NOT_FOUND",
+    "MISSING_CREDENTIAL",
+    "BACKEND_INCOMPAT",  # raised via BackendCompatError.code (non-literal)
+    # Skills.
+    "INVALID_NAME",
+    "INVALID_PATH",
+    "INVALID_PAYLOAD",
+    "INVALID_MANIFEST",
+    "SKILL_MANIFEST_REQUIRED",
+    "SKILL_MANIFEST_PROTECTED",
+    # Safety rules (tenant + platform).
+    "INVALID_RULE",
+    "SEEDED_RULE_IMMUTABLE",
+    # Pagination / channel links / WS ticket.
+    "INVALID_CURSOR",
+    "ACTOR_NOT_LINKABLE",
+    "WS_TICKET_SECRET_UNSET",  # raised via WsTicketError.code (non-literal)
+})
 
 
 class ErrorResponseException(HTTPException):

--- a/tests/webui/test_v1_error_codes.py
+++ b/tests/webui/test_v1_error_codes.py
@@ -1,0 +1,126 @@
+"""Drift guard for the ``/api/v1`` error-code catalog.
+
+Sibling of the default-deny and pagination-shape meta-tests. The error
+``code`` is a contract: clients branch on it (``MISSING_CREDENTIAL`` ->
+"configure a key first", ``RESOURCE_IN_USE`` -> "detach first", ...). Left
+as a free-form string with a hand-written doc list, that catalog rots —
+new codes ship undocumented and stale codes linger.
+
+This module pins three invariants against
+:data:`webui.v1.errors.KNOWN_ERROR_CODES`:
+
+  1. Every error ``code`` *string literal* raised under ``src/webui``
+     (``raise_error_response("X", ...)`` / ``ErrorResponseException(
+     code="X")``) is in the catalog. A new, unregistered code fails CI.
+  2. The catalog has no dead entries: it equals the set of raised literals
+     plus the small ``_DYNAMICALLY_RAISED`` allowlist (codes sourced from a
+     typed constant rather than a literal, which the AST scan can't see).
+  3. The published OpenAPI ``ErrorResponse`` doc mentions every catalog
+     code, so the contract a consumer reads stays accurate.
+
+Scope note: this is the HTTP error vocabulary only. Safety-check *finding*
+codes (JAILBREAK, TOXICITY, ...) live on ``SafetyFinding``, not on
+``ErrorResponse.code``, and are deliberately out of scope.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+import yaml
+
+from webui.v1.errors import KNOWN_ERROR_CODES
+
+# Codes raised through a non-literal expression (``exc.code`` /
+# ``SomeError.code``) that the literal AST scan cannot resolve. Kept tiny
+# and explicit so the catalog still can't silently grow stale.
+_DYNAMICALLY_RAISED: frozenset[str] = frozenset({
+    "BACKEND_INCOMPAT",       # webui/v1/coworkers.py -> BackendCompatError.code
+    "WS_TICKET_SECRET_UNSET",  # webui/v1/auth.py -> WsTicketError.code
+})
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_WEBUI = _REPO_ROOT / "src" / "webui"
+_OPENAPI = _REPO_ROOT / "contracts" / "openapi.yaml"
+
+
+def _raised_literal_codes() -> set[str]:
+    """Static-scan ``src/webui`` for error-code string literals.
+
+    Catches the first positional arg of ``raise_error_response(...)`` and
+    the ``code=`` kwarg of ``ErrorResponseException(...)``. A static scan
+    (not runtime) finds codes on handlers this test never imports and is
+    robust to a code path that only fires on an error.
+    """
+    found: set[str] = set()
+    for py in _WEBUI.rglob("*.py"):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name == "raise_error_response" and node.args:
+                arg0 = node.args[0]
+                if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+                    found.add(arg0.value)
+            if name == "ErrorResponseException":
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "code"
+                        and isinstance(kw.value, ast.Constant)
+                        and isinstance(kw.value.value, str)
+                    ):
+                        found.add(kw.value.value)
+    return found
+
+
+def test_every_raised_code_is_in_the_catalog() -> None:
+    literals = _raised_literal_codes()
+    assert literals, "No error-code literals found — the scan is broken."
+    unknown = sorted(literals - KNOWN_ERROR_CODES)
+    assert not unknown, (
+        "Error codes raised in src/webui but missing from "
+        f"KNOWN_ERROR_CODES (register them there + in the OpenAPI "
+        f"ErrorResponse doc): {unknown}"
+    )
+
+
+def test_catalog_has_no_dead_entries() -> None:
+    """Catalog == raised literals + the dynamic-source allowlist.
+
+    Fails if a catalog code is never raised (dead weight) or a dynamic code
+    isn't actually in the catalog.
+    """
+    accounted = _raised_literal_codes() | _DYNAMICALLY_RAISED
+    dead = sorted(KNOWN_ERROR_CODES - accounted)
+    assert not dead, (
+        f"KNOWN_ERROR_CODES entries that are never raised (remove them, or "
+        f"add to _DYNAMICALLY_RAISED if raised via a constant): {dead}"
+    )
+    assert _DYNAMICALLY_RAISED <= KNOWN_ERROR_CODES, (
+        "_DYNAMICALLY_RAISED has codes missing from KNOWN_ERROR_CODES: "
+        f"{sorted(_DYNAMICALLY_RAISED - KNOWN_ERROR_CODES)}"
+    )
+
+
+def _error_response_code_doc() -> str:
+    spec = yaml.safe_load(_OPENAPI.read_text())
+    return spec["components"]["schemas"]["ErrorResponse"]["properties"]["code"][
+        "description"
+    ]
+
+
+@pytest.mark.parametrize("code", sorted(KNOWN_ERROR_CODES))
+def test_openapi_doc_lists_every_catalog_code(code: str) -> None:
+    """The published ErrorResponse.code doc must mention each known code."""
+    assert code in _error_response_code_doc(), (
+        f"{code} is in KNOWN_ERROR_CODES but not documented in the OpenAPI "
+        "ErrorResponse.code description."
+    )

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1600,11 +1600,28 @@ export interface components {
     schemas: {
         ErrorResponse: {
             /**
-             * @description Stable, machine-readable code. Known values include
-             *     `RESOURCE_IN_USE`, `BACKEND_INCOMPAT`, `MISSING_CREDENTIAL`,
-             *     `BOOTSTRAP_NEEDS_TENANT_OWNER`, `NEEDS_USER_PRESENCE`,
-             *     `WS_TICKET_EXPIRED`, `SKILL_MANIFEST_PROTECTED`,
-             *     `REAUTH_REQUIRED` (design §13).
+             * @description Stable, machine-readable error code (design §13). The catalog is
+             *     kept in sync with the backend by a drift guard
+             *     (`tests/webui/test_v1_error_codes.py`); the complete set is:
+             *
+             *     Transport / CRUD: `NOT_FOUND`, `FORBIDDEN`, `CONFLICT`,
+             *     `INVALID_REQUEST`, `RESOURCE_IN_USE`, `RESOURCE_NOT_AVAILABLE`,
+             *     `ALREADY_TERMINAL`, `TENANT_SUSPENDED`.
+             *
+             *     Coworker / model / credential: `MODEL_NOT_FOUND`,
+             *     `MISSING_CREDENTIAL`, `BACKEND_INCOMPAT`.
+             *
+             *     Skills: `INVALID_NAME`, `INVALID_PATH`, `INVALID_PAYLOAD`,
+             *     `INVALID_MANIFEST`, `SKILL_MANIFEST_REQUIRED`,
+             *     `SKILL_MANIFEST_PROTECTED`.
+             *
+             *     Safety rules: `INVALID_RULE`, `SEEDED_RULE_IMMUTABLE`.
+             *
+             *     Pagination / channel links / WS ticket: `INVALID_CURSOR`,
+             *     `ACTOR_NOT_LINKABLE`, `WS_TICKET_SECRET_UNSET`.
+             *
+             *     (This is the HTTP error vocabulary; safety-check *finding*
+             *     codes live on `SafetyFinding`, not here.)
              */
             code: string;
             message: string;


### PR DESCRIPTION
## Summary

The error `code` in the `{code, message, details?}` envelope is a client contract — callers branch on it. But it was a free-form string with a hand-written, drifted doc list: many real codes undocumented, several documented codes never raised, and no test holding the line. This adds a lightweight drift guard (the same pattern as the default-deny and pagination-shape meta-tests) and refreshes the catalog to be accurate.

## What changed

- **`webui/v1/errors.py`** — add `KNOWN_ERROR_CODES`, the authoritative catalog of the **22** HTTP error codes (20 raised as string literals + `BACKEND_INCOMPAT` and `WS_TICKET_SECRET_UNSET`, which are raised via a typed constant rather than a literal). Scoped to the HTTP error vocabulary only — safety-check *finding* codes (`JAILBREAK`, `TOXICITY`, `PROMPT_INJECTION`, `DOMAIN_NOT_ALLOWED`) live on `SafetyFinding`, not on `ErrorResponse.code`, and are intentionally excluded.

- **`tests/webui/test_v1_error_codes.py`** — the guard:
  1. AST-scan `src/webui` for every `raise_error_response("X")` / `ErrorResponseException(code="X")` literal → must be ⊆ `KNOWN_ERROR_CODES` (a new, unregistered code fails CI).
  2. catalog has no dead entries: it equals the raised literals plus a tiny explicit dynamic-source allowlist.
  3. the OpenAPI `ErrorResponse.code` description mentions every catalog code (so the published contract stays accurate).

- **`contracts/openapi.yaml`** — replace the stale `ErrorResponse.code` doc list (which named never-raised codes like `BOOTSTRAP_NEEDS_TENANT_OWNER`, `REAUTH_REQUIRED` and omitted real ones like `NOT_FOUND`, `INVALID_*`) with the accurate, grouped full set; regenerate `types.ts` (the description renders as a JSDoc comment).

No runtime behavior change — test + doc only.

## Why

This is a spelling-checker for the error contract: code and published doc now stay in lockstep automatically, instead of each drifting. Had it existed, the recently-fixed list-shape and other drifts in the error catalog would've been caught at PR time without a DB.

It completes the trio of cheap, DB-free, drift-catching meta-tests:

| Guard | Catches |
|---|---|
| `test_v1_default_deny` | every v1 route is role-gated or allowlisted; every `require_action` string is in the role table |
| `test_v1_list_pagination_shape` | every list endpoint is a `*Page` envelope or an allowlisted bare array |
| `test_v1_error_codes` (this PR) | every raised error code is in the catalog and the published doc |

## Verification (local, no Docker)
- New guard: 24 cases pass (forward + reverse + 22 doc-sync params).
- `ruff check src tests` clean; OpenAPI codegen-freshness + contract green.
- Zero non-English text in the diff.

https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom

---
_Generated by [Claude Code](https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom)_