### PR TITLE
fix(test): make EC-off extra_hosts assertions platform-independent

### DIFF
--- a/tests/container/test_runner.py
+++ b/tests/container/test_runner.py
@@ -229,6 +229,13 @@ class TestBuildContainerSpec:
             patch.object(runner, "EGRESS_CONTROL_ENABLE", False),
             patch.object(runner, "NATS_URL", "nats://localhost:4222"),
             patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),
+            # Platform-dependent helper (Linux-only entry; {} on Docker
+            # Desktop) — patch for a deterministic assertion everywhere.
+            patch.object(
+                runner,
+                "get_host_gateway_extra_hosts",
+                return_value={"host.docker.internal": "host-gateway"},
+            ),
         ):
             spec = build_container_spec([], "c", "j")
 
@@ -252,11 +259,10 @@ class TestBuildContainerSpec:
         # NATS substitution restored so localhost reaches host.
         assert spec.env["NATS_URL"] == "nats://host.docker.internal:4222"
 
-        # ExtraHosts has host-gateway (Linux — empty on mac in CI, but
-        # the metadata blackhole is always there; assert on Linux only).
-        import platform
-        if platform.system() == "Linux":
-            assert spec.extra_hosts.get("host.docker.internal") == "host-gateway"
+        # ExtraHosts merges the (patched) host-gateway entry on top of
+        # the always-present metadata blackhole.
+        assert spec.extra_hosts.get("host.docker.internal") == "host-gateway"
+        assert spec.extra_hosts.get("169.254.169.254") == "127.0.0.1"
 
     def test_ec_off_carries_token_in_reverse_url_no_forward_proxy(self) -> None:
         """EC off still injects the identity token into the reverse-proxy
@@ -609,7 +615,20 @@ class TestComputeEgressRouting:
     def test_ec_off_with_token(self) -> None:
         from rolemesh.container import runner
 
-        with patch.object(runner, "EGRESS_CONTROL_ENABLE", False):
+        # get_host_gateway_extra_hosts is platform-dependent (the
+        # host-gateway entry exists on Linux only; Docker Desktop on
+        # macOS/Windows resolves host.docker.internal natively and the
+        # helper returns {}). Patch it so this test pins the WIRING
+        # contract — EC off merges the helper's output — deterministically
+        # on every platform, instead of the helper's platform logic.
+        with (
+            patch.object(runner, "EGRESS_CONTROL_ENABLE", False),
+            patch.object(
+                runner,
+                "get_host_gateway_extra_hosts",
+                return_value={"host.docker.internal": "host-gateway"},
+            ),
+        ):
             r = compute_egress_routing("TOK")
 
         assert r.proxy_base == "http://host.docker.internal:3001"
@@ -619,8 +638,10 @@ class TestComputeEgressRouting:
         assert r.dns_servers == []
         assert r.warn_missing_dns is False
         assert r.mcp_proxy_host == "host.docker.internal"
-        # EC off restores the host-gateway hosts entry.
-        assert "host.docker.internal" in r.extra_hosts
+        # EC off merges the platform helper's host-gateway entry on top
+        # of the always-present metadata blackhole.
+        assert r.extra_hosts["host.docker.internal"] == "host-gateway"
+        assert r.extra_hosts["169.254.169.254"] == "127.0.0.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`TestComputeEgressRouting::test_ec_off_with_token` (added in PR #84) fails on macOS. It asserted the `host.docker.internal: host-gateway` ExtraHosts entry unconditionally, but `get_host_gateway_extra_hosts()` returns that entry **on Linux only** — Docker Desktop (macOS/Windows) resolves `host.docker.internal` natively, so the helper correctly returns `{}` there.

**Production behaviour is correct on both platforms; this was a test bug.** CI runs Ubuntu, which is why it stayed green until a macOS run surfaced it. The older `test_rollback_mode_restores_pre_ec_routing` in the same file already knew about this — it guarded the same assertion behind `if platform.system() == "Linux"` — and the new test copied its assertion but missed the guard.

## Fix

Patch the helper in the tests instead of platform-gating the assertion:

- The unit under test is `compute_egress_routing`'s **wiring contract** ("EC off merges the helper's output into extra_hosts"), not the helper's platform detection (that's the helper's own concern). With the helper patched to a known value, the assertion is deterministic on every platform — and the test now additionally proves the helper is actually consulted.
- Upgraded the older platform-gated test to the same style (its guard meant it asserted nothing on mac), removing the file's double standard. Both tests also now pin the always-present metadata-blackhole entry.

## Verification

- Linux: `tests/container/test_runner.py` 54/54 pass.
- Simulated macOS (forced `platform.system() → "Darwin"` before import, so the helper returns `{}`): full file **54/54 pass** — including the previously failing test.



---
