### PR TITLE
fix(webui): align Bedrock credential form with Bearer-token backend

### DIFF
--- a/web/src/components/credential-dialog.test.ts
+++ b/web/src/components/credential-dialog.test.ts
@@ -5,9 +5,10 @@
 //   - Provider-locked mode: only the relevant fields render.
 //   - Provider-pick mode (provider = null): user can change provider
 //     and field set updates.
-//   - Bedrock specifically renders 4 fields (per locked decision):
-//     access key id (api_key slot), secret, region (default us-west-2),
-//     and optional session token.
+//   - Bedrock renders 2 fields: the Bedrock long-term API key
+//     (api_key slot) and region (default us-east-1). The proxy
+//     authenticates with the key as a Bearer token, so no AWS
+//     secret/session-token fields are collected.
 //   - Save → PUT /credentials/{provider} with the right body
 //     shape `{api_key, extras: {...}}` (or `extras: null` when no
 //     extras are needed).
@@ -117,21 +118,21 @@ describe('<rm-credential-dialog>', () => {
     expect(inputs[0]!.getAttribute('type')).toBe('password');
   });
 
-  it('bedrock locked mode renders 4 fields with us-west-2 default region', async () => {
+  it('bedrock locked mode renders 2 fields with us-east-1 default region', async () => {
     const el = mount();
     el.provider = 'bedrock';
     el.open = true;
     await settle(el);
     const inputs = el.querySelectorAll('input');
-    expect(inputs.length).toBe(4);
+    expect(inputs.length).toBe(2);
     // Region field: find label whose text matches "Region".
     const labels = [...el.querySelectorAll('label')].map((l) => l.textContent?.trim());
     expect(labels).toContain('Region');
     // Default region pre-filled.
     const regionInput = [...inputs].find(
-      (i) => i.getAttribute('placeholder') === 'us-west-2',
+      (i) => i.getAttribute('placeholder') === 'us-east-1',
     )!;
-    expect(regionInput.value).toBe('us-west-2');
+    expect(regionInput.value).toBe('us-east-1');
   });
 
   it('provider picker renders when provider=null and updates field set on change', async () => {
@@ -145,7 +146,7 @@ describe('<rm-credential-dialog>', () => {
     select.value = 'bedrock';
     select.dispatchEvent(new Event('change', { bubbles: true }));
     await settle(el);
-    expect(el.querySelectorAll('input').length).toBe(4); // bedrock fields
+    expect(el.querySelectorAll('input').length).toBe(2); // bedrock fields
   });
 
   it('PUT body matches the per-provider shape for openai with api_base override', async () => {
@@ -194,15 +195,17 @@ describe('<rm-credential-dialog>', () => {
     expect(stub!.calls[0]!.body).toEqual({ api_key: 'sk-fake', extras: null });
   });
 
-  it('blocks save when a required extra is empty (bedrock without secret)', async () => {
+  it('blocks save when a required extra is empty (bedrock without region)', async () => {
     const el = mount();
     el.provider = 'bedrock';
     el.open = true;
     await settle(el);
     const inputs = el.querySelectorAll<HTMLInputElement>('input');
-    // Fill access key id only — leave secret empty.
-    inputs[0]!.value = 'AKIAFAKE';
+    // Fill the Bedrock API key, then clear the pre-filled region.
+    inputs[0]!.value = 'ABSKFAKE';
     inputs[0]!.dispatchEvent(new Event('input', { bubbles: true }));
+    inputs[1]!.value = '';
+    inputs[1]!.dispatchEvent(new Event('input', { bubbles: true }));
     await settle(el);
     const saveBtn = [...el.querySelectorAll<HTMLButtonElement>('button')].find(
       (b) => b.textContent?.includes('Save'),
@@ -210,7 +213,7 @@ describe('<rm-credential-dialog>', () => {
     saveBtn.click();
     await settle(el);
     expect(stub!.calls).toHaveLength(0);
-    expect(el.textContent).toContain('AWS secret access key');
+    expect(el.textContent).toContain('Region is required');
   });
 
   it('emits credential-saved and clears the form on success', async () => {

--- a/web/src/components/credential-dialog.ts
+++ b/web/src/components/credential-dialog.ts
@@ -2,7 +2,7 @@
 //
 // Wraps <rm-dialog> (v2-A primitive). Knows which provider the user
 // is configuring; renders the right set of fields (anthropic = one
-// API key, bedrock = AWS quartet, etc.) and writes via PUT
+// API key, bedrock = API key + region, etc.) and writes via PUT
 // /api/v1/credentials/{provider} with the open-shape
 // `extras: { ... }` map per OpenAPI.
 //
@@ -95,33 +95,22 @@ export const PROVIDER_SCHEMAS: ProviderSchema[] = [
     provider: 'bedrock',
     label: 'AWS Bedrock',
     blurb:
-      'AWS access key + region. The credential proxy uses these to sign Bedrock InvokeModel calls.',
+      'Bedrock long-term API key + region. The credential proxy authenticates to Bedrock with this key as a Bearer token.',
     apiKey: {
-      label: 'AWS access key ID',
-      placeholder: 'AKIA…',
+      label: 'Bedrock API key',
+      placeholder: 'ABSK…',
       helperText:
-        'Stored as the credential\'s primary key; the secret + region land in extras.',
+        'Console → Bedrock → API keys → Generate long-term API key. Stored as the credential\'s primary key; the region lands in extras.',
     },
     requiredExtras: [
       {
-        key: 'aws_secret_access_key',
-        label: 'AWS secret access key',
-        placeholder: '…',
-      },
-      {
         key: 'region',
         label: 'Region',
-        placeholder: 'us-west-2',
-        defaultValue: 'us-west-2',
+        placeholder: 'us-east-1',
+        defaultValue: 'us-east-1',
       },
     ],
-    optionalExtras: [
-      {
-        key: 'aws_session_token',
-        label: 'AWS session token (optional)',
-        placeholder: 'For temporary credentials.',
-      },
-    ],
+    optionalExtras: [],
   },
 ];
 


### PR DESCRIPTION
## Problem

The Bedrock credential dialog was modeled on **SigV4 IAM auth**, but the backend authenticates with a **Bearer token**. The UI was the only part of the stack carrying the SigV4 mental model:

- Labeled the primary key `AWS access key ID` (`AKIA…`)
- Required an **AWS secret access key**
- Offered an optional **AWS session token**
- Blurb claimed the proxy "uses these to sign Bedrock InvokeModel calls"

None of that matches reality. The credential proxy sends the stored `api_key` as `Authorization: Bearer <key>` (`reverse_proxy.py`, bedrock branch) and **never reads** the secret or session token. Following the UI labels (real IAM `AKIA…` + secret) produces a `Bearer AKIA...` header → AWS returns 401 every time.

The whole rest of the system is already consistent on Bearer auth:
- `reverse_proxy.py` → `Bearer {api_key}`
- `pi/ai/providers/amazon_bedrock.py` → stubs dummy SigV4 creds because "the proxy overwrites the Authorization header on every request"
- `agent/executor.py` / `README` → `AWS_BEARER_TOKEN_BEDROCK` = long-term API key

Only `credential-dialog.ts` was the outlier.

### Extra concern: dead secret collection

Beyond the 401 friction, the form **required** a real long-term IAM secret access key, which the backend encrypted and persisted indefinitely while **never using it** — a minimal-collection violation (holding a high-value secret that does nothing).

## Change

Rework the bedrock schema to collect only what the proxy consumes:

- Primary key relabeled **`Bedrock API key`** (`ABSK…`) with helper text pointing at Console → Bedrock → API keys → Generate long-term API key
- **Drop** the dead `aws_secret_access_key` (required) and `aws_session_token` (optional) fields
- Keep `region` (default **`us-east-1`**)
- Blurb now describes Bearer-token auth instead of request signing

Backend (`reverse_proxy.py`, `credentials.py`, Pi provider) is untouched — it was correct.

## Tests

- Updated component tests to the new 2-field shape (`us-east-1` default; "blocks save when region cleared")
- Refreshed header/contract comments
- `npm run test`: **660/660 pass**
- `npm run build`: succeeds

https://claude.ai/code/session_011RAtPnvyKUaBTxzAJqzZXo

---
_Generated by [Claude Code](https://claude.ai/code/session_011RAtPnvyKUaBTxzAJqzZXo)_