### PR TITLE
feat(web): RBAC role-aware UI v3 (capability-gated nav, platform shell, ownership-aware pages)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -3459,6 +3459,15 @@ components:
         visibility: { $ref: '#/components/schemas/Visibility' }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+        created_by_user_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: |
+            Owner of the skill, or null for platform-default rows.
+            Surfaced on the list projection so the role-aware skills
+            page can drive ownership-escape affordances without an
+            N+1 fetch of each full skill.
 
     SkillCreate:
       type: object

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -745,6 +745,12 @@ class SkillSummary(BaseModel):
     visibility: Visibility
     created_at: str
     updated_at: str
+    # Owner of the skill (the user who created it), or ``None`` for
+    # platform-default rows. Surfaced on the list projection — not just
+    # the full ``Skill`` — so the role-aware skills page can drive the
+    # ownership-escape affordances (own-row Edit/Delete, "Mine" filter)
+    # without an N+1 fetch of each full skill.
+    created_by_user_id: str | None = None
 
 
 class SkillCreate(BaseModel):

--- a/src/webui/v1/skills.py
+++ b/src/webui/v1/skills.py
@@ -128,6 +128,7 @@ def _skill_to_summary(s: SkillDataclass, bound_count: int) -> SkillSummary:
         visibility=s.visibility,  # type: ignore[arg-type]
         created_at=s.created_at,
         updated_at=s.updated_at,
+        created_by_user_id=s.created_by_user_id,
     )
 
 

--- a/tests/webui/test_v1_skills.py
+++ b/tests/webui/test_v1_skills.py
@@ -181,6 +181,30 @@ async def test_list_skills_returns_summary_with_zero_bound_count() -> None:
     assert any(s["name"] == "a" and s["bound_coworker_count"] == 0 for s in rows)
 
 
+async def test_list_skills_summary_carries_created_by_user_id() -> None:
+    """The list projection must expose ``created_by_user_id`` (the
+    creator) so the role-aware skills page can drive ownership-escape
+    affordances — own-row Edit/Delete and the "Mine" filter — without an
+    N+1 fetch of each full skill.
+
+    Regression: ``SkillSummary`` previously dropped this field while the
+    full ``Skill`` carried it, so the frontend list view classified every
+    row as unowned and members lost the Edit/Delete shortcut on their own
+    skills.
+    """
+    user, _cw = await _make_user_and_coworker("owns")
+    async with _client(_build_app(user)) as ac:
+        await ac.post(
+            "/api/v1/skills",
+            json={"name": "mine", "files": {"SKILL.md": _skill_md("mine")}},
+            headers=_HDRS,
+        )
+        resp = await ac.get("/api/v1/skills", headers=_HDRS)
+    assert resp.status_code == 200
+    row = next(s for s in resp.json()["items"] if s["name"] == "mine")
+    assert str(row["created_by_user_id"]) == str(user.user_id)
+
+
 async def test_patch_skill_enables_and_publishes_event(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -76,6 +76,10 @@ export type ApprovalPolicyUpdate =
 export type ApprovalRequest =
   components['schemas']['ApprovalRequest'];
 export type ConditionExpr = components['schemas']['ConditionExpr'];
+export type PlatformTenantResponse =
+  components['schemas']['PlatformTenantResponse'];
+export type PlatformTenantProvision =
+  components['schemas']['PlatformTenantProvision'];
 
 export type ErrorResponseBody =
   paths['/api/v1/runs/{id}/cancel']['post']['responses']['409']['content']['application/json'];
@@ -733,6 +737,60 @@ export class ApiClient {
     if (resp.status === 409) return { ok: false, alreadyTerminal: true };
     if (!resp.ok) throw await this.parseError(resp);
     return { ok: true, alreadyTerminal: false };
+  }
+
+  // ------------------------------------------------------------------
+  // Platform-plane tenants (RBAC UI PR3, D1). Gated server-side by
+  // `platform.tenant.manage`; only a `platform_admin` reaches these.
+  // The list endpoint returns a bare array (NOT a paged envelope),
+  // unlike the tenant-plane list methods above — confirmed against
+  // `generated/types.ts:listPlatformTenants`.
+  // ------------------------------------------------------------------
+
+  async listTenants(): Promise<PlatformTenantResponse[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/platform/tenants`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as PlatformTenantResponse[];
+  }
+
+  /** Provision a new tenant. Body is `{ name, slug? }` only — the
+   *  server fills `plan` / `max_concurrent_containers` / `status`.
+   *  Returns the created row (201). */
+  async provisionTenant(
+    body: PlatformTenantProvision,
+  ): Promise<PlatformTenantResponse> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/platform/tenants`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as PlatformTenantResponse;
+  }
+
+  /** Suspend a tenant (status → `suspended`). The `__platform__`
+   *  sentinel tenant cannot be suspended — the server answers 403 and
+   *  the caller surfaces that error, not a client-side special case. */
+  async suspendTenant(id: string): Promise<PlatformTenantResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/platform/tenants/${encodeURIComponent(id)}/suspend`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as PlatformTenantResponse;
+  }
+
+  /** Resume a suspended tenant (status → `active`). */
+  async resumeTenant(id: string): Promise<PlatformTenantResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/platform/tenants/${encodeURIComponent(id)}/resume`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as PlatformTenantResponse;
   }
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -593,6 +593,34 @@ export class ApiClient {
     if (!resp.ok) throw await this.parseError(resp);
   }
 
+  /** Flip a skill's visibility to `shared` (tenant-wide). Mirrors
+   *  `shareCoworker`: the route is gated server-side by the low
+   *  `skill.use` capability, but real authorization is the ownership
+   *  escape (a member may share only what they created; owner/admin/
+   *  platform_admin may share any). Idempotent; returns the FULL Skill
+   *  (not the SkillSummary the list page holds — the caller patches the
+   *  row's `visibility`/`created_by_user_id` from it). RBAC UI PR5. */
+  async shareSkill(id: string): Promise<Skill> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}/share`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
+  }
+
+  /** Flip a skill's visibility back to `private`. Same own-or-manage
+   *  authorization as `shareSkill`. Idempotent; returns the updated
+   *  Skill. RBAC UI PR5. */
+  async unshareSkill(id: string): Promise<Skill> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}/unshare`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
+  }
+
   /** Path segments are NOT URL-encoded — the server's
    *  ``{path:path}`` matcher accepts slashes, and an encoded ``%2F``
    *  would render the wrong path. Callers must validate path shape

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -264,6 +264,32 @@ export class ApiClient {
     if (!resp.ok) throw await this.parseError(resp);
   }
 
+  /** Flip a coworker's visibility to `shared` (tenant-wide). The route
+   *  is gated server-side by the low `coworker.use` capability, but real
+   *  authorization is the ownership escape (a member may share only what
+   *  they created; owner/admin/platform_admin may share any). Idempotent;
+   *  returns the updated coworker (feat/roles, RBAC UI PR4). */
+  async shareCoworker(id: string): Promise<Coworker> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}/share`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Coworker;
+  }
+
+  /** Flip a coworker's visibility back to `private`. Same own-or-manage
+   *  authorization as `shareCoworker`. Idempotent; returns the updated
+   *  coworker (feat/roles, RBAC UI PR4). */
+  async unshareCoworker(id: string): Promise<Coworker> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}/unshare`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Coworker;
+  }
+
   async listCoworkerConversations(coworkerId: string): Promise<Conversation[]> {
     // Paged endpoint; request the max window and return items (array shape
     // preserved for callers; full page-through UI is a follow-up).

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2151,6 +2151,14 @@ export interface components {
             created_at: string;
             /** Format: date-time */
             updated_at: string;
+            /**
+             * Format: uuid
+             * @description Owner of the skill, or null for platform-default rows.
+             *     Surfaced on the list projection so the role-aware skills
+             *     page can drive ownership-escape affordances without an
+             *     N+1 fetch of each full skill.
+             */
+            created_by_user_id?: string | null;
         };
         SkillCreate: {
             /**

--- a/web/src/app.test.ts
+++ b/web/src/app.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment happy-dom
+//
+// <rm-app> — the auth state machine. The contract under test is the
+// ATOMIC bootstrap (spec §7.2): authState must NOT flip to 'authenticated'
+// until the Me cache is populated, so no sub-shell ever mounts while
+// currentMe() is null. We drive the real capabilities module (no mock) so
+// the setMe/currentMe wiring is exercised end-to-end; we mock only the two
+// true boundaries — the api client's getMe and the oidc-auth services that
+// decide which token branch resolveAuth takes.
+//
+// Shell-isolation trick: <rm-chat-shell> ALSO calls api.getMe() on mount,
+// which would pollute a "getMe called N times" spy. settings-shell and
+// activity-shell do NOT call getMe, so tests that need to count <rm-app>'s
+// own getMe calls (or assert ZERO, for D2) route to #/manage or #/activity
+// instead of the chat hash. That keeps the spy a faithful witness to
+// <rm-app>'s behaviour, not the child shell's.
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type { Me } from './api/client.js';
+
+// --- boundary mocks (hoisted) ----------------------------------------------
+
+const getMeSpy = vi.fn();
+const scheduleRefreshSpy = vi.fn();
+
+// Permissive client stub: the spied getMe plus no-op list/get methods so a
+// slotted shell that incidentally mounts doesn't throw on unmocked calls.
+vi.mock('./api/client.js', async () => {
+  const actual = await vi.importActual<typeof import('./api/client.js')>(
+    './api/client.js',
+  );
+  const empty = vi.fn().mockResolvedValue([]);
+  const single = vi.fn().mockResolvedValue(null);
+  return {
+    ...actual,
+    getApiClient: () => ({
+      getMe: getMeSpy,
+      listCoworkers: empty,
+      listModels: empty,
+      listCredentials: empty,
+      listSkills: empty,
+      listMCPServers: empty,
+      listSafetyRules: empty,
+      listSafetyDecisions: single,
+      listTelegramLinks: empty,
+      setToken: vi.fn(),
+    }),
+  };
+});
+
+// oidc-auth: the four token-source functions + the refresh scheduler. Each
+// test sets these to steer resolveToken down a specific branch. Defaults
+// (set in beforeEach) put us on the legacy / no-auth path.
+const fetchAuthConfigSpy = vi.fn();
+const getStoredTokenSpy = vi.fn();
+const handleCallbackSpy = vi.fn();
+const isTokenExpiredSpy = vi.fn();
+
+vi.mock('./services/oidc-auth.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('./services/oidc-auth.js')
+  >('./services/oidc-auth.js');
+  return {
+    ...actual,
+    fetchAuthConfig: (...a: unknown[]) => fetchAuthConfigSpy(...a),
+    getStoredToken: (...a: unknown[]) => getStoredTokenSpy(...a),
+    handleCallback: (...a: unknown[]) => handleCallbackSpy(...a),
+    isTokenExpired: (...a: unknown[]) => isTokenExpiredSpy(...a),
+    scheduleRefresh: (...a: unknown[]) => scheduleRefreshSpy(...a),
+  };
+});
+
+// Real capabilities module — NOT mocked, so the cache wiring is tested.
+import { currentMe, setMe } from './auth/capabilities.js';
+// Import the element module ONCE; this registers <rm-app> + the shells.
+import './app.js';
+import type { RmApp } from './app.js';
+
+const ME: Me = {
+  user_id: 'u-alice',
+  tenant_id: 't1',
+  name: 'Alice',
+  email: 'alice@example.com',
+  role: 'admin',
+  plane: 'tenant',
+  capabilities: ['coworker.create', 'mcp.configure'],
+};
+
+/** Flush microtasks + Lit's update queue a bounded number of times so an
+ *  awaited getMe and the subsequent re-render settle. */
+async function settle(el: RmApp, rounds = 30): Promise<void> {
+  for (let i = 0; i < rounds; i += 1) {
+    await Promise.resolve();
+    await el.updateComplete;
+  }
+}
+
+function mount(hash = '#/manage/coworkers'): RmApp {
+  location.hash = hash;
+  const el = document.createElement('rm-app') as RmApp;
+  document.body.appendChild(el);
+  return el;
+}
+
+/** True if any of the three sub-shell elements is present in the subtree. */
+function anyShell(el: RmApp): boolean {
+  return !!el.querySelector(
+    'rm-chat-shell, rm-settings-shell, rm-activity-shell',
+  );
+}
+
+beforeEach(() => {
+  setMe(null); // reset the real cache between tests
+  getMeSpy.mockReset();
+  scheduleRefreshSpy.mockReset();
+  fetchAuthConfigSpy.mockReset().mockResolvedValue(null);
+  getStoredTokenSpy.mockReset().mockReturnValue(null);
+  handleCallbackSpy.mockReset().mockResolvedValue(null);
+  isTokenExpiredSpy.mockReset().mockReturnValue(false);
+  sessionStorage.clear();
+  location.hash = '';
+});
+
+afterEach(() => {
+  document.querySelectorAll('rm-app').forEach((el) => el.remove());
+});
+
+describe('<rm-app> atomic auth+me bootstrap (§7.2)', () => {
+  it('shows Loading and mounts NO sub-shell while getMe is pending, then mounts the shell with currentMe() populated', async () => {
+    // Stored-token branch with a getMe that resolves only when we release it.
+    getStoredTokenSpy.mockReturnValue('tok-123');
+    let release!: (me: Me) => void;
+    getMeSpy.mockReturnValue(
+      new Promise<Me>((res) => {
+        release = res;
+      }),
+    );
+
+    const el = mount('#/manage/coworkers');
+    await settle(el);
+
+    // While getMe is in flight: Loading text, no sub-shell, cache empty.
+    expect(el.textContent).toContain('Loading...');
+    expect(anyShell(el)).toBe(false);
+    expect(currentMe()).toBeNull();
+
+    // Resolve getMe; the shell must mount AND see a populated cache.
+    let seenAtShellMount: Me | null = 'sentinel' as unknown as Me | null;
+    // Capture currentMe() on the first render that produces a shell.
+    release(ME);
+    await settle(el);
+    if (anyShell(el)) seenAtShellMount = currentMe();
+
+    expect(anyShell(el)).toBe(true);
+    expect(el.querySelector('rm-settings-shell')).not.toBeNull();
+    expect(seenAtShellMount).toEqual(ME);
+    expect(currentMe()).toEqual(ME);
+  });
+
+  it('drives getMe exactly once before any shell mounts on the stored-token branch', async () => {
+    getStoredTokenSpy.mockReturnValue('tok-123');
+    getMeSpy.mockResolvedValue(ME);
+
+    const el = mount('#/manage/coworkers'); // settings-shell never calls getMe
+    await settle(el);
+
+    expect(getMeSpy).toHaveBeenCalledTimes(1);
+    expect(scheduleRefreshSpy).toHaveBeenCalledWith('tok-123', expect.anything());
+    expect(el.querySelector('rm-settings-shell')).not.toBeNull();
+  });
+
+  it('url ?token= branch authenticates and loads me', async () => {
+    // happy-dom can set the query string via the full URL on location.
+    history.replaceState(null, '', '/?token=url-tok#/manage/coworkers');
+    getMeSpy.mockResolvedValue(ME);
+
+    const el = mount('#/manage/coworkers');
+    await settle(el);
+
+    expect(getMeSpy).toHaveBeenCalledTimes(1);
+    expect(currentMe()).toEqual(ME);
+    expect(el.querySelector('rm-settings-shell')).not.toBeNull();
+    // cleanup the search string so it doesn't bleed into later tests
+    history.replaceState(null, '', '/');
+  });
+});
+
+describe('<rm-app> getMe failure → login (fail closed)', () => {
+  it('ends in login state with no shell and an unpopulated cache', async () => {
+    getStoredTokenSpy.mockReturnValue('tok-123');
+    getMeSpy.mockRejectedValue(new Error('401'));
+
+    const el = mount('#/manage/coworkers');
+    await settle(el);
+
+    expect(el.querySelector('rm-login-page')).not.toBeNull();
+    expect(anyShell(el)).toBe(false);
+    expect(currentMe()).toBeNull();
+  });
+});
+
+describe('<rm-app> OIDC-configured-but-no-token → login', () => {
+  it('renders the login page without calling getMe', async () => {
+    getStoredTokenSpy.mockReturnValue(null);
+    fetchAuthConfigSpy.mockResolvedValue({ provider: 'oidc' });
+
+    const el = mount('#/manage/coworkers');
+    await settle(el);
+
+    expect(el.querySelector('rm-login-page')).not.toBeNull();
+    expect(getMeSpy).not.toHaveBeenCalled();
+    expect(anyShell(el)).toBe(false);
+  });
+});
+
+describe('<rm-app> legacy / no-auth branch (D2)', () => {
+  it('authenticates WITHOUT calling getMe and WITHOUT scheduling a refresh', async () => {
+    // No url token, no stored token, no OIDC config => legacy outcome.
+    // Route to #/activity so the mounted shell (activity) never calls getMe
+    // itself — the spy then faithfully reflects <rm-app>'s zero calls.
+    getStoredTokenSpy.mockReturnValue(null);
+    fetchAuthConfigSpy.mockResolvedValue(null);
+
+    const el = mount('#/activity/safety');
+    await settle(el);
+
+    // Authenticated chat-only deployment: a shell mounts...
+    expect(el.querySelector('rm-activity-shell')).not.toBeNull();
+    expect(el.textContent).not.toContain('Loading...');
+    expect(el.querySelector('rm-login-page')).toBeNull();
+    // ...but NO getMe and NO refresh scheduler were involved (D2).
+    expect(getMeSpy).not.toHaveBeenCalled();
+    expect(scheduleRefreshSpy).not.toHaveBeenCalled();
+    // And the cache stays empty (legacy has no Me).
+    expect(currentMe()).toBeNull();
+  });
+
+  it('chat-only deployment lands on the chat shell at the root hash', async () => {
+    getStoredTokenSpy.mockReturnValue(null);
+    fetchAuthConfigSpy.mockResolvedValue(null);
+
+    const el = mount('#/'); // root => chat shell
+    await settle(el);
+
+    expect(el.querySelector('rm-chat-shell')).not.toBeNull();
+    expect(scheduleRefreshSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app.test.ts
+++ b/web/src/app.test.ts
@@ -30,28 +30,45 @@ import type { Me } from './api/client.js';
 const getMeSpy = vi.fn();
 const scheduleRefreshSpy = vi.fn();
 
-// Permissive client stub: the spied getMe plus no-op list/get methods so a
-// slotted shell that incidentally mounts doesn't throw on unmocked calls.
+// Mirror the real ApiClient's token state so getMe can 401 when no bearer
+// has been applied. This is what makes the token→client wiring load-bearing
+// in tests: the url/oidc-callback branches resolve a token into a local var,
+// and getApiClient() seeds its token from sessionStorage — so resolveAuth
+// MUST setToken() before the first getMe() or it 401s → fail-closed to login.
+// (Regression guard: a fresh-stub-per-call mock that hardwired getMe to
+// succeed previously hid this — getMe was decoupled from the token entirely.)
+let clientToken: string | null = null;
+const setTokenSpy = vi.fn((t: string | null) => {
+  clientToken = t;
+});
+
+// Stable client stub (single identity, so setToken state persists across the
+// many getApiClient() calls in one test): the gated getMe plus no-op list/get
+// methods so a slotted shell that incidentally mounts doesn't throw.
 vi.mock('./api/client.js', async () => {
   const actual = await vi.importActual<typeof import('./api/client.js')>(
     './api/client.js',
   );
   const empty = vi.fn().mockResolvedValue([]);
   const single = vi.fn().mockResolvedValue(null);
+  const client = {
+    getMe: (...a: unknown[]) =>
+      clientToken === null
+        ? Promise.reject(new Error('401: no Authorization header'))
+        : getMeSpy(...a),
+    listCoworkers: empty,
+    listModels: empty,
+    listCredentials: empty,
+    listSkills: empty,
+    listMCPServers: empty,
+    listSafetyRules: empty,
+    listSafetyDecisions: single,
+    listTelegramLinks: empty,
+    setToken: (...a: unknown[]) => setTokenSpy(...(a as [string | null])),
+  };
   return {
     ...actual,
-    getApiClient: () => ({
-      getMe: getMeSpy,
-      listCoworkers: empty,
-      listModels: empty,
-      listCredentials: empty,
-      listSkills: empty,
-      listMCPServers: empty,
-      listSafetyRules: empty,
-      listSafetyDecisions: single,
-      listTelegramLinks: empty,
-      setToken: vi.fn(),
-    }),
+    getApiClient: () => client,
   };
 });
 
@@ -118,6 +135,8 @@ function anyShell(el: RmApp): boolean {
 
 beforeEach(() => {
   setMe(null); // reset the real cache between tests
+  clientToken = null; // no bearer applied to the client until a token branch runs
+  setTokenSpy.mockClear(); // keep the impl (sets clientToken), drop call history
   getMeSpy.mockReset();
   scheduleRefreshSpy.mockReset();
   fetchAuthConfigSpy.mockReset().mockResolvedValue(null);
@@ -188,6 +207,27 @@ describe('<rm-app> atomic auth+me bootstrap (§7.2)', () => {
     expect(currentMe()).toEqual(ME);
     expect(el.querySelector('rm-settings-shell')).not.toBeNull();
     // cleanup the search string so it doesn't bleed into later tests
+    history.replaceState(null, '', '/');
+  });
+
+  it('applies the resolved bearer to the api client BEFORE the first getMe (url ?token= branch)', async () => {
+    // Regression: the `?token=` (SaaS-passed) bearer lives only in a local
+    // var; getApiClient() seeds its token from sessionStorage. Without an
+    // explicit setToken(), the first getMe() goes out with no Authorization
+    // header → 401 → the SPA fail-closes to the login page. The gated getMe
+    // stub above 401s unless setToken ran, so this test fails without the fix.
+    history.replaceState(null, '', '/?token=saas-tok#/manage/coworkers');
+    getMeSpy.mockResolvedValue(ME);
+
+    const el = mount('#/manage/coworkers');
+    await settle(el);
+
+    expect(setTokenSpy).toHaveBeenCalledWith('saas-tok');
+    // and because the bearer was applied, getMe succeeded → authenticated:
+    expect(el.querySelector('rm-settings-shell')).not.toBeNull();
+    expect(el.querySelector('rm-login-page')).toBeNull();
+    expect(currentMe()).toEqual(ME);
+
     history.replaceState(null, '', '/');
   });
 });

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -36,6 +36,7 @@ import {
   handleCallback,
   isTokenExpired,
   scheduleRefresh,
+  storeToken,
 } from './services/oidc-auth.js';
 
 // Rewrite any v1.1 flat hash (`#/coworkers`, …) to its v2 nested
@@ -145,6 +146,15 @@ export class RmApp extends LitElement {
     // and must not schedule a refresh (no token to refresh). It flips
     // straight to authenticated via the single sink at the end of phase 3.
     if (outcome.kind === 'token') {
+      // Apply the resolved bearer to the shared client BEFORE getMe and
+      // persist it for the session. The URL (`?token=`, SaaS-passed) and
+      // OIDC-callback branches otherwise leave the token only in a local
+      // var: getApiClient() seeds from sessionStorage, so without this the
+      // very first getMe() goes out with no Authorization header → 401 →
+      // fail-closed to login. (The stored-token branch already has it in
+      // storage; setToken there is a harmless no-op-equivalent.)
+      storeToken(outcome.token);
+      getApiClient().setToken(outcome.token);
       this.startRefreshScheduler(outcome.token);
 
       // Phase 2: with authState still 'loading', populate the Me cache

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -26,9 +26,10 @@ import './components/coming-soon.js';
 import './components/chat-shell.js';
 import './components/settings-shell.js';
 import './components/activity-shell.js';
+import './components/platform-shell.js';
 import { installLegacyRedirects, topLevelShell } from './router.js';
 import { getApiClient } from './api/client.js';
-import { setMe } from './auth/capabilities.js';
+import { currentMe, setMe } from './auth/capabilities.js';
 import {
   fetchAuthConfig,
   getStoredToken,
@@ -182,6 +183,13 @@ export class RmApp extends LitElement {
     }
     if (this.authState === 'login') {
       return html`<rm-login-page></rm-login-page>`;
+    }
+    // Platform-plane users get their own shell (spec §2 — two shells).
+    // This is a PLANE check, not a role-name check: the only role-ish
+    // sentinel the SPA is allowed to dispatch on. Tenant-plane users fall
+    // through to the existing chat/manage/activity switch unchanged.
+    if (currentMe()?.plane === 'platform') {
+      return html`<rm-platform-shell></rm-platform-shell>`;
     }
     switch (this.shell) {
       case 'manage':

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -27,6 +27,8 @@ import './components/chat-shell.js';
 import './components/settings-shell.js';
 import './components/activity-shell.js';
 import { installLegacyRedirects, topLevelShell } from './router.js';
+import { getApiClient } from './api/client.js';
+import { setMe } from './auth/capabilities.js';
 import {
   fetchAuthConfig,
   getStoredToken,
@@ -82,43 +84,85 @@ export class RmApp extends LitElement {
     this.shell = topLevelShell(location.hash);
   };
 
-  private async resolveAuth() {
+  // Outcome of phase 1 of resolveAuth. No `@state` is touched while a
+  // TokenOutcome is being computed — the state machine stays 'loading'
+  // until resolveAuth itself commits a transition. Three shapes:
+  //   - 'token'  → a real bearer; do getMe → setMe before authenticating.
+  //   - 'legacy' → no auth provider configured; authenticate WITHOUT a
+  //                token, WITHOUT getMe, WITHOUT a refresh scheduler (D2 —
+  //                chat-only deployments must not regress into a getMe 401).
+  //   - 'login'  → cannot authenticate; render the login page.
+  private async resolveToken(): Promise<
+    | { kind: 'token'; token: string }
+    | { kind: 'legacy' }
+    | { kind: 'login' }
+  > {
     const params = new URLSearchParams(location.search);
 
     // 1. Token in URL query params (backward compat / SaaS-passed)
     const urlToken = params.get('token');
     if (urlToken && !isTokenExpired(urlToken)) {
-      this.authState = 'authenticated';
-      this.startRefreshScheduler(urlToken);
-      return;
+      return { kind: 'token', token: urlToken };
     }
 
     // 2. OIDC callback: code stored by /oauth2/callback page
     if (sessionStorage.getItem('oidc_code')) {
       const exchanged = await handleCallback();
       if (exchanged) {
-        this.authState = 'authenticated';
-        this.startRefreshScheduler(exchanged.id_token);
-        return;
+        return { kind: 'token', token: exchanged.id_token };
       }
     }
 
     // 3. Stored token from previous session
     const stored = getStoredToken();
     if (stored && !isTokenExpired(stored)) {
-      this.authState = 'authenticated';
-      this.startRefreshScheduler(stored);
-      return;
+      return { kind: 'token', token: stored };
     }
 
     // 4. OIDC configured but no token → show login page
     const config = await fetchAuthConfig();
     if (config) {
+      return { kind: 'login' };
+    }
+
+    // 5. Legacy / no auth provider configured → chat-only deployment.
+    return { kind: 'legacy' };
+  }
+
+  private async resolveAuth() {
+    // Phase 1: resolve a token outcome WITHOUT touching @state. authState
+    // stays 'loading' (render shows "Loading...") so no sub-shell mounts.
+    const outcome = await this.resolveToken();
+
+    if (outcome.kind === 'login') {
       this.authState = 'login';
       return;
     }
 
-    // 5. Fall back to chat panel (legacy / no auth provider configured)
+    // D2: the legacy / no-auth branch authenticates a chat-only deployment
+    // WITHOUT a token. It must not call getMe (would 401 → dead-end login)
+    // and must not schedule a refresh (no token to refresh). It flips
+    // straight to authenticated via the single sink at the end of phase 3.
+    if (outcome.kind === 'token') {
+      this.startRefreshScheduler(outcome.token);
+
+      // Phase 2: with authState still 'loading', populate the Me cache
+      // before any shell mounts. setMe() writes a plain module variable —
+      // invisible to Lit reactivity — so the state flip below MUST come
+      // after this resolves (spec §7.2 atomic bootstrap).
+      try {
+        const me = await getApiClient().getMe();
+        setMe(me);
+      } catch (err) {
+        console.error('failed to load /me', err);
+        this.authState = 'login'; // fail closed; leave the cache unset
+        return;
+      }
+    }
+
+    // Phase 3: the ONLY authenticated transition. By now either the Me
+    // cache is populated (token branch) or this is the legacy branch that
+    // intentionally has no Me. The next render picks the right shell.
     this.authState = 'authenticated';
   }
 

--- a/web/src/auth/capabilities.test.ts
+++ b/web/src/auth/capabilities.test.ts
@@ -1,0 +1,131 @@
+// capabilities.ts — the capability/ownership gating helpers (spec §7.1).
+//
+// These are the single mechanism the whole SPA gates on, so the corners
+// that matter are the null/undefined edges of `created_by_user_id` (the
+// three-value ownership-escape semantics) and the fail-closed behaviour
+// when no Me is cached. We exercise the REAL module cache (no mocks) so a
+// regression in the setMe/currentMe wiring would surface here.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Me } from '../api/client.js';
+import {
+  canManage,
+  currentMe,
+  hasCapability,
+  isOwnResource,
+  setMe,
+} from './capabilities.js';
+
+function makeMe(over: Partial<Me> = {}): Me {
+  return {
+    user_id: 'u-alice',
+    tenant_id: 't1',
+    name: 'Alice',
+    email: 'alice@example.com',
+    role: 'member',
+    plane: 'tenant',
+    capabilities: ['coworker.create', 'coworker.use'],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // Reset the module-level cache so cases don't bleed into each other.
+  setMe(null);
+});
+
+describe('currentMe / setMe', () => {
+  it('returns exactly what setMe last set, including back to null', () => {
+    expect(currentMe()).toBeNull();
+    const me = makeMe();
+    setMe(me);
+    expect(currentMe()).toBe(me);
+    setMe(null);
+    expect(currentMe()).toBeNull();
+  });
+});
+
+describe('hasCapability', () => {
+  it('is false when no Me is cached (fail-closed before boot)', () => {
+    expect(hasCapability('coworker.create')).toBe(false);
+  });
+
+  it('is true for a present action and false for an absent one', () => {
+    setMe(makeMe({ capabilities: ['coworker.create', 'skill.manage'] }));
+    expect(hasCapability('coworker.create')).toBe(true);
+    expect(hasCapability('skill.manage')).toBe(true);
+    expect(hasCapability('mcp.configure')).toBe(false);
+  });
+
+  it('is false against an empty capability list (a role with nothing)', () => {
+    setMe(makeMe({ capabilities: [] }));
+    expect(hasCapability('coworker.create')).toBe(false);
+  });
+});
+
+describe('isOwnResource (three-value ownership escape)', () => {
+  it('is true when created_by_user_id matches the cached user_id', () => {
+    setMe(makeMe({ user_id: 'u-alice' }));
+    expect(isOwnResource({ created_by_user_id: 'u-alice' })).toBe(true);
+  });
+
+  it('is false when the ids differ', () => {
+    setMe(makeMe({ user_id: 'u-alice' }));
+    expect(isOwnResource({ created_by_user_id: 'u-bob' })).toBe(false);
+  });
+
+  // The crux: a platform-default resource has a NULL owner and must NEVER
+  // count as owned — mirrors the SQL `col = :uid` where NULL never matches.
+  it('is false when created_by_user_id is null (platform-default resource)', () => {
+    setMe(makeMe({ user_id: 'u-alice' }));
+    expect(isOwnResource({ created_by_user_id: null })).toBe(false);
+  });
+
+  it('is false when created_by_user_id is undefined (field absent)', () => {
+    setMe(makeMe({ user_id: 'u-alice' }));
+    expect(isOwnResource({})).toBe(false);
+    expect(isOwnResource({ created_by_user_id: undefined })).toBe(false);
+  });
+
+  it('is false when no Me is cached, even for a non-null owner id', () => {
+    expect(isOwnResource({ created_by_user_id: 'u-alice' })).toBe(false);
+  });
+
+  // Guard against a naive `me.user_id === resource.created_by_user_id`
+  // implementation that would wrongly return true when BOTH sides are null.
+  it('is false when both the user_id and the owner id are null-ish', () => {
+    setMe(makeMe({ user_id: null as unknown as string }));
+    expect(isOwnResource({ created_by_user_id: null })).toBe(false);
+  });
+});
+
+describe('canManage (capability OR ownership)', () => {
+  it('is true via the manage capability even for a resource owned by someone else', () => {
+    setMe(makeMe({ user_id: 'u-alice', capabilities: ['coworker.manage'] }));
+    expect(canManage({ created_by_user_id: 'u-bob' }, 'coworker.manage')).toBe(
+      true,
+    );
+  });
+
+  it('is true via ownership even without the manage capability', () => {
+    setMe(makeMe({ user_id: 'u-alice', capabilities: [] }));
+    expect(
+      canManage({ created_by_user_id: 'u-alice' }, 'coworker.manage'),
+    ).toBe(true);
+  });
+
+  it('is false when the user neither has the capability nor owns the resource', () => {
+    setMe(makeMe({ user_id: 'u-alice', capabilities: ['coworker.use'] }));
+    expect(canManage({ created_by_user_id: 'u-bob' }, 'coworker.manage')).toBe(
+      false,
+    );
+  });
+
+  it('is false for a null-owner resource when the user lacks the capability', () => {
+    // Ownership escape must not fire on a platform-default resource.
+    setMe(makeMe({ user_id: 'u-alice', capabilities: ['coworker.use'] }));
+    expect(canManage({ created_by_user_id: null }, 'coworker.manage')).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/auth/capabilities.ts
+++ b/web/src/auth/capabilities.ts
@@ -1,0 +1,63 @@
+// Capability gating — the ONLY mechanism the SPA uses to decide which
+// affordances a user may see (spec §7.1). The SPA never keeps its own
+// role -> capability matrix; the backend's permissions.py is the single
+// source of truth and the wire (`GET /api/v1/me`) carries the resolved
+// `capabilities` list. Every render path reads from the cache below.
+//
+// `currentMe` is named deliberately to NOT collide with the ASYNC server
+// fetch `api.getMe()`:
+//   - api.getMe()  — async, hits /api/v1/me, called ONCE at app boot.
+//   - currentMe()  — sync, reads the module cache, called everywhere else.
+// Confusing the two is the "everything renders empty because me is null"
+// failure mode the bootstrap refactor (app.ts §7.2) exists to prevent.
+
+import type { Me } from '../api/client.js';
+
+// Module-level cache. Held in a plain `let` (no persistence, no storage).
+// Writing here does NOT trigger any Lit reactivity, which is exactly why
+// <rm-app> must keep `authState` at 'loading' until setMe() has run — see
+// the atomic-bootstrap contract in app.ts resolveAuth().
+let _me: Me | null = null;
+
+/** Setter — called once at app boot by <rm-app> after the async
+ *  api.getMe() call resolves. NOT called from any render path. */
+export function setMe(me: Me | null): void {
+  _me = me;
+}
+
+/** Synchronous cache reader — every render path uses this to gate UI. */
+export function currentMe(): Me | null {
+  return _me;
+}
+
+/** True iff the resolved Me carries `action` in its capability list.
+ *  False (fail-closed) whenever no Me is cached yet. */
+export function hasCapability(action: string): boolean {
+  return !!_me && _me.capabilities.includes(action);
+}
+
+/** Three-value-safe ownership check mirroring the backend's
+ *  `require_manage_or_owner` ownership escape. A null/undefined
+ *  `created_by_user_id` is a platform-default (system-created) resource
+ *  and NEVER qualifies as owned — matching the SQL `col = :uid` semantics
+ *  where NULL never compares equal. */
+export function isOwnResource(resource: {
+  created_by_user_id?: string | null;
+}): boolean {
+  return (
+    !!_me &&
+    !!resource.created_by_user_id &&
+    resource.created_by_user_id === _me.user_id
+  );
+}
+
+/** Frontend mirror of the backend ownership escape: a user may manage a
+ *  resource if they hold the manage capability OR they own it. UX courtesy
+ *  only — the backend still enforces; this just avoids rendering an Edit
+ *  button that 403s on click (spec §7.3). */
+export function canManage(
+  resource: { created_by_user_id?: string | null },
+  manageAction: string,
+): boolean {
+  return hasCapability(manageAction) || isOwnResource(resource);
+}

--- a/web/src/components/access-denied-page.test.ts
+++ b/web/src/components/access-denied-page.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+// <rm-access-denied> — the 403 fallback (spec §7.7). Presentation only,
+// no authorization logic. We pin two contracts:
+//   1. the required capability name appears verbatim in the copy, so the
+//      user (and any support thread) has the exact term;
+//   2. the "← Back to" link points at the slug the shell passed in, not
+//      a hardcoded default.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import './access-denied-page.js';
+import type { RmAccessDenied } from './access-denied-page.js';
+
+async function settle(el: RmAccessDenied): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+    await el.updateComplete;
+  }
+}
+
+async function mount(
+  props: Partial<
+    Pick<
+      RmAccessDenied,
+      'capability' | 'pageLabel' | 'backSlug' | 'backLabel'
+    >
+  >,
+): Promise<RmAccessDenied> {
+  const el = document.createElement('rm-access-denied') as RmAccessDenied;
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await settle(el);
+  return el;
+}
+
+describe('<rm-access-denied>', () => {
+  afterEach(() => {
+    document.querySelectorAll('rm-access-denied').forEach((el) => el.remove());
+  });
+
+  it('names the required capability verbatim in the copy', async () => {
+    const el = await mount({ capability: 'safety.read', pageLabel: 'Safety rules' });
+    const cap = el.querySelector('[data-testid="access-denied-capability"]');
+    expect(cap?.textContent?.trim()).toBe('safety.read');
+    // The capability must appear in the human sentence, not just an attr.
+    const copy = el.querySelector('[data-testid="access-denied-copy"]');
+    expect(copy?.textContent).toContain('safety.read');
+  });
+
+  it('names the gated page label in the copy when provided', async () => {
+    const el = await mount({ capability: 'safety.read', pageLabel: 'Safety rules' });
+    const copy = el.querySelector('[data-testid="access-denied-copy"]');
+    expect(copy?.textContent).toContain('Safety rules');
+  });
+
+  it('points the back-link at the slug it was given (not a hardcoded default)', async () => {
+    // A user whose first visible page is Skills (not Coworkers) must be
+    // routed back THERE — proving the target is data-driven, so a member
+    // who lost the coworkers entry would still get a working link.
+    const el = await mount({
+      capability: 'tenant.manage',
+      pageLabel: 'General',
+      backSlug: 'skills',
+      backLabel: 'Skills',
+    });
+    const back = el.querySelector('[data-testid="access-denied-back"]');
+    expect(back?.getAttribute('href')).toBe('#/manage/skills');
+    expect(back?.getAttribute('data-slug')).toBe('skills');
+    expect(back?.textContent).toContain('Skills');
+  });
+
+  it('defaults the back-link to coworkers when no slug is supplied', async () => {
+    const el = await mount({ capability: 'safety.read' });
+    const back = el.querySelector('[data-testid="access-denied-back"]');
+    expect(back?.getAttribute('href')).toBe('#/manage/coworkers');
+    expect(back?.textContent).toContain('Coworkers');
+  });
+
+  it('renders the "Access denied" heading and a lock glyph', async () => {
+    const el = await mount({ capability: 'safety.read' });
+    expect(el.textContent).toContain('Access denied');
+    // Lock glyph is an inline <svg>; assert it exists so a future
+    // refactor that drops it fails here.
+    expect(el.querySelector('.ad-glyph svg')).not.toBeNull();
+  });
+});

--- a/web/src/components/access-denied-page.ts
+++ b/web/src/components/access-denied-page.ts
@@ -1,0 +1,156 @@
+// <rm-access-denied> — the friendly 403 fallback (spec §7.7).
+//
+// Rendered in the settings-shell main pane when a user URL-jumps to a
+// slug their capabilities don't allow (e.g. a member opening
+// `#/manage/safety`). The nav rail stays visible around it — the user
+// learns *why* the page is gated and is offered a one-click way back to
+// somewhere they CAN see, rather than a silent redirect that reads like
+// a glitch.
+//
+// This component owns NO authorization. It is presentation only — the
+// shell decides when to mount it and which capability/label to pass in.
+// Light DOM + `--rm-` tokens, matching the other settings pages
+// (appearance-page.ts is the closest sibling for visual weight).
+
+import { LitElement, html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('rm-access-denied')
+export class RmAccessDenied extends LitElement {
+  /** The capability string the gated page requires (e.g.
+   *  `safety.read`). Named in the copy so the user knows exactly what
+   *  they lack — and so a support conversation has a precise term. */
+  @property({ type: String }) capability = '';
+
+  /** Human-readable name of the page that was gated (e.g.
+   *  `Safety rules`). Optional; falls back to a generic phrasing when
+   *  the shell can't name the page. */
+  @property({ type: String }) pageLabel = '';
+
+  /** Slug to return to — the first nav entry this user CAN see (usually
+   *  `coworkers`). The shell computes it from the filtered nav set and
+   *  passes it in. */
+  @property({ type: String }) backSlug = 'coworkers';
+
+  /** Display label for the back link's target (e.g. `Coworkers`). */
+  @property({ type: String }) backLabel = 'Coworkers';
+
+  protected override createRenderRoot() {
+    // Light DOM — matches the other settings pages so the `--rm-` tokens
+    // resolve at the document root. The styles are inlined as a `<style>`
+    // in render() rather than `static styles` (which only applies to a
+    // shadow root and breaks light-DOM rendering).
+    return this;
+  }
+
+  override render() {
+    const pageName = this.pageLabel ? `The ${this.pageLabel} page` : 'This page';
+    return html`
+      <style>
+        rm-access-denied {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: 100%;
+          width: 100%;
+          padding: 32px 24px;
+          font-family: var(--rm-font-body);
+          color: var(--rm-ink);
+        }
+        rm-access-denied .ad-card {
+          max-width: 440px;
+          text-align: center;
+        }
+        rm-access-denied .ad-glyph {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 52px;
+          height: 52px;
+          border-radius: var(--rm-r-lg);
+          background: var(--rm-surface-2);
+          border: 1px solid var(--rm-border);
+          color: var(--rm-ink-3);
+          margin-bottom: 18px;
+        }
+        rm-access-denied h2 {
+          margin: 0 0 10px;
+          font-size: var(--rm-text-lg);
+          font-weight: 600;
+          letter-spacing: -0.01em;
+        }
+        rm-access-denied p {
+          margin: 0 0 22px;
+          font-size: var(--rm-text-sm);
+          line-height: 1.6;
+          color: var(--rm-ink-2);
+        }
+        rm-access-denied p code {
+          font-family: var(--rm-font-mono);
+          font-size: 0.92em;
+          padding: 1px 5px;
+          border-radius: var(--rm-radius-sm);
+          background: var(--rm-accent-subtle);
+          color: var(--rm-accent-2);
+        }
+        rm-access-denied .ad-back {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 8px 16px;
+          border-radius: var(--rm-radius-sm);
+          border: 1px solid var(--rm-border);
+          background: var(--rm-surface);
+          color: var(--rm-ink);
+          font-size: var(--rm-text-sm);
+          font-weight: 500;
+          font-family: inherit;
+          text-decoration: none;
+          cursor: pointer;
+          transition: 0.12s;
+        }
+        rm-access-denied .ad-back:hover {
+          background: var(--rm-surface-2);
+          border-color: var(--rm-border-2);
+        }
+      </style>
+      <div class="ad-card" data-testid="access-denied">
+        <div class="ad-glyph" aria-hidden="true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            viewBox="0 0 24 24"
+          >
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+          </svg>
+        </div>
+        <h2>Access denied</h2>
+        <p data-testid="access-denied-copy">
+          ${pageName} requires the
+          ${this.capability
+            ? html`<code data-testid="access-denied-capability"
+                >${this.capability}</code
+              >`
+            : nothing}
+          capability, which your current role doesn't have. Ask an admin or
+          owner if you need access.
+        </p>
+        <a
+          class="ad-back"
+          data-testid="access-denied-back"
+          data-slug=${this.backSlug}
+          href=${`#/manage/${this.backSlug}`}
+        >
+          ← Back to ${this.backLabel}
+        </a>
+      </div>
+    `;
+  }
+}

--- a/web/src/components/coworker-wizard.test.ts
+++ b/web/src/components/coworker-wizard.test.ts
@@ -21,7 +21,8 @@ import {
   slugify,
   type CoworkerWizard,
 } from './coworker-wizard.js';
-import type { Backend, Coworker, CredentialResponse, Model } from '../api/client.js';
+import { setMe } from '../auth/capabilities.js';
+import type { Backend, Coworker, CredentialResponse, Me, Model } from '../api/client.js';
 
 const pageOf = <T,>(items: T[]) => ({ items, total: items.length, limit: 200, offset: 0 });
 
@@ -794,5 +795,133 @@ describe('<rm-coworker-wizard>', () => {
     const scrollContainer = tools.querySelector('div.max-h-44');
     expect(scrollContainer, 'scrollable container must exist').toBeTruthy();
     expect(scrollContainer!.className).toContain('overflow-y-auto');
+  });
+});
+
+// ---------------------------------------------------------------------
+// PR6: capability-gating the Tools step's "+ Connect a new server" action.
+//
+// Contract (spec §5.3 / §7.5): the inline add-server button is an
+// `mcp.configure` affordance — admins+ see it, members do NOT. A member
+// can still SELECT pre-configured servers (that's `coworker.use`), so the
+// existing-server list and its checkboxes must stay rendered for members;
+// only the add button and the empty-state copy change. These tests drive
+// the wizard to the Tools step (currentStep === 3) and read the rendered
+// light DOM, gating ONLY via the real `capabilities.ts` setMe — no role
+// name, no internal mocks.
+// ---------------------------------------------------------------------
+
+describe('<rm-coworker-wizard> — Tools step MCP add-server gating (PR6)', () => {
+  let fetchStub: { restore: () => void } | null = null;
+
+  /** Real Me shapes — only `capabilities` differs between them. We do NOT
+   *  branch on `role` anywhere; the wizard reads `hasCapability` off this. */
+  const memberMe = (): Me => ({
+    user_id: 'uuuuuuuu-0000-0000-0000-000000000001',
+    tenant_id: 'tttttttt-0000-0000-0000-000000000001',
+    name: 'Mia Member',
+    email: 'mia@example.com',
+    role: 'member',
+    plane: 'tenant',
+    // Member matrix per permissions.py: create/use but NOT mcp.configure.
+    capabilities: ['coworker.create', 'coworker.use', 'skill.create'],
+  });
+  const adminMe = (): Me => ({
+    user_id: 'uuuuuuuu-0000-0000-0000-000000000002',
+    tenant_id: 'tttttttt-0000-0000-0000-000000000001',
+    name: 'Ada Admin',
+    email: 'ada@example.com',
+    role: 'admin',
+    plane: 'tenant',
+    capabilities: ['coworker.create', 'coworker.use', 'mcp.configure'],
+  });
+
+  function installToolsFetch(mcpItems: unknown[]): { restore: () => void } {
+    return installFetch([
+      { match: (u) => u.endsWith('/api/v1/backends'), respond: () => jsonResp(BACKENDS) },
+      { match: (u) => u.startsWith('/api/v1/models'), respond: () => jsonResp(MODELS) },
+      { match: (u) => u === '/api/v1/credentials', respond: () => jsonResp(CREDS_ANT) },
+      {
+        match: (u) => u.split('?')[0] === '/api/v1/mcp-servers',
+        respond: () => jsonResp(pageOf(mcpItems)),
+      },
+      { match: (u) => u.split('?')[0] === '/api/v1/skills', respond: () => jsonResp(pageOf([])) },
+    ]);
+  }
+
+  /** Open the wizard, settle catalogues, jump to the Tools step (index 3). */
+  async function atToolsStep(): Promise<CoworkerWizard> {
+    const el = mount();
+    el.open = true;
+    await settle(el);
+    (el as unknown as { currentStep: number }).currentStep = 3;
+    await settle(el);
+    return el;
+  }
+
+  const addBtn = (el: CoworkerWizard): HTMLButtonElement | undefined =>
+    [...el.querySelectorAll<HTMLButtonElement>('button')].find((b) =>
+      b.textContent?.includes('Connect a new server'),
+    );
+
+  afterEach(() => {
+    fetchStub?.restore();
+    fetchStub = null;
+    setMe(null);
+    document.body.innerHTML = '';
+  });
+
+  it('member without mcp.configure: no "+ Connect a new server" button and shows the ask-your-admin hint when no servers exist', async () => {
+    setMe(memberMe());
+    fetchStub = installToolsFetch([]);
+    const el = await atToolsStep();
+
+    // The add affordance is gated off.
+    expect(addBtn(el)).toBeUndefined();
+    // Empty + no capability → the spec §7.5 copy (exact).
+    expect(el.textContent).toContain(
+      'No MCP servers configured. Ask your admin to add one.',
+    );
+    // The old/admin empty-state copy must NOT leak to members.
+    expect(el.textContent).not.toContain('connect one to bind');
+  });
+
+  it('member without mcp.configure: existing servers stay selectable (only the add button is hidden)', async () => {
+    setMe(memberMe());
+    fetchStub = installToolsFetch([
+      {
+        id: 'mmmmmmmm-0000-0000-0000-000000000001',
+        tenant_id: 't',
+        name: 'shared-github-mcp',
+        type: 'http',
+        url: 'http://x',
+        auth_mode: 'none',
+        created_at: '2026-05-20T00:00:00Z',
+        updated_at: '2026-05-20T00:00:00Z',
+      },
+    ]);
+    const el = await atToolsStep();
+
+    // Add button still hidden for the member...
+    expect(addBtn(el)).toBeUndefined();
+    // ...but the pre-configured server (and its select checkbox) render,
+    // because selecting is `coworker.use`, not `mcp.configure`.
+    expect(el.textContent).toContain('shared-github-mcp');
+    expect(el.querySelector('input.rm-checkbox')).toBeTruthy();
+    // The "ask your admin" empty-state hint is NOT shown when servers exist.
+    expect(el.textContent).not.toContain('Ask your admin to add one');
+  });
+
+  it('admin with mcp.configure: the "+ Connect a new server" button IS present', async () => {
+    setMe(adminMe());
+    fetchStub = installToolsFetch([]);
+    const el = await atToolsStep();
+
+    const btn = addBtn(el);
+    expect(btn).toBeTruthy();
+    expect(btn!.textContent?.trim()).toBe('+ Connect a new server');
+    // Admin keeps the original empty-state copy, not the member variant.
+    expect(el.textContent).toContain('connect one to bind');
+    expect(el.textContent).not.toContain('Ask your admin to add one');
   });
 });

--- a/web/src/components/coworker-wizard.ts
+++ b/web/src/components/coworker-wizard.ts
@@ -37,6 +37,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import './wizard.js';
 import { ApiError, getApiClient } from '../api/client.js';
+import { hasCapability } from '../auth/capabilities.js';
 import type {
   Backend,
   Coworker,
@@ -936,6 +937,15 @@ export class CoworkerWizard extends LitElement {
   }
 
   private renderTools() {
+    // A member (no `mcp.configure`) can still SELECT pre-configured MCP
+    // servers via `coworker.use` (spec §5.3, §7.5) — only the inline
+    // "add a new server" affordance is gated. When such a member has no
+    // servers to pick at all, the empty state points them at their admin
+    // instead of the (hidden) connect button.
+    const canConfigureMcp = hasCapability('mcp.configure');
+    const emptyCopy = canConfigureMcp
+      ? 'No MCP servers yet — connect one to bind.'
+      : 'No MCP servers configured. Ask your admin to add one.';
     return html`
       <h3 class="text-[15px] font-semibold mb-1">Tools</h3>
       <p class="text-[13px] text-ink-3 dark:text-d-ink-3 mb-4">
@@ -944,18 +954,20 @@ export class CoworkerWizard extends LitElement {
       </p>
       ${this.mcpServers.length === 0
         ? html`<div class="text-[13px] text-ink-3 dark:text-d-ink-3">
-            No MCP servers yet — connect one to bind.
+            ${emptyCopy}
           </div>`
         : html`<div class="border border-surface-3 dark:border-d-surface-3 rounded-lg overflow-hidden">
             ${this.mcpServers.map((s) => this.renderToolRow(s))}
           </div>`}
-      <button
-        type="button"
-        class="mt-3 text-[12.5px] px-3 py-1.5 rounded-md border border-surface-3
-          dark:border-d-surface-3 text-ink-2 dark:text-d-ink-2
-          hover:bg-surface-2 dark:hover:bg-d-surface-2 cursor-pointer"
-        @click=${() => this.requestAddMCPServer()}
-      >+ Connect a new server</button>
+      ${canConfigureMcp
+        ? html`<button
+            type="button"
+            class="mt-3 text-[12.5px] px-3 py-1.5 rounded-md border border-surface-3
+              dark:border-d-surface-3 text-ink-2 dark:text-d-ink-2
+              hover:bg-surface-2 dark:hover:bg-d-surface-2 cursor-pointer"
+            @click=${() => this.requestAddMCPServer()}
+          >+ Connect a new server</button>`
+        : nothing}
     `;
   }
 

--- a/web/src/components/coworkers-page.test.ts
+++ b/web/src/components/coworkers-page.test.ts
@@ -1,0 +1,389 @@
+// @vitest-environment happy-dom
+//
+// Role-aware Coworkers page (RBAC UI PR4, spec §5.1 / §7.3 / §7.4).
+//
+// What is pinned here:
+//   * Chips re-classify the ALREADY-server-filtered list (UX only):
+//     "Mine" -> own rows; "Shared by others" -> others' shared rows.
+//   * Per-row management affordances (Edit / Delete / Share) are gated by
+//     `canManage(co, 'coworker.manage')` — the ownership escape. With the
+//     manage capability every row is editable; for a plain member only
+//     own rows are, and a null-owner row is NEVER manageable.
+//   * The Share toggle calls shareCoworker / unshareCoworker.
+//
+// We mock ONLY the api client (the external boundary). The capability
+// logic uses the REAL capabilities.ts (setMe + canManage/isOwnResource):
+// mocking it would hide the very bugs these tests exist to catch.
+//
+// We deliberately do NOT assert "a member can't see X's private row" —
+// that is backend visibility filtering (`user_can_see_resource`), enforced
+// server-side and tested there. Re-asserting it here would be a forbidden
+// duplicate-source / mirror test (spec §7.3).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listCoworkersSpy = vi.fn();
+const shareCoworkerSpy = vi.fn();
+const unshareCoworkerSpy = vi.fn();
+const deleteCoworkerSpy = vi.fn();
+
+vi.mock('../api/client.js', async () => {
+  const actual = await vi.importActual<typeof import('../api/client.js')>(
+    '../api/client.js',
+  );
+  return {
+    ...actual,
+    getApiClient: () => ({
+      listCoworkers: listCoworkersSpy,
+      shareCoworker: shareCoworkerSpy,
+      unshareCoworker: unshareCoworkerSpy,
+      deleteCoworker: deleteCoworkerSpy,
+    }),
+  };
+});
+
+import { CoworkersPage } from './coworkers-page.js';
+import { setMe } from '../auth/capabilities.js';
+import type { Coworker, Me } from '../api/client.js';
+
+const MY_UID = 'u-me';
+
+// Capability sets transcribed from the backend matrix — TEST INPUTS ONLY.
+// The production code keeps no role->cap map; it reads me.capabilities.
+const MEMBER_CAPS = ['coworker.create', 'coworker.use'];
+const MANAGER_CAPS = [
+  'coworker.create',
+  'coworker.manage',
+  'coworker.use',
+];
+
+function makeMe(capabilities: string[]): Me {
+  return {
+    user_id: MY_UID,
+    tenant_id: 't-1',
+    name: 'Me',
+    email: 'me@example.com',
+    role: 'member',
+    plane: 'tenant',
+    capabilities,
+  };
+}
+
+function mkCoworker(over: Partial<Coworker>): Coworker {
+  return {
+    id: 'c-x',
+    tenant_id: 't-1',
+    name: 'cw',
+    folder: 'cw',
+    agent_backend: 'claude',
+    status: 'active',
+    max_concurrent: 2,
+    created_by_user_id: null,
+    visibility: 'private',
+    created_at: '',
+    ...over,
+  };
+}
+
+// The canonical MIXED fixture: own-private, own-shared, others'-shared,
+// and a null-owner (legacy/platform-default) row.
+const OWN_PRIVATE = mkCoworker({
+  id: 'own-priv',
+  name: 'Own Private',
+  created_by_user_id: MY_UID,
+  visibility: 'private',
+});
+const OWN_SHARED = mkCoworker({
+  id: 'own-shared',
+  name: 'Own Shared',
+  created_by_user_id: MY_UID,
+  visibility: 'shared',
+});
+const OTHERS_SHARED = mkCoworker({
+  id: 'others-shared',
+  name: 'Others Shared',
+  created_by_user_id: 'u-other',
+  visibility: 'shared',
+});
+const NULL_OWNER_SHARED = mkCoworker({
+  id: 'null-owner',
+  name: 'Legacy Shared',
+  created_by_user_id: null,
+  visibility: 'shared',
+});
+
+const MIXED = [OWN_PRIVATE, OWN_SHARED, OTHERS_SHARED, NULL_OWNER_SHARED];
+
+async function settle(el: CoworkersPage): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
+    await el.updateComplete;
+  }
+}
+
+async function mount(): Promise<CoworkersPage> {
+  const page = new CoworkersPage();
+  document.body.appendChild(page);
+  await settle(page);
+  return page;
+}
+
+/** Ids of the coworker cards currently rendered, in DOM order. */
+function visibleIds(page: CoworkersPage): string[] {
+  return Array.from(page.querySelectorAll('[data-coworker-id]')).map(
+    (el) => el.getAttribute('data-coworker-id') ?? '',
+  );
+}
+
+/** The card element for one coworker id (so we can scope per-row queries). */
+function card(page: CoworkersPage, id: string): Element | null {
+  return page.querySelector(`[data-coworker-id="${id}"]`);
+}
+
+function clickChip(page: CoworkersPage, chip: string): void {
+  page
+    .querySelector<HTMLButtonElement>(`[data-testid="coworker-chip-${chip}"]`)!
+    .click();
+}
+
+beforeEach(() => {
+  [
+    listCoworkersSpy,
+    shareCoworkerSpy,
+    unshareCoworkerSpy,
+    deleteCoworkerSpy,
+  ].forEach((s) => s.mockReset());
+  listCoworkersSpy.mockResolvedValue(MIXED);
+});
+
+afterEach(() => {
+  document.querySelectorAll('rm-coworkers-page').forEach((el) => el.remove());
+  setMe(null);
+  vi.clearAllMocks();
+});
+
+describe('CoworkersPage — filter chips (UX re-classification)', () => {
+  it('default "All visible" shows every returned row, untouched', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    // No security filtering on the frontend — all 4 server-returned rows.
+    expect(visibleIds(page)).toEqual([
+      'own-priv',
+      'own-shared',
+      'others-shared',
+      'null-owner',
+    ]);
+  });
+
+  it('chip "Mine" narrows to own rows only (both visibilities)', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    clickChip(page, 'mine');
+    await settle(page);
+    const ids = visibleIds(page);
+    expect(ids).toEqual(['own-priv', 'own-shared']);
+    // The null-owner row must NOT count as "Mine" (three-value safety).
+    expect(ids).not.toContain('null-owner');
+    expect(ids).not.toContain('others-shared');
+  });
+
+  it('chip "Shared by others" narrows to others\' shared rows only', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    clickChip(page, 'shared');
+    await settle(page);
+    const ids = visibleIds(page);
+    // own-shared is mine, so it is excluded; null-owner has no owner ->
+    // not "mine" -> it IS "shared by others" (shared + not own).
+    expect(ids).toContain('others-shared');
+    expect(ids).toContain('null-owner');
+    expect(ids).not.toContain('own-shared');
+    expect(ids).not.toContain('own-priv');
+  });
+});
+
+describe('CoworkersPage — per-row management gating (ownership escape)', () => {
+  it('with coworker.manage, Edit shows on EVERY row (incl. null-owner)', async () => {
+    setMe(makeMe(MANAGER_CAPS));
+    const page = await mount();
+    for (const id of ['own-priv', 'own-shared', 'others-shared', 'null-owner']) {
+      expect(
+        card(page, id)?.querySelector('[data-testid="coworker-edit"]'),
+        `manager should see Edit on ${id}`,
+      ).not.toBeNull();
+      expect(
+        card(page, id)?.querySelector('[data-testid="coworker-viewonly"]'),
+        `manager should NOT see a view-only hint on ${id}`,
+      ).toBeNull();
+    }
+  });
+
+  it('as a plain member, Edit shows only on own rows', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    // Own rows: editable.
+    for (const id of ['own-priv', 'own-shared']) {
+      expect(
+        card(page, id)?.querySelector('[data-testid="coworker-edit"]'),
+        `member should see Edit on own ${id}`,
+      ).not.toBeNull();
+    }
+    // Others' shared: NOT editable, shows view-only hint instead.
+    expect(
+      card(page, 'others-shared')?.querySelector(
+        '[data-testid="coworker-edit"]',
+      ),
+    ).toBeNull();
+    expect(
+      card(page, 'others-shared')?.querySelector(
+        '[data-testid="coworker-viewonly"]',
+      ),
+    ).not.toBeNull();
+  });
+
+  it('a null-owner row is NOT manageable by a member (three-value safety)', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    // The legacy/platform-default row (created_by_user_id === null) must
+    // never qualify for the ownership escape — no Edit/Delete/Share.
+    const row = card(page, 'null-owner');
+    expect(row?.querySelector('[data-testid="coworker-edit"]')).toBeNull();
+    expect(row?.querySelector('[data-testid="coworker-delete"]')).toBeNull();
+    expect(row?.querySelector('[data-testid="coworker-share"]')).toBeNull();
+    expect(
+      row?.querySelector('[data-testid="coworker-viewonly"]'),
+    ).not.toBeNull();
+  });
+});
+
+describe('CoworkersPage — share toggle (canManage-gated)', () => {
+  it('Share toggle is present exactly where canManage is true (member)', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    // Own rows -> share present.
+    expect(
+      card(page, 'own-priv')?.querySelector('[data-testid="coworker-share"]'),
+    ).not.toBeNull();
+    expect(
+      card(page, 'own-shared')?.querySelector('[data-testid="coworker-share"]'),
+    ).not.toBeNull();
+    // Non-own rows -> share absent.
+    expect(
+      card(page, 'others-shared')?.querySelector(
+        '[data-testid="coworker-share"]',
+      ),
+    ).toBeNull();
+    expect(
+      card(page, 'null-owner')?.querySelector('[data-testid="coworker-share"]'),
+    ).toBeNull();
+  });
+
+  it('clicking Share on a PRIVATE own row calls shareCoworker(id)', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    shareCoworkerSpy.mockResolvedValue({ ...OWN_PRIVATE, visibility: 'shared' });
+    const page = await mount();
+    const btn = card(page, 'own-priv')!.querySelector<HTMLButtonElement>(
+      '[data-testid="coworker-share"]',
+    )!;
+    btn.click();
+    await settle(page);
+    expect(shareCoworkerSpy).toHaveBeenCalledTimes(1);
+    expect(shareCoworkerSpy).toHaveBeenCalledWith('own-priv');
+    expect(unshareCoworkerSpy).not.toHaveBeenCalled();
+  });
+
+  it('clicking Share on a SHARED own row calls unshareCoworker(id)', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    unshareCoworkerSpy.mockResolvedValue({
+      ...OWN_SHARED,
+      visibility: 'private',
+    });
+    const page = await mount();
+    const btn = card(page, 'own-shared')!.querySelector<HTMLButtonElement>(
+      '[data-testid="coworker-share"]',
+    )!;
+    btn.click();
+    await settle(page);
+    expect(unshareCoworkerSpy).toHaveBeenCalledTimes(1);
+    expect(unshareCoworkerSpy).toHaveBeenCalledWith('own-shared');
+    expect(shareCoworkerSpy).not.toHaveBeenCalled();
+  });
+
+  it('a manager can share OTHERS\' rows too (manage capability, not ownership)', async () => {
+    setMe(makeMe(MANAGER_CAPS));
+    shareCoworkerSpy.mockResolvedValue({
+      ...NULL_OWNER_SHARED,
+      visibility: 'shared',
+    });
+    const page = await mount();
+    // The null-owner row's toggle must exist for a manager and, since it
+    // is already shared, click -> unshare.
+    unshareCoworkerSpy.mockResolvedValue({
+      ...NULL_OWNER_SHARED,
+      visibility: 'private',
+    });
+    const btn = card(page, 'null-owner')!.querySelector<HTMLButtonElement>(
+      '[data-testid="coworker-share"]',
+    );
+    expect(btn).not.toBeNull();
+    btn!.click();
+    await settle(page);
+    expect(unshareCoworkerSpy).toHaveBeenCalledWith('null-owner');
+  });
+});
+
+describe('CoworkersPage — visibility pill + new-coworker gating', () => {
+  it('renders a green "Shared" / gray "Private" pill from wire visibility', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    const priv = card(page, 'own-priv')?.querySelector(
+      '[data-testid="coworker-visibility"]',
+    );
+    const shared = card(page, 'own-shared')?.querySelector(
+      '[data-testid="coworker-visibility"]',
+    );
+    expect(priv?.textContent?.trim()).toBe('Private');
+    expect(priv?.className).toContain('rm-pill-off');
+    expect(shared?.textContent?.trim()).toBe('Shared');
+    expect(shared?.className).toContain('rm-pill-on');
+  });
+
+  it('hides the New-coworker button when coworker.create is absent', async () => {
+    // A capability the matrix never strips from a tenant role today, but
+    // the gate must be capability-driven, not assumed-on. Seed a Me with
+    // no coworker.create and assert the button vanishes.
+    setMe(makeMe(['coworker.use']));
+    const page = await mount();
+    expect(
+      page.querySelector('[data-testid="coworker-new"]'),
+      'New button must be gated on coworker.create',
+    ).toBeNull();
+  });
+
+  it('shows the New-coworker button when coworker.create is present', async () => {
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    expect(
+      page.querySelector('[data-testid="coworker-new"]'),
+    ).not.toBeNull();
+  });
+});
+
+describe('CoworkersPage — capability-aware empty states', () => {
+  it('member empty "All visible" copy points to create or ask admin', async () => {
+    listCoworkersSpy.mockResolvedValue([]);
+    setMe(makeMe(MEMBER_CAPS));
+    const page = await mount();
+    const empty = page.querySelector('[data-testid="coworker-empty"]');
+    expect(empty?.textContent).toContain('ask your admin');
+  });
+
+  it('manager empty "All visible" copy says no coworkers in the tenant', async () => {
+    listCoworkersSpy.mockResolvedValue([]);
+    setMe(makeMe(MANAGER_CAPS));
+    const page = await mount();
+    const empty = page.querySelector('[data-testid="coworker-empty"]');
+    expect(empty?.textContent).toContain('No coworkers in this tenant');
+    expect(empty?.textContent).not.toContain('ask your admin');
+  });
+});

--- a/web/src/components/coworkers-page.ts
+++ b/web/src/components/coworkers-page.ts
@@ -19,18 +19,50 @@ import { customElement, query, state } from 'lit/decorators.js';
 
 import { ApiError, getApiClient } from '../api/client.js';
 import type { Coworker, ModelProvider } from '../api/client.js';
+import {
+  canManage,
+  hasCapability,
+  isOwnResource,
+} from '../auth/capabilities.js';
 import './coworker-wizard.js';
 import './credential-dialog.js';
 import './mcp-server-dialog.js';
 import './confirm-dialog.js';
 import type { CoworkerWizard } from './coworker-wizard.js';
-import { iconPencil, iconTrash } from './icons.js';
+import { iconPencil, iconTrash, iconUsers } from './icons.js';
+
+/** UX-only view filter over the already-server-filtered list. NOT a
+ *  security boundary — the backend already visibility-filtered the rows
+ *  (spec §7.3). These chips just re-narrow what's shown for the user's
+ *  workflow. PR5 (skills page) mirrors this exact classification. */
+export type CoworkerChip = 'all' | 'mine' | 'shared';
+
+/** Classify one row against a chip selection. Pure + reusable so the
+ *  skills page (PR5) can mirror it. Three-value safe: a row with a null
+ *  `created_by_user_id` is never "mine" (it falls through `isOwnResource`,
+ *  which returns false for null) and is only kept by the "shared" chip
+ *  when its visibility says so — never by ownership. */
+export function matchesChip(co: Coworker, chip: CoworkerChip): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'mine') return isOwnResource(co);
+  // 'shared' — others' shared rows only (own rows belong under "Mine").
+  return co.visibility === 'shared' && !isOwnResource(co);
+}
 
 @customElement('rm-coworkers-page')
 export class CoworkersPage extends LitElement {
   @state() private rows: Coworker[] = [];
   @state() private loading = true;
   @state() private error: string | null = null;
+  /** Client-side view filter (spec §5.1 chips). Pure presentation — the
+   *  list is already server-side visibility-filtered; this re-narrows it. */
+  @state() private chip: CoworkerChip = 'all';
+  /** Per-row share/unshare error, keyed by coworker id. Cleared on the
+   *  next refresh, same lifecycle as `deleteError`. */
+  @state() private shareError: Record<string, string> = {};
+  /** Ids with a share/unshare POST in flight — disables that row's
+   *  toggle so a double-click can't fire two visibility flips. */
+  @state() private shareInFlight: Set<string> = new Set();
   @state() private wizardOpen = false;
   @state() private credDialogOpen = false;
   @state() private credDialogProvider: ModelProvider | null = null;
@@ -64,6 +96,7 @@ export class CoworkersPage extends LitElement {
     this.loading = true;
     this.error = null;
     this.deleteError = {};
+    this.shareError = {};
     try {
       this.rows = await this.api.listCoworkers();
     } catch (err) {
@@ -119,6 +152,36 @@ export class CoworkersPage extends LitElement {
     }
   }
 
+  /** Flip a coworker's visibility. `canManage` is the ONLY gate (spec
+   *  §7.4 — no separate `*.share` capability); the toggle only renders
+   *  where canManage is true, and the backend re-checks the ownership
+   *  escape. Optimistic: we patch the local row from the returned
+   *  coworker so the pill + tooltip flip without a full refresh. */
+  private async toggleShare(c: Coworker): Promise<void> {
+    if (this.shareInFlight.has(c.id)) return;
+    this.shareInFlight = new Set(this.shareInFlight).add(c.id);
+    this.shareError = { ...this.shareError, [c.id]: '' };
+    try {
+      const updated =
+        c.visibility === 'shared'
+          ? await this.api.unshareCoworker(c.id)
+          : await this.api.shareCoworker(c.id);
+      this.rows = this.rows.map((r) => (r.id === updated.id ? updated : r));
+    } catch (err) {
+      this.shareError = {
+        ...this.shareError,
+        [c.id]:
+          err instanceof ApiError
+            ? `${err.status} — ${err.body?.message ?? err.message}`
+            : (err as Error).message ?? 'visibility change failed',
+      };
+    } finally {
+      const next = new Set(this.shareInFlight);
+      next.delete(c.id);
+      this.shareInFlight = next;
+    }
+  }
+
   private startChat(coworker: Coworker): void {
     // chat-panel reads `agent_id` from the query string; setting it
     // before navigating to `#/` keeps the legacy URL contract intact.
@@ -130,34 +193,43 @@ export class CoworkersPage extends LitElement {
   }
 
   override render() {
+    const canCreate = hasCapability('coworker.create');
+    const visibleRows = this.rows.filter((c) => matchesChip(c, this.chip));
     return html`
       <div class="rm-spane">
         <div class="rm-ch">
           <h2>Coworkers</h2>
-          <button
-            type="button"
-            class="rm-add"
-            @click=${() => { this.wizardOpen = true; }}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-              stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path d="M12 5v14M5 12h14"/>
-            </svg>
-            New coworker
-          </button>
+          ${canCreate
+            ? html`<button
+                type="button"
+                class="rm-add"
+                data-testid="coworker-new"
+                @click=${() => { this.wizardOpen = true; }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path d="M12 5v14M5 12h14"/>
+                </svg>
+                New coworker
+              </button>`
+            : nothing}
         </div>
         <p class="rm-sub">
           Each coworker is assembled from an engine, a model, bound MCP
           servers and skills. Click one to chat or edit.
         </p>
 
+        ${this.loading || this.error || this.rows.length === 0
+          ? nothing
+          : this.renderChips()}
+
         ${this.loading
           ? html`<div class="rm-banner-loading">Loading…</div>`
           : this.error
             ? html`<div class="rm-banner-err">${this.error}</div>`
-            : this.rows.length === 0
+            : visibleRows.length === 0
               ? this.renderEmpty()
-              : this.renderList()}
+              : this.renderList(visibleRows)}
         <rm-coworker-wizard
           ?open=${this.wizardOpen}
           .editing=${this.editTarget}
@@ -221,11 +293,60 @@ export class CoworkersPage extends LitElement {
     `;
   }
 
-  private renderEmpty() {
+  private renderChips() {
+    const chips: Array<[CoworkerChip, string]> = [
+      ['all', 'All visible'],
+      ['mine', 'Mine'],
+      ['shared', 'Shared by others'],
+    ];
     return html`
-      <div class="rm-empty">
-        <span class="rm-empty-title">No coworkers yet</span>
-        Click <b>+ New coworker</b> above to start the 6-step setup.
+      <div class="rm-seg rm-chipbar" role="tablist" aria-label="Filter coworkers">
+        ${chips.map(
+          ([key, label]) => html`
+            <button
+              type="button"
+              role="tab"
+              class=${this.chip === key ? 'rm-seg--on' : ''}
+              aria-selected=${this.chip === key ? 'true' : 'false'}
+              data-testid="coworker-chip-${key}"
+              @click=${() => { this.chip = key; }}
+            >${label}</button>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  /** Empty-state copy varies by the active chip AND by whether the user
+   *  can manage coworkers tenant-wide vs is a plain member (spec §5.1).
+   *  Gated on a CAPABILITY (`coworker.manage`), never a role name — a
+   *  member's next action is "ask an admin to share / create your own",
+   *  an admin/owner's is "create the first one". */
+  private renderEmpty() {
+    const isManager = hasCapability('coworker.manage');
+    let title: string;
+    let body: unknown;
+    if (this.chip === 'mine') {
+      title = 'Nothing here yet';
+      body = html`You haven’t created any coworkers yet.`;
+    } else if (this.chip === 'shared') {
+      title = 'Nothing shared';
+      body = isManager
+        ? html`No coworkers shared by others.`
+        : html`No coworkers have been shared with you yet.`;
+    } else {
+      // 'all'
+      title = 'No coworkers yet';
+      body = isManager
+        ? html`No coworkers in this tenant yet. Click
+            <b>+ New coworker</b> above to create the first one.`
+        : html`No coworkers yet. Create one with
+            <b>+ New coworker</b>, or ask your admin to share theirs.`;
+    }
+    return html`
+      <div class="rm-empty" data-testid="coworker-empty">
+        <span class="rm-empty-title">${title}</span>
+        ${body}
       </div>
     `;
   }
@@ -237,9 +358,87 @@ export class CoworkersPage extends LitElement {
     return 'rm-pill rm-pill-off';
   }
 
-  private renderList() {
+  /** Ownership cue (spec §5.1). There is NO owner display-name on the
+   *  wire — only `created_by_user_id` — so own rows read "Created by
+   *  you" in accent; everything else is a neutral label (never an
+   *  invented person name). */
+  private renderOwnTag(c: Coworker) {
+    if (isOwnResource(c)) {
+      return html`<span
+        class="rm-own-tag rm-own-tag--mine"
+        data-testid="coworker-own-tag"
+      >Created by you</span>`;
+    }
+    return html`<span
+      class="rm-own-tag rm-own-tag--other"
+      data-testid="coworker-own-tag"
+    >Shared by another member</span>`;
+  }
+
+  /** Visibility pill — green "Shared" / gray "Private" from the wire
+   *  `visibility` (spec §7.4). */
+  private renderVisibilityPill(c: Coworker) {
+    const shared = c.visibility === 'shared';
+    return html`<span
+      class=${shared ? 'rm-pill rm-pill-on' : 'rm-pill rm-pill-off'}
+      data-testid="coworker-visibility"
+    >${shared ? 'Shared' : 'Private'}</span>`;
+  }
+
+  private renderRowActions(c: Coworker) {
+    // Single gate for ALL management affordances — the ownership escape
+    // (manage capability OR own the row), mirroring the backend. Members
+    // see a "view only" hint instead of dead Edit/Delete/Share buttons.
+    if (!canManage(c, 'coworker.manage')) {
+      return html`<span class="rm-viewonly" data-testid="coworker-viewonly"
+        >View only</span
+      >`;
+    }
+    const shared = c.visibility === 'shared';
+    const busy = this.shareInFlight.has(c.id);
     return html`
-      ${this.rows.map(
+      <span class="rm-row-acts">
+        <button
+          type="button"
+          class=${shared ? 'rm-iconbtn rm-iconbtn--on' : 'rm-iconbtn'}
+          title=${shared
+            ? 'Make private'
+            : `Share with everyone in ${c.tenant_id}`}
+          data-testid="coworker-share"
+          ?disabled=${busy}
+          aria-pressed=${shared ? 'true' : 'false'}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            void this.toggleShare(c);
+          }}
+        >${iconUsers(15)}</button>
+        <button
+          type="button"
+          class="rm-iconbtn"
+          title="Edit coworker"
+          data-testid="coworker-edit"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.openEdit(c);
+          }}
+        >${iconPencil(15)}</button>
+        <button
+          type="button"
+          class="rm-iconbtn rm-iconbtn--danger"
+          title="Delete coworker"
+          data-testid="coworker-delete"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.askDelete(c);
+          }}
+        >${iconTrash(15)}</button>
+      </span>
+    `;
+  }
+
+  private renderList(rows: Coworker[]) {
+    return html`
+      ${rows.map(
         (c) => html`
           <div
             class="rm-card"
@@ -252,33 +451,19 @@ export class CoworkersPage extends LitElement {
             <span class="rm-ic">${(c.name?.[0] ?? '?').toUpperCase()}</span>
             <span class="rm-mn">
               <b>${c.name}</b>
-              <span>${c.agent_backend} · ${c.id.slice(0, 8)}</span>
+              <span>
+                ${c.agent_backend} · ${c.id.slice(0, 8)} ·
+                ${this.renderOwnTag(c)}
+              </span>
             </span>
+            ${this.renderVisibilityPill(c)}
             <span class=${this.pillClass(c.status)}>${c.status}</span>
-            <span class="rm-row-acts">
-              <button
-                type="button"
-                class="rm-iconbtn"
-                title="Edit coworker"
-                data-testid="coworker-edit"
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  this.openEdit(c);
-                }}
-              >${iconPencil(15)}</button>
-              <button
-                type="button"
-                class="rm-iconbtn rm-iconbtn--danger"
-                title="Delete coworker"
-                data-testid="coworker-delete"
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  this.askDelete(c);
-                }}
-              >${iconTrash(15)}</button>
-            </span>
+            ${this.renderRowActions(c)}
             ${this.deleteError[c.id]
               ? html`<div class="rm-row-error">${this.deleteError[c.id]}</div>`
+              : nothing}
+            ${this.shareError[c.id]
+              ? html`<div class="rm-row-error">${this.shareError[c.id]}</div>`
               : nothing}
           </div>
         `,

--- a/web/src/components/platform-shell.test.ts
+++ b/web/src/components/platform-shell.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment happy-dom
+// <rm-platform-shell> — pins the platform-plane rail + route map (RBAC
+// UI spec §4). With a platform_admin `me` (all 4 platform caps):
+//   - all four nav entries render, in rail order
+//   - the active `tenants` slug routes to <rm-platform-tenants-page>
+//   - the other three slugs route to <rm-coming-soon>
+//   - capability gating: an entry whose capability is absent disappears
+//
+// We seed the REAL setMe()/hasCapability() from capabilities.ts (no
+// mock) — the production code keeps NO role->capability table, so we
+// feed the exact wire capability list a platform_admin receives and
+// assert which entries survive the gate. The slotted tenants-page reaches
+// for the api client on mount; we stub that boundary so the unit test
+// doesn't fan out to an unmocked fetch.
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+vi.mock('../api/client.js', async () => {
+  const actual = await vi.importActual<typeof import('../api/client.js')>(
+    '../api/client.js',
+  );
+  return {
+    ...actual,
+    getApiClient: () => ({
+      listTenants: vi.fn().mockResolvedValue([]),
+    }),
+  };
+});
+
+import { RmPlatformShell, slugFromHash } from './platform-shell.js';
+import { setMe } from '../auth/capabilities.js';
+import type { Me } from '../api/client.js';
+
+interface LocationStub {
+  hashAssignments: string[];
+  hashGetter: string;
+  restore: () => void;
+}
+
+function stubHash(initial = '#/platform/tenants'): LocationStub {
+  const stub: LocationStub = {
+    hashAssignments: [],
+    hashGetter: initial,
+    restore: () => {},
+  };
+  const desc = Object.getOwnPropertyDescriptor(location, 'hash');
+  Object.defineProperty(location, 'hash', {
+    configurable: true,
+    get: () => stub.hashGetter,
+    set: (v: string) => {
+      stub.hashAssignments.push(v);
+      stub.hashGetter = v;
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    },
+  });
+  stub.restore = () => {
+    if (desc) Object.defineProperty(location, 'hash', desc);
+  };
+  return stub;
+}
+
+async function settle(el: RmPlatformShell): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
+    await el.updateComplete;
+  }
+}
+
+async function mount(): Promise<RmPlatformShell> {
+  const el = document.createElement('rm-platform-shell') as RmPlatformShell;
+  document.body.appendChild(el);
+  await settle(el);
+  return el;
+}
+
+// The four platform-only capabilities a platform_admin receives from
+// `GET /api/v1/me` (mirrors permissions.py:_PLATFORM_ONLY_ACTIONS). TEST
+// INPUT ONLY — production keeps no role->capability map.
+const PLATFORM_CAPS = [
+  'platform.tenant.manage',
+  'model.manage',
+  'credential.pool.manage',
+  'safety.platform.manage',
+];
+
+function makePlatformMe(capabilities: string[] = PLATFORM_CAPS): Me {
+  return {
+    user_id: 'pa-1',
+    tenant_id: '__platform__',
+    name: 'Platform Admin',
+    email: 'admin@platform.test',
+    role: 'platform_admin',
+    plane: 'platform',
+    capabilities,
+  };
+}
+
+function visibleSlugs(el: RmPlatformShell): string[] {
+  return Array.from(
+    el.querySelectorAll('[data-testid="platform-nav-entry"]'),
+  ).map((b) => b.getAttribute('data-slug') ?? '');
+}
+
+describe('platform-shell slugFromHash', () => {
+  it('returns the slug from a platform hash', () => {
+    expect(slugFromHash('#/platform/tenants')).toBe('tenants');
+    expect(slugFromHash('#/platform/models')).toBe('models');
+    expect(slugFromHash('#/platform/credentials')).toBe('credentials');
+    expect(slugFromHash('#/platform/safety')).toBe('safety');
+  });
+
+  it('collapses sub-paths to the parent slug', () => {
+    expect(slugFromHash('#/platform/tenants/t-123')).toBe('tenants');
+  });
+
+  it('falls back to "tenants" for unknown slugs and stray hashes', () => {
+    expect(slugFromHash('#/platform/made-up')).toBe('tenants');
+    expect(slugFromHash('#/manage/safety')).toBe('tenants');
+    expect(slugFromHash('')).toBe('tenants');
+  });
+});
+
+describe('<rm-platform-shell>', () => {
+  let loc: LocationStub;
+
+  beforeEach(() => {
+    loc = stubHash('#/platform/tenants');
+    setMe(makePlatformMe());
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('rm-platform-shell').forEach((el) => el.remove());
+    loc.restore();
+    setMe(null);
+    vi.clearAllMocks();
+  });
+
+  it('renders all four platform nav entries in rail order for a platform_admin', async () => {
+    const el = await mount();
+    expect(visibleSlugs(el)).toEqual([
+      'tenants',
+      'models',
+      'credentials',
+      'safety',
+    ]);
+  });
+
+  it('routes the active "tenants" slug to <rm-platform-tenants-page>', async () => {
+    const el = await mount();
+    const pane = el.querySelector('[data-testid="platform-active-pane"]');
+    expect(pane?.querySelector('rm-platform-tenants-page')).not.toBeNull();
+    // ...and NOT a coming-soon stub.
+    expect(pane?.querySelector('rm-coming-soon')).toBeNull();
+  });
+
+  // The three deferred slugs each route to a <rm-coming-soon> stub
+  // (spec §5.8). Pin each individually so a future mis-wire (e.g.
+  // pointing 'models' at a real page) fails here.
+  const STUB_SLUGS: Array<[string, string]> = [
+    ['models', 'Models management'],
+    ['credentials', 'Credential pool'],
+    ['safety', 'Platform safety rules'],
+  ];
+
+  it.each(STUB_SLUGS)(
+    '%s slug routes to <rm-coming-soon> labelled "%s"',
+    async (slug, label) => {
+      loc.restore();
+      loc = stubHash(`#/platform/${slug}`);
+      const el = await mount();
+      const pane = el.querySelector('[data-testid="platform-active-pane"]');
+      const stub = pane?.querySelector('rm-coming-soon');
+      expect(stub, `expected <rm-coming-soon> for ${slug}`).not.toBeNull();
+      expect((stub as { label?: string } | null)?.label).toBe(label);
+      // The real tenants page must NOT have mounted on a stub slug.
+      expect(pane?.querySelector('rm-platform-tenants-page')).toBeNull();
+    },
+  );
+
+  it('clicking a nav entry navigates to #/platform/<slug>', async () => {
+    const el = await mount();
+    const btn = el.querySelector<HTMLButtonElement>(
+      '[data-testid="platform-nav-entry"][data-slug="models"]',
+    );
+    btn!.click();
+    await settle(el);
+    expect(loc.hashAssignments).toContain('#/platform/models');
+  });
+
+  it('highlights the active entry with class="active"', async () => {
+    loc.restore();
+    loc = stubHash('#/platform/credentials');
+    const el = await mount();
+    const active = el.querySelector(
+      '[data-testid="platform-nav-entry"][data-slug="credentials"]',
+    );
+    expect(active?.classList.contains('active')).toBe(true);
+    const inactive = el.querySelector(
+      '[data-testid="platform-nav-entry"][data-slug="tenants"]',
+    );
+    expect(inactive?.classList.contains('active')).toBe(false);
+  });
+
+  it('hides an entry whose capability the user lacks (partial-capability degrade)', async () => {
+    // A hypothetical future platform role with only tenant.manage. The
+    // gate must drop the other three entries — driven by the wire caps,
+    // NOT by the role name 'platform_admin'.
+    setMe(makePlatformMe(['platform.tenant.manage']));
+    const el = await mount();
+    expect(visibleSlugs(el)).toEqual(['tenants']);
+  });
+
+  it('renders <rm-access-denied> in the pane when URL-jumping to a gated slug', async () => {
+    setMe(makePlatformMe(['platform.tenant.manage']));
+    loc.restore();
+    loc = stubHash('#/platform/models');
+    const el = await mount();
+    const pane = el.querySelector('[data-testid="platform-active-pane"]');
+    const denied = pane?.querySelector('rm-access-denied');
+    expect(denied, 'access-denied should render in the pane').not.toBeNull();
+    expect((denied as { capability?: string } | null)?.capability).toBe(
+      'model.manage',
+    );
+    // The rail still shows what the user CAN see (no silent redirect).
+    expect(visibleSlugs(el)).toEqual(['tenants']);
+  });
+
+  it('renders a loading fallback when me is not yet cached', async () => {
+    setMe(null);
+    const el = await mount();
+    expect(
+      el.querySelector('[data-testid="platform-loading"]'),
+    ).not.toBeNull();
+    expect(
+      el.querySelectorAll('[data-testid="platform-nav-entry"]'),
+    ).toHaveLength(0);
+  });
+});

--- a/web/src/components/platform-shell.ts
+++ b/web/src/components/platform-shell.ts
@@ -1,0 +1,340 @@
+// <rm-platform-shell> — the platform-plane chrome (RBAC UI spec §2 / §4).
+//
+// Rendered by <rm-app> when `currentMe()?.plane === 'platform'` (a PLANE
+// check, never a role-name check). It lives at the same level as
+// <rm-settings-shell> and is structurally parallel to it — one nav group
+// "PLATFORM" with four hash-routed entries under `#/platform/<slug>`:
+//
+//   ─ PLATFORM
+//     Tenants          → <rm-platform-tenants-page>  (the real page)
+//     Models           → <rm-coming-soon>            (deferred, phase 3)
+//     Credential pool  → <rm-coming-soon>            (deferred, phase 3)
+//     Platform safety  → <rm-coming-soon>            (deferred, phase 3)
+//
+// Each entry carries a `requires` capability and the rail filters by it
+// via `hasCapability` (same idiom as settings-shell), so a future
+// platform role with only a SUBSET of the four platform capabilities
+// degrades gracefully — no role->capability table lives here. The strings
+// name a capability, never a role; the backend permissions.py is the
+// single source of truth and the wire carries the resolved list.
+//
+// Light DOM + `--rm-` tokens only, matching the settings-shell neighbor.
+
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { keyed } from 'lit/directives/keyed.js';
+import type { SVGTemplateResult } from 'lit';
+
+import { currentMe, hasCapability } from '../auth/capabilities.js';
+import { iconChip, iconKey, iconShield, iconUsers } from './icons.js';
+import './reauth-banner.js';
+import './coming-soon.js';
+import './platform-tenants-page.js';
+import './access-denied-page.js';
+
+interface NavEntry {
+  /** Sub-path under `#/platform/`. */
+  slug: string;
+  label: string;
+  icon: () => SVGTemplateResult;
+  render: () => TemplateResult;
+  /** Platform capability required to see this entry. Always set on this
+   *  shell (every platform page is gated). A typo silently hides the
+   *  entry for everyone — the strings must match permissions.py exactly. */
+  requires: string;
+}
+
+/**
+ * The four platform-plane pages (spec §4). Order = the rail order. Only
+ * Tenants is a real page in v3; the other three route to <rm-coming-soon>
+ * stubs (Models CRUD / Credential pool / Platform safety are deferred —
+ * their backend write endpoints exist; only the UI is pending, spec §5.8).
+ */
+const NAV_ENTRIES: NavEntry[] = [
+  {
+    slug: 'tenants',
+    label: 'Tenants',
+    icon: () => iconUsers(16),
+    render: () => html`<rm-platform-tenants-page></rm-platform-tenants-page>`,
+    requires: 'platform.tenant.manage',
+  },
+  {
+    slug: 'models',
+    label: 'Models',
+    icon: () => iconChip(16),
+    render: () =>
+      html`<rm-coming-soon label="Models management" .phase=${3}></rm-coming-soon>`,
+    requires: 'model.manage',
+  },
+  {
+    slug: 'credentials',
+    label: 'Credential pool',
+    icon: () => iconKey(16),
+    render: () =>
+      html`<rm-coming-soon label="Credential pool" .phase=${3}></rm-coming-soon>`,
+    requires: 'credential.pool.manage',
+  },
+  {
+    slug: 'safety',
+    label: 'Platform safety rules',
+    icon: () => iconShield(16),
+    render: () =>
+      html`<rm-coming-soon
+        label="Platform safety rules"
+        .phase=${3}
+      ></rm-coming-soon>`,
+    requires: 'safety.platform.manage',
+  },
+];
+
+/** Flat lookup map. Computed once at module load. */
+const ENTRY_BY_SLUG: Record<string, NavEntry> = Object.fromEntries(
+  NAV_ENTRIES.map((e) => [e.slug, e]),
+);
+
+const DEFAULT_SLUG = 'tenants';
+
+/**
+ * Resolve `#/platform/<slug>[/<rest>]` to a slug. Sub-paths collapse to
+ * the parent slug (mirrors settings-shell.slugFromHash). Unknown slugs
+ * fall back to the default.
+ */
+export function slugFromHash(hash: string): string {
+  const m = hash.match(/^#\/platform\/([^/?#]+)/);
+  if (!m) return DEFAULT_SLUG;
+  const slug = m[1];
+  return slug in ENTRY_BY_SLUG ? slug : DEFAULT_SLUG;
+}
+
+@customElement('rm-platform-shell')
+export class RmPlatformShell extends LitElement {
+  @state() private hash: string = location.hash;
+
+  protected override createRenderRoot() {
+    // Light DOM — page components resolve `--rm-` tokens + Tailwind
+    // classes at the document root (matches settings-shell).
+    return this;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.style.display = 'flex';
+    this.style.flexDirection = 'column';
+    this.style.height = '100%';
+    window.addEventListener('hashchange', this.onHashChange);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('hashchange', this.onHashChange);
+  }
+
+  private onHashChange = () => {
+    this.hash = location.hash;
+  };
+
+  private navigate(slug: string) {
+    const target = `#/platform/${slug}`;
+    if (location.hash !== target) {
+      location.hash = target;
+    }
+  }
+
+  /** Whether `currentMe()` may see `entry` — the single gate. The shell
+   *  inspects only the wire `capabilities` list via `hasCapability`,
+   *  never a role name. */
+  private canSee(entry: NavEntry): boolean {
+    return hasCapability(entry.requires);
+  }
+
+  override render(): TemplateResult {
+    // Defensive null-guard. <rm-app> holds authState at 'loading' until
+    // setMe() runs, so this should not be reached in practice.
+    const me = currentMe();
+    if (!me) {
+      return html`<div class="ps-loading" data-testid="platform-loading">
+        Loading…
+      </div>`;
+    }
+
+    const visibleEntries = NAV_ENTRIES.filter((e) => this.canSee(e));
+
+    const activeSlug = slugFromHash(this.hash);
+    const active = ENTRY_BY_SLUG[activeSlug];
+    // URL-jump guard: active slug is a real entry but one this user can't
+    // see. Keep the rail, render access-denied in the pane (no redirect).
+    const denied = !!active && !this.canSee(active);
+    const firstVisible = visibleEntries[0];
+
+    return html`
+      <style>
+        rm-platform-shell {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          min-height: 0;
+          background: var(--rm-bg);
+          color: var(--rm-ink);
+          font-family: var(--rm-font-body);
+        }
+        rm-platform-shell .ps-layout {
+          flex: 1;
+          min-height: 0;
+          display: grid;
+          grid-template-columns: 248px 1fr;
+        }
+        rm-platform-shell .ps-nav {
+          background: var(--rm-surface-2);
+          border-right: 1px solid var(--rm-border);
+          padding: 16px 12px;
+          overflow-y: auto;
+          display: flex;
+          flex-direction: column;
+        }
+        rm-platform-shell .ps-nav .sttl {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 0 8px 12px;
+        }
+        rm-platform-shell .ps-nav .sttl b {
+          font-size: var(--rm-text-md);
+          font-weight: 600;
+        }
+        rm-platform-shell .ps-nav .ng {
+          font-size: var(--rm-text-xs);
+          font-weight: 600;
+          color: var(--rm-ink-3);
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+          padding: 14px 8px 5px;
+        }
+        rm-platform-shell .ps-nav .ni {
+          display: flex;
+          align-items: center;
+          gap: 9px;
+          padding: 7px 9px;
+          border-radius: var(--rm-radius-sm);
+          font-size: 13.5px;
+          color: var(--rm-ink-2);
+          cursor: pointer;
+          background: none;
+          border: none;
+          width: 100%;
+          text-align: left;
+          font-family: inherit;
+          transition: 0.12s;
+        }
+        rm-platform-shell .ps-nav .ni:hover { background: var(--rm-surface); }
+        rm-platform-shell .ps-nav .ni.active {
+          background: var(--rm-accent-subtle);
+          color: var(--rm-accent-2);
+          font-weight: 500;
+        }
+        rm-platform-shell .ps-nav .ni .ni-icon {
+          display: inline-flex;
+          color: var(--rm-ink-3);
+          flex-shrink: 0;
+        }
+        rm-platform-shell .ps-nav .ni:hover .ni-icon,
+        rm-platform-shell .ps-nav .ni.active .ni-icon {
+          color: inherit;
+        }
+        rm-platform-shell .ps-close {
+          width: 28px;
+          height: 28px;
+          border-radius: 7px;
+          display: grid;
+          place-items: center;
+          color: var(--rm-ink-3);
+          background: none;
+          border: none;
+          cursor: pointer;
+          font-family: inherit;
+        }
+        rm-platform-shell .ps-close:hover {
+          background: var(--rm-surface-3);
+          color: var(--rm-ink);
+        }
+        rm-platform-shell .ps-main {
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+          overflow: hidden;
+        }
+        rm-platform-shell .ps-hd {
+          height: 52px;
+          display: flex;
+          align-items: center;
+          padding: 0 22px;
+          border-bottom: 1px solid var(--rm-border);
+          background: var(--rm-bg);
+        }
+        rm-platform-shell .ps-hd h2 {
+          font-size: 16px;
+          font-weight: 600;
+          margin: 0;
+        }
+        rm-platform-shell .ps-body {
+          flex: 1;
+          overflow-y: auto;
+          min-height: 0;
+        }
+        rm-platform-shell .ps-card {
+          background: none;
+          border: none;
+          border-radius: 0;
+          padding: 0;
+          min-height: 100%;
+        }
+      </style>
+      <rm-reauth-banner></rm-reauth-banner>
+      <div class="ps-layout">
+        <aside class="ps-nav" aria-label="Platform navigation">
+          <div class="sttl">
+            <b>Platform</b>
+          </div>
+          <div class="ng">Platform</div>
+          ${visibleEntries.map((entry) => this.renderEntry(entry, activeSlug))}
+        </aside>
+        <div class="ps-main">
+          <div class="ps-hd">
+            <h2 data-testid="platform-active-title">
+              ${denied ? 'Access denied' : active?.label ?? 'Platform'}
+            </h2>
+          </div>
+          <div class="ps-body">
+            <div class="ps-card" data-testid="platform-active-pane">
+              ${denied
+                ? html`<rm-access-denied
+                    data-testid="access-denied"
+                    .capability=${active!.requires}
+                    .pageLabel=${active!.label}
+                    .backSlug=${firstVisible?.slug ?? DEFAULT_SLUG}
+                    .backLabel=${firstVisible?.label ?? 'Tenants'}
+                  ></rm-access-denied>`
+                : active
+                  ? keyed(activeSlug, active.render())
+                  : nothing}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderEntry(entry: NavEntry, activeSlug: string): TemplateResult {
+    return html`
+      <button
+        class=${`ni ${entry.slug === activeSlug ? 'active' : ''}`}
+        data-testid="platform-nav-entry"
+        data-slug=${entry.slug}
+        aria-current=${entry.slug === activeSlug ? 'page' : 'false'}
+        @click=${() => this.navigate(entry.slug)}
+      >
+        <span class="ni-icon">${entry.icon()}</span>
+        <span class="ni-label">${entry.label}</span>
+      </button>
+    `;
+  }
+}

--- a/web/src/components/platform-tenants-page.test.ts
+++ b/web/src/components/platform-tenants-page.test.ts
@@ -1,0 +1,242 @@
+// @vitest-environment happy-dom
+// <rm-platform-tenants-page> — pins the list / suspend / resume /
+// provision wiring (RBAC UI spec §4). We stub ONLY the api client
+// boundary (the four platform-tenant methods) and run the real Lit
+// component against it.
+//
+// Behaviours pinned:
+//   - the list renders one row per PlatformTenantResponse
+//   - an ACTIVE row shows Suspend; clicking it calls suspendTenant(id)
+//   - a SUSPENDED row shows Resume; clicking it calls resumeTenant(id)
+//   - the provision dialog submit calls provisionTenant({name, slug?})
+//     with the entered values
+//   - a blank-name provision is rejected without an API call
+//   - the empty + error states render
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listSpy = vi.fn();
+const provisionSpy = vi.fn();
+const suspendSpy = vi.fn();
+const resumeSpy = vi.fn();
+
+vi.mock('../api/client.js', async () => {
+  const actual = await vi.importActual<typeof import('../api/client.js')>(
+    '../api/client.js',
+  );
+  return {
+    ...actual,
+    getApiClient: () => ({
+      listTenants: listSpy,
+      provisionTenant: provisionSpy,
+      suspendTenant: suspendSpy,
+      resumeTenant: resumeSpy,
+    }),
+  };
+});
+
+import { PlatformTenantsPage } from './platform-tenants-page.js';
+import type { PlatformTenantResponse } from '../api/client.js';
+
+function makeTenant(
+  over: Partial<PlatformTenantResponse> = {},
+): PlatformTenantResponse {
+  return {
+    id: 't-1',
+    name: 'Acme Corp',
+    slug: 'acme',
+    plan: null,
+    max_concurrent_containers: 5,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    ...over,
+  };
+}
+
+describe('PlatformTenantsPage', () => {
+  let page: PlatformTenantsPage;
+
+  async function waitUntilLoaded() {
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+      await page.updateComplete;
+      // @ts-expect-error — reading private state for the test
+      if (page.loading === false) return;
+    }
+    throw new Error('PlatformTenantsPage did not finish loading');
+  }
+
+  async function mountWith(rows: PlatformTenantResponse[]) {
+    listSpy.mockResolvedValue(rows);
+    page = new PlatformTenantsPage();
+    document.body.appendChild(page);
+    await waitUntilLoaded();
+  }
+
+  beforeEach(() => {
+    listSpy.mockReset();
+    provisionSpy.mockReset();
+    suspendSpy.mockReset();
+    resumeSpy.mockReset();
+    listSpy.mockResolvedValue([]);
+    provisionSpy.mockResolvedValue(makeTenant());
+    suspendSpy.mockResolvedValue(makeTenant({ status: 'suspended' }));
+    resumeSpy.mockResolvedValue(makeTenant({ status: 'active' }));
+  });
+
+  afterEach(() => {
+    page?.remove();
+  });
+
+  it('renders one row per tenant from listTenants()', async () => {
+    await mountWith([
+      makeTenant({ id: 't-1', name: 'Acme Corp' }),
+      makeTenant({ id: 't-2', name: 'Globex', status: 'suspended' }),
+    ]);
+    const rows = page.querySelectorAll('[data-testid="tenant-row"]');
+    expect(rows).toHaveLength(2);
+    expect(page.textContent).toContain('Acme Corp');
+    expect(page.textContent).toContain('Globex');
+  });
+
+  it('renders the empty state when there are no tenants', async () => {
+    await mountWith([]);
+    expect(page.querySelector('[data-testid="tenants-empty"]')).not.toBeNull();
+    expect(page.querySelectorAll('[data-testid="tenant-row"]')).toHaveLength(0);
+  });
+
+  it('renders the error banner when listTenants() rejects', async () => {
+    listSpy.mockRejectedValue(new Error('boom'));
+    page = new PlatformTenantsPage();
+    document.body.appendChild(page);
+    await waitUntilLoaded();
+    const banner = page.querySelector('[data-testid="tenants-error"]');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain('boom');
+  });
+
+  it('an active row shows Suspend and clicking it calls suspendTenant(id)', async () => {
+    await mountWith([makeTenant({ id: 't-active', status: 'active' })]);
+    const row = page.querySelector('[data-tenant-id="t-active"]');
+    const btn = row?.querySelector<HTMLButtonElement>(
+      '[data-testid="tenant-suspend"]',
+    );
+    expect(btn, 'active row must show a Suspend button').not.toBeNull();
+    // The Resume affordance must NOT be present on an active row.
+    expect(row?.querySelector('[data-testid="tenant-resume"]')).toBeNull();
+    btn!.click();
+    await page.updateComplete;
+    expect(suspendSpy).toHaveBeenCalledTimes(1);
+    expect(suspendSpy).toHaveBeenCalledWith('t-active');
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+
+  it('a suspended row shows Resume and clicking it calls resumeTenant(id)', async () => {
+    await mountWith([makeTenant({ id: 't-susp', status: 'suspended' })]);
+    const row = page.querySelector('[data-tenant-id="t-susp"]');
+    const btn = row?.querySelector<HTMLButtonElement>(
+      '[data-testid="tenant-resume"]',
+    );
+    expect(btn, 'suspended row must show a Resume button').not.toBeNull();
+    expect(row?.querySelector('[data-testid="tenant-suspend"]')).toBeNull();
+    btn!.click();
+    await page.updateComplete;
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledWith('t-susp');
+    expect(suspendSpy).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the list after a successful suspend', async () => {
+    await mountWith([makeTenant({ id: 't-active', status: 'active' })]);
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    const btn = page.querySelector<HTMLButtonElement>(
+      '[data-testid="tenant-suspend"]',
+    );
+    btn!.click();
+    // Let toggleStatus -> refresh() settle.
+    for (let i = 0; i < 20; i++) {
+      await Promise.resolve();
+      await page.updateComplete;
+    }
+    // One initial load + one refresh after the suspend.
+    expect(listSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('provision dialog submit calls provisionTenant with the entered name + slug', async () => {
+    await mountWith([]);
+    // Open the dialog.
+    page
+      .querySelector<HTMLButtonElement>('[data-testid="provision-tenant"]')!
+      .click();
+    await page.updateComplete;
+
+    const nameInput = page.querySelector<HTMLInputElement>(
+      '[data-testid="provision-name"]',
+    );
+    const slugInput = page.querySelector<HTMLInputElement>(
+      '[data-testid="provision-slug"]',
+    );
+    expect(nameInput, 'name field must render').not.toBeNull();
+    nameInput!.value = 'Initech';
+    nameInput!.dispatchEvent(new Event('input'));
+    slugInput!.value = 'initech';
+    slugInput!.dispatchEvent(new Event('input'));
+    await page.updateComplete;
+
+    page
+      .querySelector<HTMLButtonElement>('[data-testid="provision-submit"]')!
+      .click();
+    await page.updateComplete;
+
+    expect(provisionSpy).toHaveBeenCalledTimes(1);
+    expect(provisionSpy).toHaveBeenCalledWith({
+      name: 'Initech',
+      slug: 'initech',
+    });
+  });
+
+  it('omits slug from the provision body when left blank (slug? is optional)', async () => {
+    await mountWith([]);
+    page
+      .querySelector<HTMLButtonElement>('[data-testid="provision-tenant"]')!
+      .click();
+    await page.updateComplete;
+
+    const nameInput = page.querySelector<HTMLInputElement>(
+      '[data-testid="provision-name"]',
+    );
+    nameInput!.value = 'NoSlug Inc';
+    nameInput!.dispatchEvent(new Event('input'));
+    await page.updateComplete;
+
+    page
+      .querySelector<HTMLButtonElement>('[data-testid="provision-submit"]')!
+      .click();
+    await page.updateComplete;
+
+    expect(provisionSpy).toHaveBeenCalledTimes(1);
+    // No empty-string slug — the key is absent entirely.
+    expect(provisionSpy).toHaveBeenCalledWith({ name: 'NoSlug Inc' });
+    const arg = provisionSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect('slug' in arg).toBe(false);
+  });
+
+  it('rejects a blank-name provision without calling provisionTenant', async () => {
+    await mountWith([]);
+    page
+      .querySelector<HTMLButtonElement>('[data-testid="provision-tenant"]')!
+      .click();
+    await page.updateComplete;
+
+    // Submit with the name field still empty.
+    page
+      .querySelector<HTMLButtonElement>('[data-testid="provision-submit"]')!
+      .click();
+    await page.updateComplete;
+
+    expect(provisionSpy).not.toHaveBeenCalled();
+    expect(
+      page.querySelector('[data-testid="provision-error"]')?.textContent,
+    ).toContain('required');
+  });
+});

--- a/web/src/components/platform-tenants-page.ts
+++ b/web/src/components/platform-tenants-page.ts
@@ -1,0 +1,305 @@
+// <rm-platform-tenants-page> — the platform-plane Tenants page (RBAC
+// UI spec §4 / §5.x). Lists every tenant on the platform, lets the
+// operator provision a new one, and suspend / resume existing ones.
+//
+// Only reached from <rm-platform-shell> when the caller holds
+// `platform.tenant.manage` (gated at the nav level). This page owns no
+// authorization of its own — the backend enforces every action; per-row
+// buttons are a UX courtesy. The `__platform__` sentinel tenant answers
+// 403 on suspend; we surface that error inline rather than special-casing
+// it client-side (so the frontend keeps no copy of backend rules).
+//
+// Reads/writes go through the typed v1 ApiClient (D1: client.ts gained
+// listTenants / provisionTenant / suspendTenant / resumeTenant). Look and
+// feel reuse the shared settings-pages.css classes (rm-spane / rm-card /
+// rm-pill / …) so the page matches credentials-page / safety-rules-page.
+// `--rm-` tokens only — no literal colors or fonts.
+
+import { LitElement, html, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { ApiError, getApiClient } from '../api/client.js';
+import type {
+  PlatformTenantProvision,
+  PlatformTenantResponse,
+} from '../api/client.js';
+import './dialog.js';
+import { iconPlus } from './icons.js';
+
+@customElement('rm-platform-tenants-page')
+export class PlatformTenantsPage extends LitElement {
+  @state() private rows: PlatformTenantResponse[] = [];
+  @state() private loading = true;
+  @state() private listError: string | null = null;
+
+  /** Per-tenant suspend/resume in-flight + error, keyed by tenant id so
+   *  one row's failure never blocks the others. */
+  @state() private rowBusy: Record<string, boolean> = {};
+  @state() private rowError: Record<string, string> = {};
+
+  /** Provision dialog state. */
+  @state() private dialogOpen = false;
+  @state() private form: PlatformTenantProvision = { name: '', slug: '' };
+  @state() private provisionBusy = false;
+  @state() private provisionError: string | null = null;
+
+  private readonly api = getApiClient();
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    void this.refresh();
+  }
+
+  private async refresh(): Promise<void> {
+    this.loading = true;
+    this.listError = null;
+    try {
+      this.rows = await this.api.listTenants();
+    } catch (err) {
+      this.rows = [];
+      this.listError = this.errMessage(err);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private errMessage(err: unknown): string {
+    if (err instanceof ApiError) {
+      return err.body?.message ?? `HTTP ${err.status}`;
+    }
+    return (err as Error)?.message ?? 'unknown error';
+  }
+
+  /** Suspend or resume a single tenant, then refresh the list. The verb
+   *  is chosen from the row's CURRENT status by the caller; we never
+   *  infer it from a role. A 403 (e.g. the `__platform__` sentinel)
+   *  surfaces inline on the row. */
+  private async toggleStatus(row: PlatformTenantResponse): Promise<void> {
+    if (this.rowBusy[row.id]) return;
+    this.rowBusy = { ...this.rowBusy, [row.id]: true };
+    this.rowError = { ...this.rowError, [row.id]: '' };
+    try {
+      if (row.status === 'active') {
+        await this.api.suspendTenant(row.id);
+      } else {
+        await this.api.resumeTenant(row.id);
+      }
+      await this.refresh();
+    } catch (err) {
+      this.rowError = { ...this.rowError, [row.id]: this.errMessage(err) };
+    } finally {
+      this.rowBusy = { ...this.rowBusy, [row.id]: false };
+    }
+  }
+
+  private openProvision(): void {
+    this.form = { name: '', slug: '' };
+    this.provisionError = null;
+    this.provisionBusy = false;
+    this.dialogOpen = true;
+  }
+
+  private closeProvision = (): void => {
+    if (this.provisionBusy) return;
+    this.dialogOpen = false;
+  };
+
+  private async submitProvision(): Promise<void> {
+    const name = this.form.name.trim();
+    if (!name) {
+      this.provisionError = 'Name is required.';
+      return;
+    }
+    // Slug is optional; send it only when the operator typed one so the
+    // server can derive a default. An empty string is omitted (not sent
+    // as ''), matching the `slug?` shape of PlatformTenantProvision.
+    const slug = (this.form.slug ?? '').trim();
+    const body: PlatformTenantProvision = slug ? { name, slug } : { name };
+    this.provisionBusy = true;
+    this.provisionError = null;
+    try {
+      await this.api.provisionTenant(body);
+      this.dialogOpen = false;
+      await this.refresh();
+    } catch (err) {
+      this.provisionError = this.errMessage(err);
+    } finally {
+      this.provisionBusy = false;
+    }
+  }
+
+  override render() {
+    return html`
+      <div class="rm-spane">
+        <div class="rm-ch">
+          <h2>Tenants</h2>
+          <button
+            type="button"
+            class="rm-add"
+            data-testid="provision-tenant"
+            @click=${() => this.openProvision()}
+          >
+            ${iconPlus(14)}
+            Provision tenant
+          </button>
+        </div>
+        <p class="rm-sub">
+          Every tenant on the platform. Provision a new one, or suspend /
+          resume existing tenants. Suspended tenants cannot run agents.
+        </p>
+
+        ${this.loading
+          ? html`<div class="rm-banner-loading" data-testid="tenants-loading">
+              Loading…
+            </div>`
+          : this.listError
+            ? html`<div class="rm-banner-err" data-testid="tenants-error">
+                ${this.listError}
+              </div>`
+            : this.rows.length === 0
+              ? html`<div class="rm-empty" data-testid="tenants-empty">
+                  <div class="rm-empty-title">No tenants yet</div>
+                  <div>Provision the first tenant to get started.</div>
+                </div>`
+              : html`${this.rows.map((r) => this.renderRow(r))}`}
+
+        ${this.renderProvisionDialog()}
+      </div>
+    `;
+  }
+
+  private renderRow(row: PlatformTenantResponse) {
+    const active = row.status === 'active';
+    const busy = !!this.rowBusy[row.id];
+    const err = this.rowError[row.id] || '';
+    const initials = row.name.slice(0, 2).toUpperCase();
+    return html`
+      <div class="rm-card" data-tenant-id=${row.id} data-testid="tenant-row">
+        <span class="rm-ic">${initials}</span>
+        <span class="rm-mn">
+          <b>${row.name}</b>
+          <span>${row.slug ? row.slug : row.id}</span>
+        </span>
+        <span
+          class=${`rm-pill ${active ? 'rm-pill-on' : 'rm-pill-bad'}`}
+          data-testid="tenant-status"
+          >${row.status}</span
+        >
+        <span class="rm-row-acts">
+          <button
+            type="button"
+            class=${`rm-btn ${active ? 'rm-btn--danger' : 'rm-btn--primary'}`}
+            data-testid=${active ? 'tenant-suspend' : 'tenant-resume'}
+            ?disabled=${busy}
+            @click=${() => void this.toggleStatus(row)}
+          >
+            ${busy
+              ? active
+                ? 'Suspending…'
+                : 'Resuming…'
+              : active
+                ? 'Suspend'
+                : 'Resume'}
+          </button>
+        </span>
+        ${err
+          ? html`<div class="rm-row-error" data-testid="tenant-row-error">
+              ${err}
+            </div>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderProvisionDialog() {
+    return html`
+      <rm-dialog
+        title="Provision tenant"
+        ?open=${this.dialogOpen}
+        ?close-on-backdrop=${!this.provisionBusy}
+        ?close-on-esc=${!this.provisionBusy}
+        width="440px"
+        @close=${this.closeProvision}
+      >
+        <div class="mb-3">
+          <label class="block text-[12.5px] font-medium mb-1">Name</label>
+          <input
+            type="text"
+            data-testid="provision-name"
+            class="w-full text-[13.5px] px-3 py-2 rounded-md border border-surface-3
+              dark:border-d-surface-3 bg-surface-1 dark:bg-d-surface-1
+              text-ink-0 dark:text-d-ink-0 focus:outline-none focus:ring-2 focus:ring-brand"
+            placeholder="e.g. Acme Corp"
+            .value=${this.form.name}
+            @input=${(e: Event) => {
+              this.form = {
+                ...this.form,
+                name: (e.target as HTMLInputElement).value,
+              };
+            }}
+            ?disabled=${this.provisionBusy}
+          />
+        </div>
+        <div class="mb-3">
+          <label class="block text-[12.5px] font-medium mb-1"
+            >Slug <span class="text-ink-3 dark:text-d-ink-3">(optional)</span></label
+          >
+          <input
+            type="text"
+            data-testid="provision-slug"
+            class="w-full text-[13.5px] px-3 py-2 rounded-md border border-surface-3
+              dark:border-d-surface-3 bg-surface-1 dark:bg-d-surface-1
+              text-ink-0 dark:text-d-ink-0 focus:outline-none focus:ring-2 focus:ring-brand
+              font-mono"
+            placeholder="auto-derived from name if blank"
+            .value=${this.form.slug ?? ''}
+            @input=${(e: Event) => {
+              this.form = {
+                ...this.form,
+                slug: (e.target as HTMLInputElement).value,
+              };
+            }}
+            ?disabled=${this.provisionBusy}
+          />
+        </div>
+
+        ${this.provisionError
+          ? html`<div
+              class="text-[12.5px] text-red-600 dark:text-red-300 mt-2"
+              role="alert"
+              data-testid="provision-error"
+            >
+              ${this.provisionError}
+            </div>`
+          : nothing}
+
+        <div
+          slot="footer"
+          style="display: flex; gap: 8px; justify-content: flex-end;"
+        >
+          <button
+            type="button"
+            class="rm-btn rm-btn--secondary"
+            ?disabled=${this.provisionBusy}
+            @click=${this.closeProvision}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="rm-btn rm-btn--primary"
+            data-testid="provision-submit"
+            ?disabled=${this.provisionBusy}
+            @click=${() => void this.submitProvision()}
+          >
+            ${this.provisionBusy ? 'Provisioning…' : 'Provision'}
+          </button>
+        </div>
+      </rm-dialog>
+    `;
+  }
+}

--- a/web/src/components/settings-shell.test.ts
+++ b/web/src/components/settings-shell.test.ts
@@ -58,6 +58,8 @@ vi.mock('../services/safety-admin-client.ts', () => ({
 }));
 
 import { RmSettingsShell, slugFromHash } from './settings-shell.js';
+import { setMe } from '../auth/capabilities.js';
+import type { Me } from '../api/client.js';
 
 interface LocationStub {
   hashAssignments: string[];
@@ -101,6 +103,57 @@ async function mount(): Promise<RmSettingsShell> {
   return el;
 }
 
+// Capability sets per role, transcribed from the backend matrix
+// (`src/rolemesh/auth/permissions.py:_TENANT_ROLE_ACTIONS`). These are
+// TEST INPUTS ONLY — the production code keeps NO role->capability map;
+// it reads `me.capabilities` off the wire. We feed the shell the exact
+// list each role would receive from `GET /api/v1/me` and assert which
+// nav slugs survive the capability gate.
+const MEMBER_CAPS = ['coworker.create', 'coworker.use', 'skill.create'];
+const ADMIN_CAPS = [
+  'coworker.create',
+  'coworker.manage',
+  'coworker.use',
+  'skill.create',
+  'skill.manage',
+  'mcp.configure',
+  'approval_policy.manage',
+  'safety.read',
+  'safety.rule.manage',
+  'user.manage',
+  'task.manage',
+];
+const OWNER_CAPS = [...ADMIN_CAPS, 'credential.byok.manage', 'tenant.manage'];
+
+function makeMe(
+  role: Me['role'],
+  capabilities: string[],
+): Me {
+  return {
+    user_id: 'u-1',
+    tenant_id: 't-1',
+    name: 'Test User',
+    email: 'test@example.com',
+    role,
+    plane: 'tenant',
+    capabilities,
+  };
+}
+
+/** Read the visible nav slugs off a mounted shell, in rail order. */
+function visibleSlugs(el: RmSettingsShell): string[] {
+  return Array.from(
+    el.querySelectorAll('[data-testid="settings-nav-entry"]'),
+  ).map((b) => b.getAttribute('data-slug') ?? '');
+}
+
+/** Read the visible group headings (uppercase, the `.ng` rows). */
+function visibleHeadings(el: RmSettingsShell): string[] {
+  return Array.from(el.querySelectorAll('.ss-nav .ng')).map(
+    (n) => n.textContent?.trim() ?? '',
+  );
+}
+
 describe('slugFromHash', () => {
   it('returns the slug from a v2 manage hash', () => {
     expect(slugFromHash('#/manage/coworkers')).toBe('coworkers');
@@ -124,11 +177,16 @@ describe('<rm-settings-shell>', () => {
 
   beforeEach(() => {
     loc = stubHash('#/manage/coworkers');
+    // These slot-map tests assert the FULL 12-entry rail, so seed an
+    // owner (all capabilities) — the gate must not hide anything for
+    // them. The capability-gating tests below override per role.
+    setMe(makeMe('owner', OWNER_CAPS));
   });
 
   afterEach(() => {
     document.querySelectorAll('rm-settings-shell').forEach((el) => el.remove());
     loc.restore();
+    setMe(null);
     vi.clearAllMocks();
   });
 
@@ -271,5 +329,136 @@ describe('<rm-settings-shell>', () => {
       '[data-testid="settings-back"]',
     )!.click();
     expect(loc.hashAssignments).toContain('#/');
+  });
+});
+
+// PR2 — capability gating of the nav rail (spec §3). We seed the REAL
+// `setMe(me)` from capabilities.ts (no mock) with each role's actual
+// wire capability set, render, and snapshot the surviving slugs. The
+// expected slug sets come from applying the §3 `requires` gates to those
+// capabilities — NOT from a role->slug table baked into production code.
+describe('<rm-settings-shell> capability gating', () => {
+  let loc: LocationStub;
+
+  beforeEach(() => {
+    loc = stubHash('#/manage/coworkers');
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('rm-settings-shell').forEach((el) => el.remove());
+    loc.restore();
+    setMe(null);
+    vi.clearAllMocks();
+  });
+
+  it('member sees exactly the 5 ungated slugs (no governance/workspace)', async () => {
+    setMe(makeMe('member', MEMBER_CAPS));
+    const el = await mount();
+    const slugs = visibleSlugs(el);
+    // SNAPSHOT of the member rail — exact set + order per §3.
+    expect(slugs).toEqual([
+      'coworkers',
+      'skills',
+      'models',
+      'connected-channels',
+      'appearance',
+    ]);
+    expect(slugs).toHaveLength(5);
+  });
+
+  it('member render hides the GOVERNANCE and WORKSPACE group headings (empty-group hiding)', async () => {
+    setMe(makeMe('member', MEMBER_CAPS));
+    const el = await mount();
+    const headings = visibleHeadings(el);
+    // All Governance + Workspace entries are gated away, so the whole
+    // group (heading included) must vanish — only Building blocks +
+    // Account survive (Coworkers is the headingless root group). The
+    // uppercase is CSS-only; textContent keeps the source casing.
+    expect(headings).toEqual(['Building blocks', 'Account']);
+    expect(headings).not.toContain('Governance');
+    expect(headings).not.toContain('Workspace');
+  });
+
+  it('admin sees exactly 10 slugs (no credentials, no general)', async () => {
+    setMe(makeMe('admin', ADMIN_CAPS));
+    const el = await mount();
+    const slugs = visibleSlugs(el);
+    // SNAPSHOT of the admin rail — exact set + order per §3.
+    expect(slugs).toEqual([
+      'coworkers',
+      'mcp-servers',
+      'skills',
+      'models',
+      'approval-policies',
+      'safety',
+      'safety-log',
+      'members',
+      'connected-channels',
+      'appearance',
+    ]);
+    expect(slugs).toHaveLength(10);
+    // The two owner-only slugs are absent.
+    expect(slugs).not.toContain('credentials');
+    expect(slugs).not.toContain('general');
+  });
+
+  it('owner sees all 12 slugs', async () => {
+    setMe(makeMe('owner', OWNER_CAPS));
+    const el = await mount();
+    const slugs = visibleSlugs(el);
+    // SNAPSHOT of the owner rail — the canonical full nav per §3.
+    expect(slugs).toEqual([
+      'coworkers',
+      'mcp-servers',
+      'skills',
+      'models',
+      'credentials',
+      'approval-policies',
+      'safety',
+      'safety-log',
+      'general',
+      'members',
+      'connected-channels',
+      'appearance',
+    ]);
+    expect(slugs).toHaveLength(12);
+  });
+
+  it('renders <rm-access-denied> in the pane (rail still visible) when a member URL-jumps to a gated slug', async () => {
+    setMe(makeMe('member', MEMBER_CAPS));
+    loc.restore();
+    loc = stubHash('#/manage/safety');
+    const el = await mount();
+
+    // 403 page is shown in the main pane...
+    const pane = el.querySelector('[data-testid="settings-active-pane"]');
+    const denied = pane?.querySelector('rm-access-denied');
+    expect(denied, 'access-denied should render in the pane').not.toBeNull();
+    // ...naming the capability the page required.
+    expect((denied as { capability?: string } | null)?.capability).toBe(
+      'safety.read',
+    );
+    // ...the gated page component must NOT have mounted.
+    expect(pane?.querySelector('rm-safety-rules-page')).toBeNull();
+
+    // ...and the (filtered) nav rail is STILL present — no redirect.
+    const slugs = visibleSlugs(el);
+    expect(slugs).toHaveLength(5);
+    expect(slugs).toContain('coworkers');
+    // The header reflects the denied state, not a stale page title.
+    const title = el.querySelector('[data-testid="settings-active-title"]');
+    expect(title?.textContent?.trim()).toBe('Access denied');
+  });
+
+  it('renders a loading fallback (no rail, no pane) when me is not yet cached', async () => {
+    // Defensive null-guard branch. setMe(null) is the default here.
+    const el = await mount();
+    expect(
+      el.querySelector('[data-testid="settings-loading"]'),
+      'loading fallback should render when currentMe() is null',
+    ).not.toBeNull();
+    expect(el.querySelectorAll('[data-testid="settings-nav-entry"]')).toHaveLength(
+      0,
+    );
   });
 });

--- a/web/src/components/settings-shell.ts
+++ b/web/src/components/settings-shell.ts
@@ -29,6 +29,8 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { keyed } from 'lit/directives/keyed.js';
 
+import { currentMe, hasCapability } from '../auth/capabilities.js';
+
 import {
   iconBook,
   iconChevronDown,
@@ -60,6 +62,7 @@ import './appearance-page.js';
 import './coming-soon.js';
 import './skill-detail-page.js';
 import './connected-channels-page.js';
+import './access-denied-page.js';
 
 interface NavEntry {
   /** Sub-path under `#/manage/`. */
@@ -73,6 +76,14 @@ interface NavEntry {
   badge?: string;
   /** Renders the page body. */
   render: () => TemplateResult;
+  /** Capability required to see this entry (spec §3). `null` means any
+   *  authenticated user. At render time the shell hides entries whose
+   *  `requires` is set and not held by `currentMe()`. The strings here
+   *  must match the backend action names in `permissions.py` EXACTLY —
+   *  a typo silently hides the entry for everyone. The frontend keeps NO
+   *  role->capability matrix; it only names the capability each page
+   *  needs and reads `me.capabilities` from the wire. */
+  requires: string | null;
 }
 
 interface NavGroup {
@@ -83,13 +94,18 @@ interface NavGroup {
 }
 
 /**
- * The 11 settings pages. Order matches the v2-A prompt's grouping
+ * The 12 settings pages. Order matches the v2-A prompt's grouping
  * (Coworkers · Building blocks · Governance · Workspace · Account).
  *
  * Each entry just hands off to a v1.1 component — `coworkers-page`
  * et al — with the exception of `appearance-page` (new, shows
  * detected system theme) and the two `coming-soon` placeholders
  * (general + members; v3).
+ *
+ * Every entry carries a `requires` capability (spec §3); the shell
+ * filters the rail by it at render time. The strings are the only
+ * role-related constant here — and they name a *capability*, never a
+ * role. The role->capability mapping lives solely in the backend.
  */
 const NAV_GROUPS: NavGroup[] = [
   {
@@ -100,6 +116,7 @@ const NAV_GROUPS: NavGroup[] = [
         label: 'Coworkers',
         icon: () => iconUser(16),
         render: () => html`<rm-coworkers-page></rm-coworkers-page>`,
+        requires: null,
       },
     ],
   },
@@ -111,24 +128,28 @@ const NAV_GROUPS: NavGroup[] = [
         label: 'MCP servers',
         icon: () => iconServer(16),
         render: () => html`<rm-mcp-servers-page></rm-mcp-servers-page>`,
+        requires: 'mcp.configure',
       },
       {
         slug: 'skills',
         label: 'Skills',
         icon: () => iconBook(16),
         render: () => html`<rm-skills-page></rm-skills-page>`,
+        requires: null,
       },
       {
         slug: 'models',
         label: 'Models',
         icon: () => iconChip(16),
         render: () => html`<rm-models-page></rm-models-page>`,
+        requires: null,
       },
       {
         slug: 'credentials',
         label: 'Credentials',
         icon: () => iconKey(16),
         render: () => html`<rm-credentials-page></rm-credentials-page>`,
+        requires: 'credential.byok.manage',
       },
     ],
   },
@@ -141,18 +162,21 @@ const NAV_GROUPS: NavGroup[] = [
         icon: () => iconClipboardCheck(16),
         render: () =>
           html`<rm-approval-policies-page></rm-approval-policies-page>`,
+        requires: 'approval_policy.manage',
       },
       {
         slug: 'safety',
         label: 'Safety rules',
         icon: () => iconShield(16),
         render: () => html`<rm-safety-rules-page></rm-safety-rules-page>`,
+        requires: 'safety.read',
       },
       {
         slug: 'safety-log',
         label: 'Safety log',
         icon: () => iconFileText(16),
         render: () => html`<rm-safety-decisions-page></rm-safety-decisions-page>`,
+        requires: 'safety.read',
       },
     ],
   },
@@ -165,13 +189,17 @@ const NAV_GROUPS: NavGroup[] = [
         icon: () => iconHome(16),
         render: () =>
           html`<rm-coming-soon label="General" phase=${3}></rm-coming-soon>`,
+        requires: 'tenant.manage',
       },
       {
+        // D3 — Members stays a coming-soon stub in v3; this PR only adds
+        // the nav gate. No real members-page is built here.
         slug: 'members',
         label: 'Members',
         icon: () => iconUsers(16),
         render: () =>
           html`<rm-coming-soon label="Members" phase=${3}></rm-coming-soon>`,
+        requires: 'user.manage',
       },
     ],
   },
@@ -184,12 +212,14 @@ const NAV_GROUPS: NavGroup[] = [
         icon: () => iconLink(16),
         render: () =>
           html`<rm-connected-channels-page></rm-connected-channels-page>`,
+        requires: null,
       },
       {
         slug: 'appearance',
         label: 'Appearance',
         icon: () => iconSun(16),
         render: () => html`<rm-appearance-page></rm-appearance-page>`,
+        requires: null,
       },
     ],
   },
@@ -255,9 +285,44 @@ export class RmSettingsShell extends LitElement {
     location.hash = '#/';
   };
 
+  /**
+   * Whether `currentMe()` is allowed to see `entry`. An entry with a
+   * `null` requires is visible to any authenticated user; otherwise the
+   * user must hold the named capability. This is the single gate — the
+   * shell never inspects role names, only the wire `capabilities` list
+   * through `hasCapability`.
+   */
+  private canSee(entry: NavEntry): boolean {
+    return !entry.requires || hasCapability(entry.requires);
+  }
+
   override render(): TemplateResult {
+    // Defensive null-guard. PR1's bootstrap guarantees `me` is in cache
+    // before any shell mounts (app.ts holds authState at 'loading' until
+    // setMe() runs), so this branch should not be reached in practice.
+    const me = currentMe();
+    if (!me) {
+      return html`<div class="ss-loading" data-testid="settings-loading">
+        Loading…
+      </div>`;
+    }
+
+    // Filter to the groups (and entries) this user can see. A group with
+    // every entry hidden disappears entirely — heading included.
+    const visibleGroups = NAV_GROUPS.map((g) => ({
+      ...g,
+      entries: g.entries.filter((e) => this.canSee(e)),
+    })).filter((g) => g.entries.length > 0);
+
     const activeSlug = slugFromHash(this.hash);
     const active = ENTRY_BY_SLUG[activeSlug];
+    // URL-jump guard: the active slug resolved to a real entry, but one
+    // this user can't see. Keep the (filtered) rail visible and render
+    // the access-denied page in the pane — never silently redirect.
+    const denied = !!active && !this.canSee(active);
+
+    // First slug the user CAN see — the access-denied "back" target.
+    const firstVisible = visibleGroups[0]?.entries[0];
     return html`
       <style>
         rm-settings-shell {
@@ -400,19 +465,27 @@ export class RmSettingsShell extends LitElement {
             @click=${this.backToChat}
           >${iconClose(16)}</button>
         </div>
-        ${NAV_GROUPS.map((group) => this.renderGroup(group, activeSlug))}
+        ${visibleGroups.map((group) => this.renderGroup(group, activeSlug))}
       </aside>
       <div class="ss-main">
         <div class="ss-hd">
           <h2 data-testid="settings-active-title">
-            ${active?.label ?? 'Settings'}
+            ${denied ? 'Access denied' : active?.label ?? 'Settings'}
           </h2>
         </div>
         <div class="ss-body">
           <div class="ss-card" data-testid="settings-active-pane">
-            ${active
-              ? keyed(activeSlug, active.render())
-              : nothing}
+            ${denied
+              ? html`<rm-access-denied
+                  data-testid="access-denied"
+                  .capability=${active!.requires ?? ''}
+                  .pageLabel=${active!.label}
+                  .backSlug=${firstVisible?.slug ?? DEFAULT_SLUG}
+                  .backLabel=${firstVisible?.label ?? 'Coworkers'}
+                ></rm-access-denied>`
+              : active
+                ? keyed(activeSlug, active.render())
+                : nothing}
           </div>
         </div>
       </div>

--- a/web/src/components/skills-page.test.ts
+++ b/web/src/components/skills-page.test.ts
@@ -8,6 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const listSkillsSpy = vi.fn();
 const createSkillSpy = vi.fn();
 const getSkillSpy = vi.fn(); // exists for the delegated detail page
+const shareSkillSpy = vi.fn();
+const unshareSkillSpy = vi.fn();
+const deleteSkillSpy = vi.fn();
 
 vi.mock('../api/client.js', async () => {
   const actual = await vi.importActual<typeof import('../api/client.js')>(
@@ -19,11 +22,16 @@ vi.mock('../api/client.js', async () => {
       listSkills: listSkillsSpy,
       createSkill: createSkillSpy,
       getSkill: getSkillSpy,
+      shareSkill: shareSkillSpy,
+      unshareSkill: unshareSkillSpy,
+      deleteSkill: deleteSkillSpy,
     }),
   };
 });
 
 import { SkillsPage } from './skills-page.js';
+import { setMe } from '../auth/capabilities.js';
+import type { Me, SkillSummary } from '../api/client.js';
 
 async function settle(el: SkillsPage): Promise<void> {
   for (let i = 0; i < 20; i++) {
@@ -47,7 +55,14 @@ describe('SkillsPage new-skill flow (via dialog)', () => {
   let page: SkillsPage;
 
   beforeEach(async () => {
-    [listSkillsSpy, createSkillSpy, getSkillSpy].forEach((s) => s.mockReset());
+    [
+      listSkillsSpy,
+      createSkillSpy,
+      getSkillSpy,
+      shareSkillSpy,
+      unshareSkillSpy,
+      deleteSkillSpy,
+    ].forEach((s) => s.mockReset());
     listSkillsSpy.mockResolvedValue([]);
     setHash('#/skills/new');
     page = new SkillsPage();
@@ -57,6 +72,7 @@ describe('SkillsPage new-skill flow (via dialog)', () => {
 
   afterEach(() => {
     page.remove();
+    setMe(null);
     setHash('#/');
   });
 
@@ -110,11 +126,19 @@ describe('SkillsPage list view', () => {
   let page: SkillsPage;
 
   beforeEach(async () => {
-    [listSkillsSpy, createSkillSpy, getSkillSpy].forEach((s) => s.mockReset());
+    [
+      listSkillsSpy,
+      createSkillSpy,
+      getSkillSpy,
+      shareSkillSpy,
+      unshareSkillSpy,
+      deleteSkillSpy,
+    ].forEach((s) => s.mockReset());
     listSkillsSpy.mockResolvedValue([
       {
         id: 's-1', tenant_id: 't', name: 'alpha',
         description: 'desc', enabled: true, bound_coworker_count: 2,
+        visibility: 'private',
         created_at: '', updated_at: '',
       },
     ]);
@@ -126,6 +150,7 @@ describe('SkillsPage list view', () => {
 
   afterEach(() => {
     page.remove();
+    setMe(null);
     setHash('#/');
   });
 
@@ -137,5 +162,404 @@ describe('SkillsPage list view', () => {
     expect(card).toBeTruthy();
     expect(card?.textContent).toContain('alpha');
     expect(card?.textContent).toContain('2 coworker');
+  });
+});
+
+// --------------------------------------------------------------------
+// Role-aware affordances (RBAC UI PR5, spec §5.2 / §7.3 / §7.4).
+//
+// Mirrors coworkers-page.test.ts. What is pinned here:
+//   * Chips re-classify the ALREADY-server-filtered list (UX only):
+//     "Mine" -> own rows; "Shared by others" -> others' shared rows.
+//   * Per-row management affordances (Edit / Delete / Share) gated by
+//     `canManage(skill, 'skill.manage')` — the ownership escape. With the
+//     manage capability every row is editable; for a plain member only
+//     own rows are, and a null-owner row is NEVER manageable.
+//   * The Share toggle calls shareSkill / unshareSkill.
+//
+// We mock ONLY the api client (the external boundary). The capability
+// logic uses the REAL capabilities.ts (setMe + canManage/isOwnResource):
+// mocking it would hide the very bugs these tests exist to catch.
+//
+// We deliberately do NOT assert "a member can't see X's private row" —
+// that is backend visibility filtering (`user_can_see_resource`), enforced
+// server-side and tested there. Re-asserting it here would be a forbidden
+// duplicate-source / mirror test (spec §7.3).
+// --------------------------------------------------------------------
+
+const MY_UID = 'u-me';
+
+// Capability sets transcribed from the backend matrix — TEST INPUTS ONLY.
+// The production code keeps no role->cap map; it reads me.capabilities.
+const MEMBER_CAPS = ['skill.create', 'skill.use'];
+const MANAGER_CAPS = ['skill.create', 'skill.manage', 'skill.use'];
+
+function makeMe(capabilities: string[]): Me {
+  return {
+    user_id: MY_UID,
+    tenant_id: 't-1',
+    name: 'Me',
+    email: 'me@example.com',
+    role: 'member',
+    plane: 'tenant',
+    capabilities,
+  };
+}
+
+function mkSkill(over: Partial<SkillSummary>): SkillSummary {
+  return {
+    id: 's-x',
+    tenant_id: 't-1',
+    name: 'sk',
+    description: 'desc',
+    enabled: true,
+    bound_coworker_count: 0,
+    created_by_user_id: null,
+    visibility: 'private',
+    created_at: '',
+    updated_at: '',
+    ...over,
+  };
+}
+
+// The canonical MIXED fixture: own-private, own-shared, others'-shared,
+// and a null-owner (legacy/platform-default) row.
+const OWN_PRIVATE = mkSkill({
+  id: 'own-priv',
+  name: 'Own Private',
+  created_by_user_id: MY_UID,
+  visibility: 'private',
+});
+const OWN_SHARED = mkSkill({
+  id: 'own-shared',
+  name: 'Own Shared',
+  created_by_user_id: MY_UID,
+  visibility: 'shared',
+});
+const OTHERS_SHARED = mkSkill({
+  id: 'others-shared',
+  name: 'Others Shared',
+  created_by_user_id: 'u-other',
+  visibility: 'shared',
+});
+const NULL_OWNER_SHARED = mkSkill({
+  id: 'null-owner',
+  name: 'Legacy Shared',
+  created_by_user_id: null,
+  visibility: 'shared',
+});
+
+const MIXED: SkillSummary[] = [
+  OWN_PRIVATE,
+  OWN_SHARED,
+  OTHERS_SHARED,
+  NULL_OWNER_SHARED,
+];
+
+/** Ids of the skill cards currently rendered, in DOM order. */
+function visibleIds(page: SkillsPage): string[] {
+  return Array.from(page.querySelectorAll('[data-skill-id]')).map(
+    (el) => el.getAttribute('data-skill-id') ?? '',
+  );
+}
+
+/** The card element for one skill id (so we can scope per-row queries). */
+function card(page: SkillsPage, id: string): Element | null {
+  return page.querySelector(`[data-skill-id="${id}"]`);
+}
+
+function clickChip(page: SkillsPage, chip: string): void {
+  page
+    .querySelector<HTMLButtonElement>(`[data-testid="skill-chip-${chip}"]`)!
+    .click();
+}
+
+describe('SkillsPage — role-aware affordances', () => {
+  beforeEach(() => {
+    [
+      listSkillsSpy,
+      createSkillSpy,
+      getSkillSpy,
+      shareSkillSpy,
+      unshareSkillSpy,
+      deleteSkillSpy,
+    ].forEach((s) => s.mockReset());
+    listSkillsSpy.mockResolvedValue(MIXED);
+    setHash('#/skills');
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('rm-skills-page').forEach((el) => el.remove());
+    setMe(null);
+    setHash('#/');
+    vi.clearAllMocks();
+  });
+
+  async function mount(): Promise<SkillsPage> {
+    const page = new SkillsPage();
+    document.body.appendChild(page);
+    await settle(page);
+    return page;
+  }
+
+  describe('filter chips (UX re-classification)', () => {
+    it('default "All visible" shows every returned row, untouched', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      // No security filtering on the frontend — all 4 server-returned rows.
+      expect(visibleIds(page)).toEqual([
+        'own-priv',
+        'own-shared',
+        'others-shared',
+        'null-owner',
+      ]);
+    });
+
+    it('chip "Mine" narrows to own rows only (both visibilities)', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      clickChip(page, 'mine');
+      await settle(page);
+      const ids = visibleIds(page);
+      expect(ids).toEqual(['own-priv', 'own-shared']);
+      // The null-owner row must NOT count as "Mine" (three-value safety).
+      expect(ids).not.toContain('null-owner');
+      expect(ids).not.toContain('others-shared');
+    });
+
+    it('chip "Shared by others" narrows to others\' shared rows only', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      clickChip(page, 'shared');
+      await settle(page);
+      const ids = visibleIds(page);
+      // own-shared is mine, so it is excluded; null-owner has no owner ->
+      // not "mine" -> it IS "shared by others" (shared + not own).
+      expect(ids).toContain('others-shared');
+      expect(ids).toContain('null-owner');
+      expect(ids).not.toContain('own-shared');
+      expect(ids).not.toContain('own-priv');
+    });
+  });
+
+  describe('per-row management gating (ownership escape)', () => {
+    it('with skill.manage, Edit shows on EVERY row (incl. null-owner)', async () => {
+      setMe(makeMe(MANAGER_CAPS));
+      const page = await mount();
+      for (const id of [
+        'own-priv',
+        'own-shared',
+        'others-shared',
+        'null-owner',
+      ]) {
+        expect(
+          card(page, id)?.querySelector('[data-testid="skill-edit"]'),
+          `manager should see Edit on ${id}`,
+        ).not.toBeNull();
+        expect(
+          card(page, id)?.querySelector('[data-testid="skill-viewonly"]'),
+          `manager should NOT see a view-only hint on ${id}`,
+        ).toBeNull();
+      }
+    });
+
+    it('as a plain member, Edit shows only on own rows', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      // Own rows: editable.
+      for (const id of ['own-priv', 'own-shared']) {
+        expect(
+          card(page, id)?.querySelector('[data-testid="skill-edit"]'),
+          `member should see Edit on own ${id}`,
+        ).not.toBeNull();
+      }
+      // Others' shared: NOT editable, shows view-only hint instead.
+      expect(
+        card(page, 'others-shared')?.querySelector(
+          '[data-testid="skill-edit"]',
+        ),
+      ).toBeNull();
+      expect(
+        card(page, 'others-shared')?.querySelector(
+          '[data-testid="skill-viewonly"]',
+        ),
+      ).not.toBeNull();
+    });
+
+    it('a null-owner row is NOT manageable by a member (three-value safety)', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      // The legacy/platform-default row (created_by_user_id === null) must
+      // never qualify for the ownership escape — no Edit/Delete/Share.
+      const row = card(page, 'null-owner');
+      expect(row?.querySelector('[data-testid="skill-edit"]')).toBeNull();
+      expect(row?.querySelector('[data-testid="skill-delete"]')).toBeNull();
+      expect(row?.querySelector('[data-testid="skill-share"]')).toBeNull();
+      expect(
+        row?.querySelector('[data-testid="skill-viewonly"]'),
+      ).not.toBeNull();
+    });
+  });
+
+  describe('share toggle (canManage-gated)', () => {
+    it('Share toggle is present exactly where canManage is true (member)', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      // Own rows -> share present.
+      expect(
+        card(page, 'own-priv')?.querySelector('[data-testid="skill-share"]'),
+      ).not.toBeNull();
+      expect(
+        card(page, 'own-shared')?.querySelector('[data-testid="skill-share"]'),
+      ).not.toBeNull();
+      // Non-own rows -> share absent.
+      expect(
+        card(page, 'others-shared')?.querySelector(
+          '[data-testid="skill-share"]',
+        ),
+      ).toBeNull();
+      expect(
+        card(page, 'null-owner')?.querySelector('[data-testid="skill-share"]'),
+      ).toBeNull();
+    });
+
+    it('clicking Share on a PRIVATE own row calls shareSkill(id)', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      shareSkillSpy.mockResolvedValue({
+        ...OWN_PRIVATE,
+        visibility: 'shared',
+      });
+      const page = await mount();
+      const btn = card(page, 'own-priv')!.querySelector<HTMLButtonElement>(
+        '[data-testid="skill-share"]',
+      )!;
+      btn.click();
+      await settle(page);
+      expect(shareSkillSpy).toHaveBeenCalledTimes(1);
+      expect(shareSkillSpy).toHaveBeenCalledWith('own-priv');
+      expect(unshareSkillSpy).not.toHaveBeenCalled();
+    });
+
+    it('clicking Share on a SHARED own row calls unshareSkill(id)', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      unshareSkillSpy.mockResolvedValue({
+        ...OWN_SHARED,
+        visibility: 'private',
+      });
+      const page = await mount();
+      const btn = card(page, 'own-shared')!.querySelector<HTMLButtonElement>(
+        '[data-testid="skill-share"]',
+      )!;
+      btn.click();
+      await settle(page);
+      expect(unshareSkillSpy).toHaveBeenCalledTimes(1);
+      expect(unshareSkillSpy).toHaveBeenCalledWith('own-shared');
+      expect(shareSkillSpy).not.toHaveBeenCalled();
+    });
+
+    it('patches only visibility on the row from the returned full Skill (keeps summary fields)', async () => {
+      // The share endpoint returns a full Skill, which has NO description /
+      // bound_coworker_count. A naive whole-row swap (PR4's Coworker path)
+      // would blank those summary-only columns — this pins the patch-only
+      // behavior so the row keeps its description + bound count.
+      setMe(makeMe(MEMBER_CAPS));
+      shareSkillSpy.mockResolvedValue({
+        id: 'own-priv',
+        tenant_id: 't-1',
+        name: 'Own Private',
+        enabled: true,
+        created_at: '',
+        updated_at: '',
+        created_by_user_id: MY_UID,
+        visibility: 'shared',
+        // NOTE: no description, no bound_coworker_count (full Skill shape).
+      });
+      const page = await mount();
+      const btn = card(page, 'own-priv')!.querySelector<HTMLButtonElement>(
+        '[data-testid="skill-share"]',
+      )!;
+      btn.click();
+      await settle(page);
+      const row = card(page, 'own-priv')!;
+      // Visibility flipped to Shared...
+      expect(
+        row
+          .querySelector('[data-testid="skill-visibility"]')
+          ?.textContent?.trim(),
+      ).toBe('Shared');
+      // ...but the description survived (would be '—' if the row were swapped).
+      expect(row.textContent).toContain('desc');
+    });
+
+    it('a manager can share OTHERS\' rows too (manage capability, not ownership)', async () => {
+      setMe(makeMe(MANAGER_CAPS));
+      unshareSkillSpy.mockResolvedValue({
+        ...NULL_OWNER_SHARED,
+        visibility: 'private',
+      });
+      const page = await mount();
+      // The null-owner row's toggle must exist for a manager and, since it
+      // is already shared, click -> unshare.
+      const btn = card(page, 'null-owner')!.querySelector<HTMLButtonElement>(
+        '[data-testid="skill-share"]',
+      );
+      expect(btn).not.toBeNull();
+      btn!.click();
+      await settle(page);
+      expect(unshareSkillSpy).toHaveBeenCalledWith('null-owner');
+    });
+  });
+
+  describe('visibility pill + new-skill gating', () => {
+    it('renders a green "Shared" / gray "Private" pill from wire visibility', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      const priv = card(page, 'own-priv')?.querySelector(
+        '[data-testid="skill-visibility"]',
+      );
+      const shared = card(page, 'own-shared')?.querySelector(
+        '[data-testid="skill-visibility"]',
+      );
+      expect(priv?.textContent?.trim()).toBe('Private');
+      expect(priv?.className).toContain('rm-pill-off');
+      expect(shared?.textContent?.trim()).toBe('Shared');
+      expect(shared?.className).toContain('rm-pill-on');
+    });
+
+    it('hides the New-skill button when skill.create is absent', async () => {
+      // The gate must be capability-driven, not assumed-on. Seed a Me with
+      // no skill.create and assert the button vanishes.
+      setMe(makeMe(['skill.use']));
+      const page = await mount();
+      expect(
+        page.querySelector('[data-testid="skill-new"]'),
+        'New button must be gated on skill.create',
+      ).toBeNull();
+    });
+
+    it('shows the New-skill button when skill.create is present', async () => {
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      expect(page.querySelector('[data-testid="skill-new"]')).not.toBeNull();
+    });
+  });
+
+  describe('capability-aware empty states', () => {
+    it('member empty "All visible" copy points to create or ask admin', async () => {
+      listSkillsSpy.mockResolvedValue([]);
+      setMe(makeMe(MEMBER_CAPS));
+      const page = await mount();
+      const empty = page.querySelector('[data-testid="skill-empty"]');
+      expect(empty?.textContent).toContain('ask your admin');
+    });
+
+    it('manager empty "All visible" copy says no skills in the tenant', async () => {
+      listSkillsSpy.mockResolvedValue([]);
+      setMe(makeMe(MANAGER_CAPS));
+      const page = await mount();
+      const empty = page.querySelector('[data-testid="skill-empty"]');
+      expect(empty?.textContent).toContain('No skills in this tenant');
+      expect(empty?.textContent).not.toContain('ask your admin');
+    });
   });
 });

--- a/web/src/components/skills-page.ts
+++ b/web/src/components/skills-page.ts
@@ -6,19 +6,56 @@
 // that element when the hash points at a specific id. Anti-mirror:
 // hash parsing stays in one place rather than split between sibling
 // routes (the v1.1 hash router is intentionally not regex-aware).
+//
+// Role-aware affordances (RBAC UI PR5, spec §5.2 / §7.3 / §7.4) mirror
+// the coworkers page (PR4):
+//   * "+ New skill" gated on the `skill.create` capability.
+//   * Filter chips (All visible / Mine / Shared by others) re-classify
+//     the ALREADY-server-filtered list — UX only, NOT a security gate
+//     (the backend visibility-filters GET /skills; we render as-is).
+//   * Per-row Edit / Delete / Share gated by `canManage(skill,
+//     'skill.manage')` — the ownership escape. Rows a member can't
+//     manage show a "View only" hint instead of dead buttons.
+//   * "Created by you" accent cue on own rows; green "Shared" / gray
+//     "Private" pill from the wire `visibility`.
 
 import { LitElement, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { ApiError, getApiClient } from '../api/client.js';
-import type { SkillSummary } from '../api/client.js';
+import type { Skill, SkillSummary } from '../api/client.js';
+import {
+  canManage,
+  hasCapability,
+  isOwnResource,
+} from '../auth/capabilities.js';
 
 import './skill-detail-page.js';
 import './skill-dialog.js';
 import './confirm-dialog.js';
-import { iconPencil, iconTrash } from './icons.js';
+import { iconPencil, iconTrash, iconUsers } from './icons.js';
 
 type Mode = 'list' | 'new' | 'detail';
+
+/** UX-only view filter over the already-server-filtered list. NOT a
+ *  security boundary — the backend already visibility-filtered the rows
+ *  (spec §7.3). These chips just re-narrow what's shown for the user's
+ *  workflow. Mirrors the coworkers page (PR4) `CoworkerChip`. */
+export type SkillChip = 'all' | 'mine' | 'shared';
+
+/** Classify one skill row against a chip selection. Pure; mirrors the
+ *  coworkers page (PR4) `matchesChip` but typed to `SkillSummary` so the
+ *  classification stays structural (visibility + ownership). Three-value
+ *  safe: a row with a null `created_by_user_id` is never "mine" (it falls
+ *  through `isOwnResource`, which returns false for null) and is only kept
+ *  by the "shared" chip when its `visibility` says so — never by
+ *  ownership. */
+export function matchesChip(skill: SkillSummary, chip: SkillChip): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'mine') return isOwnResource(skill);
+  // 'shared' — others' shared rows only (own rows belong under "Mine").
+  return skill.visibility === 'shared' && !isOwnResource(skill);
+}
 
 interface ParsedHash {
   mode: Mode;
@@ -58,6 +95,15 @@ export class SkillsPage extends LitElement {
   @state() private listError: string | null = null;
   /** Per-row delete error. Cleared on refresh. */
   @state() private deleteError: Record<string, string> = {};
+  /** Client-side view filter (spec §5.2 chips). Pure presentation — the
+   *  list is already server-side visibility-filtered; this re-narrows it. */
+  @state() private chip: SkillChip = 'all';
+  /** Per-row share/unshare error, keyed by skill id. Cleared on the next
+   *  refresh, same lifecycle as `deleteError`. */
+  @state() private shareError: Record<string, string> = {};
+  /** Ids with a share/unshare POST in flight — disables that row's
+   *  toggle so a double-click can't fire two visibility flips. */
+  @state() private shareInFlight: Set<string> = new Set();
   /** Dialog state. `editTarget` null = create flow; non-null = edit
    *  flow. v2-C replaced the route-based create page (`#/skills/new`)
    *  with this dialog to match the prototype layout. */
@@ -125,6 +171,7 @@ export class SkillsPage extends LitElement {
     this.loading = true;
     this.listError = null;
     this.deleteError = {};
+    this.shareError = {};
     try {
       this.rows = await this.api.listSkills();
     } catch (err) {
@@ -178,6 +225,45 @@ export class SkillsPage extends LitElement {
     }
   }
 
+  /** Flip a skill's visibility. `canManage` is the ONLY gate (spec §7.4 —
+   *  no separate `*.share` capability); the toggle only renders where
+   *  canManage is true, and the backend re-checks the ownership escape.
+   *  The share endpoints return the FULL `Skill`, which lacks the
+   *  `description` / `bound_coworker_count` fields the list `SkillSummary`
+   *  carries — so we PATCH only `visibility` (and keep the row's
+   *  `created_by_user_id`) onto the existing row rather than replacing it,
+   *  which would blank those summary-only columns. (This is the one place
+   *  PR5 cannot do a whole-row swap like PR4's Coworker share.) */
+  private async toggleShare(row: SkillSummary): Promise<void> {
+    if (this.shareInFlight.has(row.id)) return;
+    this.shareInFlight = new Set(this.shareInFlight).add(row.id);
+    this.shareError = { ...this.shareError, [row.id]: '' };
+    try {
+      const updated: Skill =
+        row.visibility === 'shared'
+          ? await this.api.unshareSkill(row.id)
+          : await this.api.shareSkill(row.id);
+      this.rows = this.rows.map((r) =>
+        r.id === updated.id
+          ? {
+              ...r,
+              visibility: updated.visibility,
+              created_by_user_id: updated.created_by_user_id,
+            }
+          : r,
+      );
+    } catch (err) {
+      this.shareError = {
+        ...this.shareError,
+        [row.id]: this.errMessage(err),
+      };
+    } finally {
+      const next = new Set(this.shareInFlight);
+      next.delete(row.id);
+      this.shareInFlight = next;
+    }
+  }
+
   override render() {
     if (this.mode === 'detail' && this.skillId) {
       return html`<rm-skill-detail-page skill-id=${this.skillId}></rm-skill-detail-page>`;
@@ -186,34 +272,43 @@ export class SkillsPage extends LitElement {
   }
 
   private renderList() {
+    const canCreate = hasCapability('skill.create');
+    const visibleRows = this.rows.filter((r) => matchesChip(r, this.chip));
     return html`
       <div class="rm-spane">
         <div class="rm-ch">
           <h2>Skills</h2>
-          <button
-            type="button"
-            class="rm-add"
-            @click=${this.openCreateDialog}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-              stroke="currentColor" stroke-width="2" aria-hidden="true">
-              <path d="M12 5v14M5 12h14"/>
-            </svg>
-            New skill
-          </button>
+          ${canCreate
+            ? html`<button
+                type="button"
+                class="rm-add"
+                data-testid="skill-new"
+                @click=${this.openCreateDialog}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" stroke-width="2" aria-hidden="true">
+                  <path d="M12 5v14M5 12h14"/>
+                </svg>
+                New skill
+              </button>`
+            : nothing}
         </div>
         <p class="rm-sub">
           Tenant-wide catalog. Bind a skill to a coworker on the
           coworker detail page.
         </p>
 
+        ${this.loading || this.listError || this.rows.length === 0
+          ? nothing
+          : this.renderChips()}
+
         ${this.loading
           ? html`<div class="rm-banner-loading">Loading…</div>`
           : this.listError
             ? html`<div class="rm-banner-err">${this.listError}</div>`
-            : this.rows.length === 0
+            : visibleRows.length === 0
               ? this.renderListEmpty()
-              : this.renderRows()}
+              : this.renderRows(visibleRows)}
 
         <rm-skill-dialog
           ?open=${this.dialogOpen}
@@ -226,6 +321,30 @@ export class SkillsPage extends LitElement {
           @skill-updated=${() => { void this.refreshList(); }}
         ></rm-skill-dialog>
         ${this.renderDeleteDialog()}
+      </div>
+    `;
+  }
+
+  private renderChips() {
+    const chips: Array<[SkillChip, string]> = [
+      ['all', 'All visible'],
+      ['mine', 'Mine'],
+      ['shared', 'Shared by others'],
+    ];
+    return html`
+      <div class="rm-seg rm-chipbar" role="tablist" aria-label="Filter skills">
+        ${chips.map(
+          ([key, label]) => html`
+            <button
+              type="button"
+              role="tab"
+              class=${this.chip === key ? 'rm-seg--on' : ''}
+              aria-selected=${this.chip === key ? 'true' : 'false'}
+              data-testid="skill-chip-${key}"
+              @click=${() => { this.chip = key; }}
+            >${label}</button>
+          `,
+        )}
       </div>
     `;
   }
@@ -259,19 +378,123 @@ export class SkillsPage extends LitElement {
     `;
   }
 
+  /** Empty-state copy varies by the active chip AND by whether the user
+   *  can manage skills tenant-wide vs is a plain member (spec §5.2,
+   *  mirroring §5.1). Gated on a CAPABILITY (`skill.manage`), never a role
+   *  name — a member's next action is "ask an admin to share / create your
+   *  own", a manager's is "create the first one". */
   private renderListEmpty() {
+    const isManager = hasCapability('skill.manage');
+    let title: string;
+    let body: unknown;
+    if (this.chip === 'mine') {
+      title = 'Nothing here yet';
+      body = html`You haven’t created any skills yet.`;
+    } else if (this.chip === 'shared') {
+      title = 'Nothing shared';
+      body = isManager
+        ? html`No skills shared by others.`
+        : html`No skills have been shared with you yet.`;
+    } else {
+      // 'all'
+      title = 'No skills yet';
+      body = isManager
+        ? html`No skills in this tenant yet. Click
+            <b>+ New skill</b> above to create the first one.`
+        : html`No skills yet. Create one with
+            <b>+ New skill</b>, or ask your admin to share theirs.`;
+    }
     return html`
-      <div class="rm-empty">
-        <span class="rm-empty-title">No skills yet</span>
-        Click <b>+ New skill</b> above to create your first one.
+      <div class="rm-empty" data-testid="skill-empty">
+        <span class="rm-empty-title">${title}</span>
+        ${body}
       </div>
     `;
   }
 
-  private renderRows() {
+  /** Ownership cue (spec §5.2, mirroring §5.1). There is NO owner
+   *  display-name on the wire — only `created_by_user_id` — so own rows
+   *  read "Created by you" in accent; everything else is a neutral label
+   *  (never an invented person name). */
+  private renderOwnTag(r: SkillSummary) {
+    if (isOwnResource(r)) {
+      return html`<span
+        class="rm-own-tag rm-own-tag--mine"
+        data-testid="skill-own-tag"
+      >Created by you</span>`;
+    }
+    return html`<span
+      class="rm-own-tag rm-own-tag--other"
+      data-testid="skill-own-tag"
+    >Shared by another member</span>`;
+  }
+
+  /** Visibility pill — green "Shared" / gray "Private" from the wire
+   *  `visibility` (spec §7.4). */
+  private renderVisibilityPill(r: SkillSummary) {
+    const shared = r.visibility === 'shared';
+    return html`<span
+      class=${shared ? 'rm-pill rm-pill-on' : 'rm-pill rm-pill-off'}
+      data-testid="skill-visibility"
+    >${shared ? 'Shared' : 'Private'}</span>`;
+  }
+
+  private renderRowActions(r: SkillSummary) {
+    // Single gate for ALL management affordances — the ownership escape
+    // (manage capability OR own the row), mirroring the backend. Members
+    // see a "view only" hint instead of dead Edit/Delete/Share buttons.
+    if (!canManage(r, 'skill.manage')) {
+      return html`<span class="rm-viewonly" data-testid="skill-viewonly"
+        >View only</span
+      >`;
+    }
+    const shared = r.visibility === 'shared';
+    const busy = this.shareInFlight.has(r.id);
     return html`
-      ${this.rows.map((r) => {
+      <span class="rm-row-acts">
+        <button
+          type="button"
+          class=${shared ? 'rm-iconbtn rm-iconbtn--on' : 'rm-iconbtn'}
+          title=${shared
+            ? 'Make private'
+            : `Share with everyone in ${r.tenant_id}`}
+          data-testid="skill-share"
+          ?disabled=${busy}
+          aria-pressed=${shared ? 'true' : 'false'}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            void this.toggleShare(r);
+          }}
+        >${iconUsers(15)}</button>
+        <button
+          type="button"
+          class="rm-iconbtn"
+          title="Edit skill"
+          data-testid="skill-edit"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.editSkill(r);
+          }}
+        >${iconPencil(15)}</button>
+        <button
+          type="button"
+          class="rm-iconbtn rm-iconbtn--danger"
+          title="Delete skill"
+          data-testid="skill-delete"
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this.askDelete(r);
+          }}
+        >${iconTrash(15)}</button>
+      </span>
+    `;
+  }
+
+  private renderRows(rows: SkillSummary[]) {
+    return html`
+      ${rows.map((r) => {
         const delErr = this.deleteError[r.id] || '';
+        const shareErr = this.shareError[r.id] || '';
         const initial = (r.name?.[0] ?? '?').toUpperCase();
         return html`
           <div
@@ -285,37 +508,22 @@ export class SkillsPage extends LitElement {
             <span class="rm-ic">${initial}</span>
             <span class="rm-mn">
               <b>${r.name}</b>
-              <span>${r.description ?? '—'}</span>
+              <span>
+                ${r.description ?? '—'} · ${this.renderOwnTag(r)}
+              </span>
             </span>
             <span class="rm-meta"
               >${r.bound_coworker_count} coworker${r.bound_coworker_count === 1 ? '' : 's'}</span>
+            ${this.renderVisibilityPill(r)}
             ${r.enabled
               ? nothing
               : html`<span class="rm-pill rm-pill-off">disabled</span>`}
-            <span class="rm-row-acts">
-              <button
-                type="button"
-                class="rm-iconbtn"
-                title="Edit skill"
-                data-testid="skill-edit"
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  this.editSkill(r);
-                }}
-              >${iconPencil(15)}</button>
-              <button
-                type="button"
-                class="rm-iconbtn rm-iconbtn--danger"
-                title="Delete skill"
-                data-testid="skill-delete"
-                @click=${(e: Event) => {
-                  e.stopPropagation();
-                  this.askDelete(r);
-                }}
-              >${iconTrash(15)}</button>
-            </span>
+            ${this.renderRowActions(r)}
             ${delErr
               ? html`<div class="rm-row-error">${delErr}</div>`
+              : nothing}
+            ${shareErr
+              ? html`<div class="rm-row-error">${shareErr}</div>`
               : nothing}
           </div>
         `;

--- a/web/src/styles/settings-pages.css
+++ b/web/src/styles/settings-pages.css
@@ -264,6 +264,11 @@
   background: var(--rm-bad-subtle);
   color: var(--rm-bad);
 }
+/* Active "shared" state on the share toggle — green to match the
+ * "Shared" visibility pill, so the icon reads as "currently shared". */
+.rm-iconbtn.rm-iconbtn--on { color: var(--rm-good); }
+.rm-iconbtn.rm-iconbtn--on:hover { background: var(--rm-good-subtle); color: var(--rm-good); }
+.rm-iconbtn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 /* Provider group (Models page) — heading row + nested cards. */
 .rm-provgrp { margin-bottom: 18px; }
@@ -1006,3 +1011,32 @@ summary.list-none::marker { content: ''; }
 .rm-saf-audit-row .rm-saf-actor { font-size: 11.5px; color: var(--rm-ink-3); }
 .rm-saf-audit-row .rm-saf-ats { font-size: 11px; color: var(--rm-ink-3); margin-left: auto; font-variant-numeric: tabular-nums; }
 .rm-saf-audit-row .rm-saf-achange { font-size: 11.5px; color: var(--rm-ink-2); margin-top: 5px; padding-left: 8px; border-left: 2px solid var(--rm-border-2); }
+
+/* ---- role-aware coworkers / skills page (RBAC UI PR4, spec §5.1) ---- */
+
+/* Filter chips bar — UX re-classification of the already-server-filtered
+ * list (All visible / Mine / Shared by others). Reuses the .rm-seg
+ * segmented-control idiom; spaced under the page subtitle. */
+.rm-chipbar { margin: 2px 0 14px; }
+
+/* Ownership cue — "Created by you" (accent) vs neutral "Shared by
+ * another member" / system. Sits in the card's meta column. The accent
+ * variant is the scannable signal that a row is actionable by a member
+ * (spec §5.1 "why highlighted in accent"). */
+.rm-own-tag {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.rm-own-tag.rm-own-tag--mine { color: var(--rm-accent); }
+.rm-own-tag.rm-own-tag--other { color: var(--rm-ink-3); }
+
+/* "View only" hint shown in the action slot for rows a member can't
+ * manage — replaces the Edit/Delete/Share controls (not an empty gap). */
+.rm-viewonly {
+  font-size: 11px;
+  color: var(--rm-ink-3);
+  font-style: italic;
+  flex-shrink: 0;
+  padding-right: var(--rm-space-1);
+}


### PR DESCRIPTION
## Why

RBAC role-aware UI v3. Backend `GET /api/v1/me` (PR #72) returns `{capabilities: string[], plane: 'platform'|'tenant'}`. This wires the SPA to gate every nav entry and in-page affordance off `me.capabilities`, so the four roles (platform_admin / owner / admin / member) each see a navigation and affordance set appropriate to them — **without the frontend ever maintaining its own role→capability mapping**. The single source of truth stays `src/rolemesh/auth/permissions.py`; the SPA reads the resolved list off the wire.

Two iron rules held throughout: (1) no role→capability matrix is duplicated in the frontend; (2) no code dispatches on role name — `grep -rn "me.role ===" web/src` is **0**. The only role-ish sentinel is `me.plane === 'platform'` (a *plane* check that selects the platform shell).

## What

Delivered as 6 web commits + 1 enabling backend commit (one logical unit per commit):

- **`feat(web): capability helpers + atomic auth+me bootstrap`** — new `web/src/auth/capabilities.ts` (`setMe`/`currentMe`/`hasCapability`/`isOwnResource`/`canManage`, three-value-null-safe ownership). Refactored `<rm-app>.resolveAuth` into a discriminated-union `resolveToken()` so `authState='authenticated'` flips **exactly once, after** `setMe(me)` — no sub-shell ever mounts while `currentMe()` is null. The legacy/no-auth deployment authenticates without calling `/me` (no regression).
- **`feat(web): capability-gate settings-shell nav + access-denied`** — each of the 12 `NavEntry`s carries a `requires` capability; render filters entries and drops fully-empty groups. New `<rm-access-denied>` renders in-pane (rail preserved) on URL-jumps to gated slugs.
- **`feat(web): platform shell + tenants page + 3 coming-soon stubs`** — new `<rm-platform-shell>` (4 capability-gated entries under `#/platform/*`); new `<rm-platform-tenants-page>` (list / suspend / resume / provision-dialog); `<rm-app>` dispatches `plane === 'platform'` to it. Models / Credential pool / Platform safety route to `<rm-coming-soon>`. `ApiClient` gains `listTenants`/`provisionTenant`/`suspendTenant`/`resumeTenant`.
- **`feat(api-v1): expose created_by_user_id on SkillSummary list projection`** — the list projection dropped the owner field that the full `Skill` carries, so the skills page couldn't classify ownership from list data. Added across the 3 contract-synced sources + regenerated TS types + a backend regression test. (Approved scope expansion to give skills full parity with coworkers.)
- **`feat(web): role-aware coworkers page (canManage + chips + share)`** — per-row Edit/Delete/Share gated by `canManage(co, 'coworker.manage')` (capability **or** ownership escape); All/Mine/Shared chips over the already-server-filtered list; accent "Created by you" cue; Shared/Private pill; `shareCoworker`/`unshareCoworker`.
- **`feat(web): role-aware skills page (mirror of coworkers)`** — same treatment for skills; `shareSkill`/`unshareSkill`. (Share returns the full `Skill`, so the row patch updates only `visibility`+`created_by_user_id` to preserve list-only fields.)
- **`feat(web): gate MCP add-server in coworker wizard`** — the wizard's "+ Connect a new server" action is gated on `mcp.configure`; members with no servers see "No MCP servers configured. Ask your admin to add one." but can still select existing servers.

## Tests

+88 vitest tests (553 → 641) across `capabilities.test.ts`, `app.test.ts`, `settings-shell.test.ts`, `access-denied-page.test.ts`, `platform-shell.test.ts`, `platform-tenants-page.test.ts`, `coworkers-page.test.ts`, `skills-page.test.ts`, `coworker-wizard.test.ts`. Backend: new `test_list_skills_summary_carries_created_by_user_id` regression test. Tests seed the real `capabilities.ts` cache (no mocking of internal modules); several were mutation-checked to confirm they bite.

## Verification

All gates green: `tsc` 0 new errors (6 pre-existing baseline untouched), `lint:tokens-only` / `lint:no-admin-chat` / `lint:flat-route` clean, `openapi:check` in sync, `vitest` 641 passed; backend `pytest` contract + skills 61 passed.

Capability-gate snapshot (from the actual `settings-shell.test.ts` / `platform-shell.test.ts` output):

| Role | Visible slugs |
|---|---|
| member | coworkers, skills, models, connected-channels, appearance (**5**) |
| admin | + mcp-servers, approval-policies, safety, safety-log, members (**10**) |
| owner | + credentials, general (**12**) |
| platform_admin | platform-shell: tenants, models, credentials, safety (**4**) |

Manual traces (the four from the design handoff) hold: member ownership-escape on own rows; admin→member redirect to the 403 page on a gated slug; platform_admin sees the 4-entry platform shell (Tenants real, 3 coming-soon); and on reload to a deep `#/manage/*` URL the nav renders once `/me` resolves (Loading… meanwhile), never blank.

## Out of scope (deferred, per spec §5.8/§6)

Models CRUD UI, Credential-pool UI, Platform-safety UI (all 3 are `<rm-coming-soon>` stubs; backends ready), act-as-tenant, and a real Members page (the slug stays a coming-soon stub, gated on `user.manage`). `chat-shell.ts`'s own `/me` call is left in place (now redundant but harmless; cleanup later).
