### PR TITLE
fix(egress): make NATS reachable on the agent bridge in dev + startup gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ uv sync --extra pi --extra dev
 # Add the eval extra to use rolemesh-eval (Inspect AI based, manual)
 uv sync --extra pi --extra dev --extra eval
 
-# Bring up Postgres + NATS
+# Bring up Postgres + NATS (also creates the EC-2 agent bridge and
+# attaches NATS to it). Run this BEFORE the orchestrator: compose owns
+# the rolemesh-agent-net network in dev and the orchestrator reuses it.
+# If the orchestrator starts first it creates the network itself and a
+# later `compose up` fails on a label mismatch.
 docker compose -f docker-compose.dev.yml up -d
 
 # Build the agent and egress-gateway container images
@@ -169,7 +173,7 @@ channel with its bot tokens.
 | Key                          | Purpose                                                                  |
 |------------------------------|--------------------------------------------------------------------------|
 | `ASSISTANT_NAME`             | Display name for your AI coworker.                                       |
-| `CONTAINER_NETWORK_NAME`     | Set to enable EC-2 (Internal=true) agent bridge with egress gateway.     |
+| `CONTAINER_NETWORK_NAME`     | EC-2 agent bridge (Internal=true) + egress gateway. Defaults to `rolemesh-agent-net` (EC **on**); set to `""` to roll back to the plain Docker bridge. |
 | `ROLEMESH_ENV`               | `development` (default) or `production`. See note below.                 |
 | `ROLEMESH_SEED_ADMIN_EMAIL`  | If set, the WebUI seeds a `platform_admin` with this email at startup.   |
 | `WS_TICKET_SECRET`           | **Required.** Dedicated signing key for WebSocket handshake tickets.     |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,19 @@ services:
     command: ["--jetstream", "--store_dir=/data"]
     volumes:
       - nats-data:/data
+    # Dual-homed on purpose:
+    #   * default     — keeps the host port mappings above, so the
+    #                   orchestrator (runs on the host) and all test code
+    #                   keep reaching NATS at nats://localhost:4222.
+    #   * agent-net   — EC-2 agent containers sit on an Internal=true
+    #                   bridge with no route to the host; they dial NATS
+    #                   by the ``nats`` service name, which Docker's
+    #                   embedded DNS resolves only if the nats container
+    #                   is attached to that same bridge. Without this the
+    #                   agent's first NATS round-trip fails mid-turn.
+    networks:
+      - default
+      - agent-net
 
   postgres:
     image: postgres:16
@@ -18,6 +31,31 @@ services:
       POSTGRES_PASSWORD: rolemesh
     volumes:
       - pgdata:/var/lib/postgresql/data
+
+networks:
+  # Compose owns the EC-2 agent bridge in dev. ``ensure_agent_network``
+  # in the orchestrator is idempotent — it reuses a network that already
+  # exists by name as long as the invariants below hold, so the
+  # orchestrator (which boots after ``compose up``) attaches to this one
+  # instead of creating its own. The name MUST equal
+  # ``CONTAINER_NETWORK_NAME`` (default ``rolemesh-agent-net``).
+  #
+  # Ordering note: bring this up (``docker compose up``) BEFORE the
+  # orchestrator. If the orchestrator runs first it creates the network
+  # itself with RoleMesh labels, and a later ``compose up`` then fails
+  # with a label-mismatch error — ``docker network rm rolemesh-agent-net``
+  # to recover.
+  agent-net:
+    name: rolemesh-agent-net
+    driver: bridge
+    # Mirrors the orchestrator's Internal=true invariant (network.py).
+    # If this is false the orchestrator reuses the network but logs a
+    # "weakened isolation" warning.
+    internal: true
+    # enable_icc is intentionally left at the bridge default (true):
+    # ICC is required for the agent↔gateway and gateway↔NATS paths, and
+    # the orchestrator's reuse check defaults a missing flag to "true",
+    # so omitting it keeps both sides agreeing without a warning.
 
 volumes:
   nats-data:

--- a/src/rolemesh/container/docker_runtime.py
+++ b/src/rolemesh/container/docker_runtime.py
@@ -344,6 +344,19 @@ class DockerRuntime:
             reverse_proxy_port,
         )
 
+    async def verify_nats_reachable(
+        self,
+        network_name: str,
+        nats_url: str,
+    ) -> None:
+        from rolemesh.container.network import verify_nats_reachable
+
+        await verify_nats_reachable(
+            self._ensure_client(),
+            network_name,
+            nats_url,
+        )
+
     @staticmethod
     def _spec_to_config(spec: ContainerSpec) -> dict[str, Any]:
         """Convert a ContainerSpec to a Docker API config dict."""

--- a/src/rolemesh/container/network.py
+++ b/src/rolemesh/container/network.py
@@ -35,6 +35,7 @@ import asyncio
 import contextlib
 import uuid
 from typing import Any
+from urllib.parse import urlparse
 
 import aiodocker
 import aiodocker.exceptions
@@ -74,6 +75,25 @@ _EGRESS_NETWORK_OPTIONS: dict[str, str] = {
 # intentionally tiny; alpine is already present in most dev environments
 # and pulls in under ~5MB.
 _PROBE_IMAGE: str = "alpine:3.19"
+
+
+def agent_facing_nats_url(nats_url: str) -> str:
+    """Rewrite a loopback NATS URL to the ``nats`` service name that
+    resolves on the internal agent bridge.
+
+    Agent containers sit on an ``Internal=true`` bridge with no route to
+    the host, so the orchestrator's own ``nats://localhost:4222`` is
+    meaningless to them. They reach NATS by a ``nats`` alias attached to
+    the bridge (dev: docker-compose attaches the nats container to
+    agent-net; prod: the operator wires NATS onto the bridge). This is
+    the single source of truth shared by ``runner`` — which injects the
+    rewritten URL into each agent container's env — and the startup
+    reachability probe below, so the probe always targets exactly what
+    the agents will dial.
+    """
+    return nats_url.replace("://localhost:", "://nats:").replace(
+        "://127.0.0.1:", "://nats:"
+    )
 
 
 async def ensure_agent_network(
@@ -220,6 +240,85 @@ async def ensure_egress_network(
     logger.info("Created egress network", network=network_name, options=_EGRESS_NETWORK_OPTIONS)
 
 
+async def _run_bridge_probe(
+    client: aiodocker.Docker,
+    network_name: str,
+    probe_cmd: list[str],
+    *,
+    timeout_s: float,
+    label: str,
+    detail: str = "",
+) -> None:
+    """Run a one-shot probe container on ``network_name`` and assert it
+    exits 0. Shared by the egress-gateway and NATS reachability checks.
+
+    ``label`` must end in the word "probe" — both the timeout and
+    non-zero-exit messages read ``f"{label} failed/timed out ..."``, and
+    callers / tests grep for the adjacent ``"probe failed"`` phrase.
+    ``detail`` carries probe-specific context (network, target) appended
+    to those messages.
+
+    Skips (returns without raising) only when the probe image can't be
+    pulled — in that degraded case a missing alpine image shouldn't block
+    startup. Any other failure (timeout, non-zero exit) raises
+    RuntimeError so the caller can fail closed.
+    """
+    probe_name = f"rolemesh-probe-{uuid.uuid4().hex[:8]}"
+    config: dict[str, Any] = {
+        "Image": _PROBE_IMAGE,
+        "Cmd": probe_cmd,
+        "HostConfig": {
+            "NetworkMode": network_name,
+            "AutoRemove": False,
+            # No ExtraHosts: targets are resolved by service name via
+            # Docker embedded DNS on the agent bridge. Keeping this
+            # empty is a soft assertion that we no longer depend on the
+            # host-gateway escape hatch.
+        },
+        "AttachStdout": True,
+        "AttachStderr": True,
+    }
+
+    try:
+        await client.images.inspect(_PROBE_IMAGE)
+    except aiodocker.exceptions.DockerError:
+        logger.info("Pulling probe image", image=_PROBE_IMAGE)
+        try:
+            await client.images.pull(_PROBE_IMAGE)
+        except aiodocker.exceptions.DockerError as exc:
+            logger.warning(
+                "Could not pull probe image — skipping connectivity check; "
+                "real agents may still fail to reach the target",
+                image=_PROBE_IMAGE,
+                error=str(exc),
+            )
+            return
+
+    with contextlib.suppress(aiodocker.exceptions.DockerError):
+        stale = client.containers.container(probe_name)
+        await stale.delete(force=True)
+
+    container = await client.containers.create_or_replace(name=probe_name, config=config)
+    try:
+        await container.start()
+        try:
+            result = await asyncio.wait_for(container.wait(), timeout=timeout_s)
+        except TimeoutError as exc:
+            msg = f"{label} timed out after {timeout_s}s. {detail}".rstrip()
+            raise RuntimeError(msg) from exc
+        exit_code = int(result.get("StatusCode", -1))
+        if exit_code != 0:
+            logs = await container.log(stdout=True, stderr=True)
+            msg = (
+                f"{label} failed (exit={exit_code}). {detail} "
+                f"Probe output: {''.join(logs)[:500]}"
+            ).strip()
+            raise RuntimeError(msg)
+    finally:
+        with contextlib.suppress(aiodocker.exceptions.DockerError):
+            await container.delete(force=True)
+
+
 async def verify_egress_gateway_reachable(
     client: aiodocker.Docker,
     network_name: str,
@@ -238,11 +337,7 @@ async def verify_egress_gateway_reachable(
 
     Probe semantics:
         * DNS: ``<gateway_service_name>`` must resolve on the internal
-          bridge. Docker's embedded DNS binds the container name to its
-          bridge IP; EC-1 agents won't have their DNS pointed at the
-          gateway's resolver yet (EC-2 turns that on), so we still use
-          127.0.0.11 here. Once EC-2 lands and the container DNS is
-          pinned to the gateway, this same probe continues to work.
+          bridge via Docker's embedded DNS (127.0.0.11).
         * HTTP: ``GET /healthz`` must return 200. Unlike the pre-EC-1
           probe this path is our own — we expect a specific status, so
           the old "any HTTP response means success" logic doesn't apply.
@@ -253,7 +348,6 @@ async def verify_egress_gateway_reachable(
         logger.info("Skipping gateway reachability probe — no custom network configured")
         return
 
-    probe_name = f"rolemesh-egress-probe-{uuid.uuid4().hex[:8]}"
     wget_timeout = max(1, int(timeout_s) - 2)
     # Expect HTTP/200 specifically; /healthz is under our control so any
     # other code is a real problem.
@@ -266,71 +360,84 @@ async def verify_egress_gateway_reachable(
             "2>&1 | grep -q 'HTTP/1.[01] 200'"
         ),
     ]
+    await _run_bridge_probe(
+        client,
+        network_name,
+        probe_cmd,
+        timeout_s=timeout_s,
+        label="Egress-gateway connectivity probe",
+        detail=(
+            f"(network={network_name}, "
+            f"service={gateway_service_name}:{reverse_proxy_port}). "
+            "Is the gateway container running and attached to both networks?"
+        ),
+    )
+    logger.info(
+        "Egress gateway reachable from agent network",
+        network=network_name,
+        service=gateway_service_name,
+    )
 
-    config: dict[str, Any] = {
-        "Image": _PROBE_IMAGE,
-        "Cmd": probe_cmd,
-        "HostConfig": {
-            "NetworkMode": network_name,
-            "AutoRemove": False,
-            # No ExtraHosts: the gateway is resolved by service name via
-            # Docker embedded DNS on the agent bridge. Keeping this
-            # empty is a soft assertion that we no longer depend on the
-            # host-gateway escape hatch.
-        },
-        "AttachStdout": True,
-        "AttachStderr": True,
-    }
 
-    try:
-        await client.images.inspect(_PROBE_IMAGE)
-    except aiodocker.exceptions.DockerError:
-        logger.info("Pulling probe image", image=_PROBE_IMAGE)
-        try:
-            await client.images.pull(_PROBE_IMAGE)
-        except aiodocker.exceptions.DockerError as exc:
-            logger.warning(
-                "Could not pull probe image — skipping connectivity check; "
-                "real agents may still fail to reach the egress gateway",
-                image=_PROBE_IMAGE,
-                error=str(exc),
-            )
-            return
+async def verify_nats_reachable(
+    client: aiodocker.Docker,
+    network_name: str,
+    nats_url: str,
+    *,
+    timeout_s: float = 10.0,
+) -> None:
+    """Prove that containers on the internal agent bridge can reach NATS
+    at the address agents actually dial (EC-2).
 
-    with contextlib.suppress(aiodocker.exceptions.DockerError):
-        stale = client.containers.container(probe_name)
-        await stale.delete(force=True)
+    Mirrors ``verify_egress_gateway_reachable`` and closes the same class
+    of gap: an agent on the ``Internal=true`` bridge whose ``NATS_URL``
+    resolves to a ``nats`` alias that isn't attached to the bridge boots
+    fine and only fails on its first NATS round-trip mid-turn (the
+    dev-compose omission this guards against). Fail closed at startup.
 
-    container = await client.containers.create_or_replace(name=probe_name, config=config)
-    try:
-        await container.start()
-        try:
-            result = await asyncio.wait_for(container.wait(), timeout=timeout_s)
-        except TimeoutError as exc:
-            msg = (
-                f"Egress-gateway connectivity probe timed out after "
-                f"{timeout_s}s (network={network_name}, "
-                f"service={gateway_service_name}:{reverse_proxy_port}). "
-                "Agents on this network will not reach the gateway — "
-                "refusing to continue. Is the gateway container running "
-                "and attached to both networks?"
-            )
-            raise RuntimeError(msg) from exc
-        exit_code = int(result.get("StatusCode", -1))
-        if exit_code != 0:
-            logs = await container.log(stdout=True, stderr=True)
-            msg = (
-                f"Egress-gateway connectivity probe failed "
-                f"(exit={exit_code}, network={network_name}, "
-                f"service={gateway_service_name}:{reverse_proxy_port}). "
-                f"Probe output: {''.join(logs)[:500]}"
-            )
-            raise RuntimeError(msg)
-        logger.info(
-            "Egress gateway reachable from agent network",
-            network=network_name,
-            service=gateway_service_name,
-        )
-    finally:
-        with contextlib.suppress(aiodocker.exceptions.DockerError):
-            await container.delete(force=True)
+    The probe opens a TCP connection to ``<host>:<port>`` derived from
+    ``agent_facing_nats_url`` — the exact address injected into agent
+    containers — and checks for NATS's server-first ``INFO`` protocol
+    banner. A bare port-open check would pass spuriously against an open
+    port with nothing (or the wrong thing) behind it; requiring ``INFO``
+    confirms it is really NATS.
+
+    Raises RuntimeError on failure — caller treats startup as aborted.
+    """
+    if not network_name:
+        logger.info("Skipping NATS reachability probe — no custom network configured")
+        return
+
+    target = agent_facing_nats_url(nats_url)
+    parsed = urlparse(target)
+    host = parsed.hostname or "nats"
+    port = parsed.port or 4222
+    nc_timeout = max(1, int(timeout_s) - 2)
+    # busybox nc: connect, let NATS speak first (it sends ``INFO`` on
+    # connect), then match the banner. ``head -c`` caps the read so a
+    # chatty server can't hold the pipe open past the probe window.
+    probe_cmd = [
+        "sh",
+        "-c",
+        (
+            f"nc -w {nc_timeout} {host} {port} </dev/null 2>/dev/null "
+            "| head -c 64 | grep -q '^INFO'"
+        ),
+    ]
+    await _run_bridge_probe(
+        client,
+        network_name,
+        probe_cmd,
+        timeout_s=timeout_s,
+        label="NATS connectivity probe",
+        detail=(
+            f"(network={network_name}, target={host}:{port}). "
+            "Is the NATS container attached to the agent bridge under "
+            "the 'nats' alias?"
+        ),
+    )
+    logger.info(
+        "NATS reachable from agent network",
+        network=network_name,
+        target=f"{host}:{port}",
+    )

--- a/src/rolemesh/container/runner.py
+++ b/src/rolemesh/container/runner.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from rolemesh.auth.permissions import AgentPermissions
 from rolemesh.container.docker_runtime import _parse_memory
+from rolemesh.container.network import agent_facing_nats_url
 from rolemesh.container.runtime import (
     CONTAINER_HOST_GATEWAY,
     ContainerSpec,
@@ -430,9 +431,7 @@ def build_container_spec(
         # production the operator puts NATS on the bridge directly. The
         # orchestrator itself still uses the .env-configured URL (usually
         # localhost:4222), so rewrite here rather than in the .env.
-        nats_url = NATS_URL.replace("://localhost:", "://nats:").replace(
-            "://127.0.0.1:", "://nats:"
-        )
+        nats_url = agent_facing_nats_url(NATS_URL)
         proxy_base = f"http://{EGRESS_GATEWAY_CONTAINER_NAME}:{CREDENTIAL_PROXY_PORT}"
         forward_proxy_url = (
             f"http://{EGRESS_GATEWAY_CONTAINER_NAME}:{EGRESS_GATEWAY_FORWARD_PORT}"

--- a/src/rolemesh/egress/bootstrap.py
+++ b/src/rolemesh/egress/bootstrap.py
@@ -56,7 +56,11 @@ from rolemesh.core.config import (
     EGRESS_GATEWAY_CONTAINER_NAME,
 )
 from rolemesh.core.logger import get_logger
-from rolemesh.egress.launcher import launch_egress_gateway, wait_for_gateway_ready
+from rolemesh.egress.launcher import (
+    launch_egress_gateway,
+    wait_for_gateway_ready,
+    wait_for_nats_ready,
+)
 
 # ``rolemesh.container.runner`` imports from ``rolemesh.agent`` which
 # imports back into ``rolemesh.container.runner`` — module-level
@@ -163,6 +167,18 @@ async def ensure_gateway_running_and_register_dns(
     from rolemesh.container.runner import set_egress_gateway_dns_ip
 
     docker_client = runtime._ensure_client()  # type: ignore[attr-defined]
+
+    # EC-2 fail-closed gate: agents on the Internal=true bridge can only
+    # reach NATS via the ``nats`` alias attached to that bridge. If it
+    # isn't attached (the classic dev-compose omission where the nats
+    # container never joins agent-net), the orchestrator and gateway —
+    # which reach NATS over the host gateway — still come up clean, and
+    # the breakage only surfaces on an agent's first NATS round-trip
+    # mid-turn. Assert reachability here so startup fails loudly instead.
+    # Gated on hasattr so non-Docker runtimes (k8s) that grow their own
+    # bootstrap path are unaffected.
+    if hasattr(runtime, "verify_nats_reachable"):
+        await wait_for_nats_ready(docker_client, agent_network=CONTAINER_NETWORK_NAME)
 
     # Reuse-if-running fast path. Skips ``launch_egress_gateway``'s
     # destructive ``create_or_replace`` so a running gateway in use

--- a/src/rolemesh/egress/launcher.py
+++ b/src/rolemesh/egress/launcher.py
@@ -32,7 +32,10 @@ from typing import Any
 import aiodocker
 import aiodocker.exceptions
 
-from rolemesh.container.network import verify_egress_gateway_reachable
+from rolemesh.container.network import (
+    verify_egress_gateway_reachable,
+    verify_nats_reachable,
+)
 from rolemesh.container.runtime import (
     get_host_gateway_extra_hosts,
     rewrite_loopback_to_host_gateway,
@@ -41,6 +44,7 @@ from rolemesh.core.config import (
     CREDENTIAL_PROXY_PORT,
     EGRESS_GATEWAY_CONTAINER_NAME,
     EGRESS_GATEWAY_IMAGE,
+    NATS_URL,
     PROJECT_ROOT,
 )
 from rolemesh.core.logger import get_logger
@@ -185,6 +189,50 @@ async def wait_for_gateway_ready(
     msg = (
         f"Egress gateway did not become ready after {attempts} attempts "
         f"({attempts * interval_s:.1f}s). Last error: {last_exc}"
+    )
+    raise RuntimeError(msg) from last_exc
+
+
+async def wait_for_nats_ready(
+    client: aiodocker.Docker,
+    *,
+    agent_network: str,
+    nats_url: str = NATS_URL,
+    attempts: int = 15,
+    interval_s: float = 1.0,
+) -> None:
+    """Probe NATS from the agent bridge with retry until it answers or
+    the budget exhausts.
+
+    In dev the nats container (docker-compose) may still be coming up
+    when the orchestrator boots, so the first attempts can legitimately
+    fail; a budget around ``attempts * interval_s`` seconds absorbs that
+    cold start. A healthy NATS already attached to the bridge returns on
+    the first attempt. When EC is off (``agent_network`` empty) the
+    underlying probe is a no-op and this returns immediately.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            await verify_nats_reachable(
+                client,
+                network_name=agent_network,
+                nats_url=nats_url,
+            )
+            return
+        except RuntimeError as exc:
+            last_exc = exc
+            logger.debug(
+                "NATS not reachable yet, retrying",
+                attempt=attempt,
+                max_attempts=attempts,
+            )
+            await asyncio.sleep(interval_s)
+    assert last_exc is not None
+    msg = (
+        f"NATS not reachable from the agent bridge after {attempts} attempts "
+        f"({attempts * interval_s:.1f}s). Agents will fail on their first "
+        f"NATS round-trip. Last error: {last_exc}"
     )
     raise RuntimeError(msg) from last_exc
 

--- a/tests/container/test_network.py
+++ b/tests/container/test_network.py
@@ -11,9 +11,11 @@ import aiodocker.exceptions
 import pytest
 
 from rolemesh.container.network import (
+    agent_facing_nats_url,
     ensure_agent_network,
     ensure_egress_network,
     verify_egress_gateway_reachable,
+    verify_nats_reachable,
 )
 
 
@@ -384,3 +386,114 @@ async def test_timeout_raises_runtime_error_and_cleans_probe() -> None:
             timeout_s=0.01,
         )
     probe.delete.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# agent_facing_nats_url — single source of truth for the bridge rewrite
+# ---------------------------------------------------------------------------
+
+
+def test_agent_facing_nats_url_rewrites_loopback_forms() -> None:
+    assert agent_facing_nats_url("nats://localhost:4222") == "nats://nats:4222"
+    assert agent_facing_nats_url("nats://127.0.0.1:4222") == "nats://nats:4222"
+
+
+def test_agent_facing_nats_url_leaves_non_loopback_untouched() -> None:
+    # An operator who already points NATS_URL at a real host/alias should
+    # not have it rewritten out from under them.
+    assert agent_facing_nats_url("nats://nats.prod:4222") == "nats://nats.prod:4222"
+    assert agent_facing_nats_url("nats://10.0.0.5:4222") == "nats://10.0.0.5:4222"
+
+
+# ---------------------------------------------------------------------------
+# verify_nats_reachable
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_nats_reachable_success() -> None:
+    probe = _make_probe_container(exit_code=0)
+    client = MagicMock()
+    client.images = MagicMock()
+    client.images.inspect = AsyncMock()
+    client.images.pull = AsyncMock()
+    client.containers = MagicMock()
+    client.containers.container = MagicMock(side_effect=_docker_error(404, "no stale"))
+    client.containers.create_or_replace = AsyncMock(return_value=probe)
+
+    await verify_nats_reachable(
+        client,
+        network_name="rolemesh-agent-net",
+        nats_url="nats://localhost:4222",
+    )
+
+    probe.start.assert_awaited_once()
+    probe.wait.assert_awaited_once()
+    probe.delete.assert_awaited()
+
+
+async def test_verify_nats_reachable_nonzero_exit_raises() -> None:
+    probe = _make_probe_container(exit_code=1)
+    client = MagicMock()
+    client.images = MagicMock()
+    client.images.inspect = AsyncMock()
+    client.images.pull = AsyncMock()
+    client.containers = MagicMock()
+    client.containers.container = MagicMock(side_effect=_docker_error(404, "no stale"))
+    client.containers.create_or_replace = AsyncMock(return_value=probe)
+
+    with pytest.raises(RuntimeError, match="probe failed"):
+        await verify_nats_reachable(
+            client,
+            network_name="rolemesh-agent-net",
+            nats_url="nats://localhost:4222",
+        )
+    probe.delete.assert_awaited()
+
+
+async def test_verify_nats_reachable_empty_network_name_is_noop() -> None:
+    client = MagicMock()
+    client.containers = MagicMock()
+    client.containers.create_or_replace = AsyncMock()
+
+    await verify_nats_reachable(
+        client,
+        network_name="",
+        nats_url="nats://localhost:4222",
+    )
+
+    client.containers.create_or_replace.assert_not_awaited()
+
+
+async def test_verify_nats_reachable_probe_targets_service_name_and_info_banner() -> None:
+    """The probe must dial the rewritten ``nats`` alias on the agent
+    bridge (not localhost) and match NATS's server-first INFO banner —
+    a bare port-open check would pass against the wrong service."""
+    probe = _make_probe_container(exit_code=0)
+    captured: dict[str, Any] = {}
+
+    async def _capture_create(name: str, config: dict[str, Any]) -> MagicMock:
+        captured["config"] = config
+        return probe
+
+    client = MagicMock()
+    client.images = MagicMock()
+    client.images.inspect = AsyncMock()
+    client.containers = MagicMock()
+    client.containers.container = MagicMock(side_effect=_docker_error(404, "no stale"))
+    client.containers.create_or_replace = AsyncMock(side_effect=_capture_create)
+
+    await verify_nats_reachable(
+        client,
+        network_name="rolemesh-agent-net",
+        nats_url="nats://localhost:4222",
+    )
+
+    host_config = captured["config"]["HostConfig"]
+    assert host_config["NetworkMode"] == "rolemesh-agent-net"
+    assert not host_config.get("ExtraHosts")
+    probe_cmd = " ".join(captured["config"]["Cmd"])
+    # Localhost must have been rewritten to the bridge-resolvable alias.
+    assert "nats 4222" in probe_cmd
+    assert "localhost" not in probe_cmd
+    # INFO banner check, not a bare `nc -z` port probe.
+    assert "INFO" in probe_cmd

--- a/tests/container/test_startup_order.py
+++ b/tests/container/test_startup_order.py
@@ -153,6 +153,11 @@ async def test_launch_aborts_when_gateway_launch_fails() -> None:
 
     with (
         patch.object(main_module, "_runtime", rt),
+        # bootstrap is imported lazily inside the call below, so patching
+        # the launcher source binds these mocks into bootstrap. The NATS
+        # gate runs first; stub it to a no-op so the launch failure is
+        # what propagates.
+        patch("rolemesh.egress.launcher.wait_for_nats_ready", AsyncMock()),
         patch("rolemesh.egress.launcher.launch_egress_gateway", launch_mock),
         patch("rolemesh.egress.launcher.wait_for_gateway_ready", wait_mock),
         pytest.raises(RuntimeError, match="image missing"),
@@ -181,6 +186,7 @@ async def test_launch_aborts_when_gateway_readiness_probe_fails() -> None:
 
     with (
         patch.object(main_module, "_runtime", rt),
+        patch.object(bootstrap, "wait_for_nats_ready", AsyncMock()),
         patch.object(bootstrap, "launch_egress_gateway", launch_mock),
         patch.object(bootstrap, "wait_for_gateway_ready", wait_mock),
         pytest.raises(RuntimeError, match="probe exhausted"),

--- a/tests/egress/test_bootstrap.py
+++ b/tests/egress/test_bootstrap.py
@@ -29,6 +29,20 @@ import aiodocker.exceptions
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _stub_nats_probe() -> Any:
+    """EC-2 added a NATS reachability gate at the top of
+    ``ensure_gateway_running_and_register_dns``. These tests target the
+    gateway-bootstrap logic, so stub the probe to a no-op by default;
+    its own fail-closed behaviour is covered by the dedicated tests at
+    the end of this file, which re-patch it.
+    """
+    from rolemesh.egress import bootstrap
+
+    with patch.object(bootstrap, "wait_for_nats_ready", AsyncMock()):
+        yield
+
+
 @pytest.fixture
 def _runner_module() -> Any:
     """Import ``rolemesh.container.runner`` via a path that does NOT
@@ -397,3 +411,84 @@ async def test_inspect_format_anomaly_falls_through_to_launch(_runner_module: An
         "missing IP in existing container's inspect should trigger "
         "a fresh launch, not register a None IP"
     )
+
+
+# ---------------------------------------------------------------------------
+# EC-2 NATS reachability gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nats_unreachable_aborts_before_touching_gateway(
+    _runner_module: Any,
+) -> None:
+    """If NATS isn't reachable on the agent bridge the bootstrap fails
+    closed at the top — before launching or even inspecting the gateway.
+    Without this gate agents come up clean and only fail on their first
+    NATS round-trip mid-turn (the dev-compose omission this guards).
+    """
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+    _wire_existing_gateway(runtime, _make_gateway_inspect(running=True))
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(
+            bootstrap,
+            "wait_for_nats_ready",
+            AsyncMock(side_effect=RuntimeError("nats not on bridge")),
+        ),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()) as launch_mock,
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()) as wait_mock,
+        patch.object(_runner_module, "set_egress_gateway_dns_ip") as set_dns_mock,
+        pytest.raises(RuntimeError, match="nats not on bridge"),
+    ):
+        await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    launch_mock.assert_not_called()
+    wait_mock.assert_not_called()
+    set_dns_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nats_gate_runs_on_the_reuse_path(_runner_module: Any) -> None:
+    """The NATS gate is checked even when an existing gateway is reused
+    (the common steady-state path), not just on fresh launch."""
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+    _wire_existing_gateway(runtime, _make_gateway_inspect(running=True))
+    nats_probe = AsyncMock()
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(bootstrap, "wait_for_nats_ready", nats_probe),
+        patch.object(bootstrap, "launch_egress_gateway", AsyncMock()) as launch_mock,
+        patch.object(bootstrap, "wait_for_gateway_ready", AsyncMock()),
+        patch.object(_runner_module, "set_egress_gateway_dns_ip"),
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result == "172.18.0.7"
+    nats_probe.assert_awaited_once()
+    launch_mock.assert_not_called()  # reuse path, no relaunch
+
+
+@pytest.mark.asyncio
+async def test_nats_gate_skipped_when_ec2_inactive() -> None:
+    """Rollback mode (``CONTAINER_NETWORK_NAME=""``) short-circuits before
+    the NATS gate — there's no agent bridge to probe."""
+    from rolemesh.egress import bootstrap
+
+    runtime = _make_runtime()
+    nats_probe = AsyncMock()
+
+    with (
+        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", ""),
+        patch.object(bootstrap, "wait_for_nats_ready", nats_probe),
+    ):
+        result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)
+
+    assert result is None
+    nats_probe.assert_not_awaited()


### PR DESCRIPTION
## Problem

EC-2 puts agent containers on an `Internal=true` bridge with no route to the host, so the orchestrator rewrites their `NATS_URL` to `nats://nats:4222` (`runner.py`) and relies on Docker embedded DNS resolving the `nats` alias on `rolemesh-agent-net`. In dev, the `docker-compose.dev.yml` `nats` service was never attached to that bridge, so **every agent's first NATS round-trip failed mid-turn**.

It stayed invisible because the gap sat in the seam between paths that each wire NATS manually:

- **Orchestrator & gateway are unaffected** — they reach NATS over the host gateway (`host.docker.internal`), so startup looks clean.
- **CI never exercises it** — the egress integration tests are `@pytest.mark.integration`, which `pyproject.toml`'s default `-m 'not integration'` deselects; CI is unit-only.
- **The integration fixtures wire `nats` onto agent-net themselves** (`conftest.py`), so a green integration run actively *masks* the dev gap.
- **`CONTAINER_NETWORK_NAME` defaults to on** in code, but the README described it as opt-in.
- **Failure is deferred** — nothing at boot dials `nats://nats:4222` from the bridge; the startup self-check probes the gateway, not NATS.

## Changes

- **`docker-compose.dev.yml`** — compose now owns the `rolemesh-agent-net` bridge (`Internal=true`, named to match `CONTAINER_NETWORK_NAME`) and dual-homes the `nats` container on it. The orchestrator reuses the network via its existing idempotent `ensure_agent_network` path. **No production code path changes** — prod still has the orchestrator create the bridge.
- **`network.py`** — add `verify_nats_reachable`, a fail-closed startup probe that opens a TCP connection to the agent-facing NATS address and checks NATS's `INFO` banner, mirroring `verify_egress_gateway_reachable`. Extract a shared `_run_bridge_probe` so the gateway and NATS checks don't duplicate the pull/create/wait/cleanup logic.
- **`network.py` / `runner.py`** — add `agent_facing_nats_url` as the single source of truth for the loopback→`nats` rewrite; `runner` now uses it instead of inlining the replace.
- **`bootstrap.py`** — run the NATS gate at the top of the shared egress bootstrap so **all** agent-spawning entry points (orchestrator, eval CLI) fail loudly at startup instead of mid-turn. Gated on `hasattr` for non-Docker runtimes (k8s).
- **`launcher.py` / `docker_runtime.py`** — `wait_for_nats_ready` retry wrapper + runtime method forwarding, mirroring the gateway path.
- **`README.md`** — correct the misleading "set to enable" note (EC is on by default) and document the compose-before-orchestrator startup order + the network-label-collision caveat.

## Code volume

10 files changed, **+507 / −68**. Production `+249 / −66` (净 +183), tests `+214`, compose+docs `+44 / −2`. Core new logic (the NATS probe itself) is ~50 lines; the rest is comments, the retry wrapper, runtime forwarding, and docs.

## Testing

- `ruff check src/ tests/` — clean (CI parity).
- Directly affected modules — **58 passed** (`test_network`, `test_startup_order`, `test_launcher`, `test_bootstrap`), including new unit tests for `verify_nats_reachable`, `agent_facing_nats_url`, and the bootstrap gate (abort / reuse-path / EC-off-skip).
- `tests/container` + `tests/egress` — **575 passed**. (41 errors are environmental — this sandbox has no Docker socket / DB; they reproduce identically on `main`.)
- `test_executor` (imports `runner`/`build_container_spec`) — 27/27, confirming the new `runner→network` import introduces no cycle.

> Note: the new NATS probe relies on alpine busybox `nc -w` reading NATS's server-first `INFO` banner. If some busybox build doesn't read the server-first banner, the check degrades to a port-open probe — same control flow, slightly weaker assertion.

https://claude.ai/code/session_011E3MSN94gjE33w82hxu8xr

---
_Generated by [Claude Code](https://claude.ai/code/session_011E3MSN94gjE33w82hxu8xr)_