### PR TITLE
feat(egress): restore EC=off behind EGRESS_CONTROL_ENABLE; token-based credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,11 @@ channel with its bot tokens.
 | Key                          | Purpose                                                                  |
 |------------------------------|--------------------------------------------------------------------------|
 | `ASSISTANT_NAME`             | Display name for your AI coworker.                                       |
-| `CONTAINER_NETWORK_NAME`     | EC-2 agent bridge (Internal=true) + egress gateway. Defaults to `rolemesh-agent-net` (EC **on**); set to `""` to roll back to the plain Docker bridge. |
+| `EGRESS_CONTROL_ENABLE`      | Master switch for Egress Control. Default **on**. On: agents run on the Internal=true bridge behind the egress gateway (network isolation + forward/DNS proxies + per-tenant credentials). Off (`0`): agents run on the Docker default bridge and reach a host-side credential proxy directly — egress **network** control is disabled, but per-tenant **credential** isolation is preserved. Replaces the old `CONTAINER_NETWORK_NAME=""` off-switch. |
+| `CONTAINER_NETWORK_NAME`     | Name of the EC agent bridge (Internal=true). Defaults to `rolemesh-agent-net`. Only consulted when EC is on; with EC on it must be non-empty (empty → startup error). |
 | `EGRESS_DNS_ALLOWLIST`       | Platform-wide DNS allowlist for the gateway resolver (comma-separated, `exact` or `*.suffix`). Default **empty** — proxied traffic never needs agent-side DNS, so the resolver is a tripwire; see docs/16. |
 | `EGRESS_DNS_MODE`            | `enforce` (default: non-matching names get NXDOMAIN) or `observe` (resolve everything, log would-be blocks; migration aid only). |
-| `EGRESS_TOKEN_SECRET`        | **Required under EC.** Shared HMAC secret (≥16 chars) the orchestrator signs and the gateway verifies agent identity tokens with. Same value in both processes via the shared `.env`; never injected into agent containers. Missing → orchestrator/gateway refuse to boot. |
+| `EGRESS_TOKEN_SECRET`        | **Required in both EC modes.** Shared HMAC secret (≥16 chars) used to sign and verify agent identity tokens. EC on: the gateway verifies; EC off: the host-side credential proxy verifies (it's how per-tenant credential isolation survives with EC off). Never injected into agent containers. Missing → refuse to boot. |
 | `EGRESS_TOKEN_TTL_SECONDS`   | Max lifetime of an identity token (and thus an agent container before the orchestrator re-mints). Default 7 days. |
 | `ROLEMESH_ENV`               | `development` (default) or `production`. See note below.                 |
 | `ROLEMESH_SEED_ADMIN_EMAIL`  | If set, the WebUI seeds a `platform_admin` with this email at startup.   |

--- a/docs/16-egress-control-architecture-cn.md
+++ b/docs/16-egress-control-architecture-cn.md
@@ -412,13 +412,41 @@ EC 模块**完全复用** Safety Framework 已有的基础设施，**不新建**
 | 风险 | 严重度 | 缓解 |
 |---|---|---|
 | Gateway 挂 = 全租户断网 | 高 | restart-unless-stopped + 监控；V2 double-replica |
-| Identity 信息丢失（orchestrator 重启） | 中 | Gateway 重启时通过 internal REST 拉快照；orchestrator 重启时主动 republish lifecycle |
 | `safety.rule.changed` 事件丢失 | 低 | Gateway 后台每 5 分钟对账（拉全量做对比） |
 | DNS resolver 上游不可达 | 中 | 配多个 upstream（8.8.8.8 + 1.1.1.1 fallback） |
 | Docker `--internal` 在某 dockerd 版本行为异常 | 高 | EC-1 集成测试第 1 项必过；CI 守护 |
 | reverse_proxy 搬迁破坏现有 LLM 调用 | 高 | 严格保持 `credential_proxy.py` public API；测试覆盖所有 provider |
 
-回滚开关：`CONTAINER_NETWORK_NAME=""` → orchestrator 不创建任何网络（agent 用默认 bridge），完全退到 Container Hardening 之前的行为。**仅紧急用**。
+### 关闭 Egress Control（`EGRESS_CONTROL_ENABLE=0`）
+
+EC 由单一开关 `EGRESS_CONTROL_ENABLE`（默认开）控制。关闭是受支持的
+模式,不只是应急手段——在不便用自定义 Docker 网桥或没有 gateway 镜像的
+宿主（含 Docker Desktop）上有用。变化:
+
+| | EC 开 | EC 关 |
+|---|---|---|
+| Agent 网桥 | `Internal=true`,无宿主路由 | Docker 默认 bridge |
+| egress 网络管控 | forward proxy + DNS resolver + 隔离 | **关**——agent 可直连外网 |
+| 凭证注入 | gateway 容器（无状态、远程 resolver） | orchestrator 内 host 侧 proxy（本地 DB resolver） |
+| 多租户凭证隔离 | 有 | **有**（保留） |
+| 身份 | 请求里的签名 token | **请求里的签名 token**（同一机制） |
+
+关键点:关 EC 丢的是**网络**管控,保留的是**多租户凭证隔离**。这之所以
+成立,是因为身份是请求里携带的签名 token（reverse proxy URL 路径段）,而
+非从网络位置推断——所以 host 侧 proxy 验同一个 token、还原 tenant、注入该
+租户自己的 key。租户 A 仍拿不到租户 B 的凭证。
+
+由于 token 身份与拓扑无关,EC=off 在 Docker Desktop / WSL 上也能用——旧的
+源 IP 方案做不到（VM 的 NAT 把真实容器 IP 藏掉了）。`EGRESS_TOKEN_SECRET`
+两种模式都必需。
+
+形态说明:host 侧 credential proxy 监听器**仅**在 EC 关时绑定（那是唯一
+agent 会拨它的配置,经 `host.docker.internal:3001`）。EC 开时 agent 打到
+gateway 容器,不绑 host 监听器;而喂给 gateway 快照的 MCP 注册表 / token
+vault 接线两种模式都照常跑。
+
+迁移:历史上的 `CONTAINER_NETWORK_NAME=""` 关闭开关已废除。改用
+`EGRESS_CONTROL_ENABLE=0`;EC 开时网桥名为空现在是启动错误。
 
 ---
 

--- a/docs/16-egress-control-architecture.md
+++ b/docs/16-egress-control-architecture.md
@@ -436,13 +436,48 @@ The cost is that EC's design is **deeply bound** to the V1 shape of the Safety F
 | Risk | Severity | Mitigation |
 |---|---|---|
 | Gateway down = all tenants offline | High | restart-unless-stopped + monitoring; V2 double-replica |
-| Identity info lost (orchestrator restart) | Medium | Gateway restart pulls a snapshot via internal REST; orchestrator restart proactively republishes lifecycle |
 | `safety.rule.changed` event lost | Low | Gateway reconciles every 5 minutes (pulls full set, diffs) |
 | DNS resolver upstream unreachable | Medium | Configure multiple upstreams (8.8.8.8 + 1.1.1.1 fallback) |
 | Docker `--internal` behaves oddly on some dockerd version | High | EC-1 integration test item 1 must pass; CI guards |
 | reverse_proxy migration breaks existing LLM calls | High | Strictly preserve `credential_proxy.py` public API; tests cover every provider |
 
-Rollback switch: `CONTAINER_NETWORK_NAME=""` → orchestrator creates no network (agents use default bridge), full rollback to pre-Container-Hardening behavior. **Emergency use only.**
+### Turning Egress Control off (`EGRESS_CONTROL_ENABLE=0`)
+
+EC is a single switch, `EGRESS_CONTROL_ENABLE` (default on). Off is a
+supported mode, not just an emergency hatch — useful on hosts where
+custom Docker bridges or the gateway image aren't available (incl.
+Docker Desktop). What changes:
+
+| | EC on | EC off |
+|---|---|---|
+| Agent bridge | `Internal=true`, no host route | Docker default bridge |
+| Egress network control | forward proxy + DNS resolver + isolation | **off** — agent can reach the internet directly |
+| Credential injection | gateway container (stateless, remote resolver) | host-side proxy in the orchestrator (local DB resolver) |
+| Per-tenant credential isolation | yes | **yes** (preserved) |
+| Identity | signed token in request | **signed token in request** (same mechanism) |
+
+The key point: turning EC off drops the **network** controls but keeps
+**multi-tenant credential isolation**. That works because identity is a
+signed token carried in the request (the reverse-proxy URL path), not an
+inference from network position — so the host-side proxy verifies the
+same token, recovers the tenant, and injects that tenant's own key.
+Tenant A still cannot obtain tenant B's credential.
+
+Because token identity is topology-independent, EC=off also works on
+Docker Desktop / WSL, where the old source-IP scheme could not (the VM
+NAT hid the real container IP). `EGRESS_TOKEN_SECRET` is required in
+both modes.
+
+Form note: the host-side credential proxy listener is bound **only**
+when EC is off (that is the one configuration where agents dial it, via
+`host.docker.internal:3001`). With EC on, agents reach the gateway
+container instead, so no host listener is bound; the MCP-registry /
+token-vault wiring that feeds the gateway's snapshot still runs in both
+modes.
+
+Migration: the historical `CONTAINER_NETWORK_NAME=""` off-switch is
+gone. Set `EGRESS_CONTROL_ENABLE=0` instead; an empty bridge name with
+EC on is now a startup error.
 
 ---
 

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -22,8 +22,8 @@ from rolemesh.container.erofs_watcher import ErofsWatcher
 from rolemesh.container.runner import (
     build_container_spec,
     build_volume_mounts,
+    compute_egress_routing,
 )
-from rolemesh.container.runtime import CONTAINER_HOST_GATEWAY
 from rolemesh.container.skill_projection import (
     cleanup_spawn_skills,
     materialize_skills_for_spawn,
@@ -33,8 +33,6 @@ from rolemesh.core.config import (
     CONTAINER_TIMEOUT,
     CREDENTIAL_PROXY_PORT,
     DATA_DIR,
-    EGRESS_CONTROL_ENABLE,
-    EGRESS_GATEWAY_CONTAINER_NAME,
     IDLE_TIMEOUT,
     MCP_PROXY_PREFIX,
 )
@@ -330,16 +328,12 @@ class ContainerAgentExecutor:
         logs_dir.mkdir(parents=True, exist_ok=True)
 
         # Build MCP server specs from the coworker's projected bindings.
-        # proxy_host branches on EC: egress-gateway service name when
-        # EC is active, host.docker.internal for the pre-EC rollback
-        # path — matches build_container_spec's env routing so a
-        # coworker's MCP proxy URL hits the same endpoint agents use
-        # for LLM calls.
-        mcp_proxy_host = (
-            EGRESS_GATEWAY_CONTAINER_NAME
-            if EGRESS_CONTROL_ENABLE
-            else CONTAINER_HOST_GATEWAY
-        )
+        # The MCP proxy host comes from the same single source of truth
+        # as build_container_spec's LLM env routing (EgressRouting), so a
+        # coworker's MCP proxy URL always hits the same endpoint agents
+        # use for LLM calls — gateway service name with EC on, host
+        # gateway with EC off.
+        mcp_proxy_host = compute_egress_routing(egress_token).mcp_proxy_host
         mcp_specs: list[McpServerSpec] | None = None
         coworker_mcp_configs = self._get_mcp_configs(coworker.id)
         if coworker_mcp_configs:

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -30,10 +30,10 @@ from rolemesh.container.skill_projection import (
 )
 from rolemesh.core.config import (
     CONTAINER_MAX_OUTPUT_SIZE,
-    CONTAINER_NETWORK_NAME,
     CONTAINER_TIMEOUT,
     CREDENTIAL_PROXY_PORT,
     DATA_DIR,
+    EGRESS_CONTROL_ENABLE,
     EGRESS_GATEWAY_CONTAINER_NAME,
     IDLE_TIMEOUT,
     MCP_PROXY_PREFIX,
@@ -264,11 +264,12 @@ class ContainerAgentExecutor:
         container_name = f"rolemesh-{safe_name}-{start_epoch_ms}"
 
         # Token-identity: mint the signed token this container will carry
-        # in its proxy env. Only under EC (no gateway to verify against
-        # otherwise) and only when an authority is wired. None flows
-        # through as token-free URLs + gateway IP fallback.
+        # in its proxy env. Minted in BOTH EC modes — the verifier is the
+        # gateway (EC on) or the host-side credential proxy (EC off); both
+        # share the secret. None only when no authority is wired (eval CLI
+        # / tests), which yields token-free URLs.
         egress_token: str | None = None
-        if self._token_authority is not None and CONTAINER_NETWORK_NAME:
+        if self._token_authority is not None:
             egress_token = self._token_authority.mint(
                 Identity(
                     tenant_id=tenant_id,
@@ -336,7 +337,7 @@ class ContainerAgentExecutor:
         # for LLM calls.
         mcp_proxy_host = (
             EGRESS_GATEWAY_CONTAINER_NAME
-            if CONTAINER_NETWORK_NAME
+            if EGRESS_CONTROL_ENABLE
             else CONTAINER_HOST_GATEWAY
         )
         mcp_specs: list[McpServerSpec] | None = None

--- a/src/rolemesh/container/docker_runtime.py
+++ b/src/rolemesh/container/docker_runtime.py
@@ -227,9 +227,9 @@ class DockerRuntime:
             msg = (
                 f"dockerd {version_str} is below the hardening floor "
                 f"{_MIN_DOCKERD_VERSION[0]}.{_MIN_DOCKERD_VERSION[1]}. "
-                "Upgrade Docker, or set CONTAINER_NETWORK_NAME='' to fall "
+                "Upgrade Docker, or set EGRESS_CONTROL_ENABLE=0 to fall "
                 "back to the default bridge (at the cost of losing custom-"
-                "network isolation)."
+                "network isolation and egress control)."
             )
             raise IncompatibleDockerVersionError(msg)
         logger.info("dockerd version OK", version=version_str)

--- a/src/rolemesh/container/runner.py
+++ b/src/rolemesh/container/runner.py
@@ -33,6 +33,7 @@ from rolemesh.core.config import (
     CONTAINER_PIDS_LIMIT,
     CREDENTIAL_PROXY_PORT,
     DATA_DIR,
+    EGRESS_CONTROL_ENABLE,
     EGRESS_GATEWAY_CONTAINER_NAME,
     EGRESS_GATEWAY_FORWARD_PORT,
     NATS_URL,
@@ -319,21 +320,20 @@ _METADATA_BLACKHOLE: dict[str, str] = {
 def _build_extra_hosts() -> dict[str, str]:
     """Return /etc/hosts entries for the agent container.
 
-    EC enabled (``CONTAINER_NETWORK_NAME`` non-empty):
+    EC enabled:
       Agent bridge is ``Internal=true`` and the gateway is reached by
       service name via Docker embedded DNS — ``host.docker.internal``
       isn't needed (and wouldn't route there anyway). Only the
       metadata-service blackhole entries remain.
 
-    EC off (rollback):
+    EC off:
       Reinstate ``host.docker.internal:host-gateway`` so agents on the
-      default bridge can reach the host-side credential proxy the way
-      they did pre-EC-1. Metadata blackhole still applies.
+      default bridge can reach the host-side credential proxy.
+      Metadata blackhole still applies.
     """
     hosts: dict[str, str] = dict(_METADATA_BLACKHOLE)
-    if not CONTAINER_NETWORK_NAME:
-        # Pre-EC / rollback: restore the host-gateway ExtraHosts entry
-        # that the pre-EC-1 orchestrator relied on so
+    if not EGRESS_CONTROL_ENABLE:
+        # EC off: restore the host-gateway ExtraHosts entry so
         # ``http://host.docker.internal:3001`` reaches the host-side
         # start_credential_proxy.
         hosts.update(get_host_gateway_extra_hosts())
@@ -434,7 +434,7 @@ def build_container_spec(
     #     OPENAI base URLs point at the host-side credential_proxy via
     #     host-gateway. No HTTP(S)_PROXY env is injected — there is no
     #     forward proxy.
-    if CONTAINER_NETWORK_NAME:
+    if EGRESS_CONTROL_ENABLE:
         # Agent bridge is Internal=true — no route to the host. NATS must
         # be reachable by a name that resolves on agent-net. In local dev
         # that's the ``nats`` alias we attach to the nats container; in
@@ -465,12 +465,15 @@ def build_container_spec(
             "NO_PROXY": f"{EGRESS_GATEWAY_CONTAINER_NAME},localhost,127.0.0.1",
         }
     else:
-        # Rollback: emulate pre-EC-1 routing. Token identity is an
-        # EC-on concept (the host-side proxy gains it in the EC=off
-        # restoration step); keep the token-free reverse-proxy prefix.
+        # EC off: agent is on the host bridge and reaches the host-side
+        # credential proxy via host.docker.internal. No forward proxy
+        # exists (so no HTTP_PROXY env), but the reverse-proxy URL still
+        # carries the identity token so the host proxy can verify it and
+        # inject the requesting tenant's credential — per-tenant isolation
+        # without the network isolation.
         nats_url = NATS_URL.replace("localhost", CONTAINER_HOST_GATEWAY)
         proxy_base = f"http://{CONTAINER_HOST_GATEWAY}:{CREDENTIAL_PROXY_PORT}"
-        provider_prefix = "/proxy"
+        provider_prefix = f"/proxy/{egress_token}" if egress_token else "/proxy"
         proxy_env = {}
 
     env: dict[str, str] = {
@@ -607,10 +610,10 @@ def build_container_spec(
     # resolver and the DNS exfil protection never runs. See the P1
     # finding in the EC-2 code review.
     dns_servers: list[str] = []
-    if CONTAINER_NETWORK_NAME and _EGRESS_GATEWAY_DNS_IP:
+    if EGRESS_CONTROL_ENABLE and _EGRESS_GATEWAY_DNS_IP:
         dns_servers = [_EGRESS_GATEWAY_DNS_IP]
-    elif CONTAINER_NETWORK_NAME:
-        # Custom bridge configured but gateway IP wasn't registered —
+    elif EGRESS_CONTROL_ENABLE:
+        # EC on but gateway IP wasn't registered —
         # typically means the orchestrator forgot to call
         # ``set_egress_gateway_dns_ip`` after launching the gateway, or
         # the gateway launch was skipped (tests). Log loudly so this
@@ -638,7 +641,10 @@ def build_container_spec(
         pids_limit=CONTAINER_PIDS_LIMIT,
         dns=dns_servers,
         ulimits=_default_ulimits(),
-        network_name=CONTAINER_NETWORK_NAME or None,
+        # EC off → Docker default bridge (None), even though the bridge
+        # name is still configured; EC on → the named Internal=true bridge
+        # (``or None`` keeps an empty name mapping to the default bridge).
+        network_name=(CONTAINER_NETWORK_NAME or None) if EGRESS_CONTROL_ENABLE else None,
         runtime=oci_runtime,
     )
 

--- a/src/rolemesh/container/runner.py
+++ b/src/rolemesh/container/runner.py
@@ -317,27 +317,115 @@ _METADATA_BLACKHOLE: dict[str, str] = {
 }
 
 
-def _build_extra_hosts() -> dict[str, str]:
-    """Return /etc/hosts entries for the agent container.
+@dataclass(frozen=True)
+class EgressRouting:
+    """Per-spawn agent network routing, derived from the EC mode once.
 
-    EC enabled:
-      Agent bridge is ``Internal=true`` and the gateway is reached by
-      service name via Docker embedded DNS — ``host.docker.internal``
-      isn't needed (and wouldn't route there anyway). Only the
-      metadata-service blackhole entries remain.
+    THE single place the EC=on/off topology fork is decided for the
+    spawn path. Seven behaviours used to fork on EGRESS_CONTROL_ENABLE
+    across runner + container_executor; one of them (the host proxy's
+    token wiring) shipped broken for two release cycles precisely
+    because the fork points were scattered. Everything an agent spawn
+    needs to know about "where do my bytes go" is now a field here,
+    computed by :func:`compute_egress_routing` — adding an eighth
+    behaviour means adding a field, and every consumer is forced
+    through the same decision.
+
+    This is also the staging ground for the planned ContainerPlatform
+    abstraction (docker|k8s runtime decoupling): the whole of
+    ``compute_egress_routing`` becomes the Docker implementation of
+    ``platform.agent_routing()`` when that lands.
+    """
+
+    nats_url: str
+    proxy_base: str            # http://host:port — no path
+    provider_prefix: str       # "/proxy/<token>" or "/proxy"
+    proxy_env: dict[str, str]  # HTTP_PROXY/HTTPS_PROXY/NO_PROXY, or {}
+    network_name: str | None   # named EC bridge, or None = default bridge
+    dns_servers: list[str]
+    warn_missing_dns: bool     # EC on but gateway DNS IP unregistered
+    extra_hosts: dict[str, str]
+    mcp_proxy_host: str        # host part of agent-facing MCP proxy URLs
+
+
+def compute_egress_routing(egress_token: str | None) -> EgressRouting:
+    """Derive the agent's network routing for one spawn.
+
+    Pure and side-effect free (the missing-DNS warning is returned as a
+    flag so the caller logs it with its own spawn context). The only
+    ``if EGRESS_CONTROL_ENABLE`` on the spawn path lives here.
+
+    EC on:
+      Agent sits on the Internal=true bridge. NATS is reached by the
+      ``nats`` alias on agent-net; LLM/MCP calls go to the gateway
+      container by service name; HTTP(S)_PROXY points every client at
+      the forward proxy; DNS is pinned to the gateway's resolver; only
+      the metadata blackhole rides in extra_hosts.
 
     EC off:
-      Reinstate ``host.docker.internal:host-gateway`` so agents on the
-      default bridge can reach the host-side credential proxy.
-      Metadata blackhole still applies.
+      Agent sits on Docker's default bridge. NATS and the host-side
+      credential proxy are reached via host.docker.internal (added to
+      extra_hosts); no forward proxy exists so no HTTP(S)_PROXY env;
+      DNS is Docker's default. The reverse-proxy URL still carries the
+      identity token so the host proxy can verify it and inject the
+      requesting tenant's credential — per-tenant isolation without
+      the network isolation.
+
+    The signed token rides in two places (spike-verified): the
+    forward-proxy userinfo (clients emit Proxy-Authorization
+    automatically) and a leading path segment on each reverse-proxy
+    base URL (SDKs preserve the prefix before appending /v1/messages).
     """
-    hosts: dict[str, str] = dict(_METADATA_BLACKHOLE)
-    if not EGRESS_CONTROL_ENABLE:
-        # EC off: restore the host-gateway ExtraHosts entry so
-        # ``http://host.docker.internal:3001`` reaches the host-side
-        # start_credential_proxy.
-        hosts.update(get_host_gateway_extra_hosts())
-    return hosts
+    provider_prefix = f"/proxy/{egress_token}" if egress_token else "/proxy"
+    extra_hosts: dict[str, str] = dict(_METADATA_BLACKHOLE)
+
+    if EGRESS_CONTROL_ENABLE:
+        # NATS must be reachable by a name that resolves on agent-net.
+        # In local dev that's the ``nats`` alias we attach to the nats
+        # container; in production the operator puts NATS on the bridge
+        # directly. The orchestrator itself still uses the .env URL
+        # (usually localhost:4222), so rewrite here, not in the .env.
+        forward_authority = (
+            f"job:{egress_token}@{EGRESS_GATEWAY_CONTAINER_NAME}"
+            if egress_token
+            else EGRESS_GATEWAY_CONTAINER_NAME
+        )
+        forward_proxy_url = (
+            f"http://{forward_authority}:{EGRESS_GATEWAY_FORWARD_PORT}"
+        )
+        return EgressRouting(
+            nats_url=agent_facing_nats_url(NATS_URL),
+            proxy_base=f"http://{EGRESS_GATEWAY_CONTAINER_NAME}:{CREDENTIAL_PROXY_PORT}",
+            provider_prefix=provider_prefix,
+            proxy_env={
+                "HTTP_PROXY": forward_proxy_url,
+                "HTTPS_PROXY": forward_proxy_url,
+                "NO_PROXY": f"{EGRESS_GATEWAY_CONTAINER_NAME},localhost,127.0.0.1",
+            },
+            # ``or None`` keeps an empty bridge name mapping to the
+            # default bridge instead of an empty NetworkMode string.
+            network_name=CONTAINER_NETWORK_NAME or None,
+            dns_servers=[_EGRESS_GATEWAY_DNS_IP] if _EGRESS_GATEWAY_DNS_IP else [],
+            warn_missing_dns=not _EGRESS_GATEWAY_DNS_IP,
+            extra_hosts=extra_hosts,
+            mcp_proxy_host=EGRESS_GATEWAY_CONTAINER_NAME,
+        )
+
+    # EC off: restore the host-gateway ExtraHosts entry so
+    # ``http://host.docker.internal:3001`` reaches the host-side
+    # start_credential_proxy.
+    extra_hosts.update(get_host_gateway_extra_hosts())
+    return EgressRouting(
+        nats_url=NATS_URL.replace("localhost", CONTAINER_HOST_GATEWAY),
+        proxy_base=f"http://{CONTAINER_HOST_GATEWAY}:{CREDENTIAL_PROXY_PORT}",
+        provider_prefix=provider_prefix,
+        proxy_env={},
+        network_name=None,
+        dns_servers=[],
+        warn_missing_dns=False,
+        extra_hosts=extra_hosts,
+        mcp_proxy_host=CONTAINER_HOST_GATEWAY,
+    )
 
 
 def _clamp_memory(value: str, max_value: str, *, coworker_name: str) -> str:
@@ -419,66 +507,14 @@ def build_container_spec(
     """
     image = backend_config.image if backend_config else CONTAINER_IMAGE
 
-    # Branch on whether EC is active. The whole env block flips
-    # between EC and rollback modes:
-    #
-    #   EC enabled — the agent is on the Internal=true bridge and
-    #     reaches the gateway by service name. NATS_URL is passed
-    #     through as-is (operator ensures NATS is reachable on the
-    #     bridge; documented in deployment.md). Proxy env vars point
-    #     every HTTP client at the forward proxy.
-    #
-    #   EC off — pre-EC-1 behaviour. NATS_URL's ``localhost`` is
-    #     substituted for host-gateway so agents on Docker's default
-    #     bridge can reach the NATS process on the host. ANTHROPIC /
-    #     OPENAI base URLs point at the host-side credential_proxy via
-    #     host-gateway. No HTTP(S)_PROXY env is injected — there is no
-    #     forward proxy.
-    if EGRESS_CONTROL_ENABLE:
-        # Agent bridge is Internal=true — no route to the host. NATS must
-        # be reachable by a name that resolves on agent-net. In local dev
-        # that's the ``nats`` alias we attach to the nats container; in
-        # production the operator puts NATS on the bridge directly. The
-        # orchestrator itself still uses the .env-configured URL (usually
-        # localhost:4222), so rewrite here rather than in the .env.
-        nats_url = agent_facing_nats_url(NATS_URL)
-        proxy_base = f"http://{EGRESS_GATEWAY_CONTAINER_NAME}:{CREDENTIAL_PROXY_PORT}"
-        # Token-identity: the signed token rides in two places per the
-        # spike-verified mechanisms — the forward-proxy userinfo
-        # (clients emit Proxy-Authorization automatically) and a leading
-        # path segment on each reverse-proxy base URL (SDKs preserve the
-        # prefix before appending /v1/messages). ``provider_prefix`` is
-        # the reverse-proxy path root: ``/proxy/<token>`` with a token,
-        # plain ``/proxy`` without (dual-run IP-fallback path).
-        if egress_token:
-            forward_authority = f"job:{egress_token}@{EGRESS_GATEWAY_CONTAINER_NAME}"
-            provider_prefix = f"/proxy/{egress_token}"
-        else:
-            forward_authority = EGRESS_GATEWAY_CONTAINER_NAME
-            provider_prefix = "/proxy"
-        forward_proxy_url = (
-            f"http://{forward_authority}:{EGRESS_GATEWAY_FORWARD_PORT}"
-        )
-        proxy_env: dict[str, str] = {
-            "HTTP_PROXY": forward_proxy_url,
-            "HTTPS_PROXY": forward_proxy_url,
-            "NO_PROXY": f"{EGRESS_GATEWAY_CONTAINER_NAME},localhost,127.0.0.1",
-        }
-    else:
-        # EC off: agent is on the host bridge and reaches the host-side
-        # credential proxy via host.docker.internal. No forward proxy
-        # exists (so no HTTP_PROXY env), but the reverse-proxy URL still
-        # carries the identity token so the host proxy can verify it and
-        # inject the requesting tenant's credential — per-tenant isolation
-        # without the network isolation.
-        nats_url = NATS_URL.replace("localhost", CONTAINER_HOST_GATEWAY)
-        proxy_base = f"http://{CONTAINER_HOST_GATEWAY}:{CREDENTIAL_PROXY_PORT}"
-        provider_prefix = f"/proxy/{egress_token}" if egress_token else "/proxy"
-        proxy_env = {}
+    # All EC=on/off topology decisions (NATS URL, proxy base, token
+    # placement, proxy env, bridge, DNS, extra_hosts) are made in one
+    # place — see EgressRouting / compute_egress_routing above.
+    routing = compute_egress_routing(egress_token)
 
     env: dict[str, str] = {
         "TZ": TIMEZONE,
-        "NATS_URL": nats_url,
+        "NATS_URL": routing.nats_url,
         "JOB_ID": job_id,
         # Per-provider proxy URL. The reverse proxy routes everything
         # through ``/proxy/{provider}/`` since the legacy catch-all was
@@ -486,25 +522,22 @@ def build_container_spec(
         # without the suffix the SDK hits 404. Both Pi and Claude SDKs
         # honour ANTHROPIC_BASE_URL and append ``/v1/messages`` etc., so
         # the suffix flows through cleanly.
-        "ANTHROPIC_BASE_URL": f"{proxy_base}{provider_prefix}/anthropic",
+        "ANTHROPIC_BASE_URL": f"{routing.proxy_base}{routing.provider_prefix}/anthropic",
         # Multi-provider proxy URLs for Pi backend (each SDK reads its own env var)
-        "OPENAI_BASE_URL": f"{proxy_base}{provider_prefix}/openai",
+        "OPENAI_BASE_URL": f"{routing.proxy_base}{routing.provider_prefix}/openai",
         # Bedrock — boto3 honours ``BEDROCK_BASE_URL`` as ``endpoint_url``.
-        # Same per-spawn ``proxy_base`` as Anthropic/OpenAI so EC-2
-        # (agent on Internal=true bridge) and rollback (agent on host
-        # bridge) both resolve a reachable address. Setting this here
-        # rather than in ``_pi_extra_env`` is deliberate — that helper
-        # runs at module load time, before CONTAINER_NETWORK_NAME is
-        # decided per spawn, and would have to reimplement the EC-2
-        # branching that already lives above (proxy_base).
-        "BEDROCK_BASE_URL": f"{proxy_base}{provider_prefix}/bedrock",
+        # Same per-spawn ``proxy_base`` as Anthropic/OpenAI so both EC
+        # modes resolve a reachable address. Setting this here rather
+        # than in ``_pi_extra_env`` is deliberate — that helper runs at
+        # module load time, before the per-spawn routing is decided.
+        "BEDROCK_BASE_URL": f"{routing.proxy_base}{routing.provider_prefix}/bedrock",
         # Redirect Claude Code CLI's .claude.json writes into the per-coworker
         # writable bind mount at /home/agent/.claude. Without this, the CLI
         # tries to write /home/agent/.claude.json on the readonly rootfs and
         # the Claude backend fails its 30s initialize handshake.
         # Pi backend ignores this env, so shipping it unconditionally is safe.
         "CLAUDE_CONFIG_DIR": "/home/agent/.claude",
-        **proxy_env,
+        **routing.proxy_env,
     }
 
     # Mirror the host's auth method with a placeholder value.
@@ -603,21 +636,13 @@ def build_container_spec(
     # the whole point, and Docker itself will reject an unregistered runtime.
     oci_runtime = (cfg.runtime if cfg and cfg.runtime else CONTAINER_OCI_RUNTIME)
 
-    # EC-2: pin the egress gateway as DNS so every agent DNS query
-    # flows through the authoritative resolver. Without this the
-    # dns_resolver.py module is dead code — agents keep resolving via
-    # Docker's embedded DNS (127.0.0.11) which forwards to the host
-    # resolver and the DNS exfil protection never runs. See the P1
-    # finding in the EC-2 code review.
-    dns_servers: list[str] = []
-    if EGRESS_CONTROL_ENABLE and _EGRESS_GATEWAY_DNS_IP:
-        dns_servers = [_EGRESS_GATEWAY_DNS_IP]
-    elif EGRESS_CONTROL_ENABLE:
-        # EC on but gateway IP wasn't registered —
-        # typically means the orchestrator forgot to call
-        # ``set_egress_gateway_dns_ip`` after launching the gateway, or
-        # the gateway launch was skipped (tests). Log loudly so this
-        # gap isn't silent in production.
+    # EC-2: the gateway is pinned as the agent's DNS (routing.dns_servers)
+    # so every query flows through the authoritative resolver. When EC is
+    # on but the gateway IP wasn't registered yet — the orchestrator
+    # forgot to call ``set_egress_gateway_dns_ip`` after launch, or launch
+    # was skipped (tests) — dns_resolver.py is dead code and DNS exfil
+    # protection is inactive, so warn loudly.
+    if routing.warn_missing_dns:
         logger.warning(
             "No egress gateway DNS IP registered — agent will use Docker's "
             "default resolver; DNS exfil protection is inactive",
@@ -631,7 +656,7 @@ def build_container_spec(
         mounts=mounts,
         env=env,
         user=user,
-        extra_hosts=_build_extra_hosts(),
+        extra_hosts=routing.extra_hosts,
         entrypoint=backend_config.entrypoint if backend_config else None,
         memory_limit=memory_limit,
         cpu_limit=cpu_limit,
@@ -639,12 +664,9 @@ def build_container_spec(
         readonly_rootfs=True,
         tmpfs=_default_tmpfs(run_uid, run_gid),
         pids_limit=CONTAINER_PIDS_LIMIT,
-        dns=dns_servers,
+        dns=routing.dns_servers,
         ulimits=_default_ulimits(),
-        # EC off → Docker default bridge (None), even though the bridge
-        # name is still configured; EC on → the named Internal=true bridge
-        # (``or None`` keeps an empty name mapping to the default bridge).
-        network_name=(CONTAINER_NETWORK_NAME or None) if EGRESS_CONTROL_ENABLE else None,
+        network_name=routing.network_name,
         runtime=oci_runtime,
     )
 

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -1,4 +1,31 @@
-"""Configuration constants and paths."""
+"""Configuration constants and paths.
+
+Where does a new env-driven setting go? ONE authoritative read site per
+env var — never two. Pick by consumer scope:
+
+1. Read by MULTIPLE modules, non-sensitive, no parse-time validation
+   beyond a cast → module-level constant HERE (ports, image names,
+   bridge names, mode switches like EGRESS_CONTROL_ENABLE).
+
+2. Read by ONE component, or needs construction-time validation /
+   fail-closed semantics, or is a SECRET → a ``from_env()`` on that
+   component's own config object (see egress/token_identity.py
+   TokenAuthority, egress/dns_policy.py GlobalDnsPolicy). Do NOT
+   mirror it here: a second reader of the same env var silently
+   drifts from the real one (we shipped exactly that bug once —
+   a dead EGRESS_TOKEN_TTL_SECONDS constant nobody imported).
+   Other modules that need the value take the constructed object
+   via dependency injection, not a re-read of os.environ.
+
+3. Deployment-level override with a single use site and no fan-out
+   (e.g. ANTHROPIC_BASE_URL upstream override in reverse_proxy) →
+   lazy read at the use site, with a comment saying why.
+
+Module-level constants here are frozen at import; tests overriding
+them must patch every importing module's binding (a documented trap —
+see tests/container/test_startup_order.py). Category-2 objects are
+monkeypatch.setenv-testable, which is one of the reasons they exist.
+"""
 
 from __future__ import annotations
 
@@ -172,12 +199,9 @@ EGRESS_GATEWAY_DNS_PORT: int = int(
 )
 
 # Egress identity tokens: EGRESS_TOKEN_SECRET and EGRESS_TOKEN_TTL_SECONDS
-# are deliberately NOT mirrored here. They are component-scoped config
-# with a single consumer — rolemesh.egress.token_identity.TokenAuthority
-# .from_env() reads, validates, and fail-closes on them at construction.
-# Mirroring them as module constants would create a second reader of the
-# same env vars that silently drifts from the real one (which is exactly
-# what happened once; see the config-pattern note in docs/16).
+# are deliberately NOT mirrored here — category 2 of the module-docstring
+# rules (single consumer + validation + secret). Their one read site is
+# rolemesh.egress.token_identity.TokenAuthority.from_env().
 
 # Allowlist for env vars that the orchestrator dynamically injects into
 # containers (R8). Anything produced by build_container_spec() or passed

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -171,16 +171,13 @@ EGRESS_GATEWAY_DNS_PORT: int = int(
     os.environ.get("EGRESS_GATEWAY_DNS_PORT", "53")
 )
 
-# Egress identity tokens (token-identity refactor). The orchestrator
-# mints a signed token per spawn; the gateway verifies it. Secret is
-# read lazily in rolemesh.egress.token_identity (sensitive, no default,
-# fail-closed under EC); only the non-secret TTL lives here so the
-# value has a documented home. ``EGRESS_TOKEN_TTL_SECONDS`` bounds how
-# long a single token (and thus a single agent container before the
-# orchestrator re-mints) may live; default 7 days, see token_identity.
-EGRESS_TOKEN_TTL_SECONDS: int = int(
-    os.environ.get("EGRESS_TOKEN_TTL_SECONDS", str(7 * 24 * 60 * 60))
-)
+# Egress identity tokens: EGRESS_TOKEN_SECRET and EGRESS_TOKEN_TTL_SECONDS
+# are deliberately NOT mirrored here. They are component-scoped config
+# with a single consumer — rolemesh.egress.token_identity.TokenAuthority
+# .from_env() reads, validates, and fail-closes on them at construction.
+# Mirroring them as module constants would create a second reader of the
+# same env vars that silently drifts from the real one (which is exactly
+# what happened once; see the config-pattern note in docs/16).
 
 # Allowlist for env vars that the orchestrator dynamically injects into
 # containers (R8). Anything produced by build_container_spec() or passed

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -101,8 +101,44 @@ CONTAINER_MAX_CPU: float = float(os.environ.get("CONTAINER_MAX_CPU", "4.0"))
 # bridge. Containers on it physically cannot route to the public internet
 # — all outbound traffic must flow through the egress gateway which sits
 # on a second bridge (CONTAINER_EGRESS_NETWORK_NAME) with a real default
-# route.
+# route. This name is ONLY a bridge name now; whether egress control is
+# active is governed by EGRESS_CONTROL_ENABLE below.
 CONTAINER_NETWORK_NAME: str = os.environ.get("CONTAINER_NETWORK_NAME", "rolemesh-agent-net")
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Parse a boolean env var. Accepts 1/0, true/false, yes/no, on/off
+    (case-insensitive). Unset → *default*; an unrecognised value raises
+    so a typo fails the boot loudly rather than silently flipping a
+    security-relevant switch."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    val = raw.strip().lower()
+    if val in ("1", "true", "yes", "on"):
+        return True
+    if val in ("0", "false", "no", "off"):
+        return False
+    raise ValueError(
+        f"{name} must be a boolean (1/0, true/false, yes/no, on/off), got {raw!r}"
+    )
+
+
+# Master switch for Egress Control (EC-1/2/3). The single authoritative
+# knob: when on, agents run on the Internal=true bridge behind the egress
+# gateway (network-layer enforcement + forward/DNS proxies + per-tenant
+# credential injection at the gateway). When off, agents run on the host
+# bridge and reach a host-side credential proxy directly — egress NETWORK
+# control is disabled, but multi-tenant CREDENTIAL isolation is preserved
+# (the host proxy verifies the same signed identity token and injects the
+# requesting tenant's own key). See docs/16.
+#
+# Replaces the historical overload where CONTAINER_NETWORK_NAME="" doubled
+# as the EC off-switch. That overload is gone: an empty bridge name with
+# EC on is now a hard configuration error (see startup validation), and
+# operators turn EC off with EGRESS_CONTROL_ENABLE=0.
+EGRESS_CONTROL_ENABLE: bool = _env_flag("EGRESS_CONTROL_ENABLE", default=True)
+
 
 # Outbound bridge used by the egress gateway (EC-1). Regular bridge with
 # icc=false. The gateway container is dual-homed: agent-net (internal) on

--- a/src/rolemesh/egress/bootstrap.py
+++ b/src/rolemesh/egress/bootstrap.py
@@ -53,6 +53,7 @@ from rolemesh.core.config import (
     CONTAINER_EGRESS_NETWORK_NAME,
     CONTAINER_NETWORK_NAME,
     CREDENTIAL_PROXY_PORT,
+    EGRESS_CONTROL_ENABLE,
     EGRESS_GATEWAY_CONTAINER_NAME,
 )
 from rolemesh.core.logger import get_logger
@@ -130,13 +131,12 @@ async def _registered_gateway_ip_after_launch(
 
 
 def _ec2_active(runtime: ContainerRuntime) -> bool:
-    """EC-2 is active when both the operator opted in
-    (``CONTAINER_NETWORK_NAME`` is non-empty) and the runtime
-    backend supports egress networks (Docker today; k8s grows its
-    own bootstrap path later).
+    """EC-2 is active when the operator left egress control on
+    (``EGRESS_CONTROL_ENABLE``) and the runtime backend supports egress
+    networks (Docker today; k8s grows its own bootstrap path later).
     """
     return bool(
-        CONTAINER_NETWORK_NAME
+        EGRESS_CONTROL_ENABLE
         and hasattr(runtime, "ensure_egress_network")
         and hasattr(runtime, "verify_egress_gateway_reachable")
     )

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -63,6 +63,7 @@ from rolemesh.core.config import (
     CONTAINER_IMAGE,
     CONTAINER_NETWORK_NAME,
     CREDENTIAL_PROXY_PORT,
+    EGRESS_CONTROL_ENABLE,
     EGRESS_GATEWAY_IMAGE,
     GLOBAL_MAX_CONTAINERS,
     NATS_URL,
@@ -123,6 +124,8 @@ from rolemesh.egress.token_identity import TokenAuthority
 from rolemesh.security.credential_proxy import register_mcp_server, set_token_vault, start_credential_proxy
 
 if TYPE_CHECKING:
+    from aiohttp import web
+
     from rolemesh.container.runtime import ContainerRuntime
     from rolemesh.core.types import (
         ChannelBinding,
@@ -1723,12 +1726,32 @@ async def _ensure_container_system_running() -> None:
     global _runtime
     _runtime = get_runtime()
     await _runtime.ensure_available()
-    if hasattr(_runtime, "ensure_agent_network"):
-        await _runtime.ensure_agent_network(CONTAINER_NETWORK_NAME)
-    # egress-net only exists to carry the gateway's outbound; if EC is
-    # turned off there's no gateway to attach, so skip the bridge too.
-    if CONTAINER_NETWORK_NAME and hasattr(_runtime, "ensure_egress_network"):
-        await _runtime.ensure_egress_network(CONTAINER_EGRESS_NETWORK_NAME)
+
+    # Egress control bridges only exist when EC is on. With EC off the
+    # agent runs on Docker's default bridge and reaches the host-side
+    # credential proxy — no internal/egress bridges, no gateway.
+    if EGRESS_CONTROL_ENABLE:
+        if not CONTAINER_NETWORK_NAME:
+            raise RuntimeError(
+                "EGRESS_CONTROL_ENABLE is on but CONTAINER_NETWORK_NAME is "
+                "empty — egress control needs a named Internal=true bridge. "
+                "Set CONTAINER_NETWORK_NAME, or disable EC with "
+                "EGRESS_CONTROL_ENABLE=0."
+            )
+        if hasattr(_runtime, "ensure_agent_network"):
+            await _runtime.ensure_agent_network(CONTAINER_NETWORK_NAME)
+        if hasattr(_runtime, "ensure_egress_network"):
+            await _runtime.ensure_egress_network(CONTAINER_EGRESS_NETWORK_NAME)
+    elif not CONTAINER_NETWORK_NAME:
+        # Legacy migration aid: CONTAINER_NETWORK_NAME="" used to be the
+        # EC off-switch. It no longer is — EGRESS_CONTROL_ENABLE governs
+        # that. Since EC is already off here this is harmless, but warn
+        # so operators move to the dedicated switch.
+        logger.warning(
+            "CONTAINER_NETWORK_NAME is empty. This no longer disables "
+            "egress control; use EGRESS_CONTROL_ENABLE=0 instead. "
+            "(EC is already off here via EGRESS_CONTROL_ENABLE.)"
+        )
 
     # INV-3: name prefix alone is not safe — a foreign container the
     # user happens to name with "rolemesh-" could be killed. The image
@@ -1813,11 +1836,12 @@ async def main() -> None:
         # Frontdesk v1.2: the executor injects this for is_frontdesk spawns.
         return render_agent_catalog(_state, tenant_id, exclude=exclude_id)
 
-    # Token-identity: build the shared signing authority once. Under EC
-    # this fail-closes if EGRESS_TOKEN_SECRET is unset (same secret the
-    # gateway loads). With EC off there is no gateway to verify against,
-    # so the authority stays None and spawns are token-free.
-    _token_authority = TokenAuthority.from_env() if CONTAINER_NETWORK_NAME else None
+    # Token-identity: build the shared signing authority once. Required
+    # in BOTH modes — EC=on the gateway verifies with the same secret;
+    # EC=off the host-side credential proxy verifies it to recover the
+    # tenant for per-tenant credential injection. Fail-closes if
+    # EGRESS_TOKEN_SECRET is unset (see TokenAuthority.from_env).
+    _token_authority = TokenAuthority.from_env()
 
     # Build one executor per backend.
     for cfg in (CLAUDE_CODE_BACKEND, PI_BACKEND):
@@ -1842,15 +1866,26 @@ async def main() -> None:
     set_credential_vault(create_credential_vault_from_env())
     _credential_resolver = CredentialResolver(get_credential_vault())
 
-    # Host-side credential proxy: bound so the `register_mcp_server` /
-    # `set_token_vault` wiring below has a sink to write to. Agents
-    # reach the gateway container directly via Docker DNS, not this
-    # host listener.
-    proxy_runner = await start_credential_proxy(
-        CREDENTIAL_PROXY_PORT,
-        PROXY_BIND_HOST,
-        credential_resolver=_credential_resolver,
-    )
+    # Host-side credential proxy. Only bound when EC is OFF — that is the
+    # one configuration where agents dial it (on the host bridge, via
+    # host.docker.internal:3001). With EC on, agents reach the gateway
+    # container instead, so binding a host listener here would be dead
+    # weight; the MCP-registry / token-vault wiring below still runs
+    # unconditionally because it populates process globals that feed the
+    # gateway's snapshot RPC in EC=on (register_mcp_server ->
+    # get_mcp_registry -> fetch_all_mcp_servers).
+    #
+    # The token authority IS wired here so the host proxy verifies the
+    # agent's signed token and injects the requesting tenant's credential
+    # — the per-tenant isolation that keeps working with EC off.
+    proxy_runner: web.AppRunner | None = None
+    if not EGRESS_CONTROL_ENABLE:
+        proxy_runner = await start_credential_proxy(
+            CREDENTIAL_PROXY_PORT,
+            PROXY_BIND_HOST,
+            credential_resolver=_credential_resolver,
+            token_authority=_token_authority,
+        )
 
     # Gateway reachability is already enforced in
     # _ensure_container_system_running() via wait_for_gateway_ready. No
@@ -2145,7 +2180,8 @@ async def main() -> None:
     if _safety_thread_pool is not None:
         with contextlib.suppress(Exception):
             _safety_thread_pool.shutdown(wait=False)  # type: ignore[attr-defined]
-    await proxy_runner.cleanup()
+    if proxy_runner is not None:
+        await proxy_runner.cleanup()
     await _queue.shutdown(10000)
     for gw in _gateways.values():
         await gw.shutdown()

--- a/tests/container/test_runner.py
+++ b/tests/container/test_runner.py
@@ -208,10 +208,8 @@ class TestBuildContainerSpec:
             runner.set_egress_gateway_dns_ip(None)
 
     def test_rollback_mode_restores_pre_ec_routing(self) -> None:
-        """``CONTAINER_NETWORK_NAME=""`` is documented as a rollback
-        switch. Pre-Path-C it was half-finished — EC-1 env still
-        pointed agents at ``egress-gateway`` which doesn't exist on
-        the default bridge. Path C completes the rollback:
+        """``EGRESS_CONTROL_ENABLE=0`` routes agents at the host-side
+        credential proxy instead of the gateway container:
 
           * ANTHROPIC_BASE_URL / OPENAI_BASE_URL go to
             ``host.docker.internal:3001`` via host-gateway
@@ -220,14 +218,14 @@ class TestBuildContainerSpec:
           * ExtraHosts includes ``host.docker.internal:host-gateway``
             (Linux) so the above URLs actually resolve
 
-        Pin the full rollback shape here so regressing this path shows
+        Pin the full EC-off shape here so regressing this path shows
         up as a single-line test failure rather than a mysterious
         "agent can't reach LLM after toggling the switch".
         """
         from rolemesh.container import runner
 
         with (
-            patch.object(runner, "CONTAINER_NETWORK_NAME", ""),
+            patch.object(runner, "EGRESS_CONTROL_ENABLE", False),
             patch.object(runner, "NATS_URL", "nats://localhost:4222"),
             patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),
         ):
@@ -259,6 +257,29 @@ class TestBuildContainerSpec:
         if platform.system() == "Linux":
             assert spec.extra_hosts.get("host.docker.internal") == "host-gateway"
 
+    def test_ec_off_carries_token_in_reverse_url_no_forward_proxy(self) -> None:
+        """EC off still injects the identity token into the reverse-proxy
+        URL so the host-side proxy can recover the tenant — but injects no
+        HTTP_PROXY, because there is no forward proxy off the gateway."""
+        from rolemesh.container import runner
+
+        with (
+            patch.object(runner, "EGRESS_CONTROL_ENABLE", False),
+            patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),
+        ):
+            spec = build_container_spec([], "c", "j", egress_token="TOK123")
+
+        # Token rides in the reverse-proxy path, host-gateway host.
+        assert spec.env["ANTHROPIC_BASE_URL"] == (
+            "http://host.docker.internal:3001/proxy/TOK123/anthropic"
+        )
+        assert spec.env["BEDROCK_BASE_URL"] == (
+            "http://host.docker.internal:3001/proxy/TOK123/bedrock"
+        )
+        # No forward proxy in EC off.
+        assert "HTTP_PROXY" not in spec.env
+        assert "HTTPS_PROXY" not in spec.env
+
     def test_spec_dns_empty_when_gateway_ip_unregistered(self) -> None:
         """Without the registered IP, build_container_spec falls back
         to an empty Dns list (Docker keeps its embedded resolver). A
@@ -270,8 +291,8 @@ class TestBuildContainerSpec:
              patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"):
             spec = build_container_spec([], "c", "j")
         assert spec.dns == []
-        # WARN fires because CONTAINER_NETWORK_NAME is set by default
-        # but the gateway IP isn't.
+        # WARN fires because EC is on by default (EGRESS_CONTROL_ENABLE)
+        # but the gateway IP isn't registered.
         warn_calls = [
             call for call in mock_logger.warning.call_args_list
             if "egress gateway DNS IP" in str(call)
@@ -527,8 +548,19 @@ class TestMetadataBlackholeAndNetwork:
         # Default config points at rolemesh-agent-net unless CONTAINER_NETWORK_NAME='' is set.
         assert spec.network_name == "rolemesh-agent-net"
 
+    def test_ec_off_yields_no_network_name(self) -> None:
+        """EC off -> Docker default bridge (network_name None), even though
+        the bridge name is still configured by default."""
+        with (
+            patch("rolemesh.container.runner.EGRESS_CONTROL_ENABLE", False),
+            patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),
+        ):
+            spec = build_container_spec([], "c", "j")
+        assert spec.network_name is None
+
     def test_empty_network_name_yields_none(self) -> None:
-        """Operator escape hatch: CONTAINER_NETWORK_NAME='' -> None -> Docker default bridge."""
+        """Defensive: an empty bridge name still maps to the default
+        bridge (None) rather than an empty NetworkMode string."""
         with (
             patch("rolemesh.container.runner.CONTAINER_NETWORK_NAME", ""),
             patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),

--- a/tests/container/test_runner.py
+++ b/tests/container/test_runner.py
@@ -16,6 +16,7 @@ from rolemesh.container.runner import (
     _filter_env_allowlist,
     build_container_spec,
     build_volume_mounts,
+    compute_egress_routing,
 )
 from rolemesh.container.runtime import VolumeMount
 from rolemesh.core.types import ContainerConfig, Coworker
@@ -567,6 +568,59 @@ class TestMetadataBlackholeAndNetwork:
         ):
             spec = build_container_spec([], "c", "j")
         assert spec.network_name is None
+
+
+class TestComputeEgressRouting:
+    """Single source of truth for the EC=on/off spawn-path fork."""
+
+    def test_ec_on_with_token(self) -> None:
+        from rolemesh.container import runner
+
+        with (
+            patch.object(runner, "EGRESS_CONTROL_ENABLE", True),
+            patch.object(runner, "_EGRESS_GATEWAY_DNS_IP", "172.20.0.2"),
+        ):
+            r = compute_egress_routing("TOK")
+
+        assert r.proxy_base == "http://egress-gateway:3001"
+        assert r.provider_prefix == "/proxy/TOK"
+        assert r.proxy_env["HTTP_PROXY"] == "http://job:TOK@egress-gateway:3128"
+        assert r.proxy_env["HTTPS_PROXY"] == "http://job:TOK@egress-gateway:3128"
+        assert r.network_name == "rolemesh-agent-net"
+        assert r.dns_servers == ["172.20.0.2"]
+        assert r.warn_missing_dns is False
+        assert r.mcp_proxy_host == "egress-gateway"
+        assert "host.docker.internal" not in r.extra_hosts
+
+    def test_ec_on_without_token_or_dns_ip(self) -> None:
+        from rolemesh.container import runner
+
+        with (
+            patch.object(runner, "EGRESS_CONTROL_ENABLE", True),
+            patch.object(runner, "_EGRESS_GATEWAY_DNS_IP", None),
+        ):
+            r = compute_egress_routing(None)
+
+        assert r.provider_prefix == "/proxy"  # no token segment
+        assert r.proxy_env["HTTP_PROXY"] == "http://egress-gateway:3128"  # no userinfo
+        assert r.dns_servers == []
+        assert r.warn_missing_dns is True  # EC on but no gateway DNS IP
+
+    def test_ec_off_with_token(self) -> None:
+        from rolemesh.container import runner
+
+        with patch.object(runner, "EGRESS_CONTROL_ENABLE", False):
+            r = compute_egress_routing("TOK")
+
+        assert r.proxy_base == "http://host.docker.internal:3001"
+        assert r.provider_prefix == "/proxy/TOK"  # token still carried
+        assert r.proxy_env == {}  # no forward proxy off the gateway
+        assert r.network_name is None  # default bridge
+        assert r.dns_servers == []
+        assert r.warn_missing_dns is False
+        assert r.mcp_proxy_host == "host.docker.internal"
+        # EC off restores the host-gateway hosts entry.
+        assert "host.docker.internal" in r.extra_hosts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/container/test_startup_order.py
+++ b/tests/container/test_startup_order.py
@@ -19,7 +19,7 @@ back together. These tests pin the invariants for each phase:
   3. Happy path of bridge-prep: four steps in order, NO launch/wait.
   4. launch_egress_gateway() failure must prevent the readiness probe.
   5. wait_for_gateway_ready() failure must propagate (fail-closed).
-  6. Path C rollback (``CONTAINER_NETWORK_NAME=""``) skips the egress
+  6. EC off (``EGRESS_CONTROL_ENABLE=0``) skips the egress
      bridge in phase 1 and the entire launch path in phase 2.
   7. Backends without the EC-1 hooks (future k8s) fall back to the old
      surface gracefully — we use hasattr() gates for each hook so a
@@ -196,41 +196,50 @@ async def test_launch_aborts_when_gateway_readiness_probe_fails() -> None:
     launch_mock.assert_awaited_once()
 
 
-async def test_rollback_mode_skips_egress_bridge() -> None:
-    """Path C contract on the bridge-prep half: ``CONTAINER_NETWORK_NAME=""``
-    is the operator rollback switch, and ``_ensure_container_system_running``
-    must skip ``ensure_egress_network`` (the egress bridge has no purpose
-    when the gateway is disabled). Other steps still run.
-
-    Pre-Path-C the code tried to create the egress bridge unconditionally
-    and crashed when the operator opted out.
+async def test_ec_off_skips_both_bridges() -> None:
+    """EC off (``EGRESS_CONTROL_ENABLE=0``): ``_ensure_container_system_running``
+    creates NEITHER bridge — agents run on Docker's default bridge — and
+    only ``cleanup_orphans`` runs alongside the version gate.
     """
     from rolemesh import main as main_module
 
     rt = _make_runtime_mock()
 
     with (
-        patch.object(main_module, "CONTAINER_NETWORK_NAME", ""),
+        patch.object(main_module, "EGRESS_CONTROL_ENABLE", False),
         patch.object(main_module, "get_runtime", return_value=rt),
     ):
         await main_module._ensure_container_system_running()
 
     rt.ensure_available.assert_awaited_once()
-    rt.ensure_agent_network.assert_awaited_once_with("")
+    rt.ensure_agent_network.assert_not_awaited()
     rt.ensure_egress_network.assert_not_awaited()
     rt.cleanup_orphans.assert_awaited_once()
 
 
-async def test_launch_skips_in_rollback_mode() -> None:
-    """Path C contract on the launch half: ``CONTAINER_NETWORK_NAME=""``
-    must short-circuit ``_launch_egress_gateway_once_ready`` so launch +
-    readiness probe + IP discovery are all skipped. Pre-Path-C, launch
-    was attempted with an empty network name and crashed startup.
+async def test_ec_on_empty_bridge_name_is_config_error() -> None:
+    """EC on with an empty bridge name is a hard config error — there's
+    no Internal=true bridge to enforce isolation on."""
+    from rolemesh import main as main_module
 
-    The rollback gate was moved into ``bootstrap._ec2_active`` after
-    the egress-helper extraction, so we patch
-    ``CONTAINER_NETWORK_NAME`` on the bootstrap module — patching
-    main's reference no longer reaches the read site.
+    rt = _make_runtime_mock()
+
+    with (
+        patch.object(main_module, "EGRESS_CONTROL_ENABLE", True),
+        patch.object(main_module, "CONTAINER_NETWORK_NAME", ""),
+        patch.object(main_module, "get_runtime", return_value=rt),
+        pytest.raises(RuntimeError, match="EGRESS_CONTROL_ENABLE"),
+    ):
+        await main_module._ensure_container_system_running()
+
+
+async def test_launch_skips_when_egress_control_disabled() -> None:
+    """EC off must short-circuit ``_launch_egress_gateway_once_ready`` so
+    launch + readiness probe + IP discovery are all skipped.
+
+    The EC gate lives in ``bootstrap._ec2_active``, which reads
+    ``EGRESS_CONTROL_ENABLE``, so we patch it on the bootstrap module —
+    patching main's reference no longer reaches the read site.
     """
     from rolemesh import main as main_module
     from rolemesh.egress import bootstrap
@@ -240,7 +249,7 @@ async def test_launch_skips_in_rollback_mode() -> None:
     wait_mock = AsyncMock()
 
     with (
-        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", ""),
+        patch.object(bootstrap, "EGRESS_CONTROL_ENABLE", False),
         patch.object(main_module, "_runtime", rt),
         patch.object(bootstrap, "launch_egress_gateway", launch_mock),
         patch.object(bootstrap, "wait_for_gateway_ready", wait_mock),

--- a/tests/egress/test_bootstrap.py
+++ b/tests/egress/test_bootstrap.py
@@ -155,12 +155,12 @@ async def test_returns_none_when_runtime_lacks_ec2_methods() -> None:
 
 
 @pytest.mark.asyncio
-async def test_returns_none_when_container_network_name_unset() -> None:
-    """Rollback mode (operator turned EC off) — no-op."""
+async def test_returns_none_when_egress_control_disabled() -> None:
+    """EC off (EGRESS_CONTROL_ENABLE=0) — no-op even on a capable runtime."""
     from rolemesh.egress.bootstrap import ensure_gateway_running_and_register_dns
 
     runtime = _make_runtime(ec2_capable=True)
-    with patch("rolemesh.egress.bootstrap.CONTAINER_NETWORK_NAME", ""):
+    with patch("rolemesh.egress.bootstrap.EGRESS_CONTROL_ENABLE", False):
         result = await ensure_gateway_running_and_register_dns(runtime)
 
     assert result is None
@@ -477,15 +477,15 @@ async def test_nats_gate_runs_on_the_reuse_path(_runner_module: Any) -> None:
 
 @pytest.mark.asyncio
 async def test_nats_gate_skipped_when_ec2_inactive() -> None:
-    """Rollback mode (``CONTAINER_NETWORK_NAME=""``) short-circuits before
-    the NATS gate — there's no agent bridge to probe."""
+    """EC off (``EGRESS_CONTROL_ENABLE=0``) short-circuits before the NATS
+    gate — there's no agent bridge to probe."""
     from rolemesh.egress import bootstrap
 
     runtime = _make_runtime()
     nats_probe = AsyncMock()
 
     with (
-        patch.object(bootstrap, "CONTAINER_NETWORK_NAME", ""),
+        patch.object(bootstrap, "EGRESS_CONTROL_ENABLE", False),
         patch.object(bootstrap, "wait_for_nats_ready", nats_probe),
     ):
         result = await bootstrap.ensure_gateway_running_and_register_dns(runtime)


### PR DESCRIPTION
## Step 3 of 3: restore EC=off behind a dedicated switch

The final step of the egress-identity refactor. Introduces **`EGRESS_CONTROL_ENABLE`** (default on) as the single authoritative EC switch and fixes the long-broken EC=off path. Thanks to token identity (steps 2a/2b), EC=off now **keeps multi-tenant credential isolation** — the bug it always had — because identity is a signed token carried in the request, not an inference from network position. The host-side proxy verifies the same token, recovers the tenant, and injects that tenant's own key.

### Why the fix is small now

The two "断点" identified at the very start (bridge-IP publishing + a host-side resolver) both evaporated under tokens: identity travels in-band, so EC=off needs no IP lookup and no lifecycle events — just the host proxy wired with the same `TokenAuthority`. The reverse-proxy code already supported tokens (2a) and the gateway instance already used them (2b); the host instance simply never had `token_authority` passed because, in the default EC=on config, **agents don't dial it**.

### Switch decoupling (clean break, per review decision)

- `config`: `EGRESS_CONTROL_ENABLE` via `_env_flag` (1/0, true/false, yes/no, on/off; an unrecognised value fails the boot). `CONTAINER_NETWORK_NAME` is now purely a bridge name.
- Every "is EC on?" use of `CONTAINER_NETWORK_NAME` → `EGRESS_CONTROL_ENABLE` (main network setup, `bootstrap._ec2_active`, runner spec branch + DNS inject + `_build_extra_hosts` + `network_name`, executor MCP host).
- **Migration guard**: EC on + empty bridge name → hard startup error; legacy `CONTAINER_NETWORK_NAME=""` with EC off → warning pointing at the new switch.

### Core fix

- `main`: build `TokenAuthority` unconditionally (both modes verify tokens); wire `token_authority` into the host-side proxy.
- `container_executor`: mint the per-spawn token in both modes (verifier is the gateway in EC=on, the host proxy in EC=off — same secret).
- `runner`: the EC-off reverse-proxy URL carries `/proxy/<token>/...`; still **no** `HTTP_PROXY` (there is no forward proxy off the gateway). `network_name` is `None` in EC=off (default bridge).

### Form refactor (the cleanup agreed on review)

The host-side credential proxy listener is now bound **only** in EC=off — the one config where agents dial it (`host.docker.internal:3001`). In EC=on agents reach the gateway container, so binding a host listener was dead weight whose role silently inverted by mode — **which is exactly how the EC=off bug hid through 2a/2b**. `register_mcp_server` / `set_token_vault` stay unconditional (they feed the gateway snapshot in EC=on). Verified no EC=on caller dials the host listener before removing it.

### EC=off semantics (documented)

Drops egress **network** control (forward proxy, DNS resolver, internal-bridge isolation); preserves multi-tenant **credential** isolation. `EGRESS_TOKEN_SECRET` is now required in **both** modes. Because token identity is topology-independent, EC=off also works on **Docker Desktop / WSL**, which the old source-IP scheme never could.

## Testing

- **ruff clean**; full CI-parity (`pytest tests/ --ignore=tests/attack_sim -n auto`): **2023 passed / 0 failed** (782 errors are this sandbox's missing Docker socket, identical to main).
- Retargeted the rollback/`_ec2_active`/startup-order tests to the new switch; **new** cases: EC-off token-in-path + no-forward-proxy, EC-off skips both bridges, EC-on + empty bridge name is a config error.
- EC=off per-tenant credential isolation is already exercised end-to-end by `test_reverse_proxy_db_credentials` (host proxy + token-in-path → per-tenant key).

## Acceptance checklist

- [ ] `pytest tests/container tests/egress -q` green
- [ ] **EC=off real-stack smoke**: set `EGRESS_CONTROL_ENABLE=0` + `EGRESS_TOKEN_SECRET`, run two tenants, confirm each gets its **own** LLM key (cross-tenant isolation holds) and that no internal/egress bridge or gateway is created
- [ ] Confirm EC=on still behaves exactly as before (default config unchanged)
- [ ] Confirm `EGRESS_CONTROL_ENABLE=1` + `CONTAINER_NETWORK_NAME=""` fails fast with the config error
- [ ] (Optional) EC=off on Docker Desktop now works

Net **+277 / −93**, no new modules.

This completes the three-step arc: platform DNS (#81) → token identity (#82) → IP-scheme removal (#83) → EC=off restoration (this).

https://claude.ai/code/session_01WW72gXBjSTy83CmtfAPpRw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW72gXBjSTy83CmtfAPpRw)_