### PR TITLE
fix(api-v1): bind message-cursor timestamp as datetime, not str

### DIFF
--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import base64
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 import asyncpg
@@ -265,21 +266,19 @@ async def list_conversation_messages(
     if before is not None:
         try:
             cur_ts, cur_id = _decode_message_cursor(before)
+            # Bind the cursor timestamp as a datetime: asyncpg rejects a
+            # plain str for a timestamptz parameter (DataError), which 400'd
+            # a page's own valid next_cursor when walking older on page 2.
+            cur_dt = datetime.fromisoformat(cur_ts)
         except ValueError:
             raise_error_response(
                 "INVALID_CURSOR",
                 "Malformed pagination cursor.",
                 status_code=400,
             )
-        # Keyset seek on (timestamp, id), newest-first. Written as an
-        # explicit OR rather than a row-constructor comparison
-        # ``(timestamp, id) < ($3, $4)`` so BOTH bound params carry an
-        # explicit cast ($3 timestamptz, $4 text — messages.id is TEXT). A
-        # bare param inside a row constructor left Postgres unable to resolve
-        # its type, which surfaced as a query error on the second page (the
-        # only path that binds the cursor) — a page's own next_cursor came
-        # back looking "invalid".
-        params.extend((cur_ts, cur_id))
+        # Keyset seek on (timestamp, id), newest-first: rows strictly older
+        # than the cursor, with id as the tiebreak at an equal timestamp.
+        params.extend((cur_dt, cur_id))
         where += (
             " AND (timestamp < $3::timestamptz"
             " OR (timestamp = $3::timestamptz AND id < $4::text))"
@@ -295,8 +294,9 @@ async def list_conversation_messages(
         async with tenant_conn(user.tenant_id) as conn:
             rows_desc = await conn.fetch(sql, *params)
     except asyncpg.DataError:
-        # A cursor that base64-decodes but carries a bad timestamp (the
-        # ``$3::timestamptz`` cast then fails) — still a malformed cursor.
+        # Defensive belt: a malformed cursor is normally rejected above when
+        # its timestamp fails to parse; this keeps any residual bad-data query
+        # error a 400 rather than a 500.
         raise_error_response(
             "INVALID_CURSOR",
             "Malformed pagination cursor.",


### PR DESCRIPTION
## Problem
`GET /api/v1/conversations/{id}/messages` keyset-paginates with an opaque cursor. `_decode_message_cursor` returns the timestamp as a **`str`**, which the handler bound to a `$N::timestamptz` parameter. asyncpg rejects a `str` for a `timestamptz` param:

```
DataError: invalid input for query argument $1: '2026-...' (expected a datetime.date or datetime.datetime instance, got 'str')
```

So **page 2** — the only request that carries a cursor — returned `400 INVALID_CURSOR` on a page's *own* valid `next_cursor`. Page 1 (no cursor) worked, masking it. A prior commit (`ad97b4f`) rewrote the row comparison but did not change the parameter type, so the bug remained and `test_messages_cursor_pagination_walks_older` has been red on `main`.

## Fix
Parse the decoded timestamp with `datetime.fromisoformat` before binding, so asyncpg gets a `datetime`. A genuinely malformed timestamp still raises `ValueError` and 400s through the existing `INVALID_CURSOR` path; the `asyncpg.DataError` branch becomes a defensive belt.

## Test
No new test needed — the existing `tests/webui/test_v1_conversations.py::test_messages_cursor_pagination_walks_older` walks page1→page2 and was **red before / green after**. Full conversations suite (13) passes; ruff clean.

> Companion PR: the same `str`→`::timestamptz` pattern in safety-decisions `from_ts`/`to_ts` (`fix/safety-decisions-timestamptz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)