### PR TITLE
fix(api-v1): parse safety-decision from_ts/to_ts as datetime, not str

### DIFF
--- a/src/rolemesh/db/safety.py
+++ b/src/rolemesh/db/safety.py
@@ -9,6 +9,7 @@ from rolemesh.db._pool import tenant_conn
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+    from datetime import datetime
 
     import asyncpg
 
@@ -467,8 +468,8 @@ async def insert_safety_decision(
 async def stream_safety_decisions(
     tenant_id: str,
     *,
-    from_ts: str | None = None,
-    to_ts: str | None = None,
+    from_ts: datetime | None = None,
+    to_ts: datetime | None = None,
     verdict_action: str | None = None,
     coworker_id: str | None = None,
     stage: str | None = None,
@@ -481,11 +482,10 @@ async def stream_safety_decisions(
     flat list of dicts with the same shape as ``list_safety_decisions``
     (caller picks which fields to put on the CSV row).
 
-    ``from_ts`` / ``to_ts`` are ISO-8601 strings coerced to
-    ``timestamptz`` inside the query so operators can write
-    ``"2026-04-01"`` or ``"2026-04-01T00:00:00+00:00"`` interchangeably.
-    Malformed timestamps raise at query time (psycopg surface) which
-    the REST layer turns into 422.
+    ``from_ts`` / ``to_ts`` are ``datetime`` bounds on ``created_at``.
+    They must be ``datetime``, not str: asyncpg binds a timestamptz
+    parameter from a datetime, so the REST layer parses the ISO-8601
+    query string (and 422s a malformed value) before calling here.
     """
     clauses = ["tenant_id = $1::uuid"]
     params: list[Any] = [tenant_id]
@@ -599,8 +599,8 @@ def _safety_decision_where_clauses(
     verdict_action: str | None,
     coworker_id: str | None,
     stage: str | None,
-    from_ts: str | None,
-    to_ts: str | None,
+    from_ts: datetime | None,
+    to_ts: datetime | None,
     check_id: str | None = None,
     rule_id: str | None = None,
 ) -> tuple[str, list[Any]]:
@@ -656,8 +656,8 @@ async def count_safety_decisions(
     verdict_action: str | None = None,
     coworker_id: str | None = None,
     stage: str | None = None,
-    from_ts: str | None = None,
-    to_ts: str | None = None,
+    from_ts: datetime | None = None,
+    to_ts: datetime | None = None,
     check_id: str | None = None,
     rule_id: str | None = None,
 ) -> int:
@@ -692,8 +692,8 @@ async def list_safety_decisions(
     verdict_action: str | None = None,
     coworker_id: str | None = None,
     stage: str | None = None,
-    from_ts: str | None = None,
-    to_ts: str | None = None,
+    from_ts: datetime | None = None,
+    to_ts: datetime | None = None,
     check_id: str | None = None,
     rule_id: str | None = None,
     limit: int = 200,

--- a/src/webui/v1/safety.py
+++ b/src/webui/v1/safety.py
@@ -571,6 +571,25 @@ async def list_checks(
     return out
 
 
+def _parse_decision_ts(raw: str | None, field: str) -> datetime | None:
+    """Parse an ISO-8601 ``from_ts`` / ``to_ts`` query value to a datetime.
+
+    asyncpg binds a timestamptz parameter from a datetime, not a str, so the
+    range filter is parsed here at the edge. A malformed value is a 422
+    rather than a query-time DataError (which surfaced as an unhandled 500).
+    """
+    if raw is None:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        raise_error_response(
+            "INVALID_REQUEST",
+            f"Query parameter '{field}' must be an ISO-8601 timestamp.",
+            status_code=422,
+        )
+
+
 @router.get("/decisions", response_model=SafetyDecisionPage)
 async def list_decisions(
     verdict_action: SafetyVerdictAction | None = None,
@@ -596,13 +615,15 @@ async def list_decisions(
     catalogs) and tests for array overlap; ``rule_id`` tests array
     containment against ``triggered_rule_ids``.
     """
+    from_dt = _parse_decision_ts(from_ts, "from_ts")
+    to_dt = _parse_decision_ts(to_ts, "to_ts")
     total = await count_safety_decisions(
         user.tenant_id,
         verdict_action=verdict_action,
         coworker_id=coworker_id,
         stage=stage,
-        from_ts=from_ts,
-        to_ts=to_ts,
+        from_ts=from_dt,
+        to_ts=to_dt,
         check_id=check_id,
         rule_id=rule_id,
     )
@@ -611,8 +632,8 @@ async def list_decisions(
         verdict_action=verdict_action,
         coworker_id=coworker_id,
         stage=stage,
-        from_ts=from_ts,
-        to_ts=to_ts,
+        from_ts=from_dt,
+        to_ts=to_dt,
         check_id=check_id,
         rule_id=rule_id,
         limit=limit,
@@ -852,13 +873,15 @@ async def export_decisions_csv(
     ``GET /safety/decisions/{id}``.
     """
     tid = user.tenant_id
+    from_dt = _parse_decision_ts(from_ts, "from_ts")
+    to_dt = _parse_decision_ts(to_ts, "to_ts")
 
     async def _generate() -> AsyncIterator[bytes]:
         yield (",".join(_CSV_COLUMNS) + "\n").encode("utf-8")
         async for chunk in db.stream_safety_decisions(
             tid,
-            from_ts=from_ts,
-            to_ts=to_ts,
+            from_ts=from_dt,
+            to_ts=to_dt,
             verdict_action=verdict_action,
             coworker_id=coworker_id,
             stage=stage,

--- a/tests/webui/test_v1_safety.py
+++ b/tests/webui/test_v1_safety.py
@@ -682,3 +682,85 @@ async def test_get_decision_findings_round_trip() -> None:
     assert codes == {"PII.SSN", "TOOL.SLOW"}
     pii = next(f for f in body["findings"] if f["code"] == "PII.SSN")
     assert pii["metadata"] == {"position": 42}
+
+
+# ---------------------------------------------------------------------------
+# Decisions time-range filter (from_ts / to_ts)
+#
+# asyncpg binds a timestamptz parameter from a datetime, not a str. The
+# endpoint took the filter as a raw ISO string and handed it to a
+# ``$N::timestamptz`` query param, so ANY value (even a valid date) raised
+# DataError -> unhandled 500. It stayed hidden because no test passed these
+# params. These tests pass real values.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_decisions_from_ts_filters_without_500() -> None:
+    """A valid ISO ``from_ts`` must filter, not 500.
+
+    Regression: a far-past ``from_ts`` should still include a just-created
+    decision (created_at >= from_ts); a far-future ``from_ts`` excludes it.
+    """
+    user, _ = await _make_user("fts")
+    rid = await _seed_decision(user.tenant_id, summary="recent")
+
+    async with _client(_build_app(user)) as ac:
+        past = await ac.get(
+            "/api/v1/safety/decisions?from_ts=2000-01-01T00:00:00Z",
+            headers=_HDRS,
+        )
+        future = await ac.get(
+            "/api/v1/safety/decisions?from_ts=2999-01-01T00:00:00Z",
+            headers=_HDRS,
+        )
+    assert past.status_code == 200, past.text
+    assert rid in {it["id"] for it in past.json()["items"]}
+    assert past.json()["total"] == 1
+    assert future.status_code == 200, future.text
+    assert future.json()["items"] == []
+    assert future.json()["total"] == 0
+
+
+async def test_list_decisions_to_ts_filters_without_500() -> None:
+    user, _ = await _make_user("tts")
+    rid = await _seed_decision(user.tenant_id, summary="recent")
+
+    async with _client(_build_app(user)) as ac:
+        future = await ac.get(
+            "/api/v1/safety/decisions?to_ts=2999-01-01T00:00:00Z",
+            headers=_HDRS,
+        )
+        past = await ac.get(
+            "/api/v1/safety/decisions?to_ts=2000-01-01T00:00:00Z",
+            headers=_HDRS,
+        )
+    assert future.status_code == 200, future.text
+    assert rid in {it["id"] for it in future.json()["items"]}
+    assert past.status_code == 200, past.text
+    assert past.json()["items"] == []
+
+
+async def test_list_decisions_malformed_ts_is_422_not_500() -> None:
+    """A garbage timestamp is a client error (422), never an unhandled 500."""
+    user, _ = await _make_user("bts")
+    await _seed_decision(user.tenant_id, summary="x")
+
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get(
+            "/api/v1/safety/decisions?from_ts=not-a-date", headers=_HDRS,
+        )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_export_decisions_csv_from_ts_without_500() -> None:
+    """CSV export shares the same str->timestamptz path via stream_*."""
+    user, _ = await _make_user("csv")
+    await _seed_decision(user.tenant_id, summary="exported")
+
+    async with _client(_build_app(user)) as ac:
+        resp = await ac.get(
+            "/api/v1/safety/decisions.csv?from_ts=2000-01-01T00:00:00Z",
+            headers=_HDRS,
+        )
+    assert resp.status_code == 200, resp.text
+    assert "exported" in resp.text


### PR DESCRIPTION
## Problem
`list_safety_decisions` / `count_safety_decisions` / `stream_safety_decisions` bound the `from_ts`/`to_ts` filter **strings** to `$N::timestamptz` query params. asyncpg rejects a `str` for a `timestamptz` param (`DataError`, expects a datetime), so **any** date-range filter on `GET /api/v1/safety/decisions` or the CSV export `GET /api/v1/safety/decisions.csv` returned an **unhandled 500** — for every value, not just malformed ones.

Reachable from user input: the REST endpoints expose `from_ts`/`to_ts` query params (safety.read gated) and pass them straight through. It stayed hidden only because **no test passed these params** (the `if from_ts is not None` branch was never exercised). The db docstring even claimed "psycopg surface … REST turns into 422", which was wrong on both counts (it's asyncpg, and there was no 422 handler).

Same root cause as the message-cursor fix (#73).

## Fix
- **db.safety**: `from_ts`/`to_ts` are `datetime` (not `str`) on `stream`/`count`/`list` and the shared where-clause helper; corrected the docstring.
- **REST**: parse the ISO-8601 query strings at the edge (`_parse_decision_ts`), returning **422 `INVALID_REQUEST`** on a malformed value *before* the query (and before the CSV stream starts).

## Tests
Adds the missing coverage that hid this — tests that **do** pass `from_ts`/`to_ts`:
- valid `from_ts`/`to_ts` filter (past includes / future excludes), no 500
- malformed timestamp → 422 (not 500)
- CSV export with `from_ts`

Red before (4× `DataError`), green after. Safety scope regression (83 tests) passes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)