### PR TITLE
  fix(security): fail closed on empty tenant scope for scheduled tasks

### DIFF
--- a/src/rolemesh/auth/external_jwt_provider.py
+++ b/src/rolemesh/auth/external_jwt_provider.py
@@ -61,7 +61,11 @@ class ExternalJwtProvider:
 
             user_id = str(payload.get(self._claim_user_id, ""))
             tenant_id = str(payload.get(self._claim_tenant_id, ""))
-            if not user_id:
+            # Require BOTH a user and a tenant. A missing/empty tenant claim
+            # used to fall through as tenant_id="" — which tenant-scoped reads
+            # could (mis)read as "no tenant scope", leaking across tenants.
+            # Reject under-specified tokens here, the auth entry point.
+            if not user_id or not tenant_id:
                 return None
 
             role = str(payload.get(self._claim_role, "member"))

--- a/src/rolemesh/db/task.py
+++ b/src/rolemesh/db/task.py
@@ -140,34 +140,30 @@ async def count_tasks(
 
 
 async def get_all_tasks(
-    tenant_id: str | None = None, *, limit: int | None = None, offset: int = 0,
+    tenant_id: str, *, limit: int | None = None, offset: int = 0,
 ) -> list[ScheduledTask]:
-    """Get all scheduled tasks, optionally filtered by tenant and paginated.
+    """Get a tenant's scheduled tasks (newest first), optionally paginated.
 
-    Treats both ``None`` and ``""`` as "no tenant scope" so callers
-    that build the parameter from an admin REST query string don't
-    accidentally pass an empty value into ``tenant_conn`` and trigger
-    fail-closed (current_tenant_id = NULL → RLS drops every row).
+    ``tenant_id`` is required: every row is filtered by ``WHERE tenant_id = ...``
+    over an RLS-bound connection. There is deliberately NO cross-tenant/admin
+    path here — an earlier branch that treated an empty ``tenant_id`` as "list
+    every tenant" (over ``admin_conn``) was a cross-tenant leak, reachable from
+    ``GET /api/v1/tasks`` whenever auth left the tenant claim blank. A caller
+    that genuinely needs a cross-tenant view must say so with its own
+    admin-gated query rather than passing an empty scope here.
     """
-    if tenant_id:
-        sql = (
-            "SELECT * FROM scheduled_tasks "
-            "WHERE tenant_id = $1::uuid ORDER BY created_at DESC"
-        )
-        params: list[object] = [tenant_id]
-        if limit is not None:
-            params.extend((limit, offset))
-            sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
-        async with tenant_conn(tenant_id) as conn:
-            rows = await conn.fetch(sql, *params)
-    else:
-        sql = "SELECT * FROM scheduled_tasks ORDER BY created_at DESC"
-        params = []
-        if limit is not None:
-            params.extend((limit, offset))
-            sql += " LIMIT $1 OFFSET $2"
-        async with admin_conn() as conn:
-            rows = await conn.fetch(sql, *params)
+    if not tenant_id:
+        raise ValueError("get_all_tasks requires a non-empty tenant_id")
+    sql = (
+        "SELECT * FROM scheduled_tasks "
+        "WHERE tenant_id = $1::uuid ORDER BY created_at DESC"
+    )
+    params: list[object] = [tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
+    async with tenant_conn(tenant_id) as conn:
+        rows = await conn.fetch(sql, *params)
     return [_record_to_scheduled_task(row) for row in rows]
 
 

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -40,6 +40,13 @@ async def get_current_user(request: Request) -> AuthenticatedUser:
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
+    # Defense in depth: every authenticated principal must be bound to a
+    # tenant. No /api/v1 surface serves a tenant-less identity, and an empty
+    # tenant_id reaching a tenant-scoped query is a cross-tenant leak, so deny
+    # it at this single chokepoint rather than trusting each handler.
+    if not user.tenant_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
     if await get_tenant_status(user.tenant_id) == "suspended":
         raise_error_response(
             "TENANT_SUSPENDED",

--- a/tests/auth/test_current_user_tenant_guard.py
+++ b/tests/auth/test_current_user_tenant_guard.py
@@ -1,0 +1,35 @@
+"""``get_current_user`` must reject an authenticated principal with no tenant.
+
+This is the single ``/api/v1`` auth chokepoint, so it is the belt-and-braces
+complement to the provider-level tenant check: even if some provider returns a
+user with an empty ``tenant_id``, a tenant-less identity reaching a
+tenant-scoped query is a cross-tenant leak and must be denied here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from rolemesh.auth.provider import AuthenticatedUser
+from webui.dependencies import get_current_user
+
+
+def _request_with_bearer() -> Request:
+    return Request(
+        {"type": "http", "headers": [(b"authorization", b"Bearer x")]},
+    )
+
+
+async def test_rejects_authenticated_user_without_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_auth(token: str) -> AuthenticatedUser:
+        return AuthenticatedUser(user_id="u1", tenant_id="", role="member")
+
+    monkeypatch.setattr("webui.auth.authenticate_ws", _fake_auth)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(_request_with_bearer())
+    assert exc.value.status_code == 401

--- a/tests/auth/test_external_jwt_provider.py
+++ b/tests/auth/test_external_jwt_provider.py
@@ -1,0 +1,72 @@
+"""Unit tests for ExternalJwtProvider claim validation.
+
+No DB / network: tokens are signed with a local HS256 secret and the provider
+is exercised directly, so these assert the claim-to-identity mapping in
+isolation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import jwt
+
+from rolemesh.auth.external_jwt_provider import ExternalJwtProvider
+
+if TYPE_CHECKING:
+    import pytest
+
+_SECRET = "unit-test-secret-padded-to-32-bytes-min"
+
+
+def _provider(monkeypatch: pytest.MonkeyPatch) -> ExternalJwtProvider:
+    # The provider snapshots its config in __init__, so set env BEFORE building.
+    monkeypatch.setenv("EXTERNAL_JWT_SECRET", _SECRET)
+    monkeypatch.setenv("EXTERNAL_JWT_ALGORITHMS", "HS256")
+    return ExternalJwtProvider()
+
+
+def _token(**claims: object) -> str:
+    return jwt.encode(claims, _SECRET, algorithm="HS256")
+
+
+async def test_rejects_token_missing_tenant_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A signature-valid token with no tenant claim must not authenticate.
+
+    Regression: it previously yielded ``AuthenticatedUser(tenant_id='')``,
+    which a tenant-scoped read could treat as "no tenant scope" and leak
+    across tenants. An under-specified token must fail closed at the provider.
+    """
+    provider = _provider(monkeypatch)
+    token = _token(sub="user-1", role="member")  # no tenant ("tid") claim
+    assert await provider.authenticate(token) is None
+
+
+async def test_rejects_token_with_empty_tenant_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider(monkeypatch)
+    token = _token(sub="user-1", tid="", role="member")
+    assert await provider.authenticate(token) is None
+
+
+async def test_rejects_token_missing_user_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider(monkeypatch)
+    token = _token(tid="tenant-1", role="member")  # no user ("sub") claim
+    assert await provider.authenticate(token) is None
+
+
+async def test_accepts_token_with_user_and_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _provider(monkeypatch)
+    token = _token(sub="user-1", tid="tenant-9", role="owner")
+    user = await provider.authenticate(token)
+    assert user is not None
+    assert user.user_id == "user-1"
+    assert user.tenant_id == "tenant-9"
+    assert user.role == "owner"

--- a/tests/db/test_pg.py
+++ b/tests/db/test_pg.py
@@ -377,3 +377,37 @@ async def test_log_task_run() -> None:
             status="success",
         )
     )
+
+
+async def test_get_all_tasks_rejects_empty_tenant_scope() -> None:
+    """An empty tenant scope must never enumerate other tenants' tasks.
+
+    Regression: ``get_all_tasks('')`` used to fall through to an ``admin_conn``
+    branch that listed EVERY tenant's rows. That path was reachable from
+    ``GET /api/v1/tasks`` whenever an auth provider left the tenant claim blank
+    (``AuthenticatedUser.tenant_id == ''``) — a cross-tenant leak. The helper
+    must now fail closed instead of widening to all tenants.
+    """
+    t_a, cw_a, _, _ = await _create_chain()
+    t_b, cw_b, _, _ = await _create_chain()
+    for tid_, cwid_, prompt_ in ((t_a, cw_a, "a-task"), (t_b, cw_b, "b-task")):
+        await create_task(
+            ScheduledTask(
+                id=str(uuid.uuid4()),
+                tenant_id=tid_,
+                coworker_id=cwid_,
+                prompt=prompt_,
+                schedule_type="cron",
+                schedule_value="0 9 * * *",
+                context_mode="group",
+                next_run="2024-01-02T09:00:00+00:00",
+                status="active",
+            )
+        )
+
+    # Normal path still works and stays isolated: tenant A sees only its task.
+    assert len(await get_all_tasks(t_a)) == 1
+
+    # An empty / missing scope must NOT list across tenants — fail closed.
+    with pytest.raises(ValueError):
+        await get_all_tasks("")


### PR DESCRIPTION
  ## Problem
  An external-JWT token missing its tenant claim authenticated as
  `AuthenticatedUser(tenant_id="")`. `GET /api/v1/tasks` passed that straight to
  `db.get_all_tasks()`, whose empty-`tenant_id` branch listed **every tenant's**
  `scheduled_tasks` over `admin_conn` (RLS-bypassing) — a cross-tenant leak. On
  the same request `count_tasks()` fail-closed to `0`, so the response even
  returned `{items: [all tenants' rows], total: 0}`.
  
  ## Fix (defense in depth, fail-closed at all three layers)
  - **`external_jwt_provider`** — reject tokens whose tenant claim is missing/empty.
  - **`get_current_user`** — deny tenant-less principals at the single `/api/v1` chokepoint.
  - **`db.get_all_tasks`** — require a non-empty `tenant_id`; drop the `admin_conn`
    all-tenant branch (no caller needs it). Clears the INV-1 tenant-predicate lint.

  ## Tests (red→green verified)
  - `test_get_all_tasks_rejects_empty_tenant_scope` — `get_all_tasks("")` leaked both
    tenants before / raises after; normal path stays isolated.
  - `test_external_jwt_provider.py` — missing/empty tenant claim → `None`.
  - `test_current_user_tenant_guard.py` — empty-tenant principal → 401.

  ## Verification
  Ruff clean; INV-1 lint green; 117-test regression pass across `/tasks`, db task
  CRUD, `tests/auth/`, delete-user-cancels-tasks.