### PR TITLE
Surface role capabilities + plane on GET /me (backend single source of truth)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -2728,7 +2728,7 @@ components:
 
     Me:
       type: object
-      required: [user_id, tenant_id, role]
+      required: [user_id, tenant_id, role, plane, capabilities]
       properties:
         user_id: { type: string }
         tenant_id: { type: string }
@@ -2736,7 +2736,22 @@ components:
         email: { type: string, nullable: true }
         role:
           type: string
-          enum: [owner, admin, member]
+          enum: [platform_admin, owner, admin, member]
+        plane:
+          type: string
+          enum: [tenant, platform]
+          description: |
+            `platform` only for the platform-superset role
+            (`platform_admin`); otherwise `tenant`.
+        capabilities:
+          type: array
+          items: { type: string }
+          description: |
+            The caller's capability actions (e.g. `coworker.manage`),
+            populated server-side from the role->action matrix. The SPA
+            renders affordances from this list and keeps no copy of the
+            matrix; the server still enforces every action via
+            `require_action` / ownership checks.
 
     BackendName:
       type: string

--- a/src/rolemesh/auth/permissions.py
+++ b/src/rolemesh/auth/permissions.py
@@ -124,6 +124,19 @@ def user_can(role: UserRole, action: str) -> bool:
     return action in _USER_ROLE_ACTIONS.get(role, set())
 
 
+def role_capabilities(role: UserRole) -> list[str]:
+    """Sorted capability actions a role holds.
+
+    The single source of truth is ``_USER_ROLE_ACTIONS`` — this is what the
+    SPA reads (via ``Me.capabilities``) to show/hide affordances, so the
+    client never keeps its own copy of the matrix. This is NOT an
+    enforcement path: ``require_action`` / ``require_manage_or_owner`` do the
+    real, fail-closed checks server-side. An unknown role yields an empty
+    list (fail-closed).
+    """
+    return sorted(_USER_ROLE_ACTIONS.get(role, set()))
+
+
 # ---------------------------------------------------------------------------
 # Agent permissions
 # ---------------------------------------------------------------------------

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -29,7 +29,11 @@ CoworkerStatus = Literal["active", "paused", "disabled"]
 # only; 'shared' = whole tenant.
 Visibility = Literal["private", "shared"]
 AuthMode = Literal["external", "oidc", "builtin", "bootstrap"]
-UserRole = Literal["owner", "admin", "member"]
+# Includes ``platform_admin`` (the platform-plane superset role): a seeded
+# platform_admin authenticates and hits ``/me`` like anyone else, so the wire
+# role must be able to represent it.
+UserRole = Literal["platform_admin", "owner", "admin", "member"]
+Plane = Literal["tenant", "platform"]
 # Platform tenant lifecycle state (mirrors the tenants.status CHECK).
 TenantStatus = Literal["active", "suspended"]
 
@@ -110,7 +114,16 @@ class WsTicket(BaseModel):
 
 
 class Me(BaseModel):
-    """Identity surfacing for the SPA's user-menu."""
+    """Identity surfacing for the SPA's user-menu.
+
+    ``capabilities`` is the caller's action set, populated server-side from
+    the role->action matrix (``rolemesh.auth.permissions``). The SPA renders
+    affordances from ``capabilities.includes(...)`` and never keeps its own
+    copy of the matrix; the backend stays the single source of truth and the
+    real enforcement still happens in ``require_action`` /
+    ``require_manage_or_owner``. ``plane`` is ``"platform"`` only for the
+    platform-superset role, else ``"tenant"``.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -119,6 +132,8 @@ class Me(BaseModel):
     name: str | None = None
     email: str | None = None
     role: UserRole
+    plane: Plane
+    capabilities: list[str]
 
 
 # ---------------------------------------------------------------------------

--- a/src/webui/v1/auth.py
+++ b/src/webui/v1/auth.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 import asyncpg
 from fastapi import APIRouter, Depends, Response
 
+from rolemesh.auth.permissions import role_capabilities
 from rolemesh.auth.ws_ticket import WsTicketError, issue_ws_ticket
 from rolemesh.db import get_conversation
 from webui.dependencies import get_current_user
@@ -151,6 +152,10 @@ def _user_to_me(user: AuthenticatedUser) -> Me:
         name=user.name,
         email=user.email,
         role=user.role,  # type: ignore[arg-type]
+        plane="platform" if user.role == "platform_admin" else "tenant",
+        # Single source of truth: the role->action matrix. The SPA renders
+        # from this list; the server still enforces via require_action.
+        capabilities=role_capabilities(user.role),  # type: ignore[arg-type]
     )
 
 

--- a/tests/webui/test_v1_auth_endpoints.py
+++ b/tests/webui/test_v1_auth_endpoints.py
@@ -187,6 +187,11 @@ async def test_me_returns_caller_identity() -> None:
     assert body["tenant_id"] == tid
     assert body["role"] == "owner"
     assert body["name"] == "Alice"
+    # Capabilities + plane are surfaced from the role->action matrix so the
+    # SPA renders affordances without copying the matrix client-side.
+    assert body["plane"] == "tenant"
+    assert "coworker.manage" in body["capabilities"]
+    assert "credential.pool.manage" not in body["capabilities"]  # platform-only
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webui/test_v1_me_capabilities.py
+++ b/tests/webui/test_v1_me_capabilities.py
@@ -1,0 +1,63 @@
+"""``GET /api/v1/me`` capabilities/plane reflect the role->action matrix.
+
+These run without a DB: they call the wire projection directly. The point
+is to pin that ``Me.capabilities`` is *derived from*
+``rolemesh.auth.permissions._USER_ROLE_ACTIONS`` (the single source of
+truth), not a hand-maintained copy — so the SPA can branch on
+``capabilities`` while the server keeps doing the real enforcement in
+``require_action`` / ``require_manage_or_owner``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.auth.permissions import (
+    _USER_ROLE_ACTIONS,
+    role_capabilities,
+)
+from rolemesh.auth.provider import AuthenticatedUser
+from webui.v1.auth import _user_to_me
+
+_ROLES = ["platform_admin", "owner", "admin", "member"]
+
+
+def _me(role: str):
+    return _user_to_me(
+        AuthenticatedUser(
+            user_id="u", tenant_id="t", role=role, email="e@x", name="N",
+        )
+    )
+
+
+@pytest.mark.parametrize("role", _ROLES)
+def test_me_capabilities_equal_the_role_table(role: str) -> None:
+    me = _me(role)
+    assert me.capabilities == sorted(_USER_ROLE_ACTIONS[role])
+    assert me.role == role
+
+
+@pytest.mark.parametrize("role", _ROLES)
+def test_me_plane_is_platform_only_for_platform_admin(role: str) -> None:
+    assert _me(role).plane == (
+        "platform" if role == "platform_admin" else "tenant"
+    )
+
+
+def test_platform_admin_capabilities_are_the_superset() -> None:
+    # The platform-superset role must hold every other role's actions.
+    union: set[str] = set()
+    for r in ("owner", "admin", "member"):
+        union |= set(_USER_ROLE_ACTIONS[r])
+    assert union <= set(_me("platform_admin").capabilities)
+
+
+def test_member_cannot_see_manage_affordances() -> None:
+    caps = set(_me("member").capabilities)
+    assert "coworker.create" in caps
+    assert "coworker.manage" not in caps
+    assert "user.manage" not in caps
+
+
+def test_role_capabilities_is_fail_closed_for_unknown_role() -> None:
+    assert role_capabilities("nope") == []  # type: ignore[arg-type]

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -1655,7 +1655,21 @@ export interface components {
             name?: string;
             email?: string | null;
             /** @enum {string} */
-            role: "owner" | "admin" | "member";
+            role: "platform_admin" | "owner" | "admin" | "member";
+            /**
+             * @description `platform` only for the platform-superset role
+             *     (`platform_admin`); otherwise `tenant`.
+             * @enum {string}
+             */
+            plane: "tenant" | "platform";
+            /**
+             * @description The caller's capability actions (e.g. `coworker.manage`),
+             *     populated server-side from the role->action matrix. The SPA
+             *     renders affordances from this list and keeps no copy of the
+             *     matrix; the server still enforces every action via
+             *     `require_action` / ownership checks.
+             */
+            capabilities: string[];
         };
         /**
          * @description Backend runtime identifier. Mirrors

--- a/web/src/components/chat-shell.test.ts
+++ b/web/src/components/chat-shell.test.ts
@@ -87,6 +87,8 @@ const ME: Me = {
   name: 'Jerry Guan',
   email: 'j@example.com',
   role: 'owner',
+  plane: 'tenant',
+  capabilities: [],
 };
 
 function conv(id: string, name: string, when: Date): Conversation {


### PR DESCRIPTION
## Summary

The SPA needs to show/hide affordances by capability, but it must not keep its own copy of the role→action matrix — that copy inevitably drifts from the server's real rules. So surface the matrix on `GET /api/v1/me` and have the SPA render from it; the backend stays the single source of truth and keeps doing all real enforcement.

## What changed

**Backend (no new authorization logic — the matrix already lives in `_USER_ROLE_ACTIONS`)**
- `rolemesh.auth.permissions`: new public `role_capabilities(role) -> list[str]` = `sorted(_USER_ROLE_ACTIONS[role])`, fail-closed (`[]`) for an unknown role.
- `Me` gains `capabilities: list[str]` (the caller's actions, e.g. `coworker.manage`) and `plane: "tenant" | "platform"`, populated in `_user_to_me`. This is render-only data — `require_action` / `require_manage_or_owner` still do every real, fail-closed check.

**Also fixes a latent 500**
`Me.role` was `Literal["owner","admin","member"]` — it excluded `platform_admin`, which is a real seeded role that authenticates and hits `/me`. Its `/me` would 500 on the role Literal today, and `plane="platform"` was unreachable. Expanded the wire `UserRole` / `Me.role` enum to include `platform_admin` (additive).

**Contract**
`Me` schema gains `plane` + `capabilities` (required) and the role enum gains `platform_admin`; regenerated `types.ts`. Updated the one SPA `Me` literal in tests.

## Guard
`tests/webui/test_v1_me_capabilities.py` (no DB) pins that `Me.capabilities == sorted(_USER_ROLE_ACTIONS[role])` for every role — so it can never become a hand-maintained copy — plus `plane` is `platform` only for `platform_admin`, the superset invariant holds, and the accessor is fail-closed. Observed projection: platform_admin 17 caps (plane=platform), owner 13, admin 11, member 3.

## Verification (local, no Docker)
- New guard (11 cases) + existing gate suite (default-deny, list-shape, error-codes, OpenAPI codegen-freshness + contract) green.
- `ruff check src tests` clean; no new mypy errors.
- Frontend `tsc` at baseline (no new errors); vitest 553 passing.
- Zero non-English text in the diff.

The `/me` endpoint's DB-backed assertions (now checking `plane`/`capabilities`) run in CI (testcontainers Postgres needs Docker).

https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom

---
_Generated by [Claude Code](https://claude.ai/code/session_011ze4JPqmE8jFPPHcgV8Gom)_