### PR TITLE
feat(egress): platform-managed provider allowlist for BYOK

### DIFF
--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -76,7 +76,12 @@ from .policy_cache import (
 )
 from .remote_credentials import RemoteCredentialResolver
 from .remote_token_vault import RemoteTokenVault
-from .reverse_proxy import set_token_vault, start_credential_proxy
+from .reverse_proxy import (
+    is_known_provider_host,
+    known_provider_endpoints,
+    set_token_vault,
+    start_credential_proxy,
+)
 from .safety_call import AuditPublisher, EgressSafetyCaller
 from .token_identity import TokenAuthority
 
@@ -245,10 +250,20 @@ async def main() -> None:
                 "(expected until EC-3 lands) — all requests will be blocked"
             )
 
+        # Platform-managed provider allow layer: known LLM-provider hosts
+        # are always permitted egress so a tenant's BYOK credential works
+        # without hand-configuring an egress allowlist. Per-tenant rules in
+        # the policy cache still govern MCP and any custom egress.
         safety = EgressSafetyCaller(
             cache=cache,
             checks=check_map,
             audit_publisher=audit,
+            platform_allow=is_known_provider_host,
+        )
+        logger.info(
+            "gateway: platform provider allowlist active",
+            endpoints=sorted(f"{h}:{p}" for h, p in known_provider_endpoints()),
+            bedrock="bedrock-runtime.<region>.amazonaws.com:443",
         )
 
         # --- MCP server registry: snapshot + hot reload --------------

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -31,6 +31,7 @@ hidden code path where credentials come from somewhere else.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 from urllib.parse import urlparse
@@ -191,6 +192,73 @@ def _bedrock_upstream(cred: dict[str, Any]) -> str:
         region = str(extras.get("region") or "")
     region = region or BEDROCK_DEFAULT_REGION
     return f"https://bedrock-runtime.{region}.amazonaws.com"
+
+
+# ---------------------------------------------------------------------------
+# Platform-managed provider allowlist
+# ---------------------------------------------------------------------------
+#
+# Known LLM-provider upstreams the platform always allows egress to, so a
+# tenant's BYOK credential works without anyone hand-configuring an
+# ``egress.domain_rule``. The gateway consumes ``is_known_provider_host``
+# as its platform-allow layer (see ``EgressSafetyCaller.decide``); the
+# per-tenant ``safety_rules`` allowlist is left for everything else (MCP,
+# tenant-custom egress).
+#
+# Hosts are derived from the SAME routing source the reverse proxy dials —
+# ``_provider_upstream`` / ``_anthropic_upstream`` — so deployment
+# ``*_BASE_URL`` overrides are honoured automatically and the allow set
+# never drifts from where requests actually go. Bedrock is region-templated
+# (the region travels with the tenant credential), so it is matched by
+# shape rather than enumerated.
+
+# bedrock-runtime.<region>.amazonaws.com — region segment is a non-empty
+# AWS-region token. Anchored so it cannot be a suffix of an attacker host.
+_BEDROCK_HOST_RE = re.compile(r"^bedrock-runtime\.[a-z0-9-]+\.amazonaws\.com$")
+
+
+def _upstream_host_port(upstream: str) -> tuple[str, int] | None:
+    """Parse ``(host, port)`` from an upstream URL using the same default
+    port rule the proxy applies when it dials (443 for https, 80 for http)."""
+    up = urlparse(upstream)
+    host = up.hostname
+    if not host:
+        return None
+    port = up.port or (443 if up.scheme == "https" else 80)
+    return host.lower(), port
+
+
+def known_provider_endpoints() -> set[tuple[str, int]]:
+    """Static provider ``(host, port)`` endpoints the platform allows.
+
+    Recomputed from the routing helpers (and thus the live ``*_BASE_URL``
+    env overrides) rather than cached, keeping it correct without a
+    process restart. Bedrock is excluded here and handled by shape in
+    :func:`is_known_provider_host`.
+    """
+    out: set[tuple[str, int]] = set()
+    for upstream in (
+        _anthropic_upstream(),
+        *(_provider_upstream(t) for t in _PROVIDER_TEMPLATES.values()),
+    ):
+        hp = _upstream_host_port(upstream)
+        if hp is not None:
+            out.add(hp)
+    return out
+
+
+def is_known_provider_host(host: str, port: int) -> bool:
+    """True when ``host:port`` is a platform-vetted LLM provider endpoint.
+
+    Used by the egress gateway as a platform-managed allow layer so BYOK
+    LLM calls work out of the box. Bedrock matches by region-templated
+    shape on the standard HTTPS port; everything else must match a
+    derived ``(host, port)`` endpoint exactly.
+    """
+    h = host.lower().rstrip(".")
+    if (h, port) in known_provider_endpoints():
+        return True
+    return port == 443 and bool(_BEDROCK_HOST_RE.match(h))
 
 
 # ---------------------------------------------------------------------------

--- a/src/rolemesh/egress/safety_call.py
+++ b/src/rolemesh/egress/safety_call.py
@@ -143,14 +143,21 @@ class EgressSafetyCaller:
             # come from an authenticated coworker.
             return decision
 
-        # Platform-managed provider allow. Deliberately ahead of the
-        # ``seeded`` gate: known LLM-provider egress is a platform-level
-        # fact that does not depend on the tenant rule snapshot, so BYOK
-        # keeps working during the degraded-startup window. MCP and any
-        # tenant-custom egress still fall through to the tenant allowlist
-        # below.
-        if self._platform_allow is not None and self._platform_allow(
-            request.host, request.port
+        # Platform-managed provider allow — scoped to the reverse
+        # (credential) proxy ONLY. That path's host is server-derived from
+        # the matched provider template, so allowing known LLM endpoints
+        # there lets BYOK work without a per-tenant rule. The forward proxy
+        # and DNS resolver carry an agent-CONTROLLED host (the CONNECT
+        # target / queried name), so they must NOT be short-circuited —
+        # they fall through to the tenant allowlist + default-deny below,
+        # preserving that guarantee for these hosts on the agent-controlled
+        # paths. Deliberately ahead of the ``seeded`` gate: known-provider
+        # egress is a platform fact independent of the tenant snapshot, so
+        # BYOK keeps working during the degraded-startup window.
+        if (
+            request.mode == "reverse"
+            and self._platform_allow is not None
+            and self._platform_allow(request.host, request.port)
         ):
             decision = EgressDecision(
                 action="allow",

--- a/src/rolemesh/egress/safety_call.py
+++ b/src/rolemesh/egress/safety_call.py
@@ -40,6 +40,8 @@ from typing import TYPE_CHECKING, Any, Literal
 from rolemesh.core.logger import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import nats.aio.client
 
     from .policy_cache import PolicyCache
@@ -105,10 +107,16 @@ class EgressSafetyCaller:
         cache: PolicyCache,
         checks: dict[str, CheckFunc],
         audit_publisher: AuditPublisher,
+        platform_allow: Callable[[str, int], bool] | None = None,
     ) -> None:
         self._cache = cache
         self._checks = checks
         self._audit = audit_publisher
+        # Platform-managed allow layer: a host/port predicate that short-
+        # circuits to ALLOW for known LLM-provider endpoints, so BYOK works
+        # without a per-tenant egress allowlist. ``None`` disables it (the
+        # gateway always wires it; unit tests opt in).
+        self._platform_allow = platform_allow
         self._audit_tasks: set[asyncio.Task[None]] = set()
 
     async def decide(
@@ -133,6 +141,33 @@ class EgressSafetyCaller:
             # writing to a "system" tenant) matches the multi-tenant
             # isolation guarantee in subscriber.py: every row must
             # come from an authenticated coworker.
+            return decision
+
+        # Platform-managed provider allow. Deliberately ahead of the
+        # ``seeded`` gate: known LLM-provider egress is a platform-level
+        # fact that does not depend on the tenant rule snapshot, so BYOK
+        # keeps working during the degraded-startup window. MCP and any
+        # tenant-custom egress still fall through to the tenant allowlist
+        # below.
+        if self._platform_allow is not None and self._platform_allow(
+            request.host, request.port
+        ):
+            decision = EgressDecision(
+                action="allow",
+                reason="Platform-managed provider allowlist",
+                findings=[
+                    {
+                        "code": "EGRESS.PLATFORM_PROVIDER_ALLOWED",
+                        "severity": "info",
+                        "message": (
+                            f"platform-managed provider host "
+                            f"{request.host}:{request.port}"
+                        ),
+                        "metadata": {"host": request.host, "port": request.port},
+                    }
+                ],
+            )
+            self._publish_audit(identity=identity, request=request, decision=decision)
             return decision
 
         if not self._cache.seeded:

--- a/tests/egress/test_provider_hosts.py
+++ b/tests/egress/test_provider_hosts.py
@@ -1,0 +1,79 @@
+"""Tests for the platform-managed provider allowlist matcher.
+
+``is_known_provider_host`` is the gateway's platform-allow layer: it must
+recognise every LLM-provider upstream the reverse proxy actually dials
+(including ``*_BASE_URL`` deployment overrides and Bedrock's region-
+templated host) while NOT accidentally whitelisting anything else.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rolemesh.egress.reverse_proxy import (
+    is_known_provider_host,
+    known_provider_endpoints,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_static_provider_hosts_allowed() -> None:
+    assert is_known_provider_host("api.anthropic.com", 443)
+    assert is_known_provider_host("api.openai.com", 443)
+    assert is_known_provider_host("generativelanguage.googleapis.com", 443)
+
+
+def test_host_match_is_case_and_trailing_dot_insensitive() -> None:
+    assert is_known_provider_host("API.Anthropic.com", 443)
+    assert is_known_provider_host("api.anthropic.com.", 443)
+
+
+def test_wrong_port_blocked() -> None:
+    # A matching host on the wrong port must not be allowed — leaving the
+    # port open would whitelist non-TLS services on the same host.
+    assert not is_known_provider_host("api.anthropic.com", 80)
+    assert not is_known_provider_host("api.anthropic.com", 22)
+
+
+def test_unknown_host_blocked() -> None:
+    assert not is_known_provider_host("mcp.example.com", 443)
+    assert not is_known_provider_host("attacker.com", 443)
+    # Suffix/lookalike must not match the anchored set.
+    assert not is_known_provider_host("api.anthropic.com.evil.com", 443)
+
+
+def test_bedrock_region_templated_host_allowed() -> None:
+    assert is_known_provider_host("bedrock-runtime.us-east-1.amazonaws.com", 443)
+    assert is_known_provider_host("bedrock-runtime.eu-west-3.amazonaws.com", 443)
+
+
+def test_bedrock_shape_is_anchored() -> None:
+    # Empty region, wrong service, or a lookalike suffix must not match.
+    assert not is_known_provider_host("bedrock-runtime..amazonaws.com", 443)
+    assert not is_known_provider_host("s3.us-east-1.amazonaws.com", 443)
+    assert not is_known_provider_host(
+        "bedrock-runtime.us-east-1.amazonaws.com.evil.com", 443
+    )
+    # Right shape, wrong port.
+    assert not is_known_provider_host("bedrock-runtime.us-east-1.amazonaws.com", 80)
+
+
+def test_base_url_override_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deployment that points OpenAI at a self-hosted gateway should have
+    that host (and its port) allowed automatically — derived, not hardcoded."""
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://llm-proxy.internal:8443/v1")
+    assert ("llm-proxy.internal", 8443) in known_provider_endpoints()
+    assert is_known_provider_host("llm-proxy.internal", 8443)
+    # The stock host is no longer the configured upstream, but the default
+    # template host stays in the set only if still derived; with an override
+    # the override host is what matters for this deployment.
+    assert is_known_provider_host("llm-proxy.internal", 8443)
+
+
+def test_known_endpoints_default_set() -> None:
+    eps = known_provider_endpoints()
+    assert ("api.anthropic.com", 443) in eps
+    assert ("api.openai.com", 443) in eps
+    assert ("generativelanguage.googleapis.com", 443) in eps

--- a/tests/egress/test_safety_call.py
+++ b/tests/egress/test_safety_call.py
@@ -407,6 +407,49 @@ async def test_platform_allow_decision_is_audited() -> None:
     assert payload["verdict_action"] == "allow"
 
 
+async def test_platform_allow_does_not_apply_to_forward_proxy() -> None:
+    """Platform-allow is scoped to the reverse (credential) proxy. On the
+    forward proxy the host is the agent's CONNECT target — agent-controlled
+    — so a known provider host must still go through the tenant allowlist
+    and default-deny, NOT be short-circuited."""
+    nc = _FakeNats(published=[])
+    cache = PolicyCache()
+    await cache.seed([])  # tenant has zero egress rules
+    caller = EgressSafetyCaller(
+        cache=cache,
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        platform_allow=lambda host, port: True,  # would allow everything
+    )
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(
+            host="api.anthropic.com", port=443, mode="forward", method="CONNECT"
+        ),
+    )
+    assert decision.action == "block"
+    assert "No egress allowlist rule matched" in decision.reason
+
+
+async def test_platform_allow_does_not_apply_to_dns() -> None:
+    """Same scope guarantee for the DNS resolver path: the queried name is
+    agent-controlled, so platform-allow must not short-circuit it."""
+    nc = _FakeNats(published=[])
+    cache = PolicyCache()
+    await cache.seed([])
+    caller = EgressSafetyCaller(
+        cache=cache,
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        platform_allow=lambda host, port: True,
+    )
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="api.anthropic.com", port=443, mode="dns", qtype="A"),
+    )
+    assert decision.action == "block"
+
+
 async def test_unknown_check_id_is_skipped() -> None:
     """A rule referencing a check_id we don't have is a config error —
     skip it rather than treating it as a hit (which would silently

--- a/tests/egress/test_safety_call.py
+++ b/tests/egress/test_safety_call.py
@@ -324,6 +324,89 @@ async def test_forward_mode_audit_does_not_redact() -> None:
     assert "***" not in payload["context_summary"]
 
 
+async def test_platform_allow_short_circuits_to_allow() -> None:
+    """A known provider host is allowed by the platform layer without any
+    tenant rule — BYOK works without a hand-configured egress allowlist."""
+    nc = _FakeNats(published=[])
+    cache = PolicyCache()
+    await cache.seed([])  # tenant has zero egress rules
+    caller = EgressSafetyCaller(
+        cache=cache,
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        platform_allow=lambda host, port: host == "api.anthropic.com" and port == 443,
+    )
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="api.anthropic.com", port=443, mode="reverse"),
+    )
+    assert decision.action == "allow"
+    assert decision.reason == "Platform-managed provider allowlist"
+    assert decision.findings[0]["code"] == "EGRESS.PLATFORM_PROVIDER_ALLOWED"
+
+
+async def test_platform_allow_works_during_degraded_startup() -> None:
+    """Provider egress must not depend on the tenant rule snapshot: a known
+    host is allowed even before the cache is seeded (degraded startup)."""
+    nc = _FakeNats(published=[])
+    caller = EgressSafetyCaller(
+        cache=PolicyCache(),  # never seeded
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        platform_allow=lambda host, port: True,
+    )
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="api.openai.com", port=443, mode="reverse"),
+    )
+    assert decision.action == "allow"
+    assert decision.reason == "Platform-managed provider allowlist"
+
+
+async def test_platform_allow_miss_falls_through_to_tenant_rules() -> None:
+    """A non-provider host (e.g. an MCP server) is NOT short-circuited; it
+    falls through to the tenant allowlist, which default-denies when empty."""
+    nc = _FakeNats(published=[])
+    cache = PolicyCache()
+    await cache.seed([])
+    caller = EgressSafetyCaller(
+        cache=cache,
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        platform_allow=lambda host, port: host == "api.anthropic.com" and port == 443,
+    )
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=443, mode="reverse"),
+    )
+    assert decision.action == "block"
+    assert "No egress allowlist rule matched" in decision.reason
+
+
+async def test_platform_allow_decision_is_audited() -> None:
+    """Platform-allowed egress still writes an audit row (allow verdict)."""
+    nc = _FakeNats(published=[])
+    cache = PolicyCache()
+    await cache.seed([])
+    caller = EgressSafetyCaller(
+        cache=cache,
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        platform_allow=lambda host, port: True,
+    )
+    await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="api.anthropic.com", port=443, mode="reverse"),
+    )
+    for _ in range(50):
+        await asyncio.sleep(0.02)
+        if nc.published:
+            break
+    assert nc.published, "platform-allow decision was not audited"
+    _, payload = nc.published[-1]
+    assert payload["verdict_action"] == "allow"
+
+
 async def test_unknown_check_id_is_skipped() -> None:
     """A rule referencing a check_id we don't have is a config error —
     skip it rather than treating it as a hit (which would silently


### PR DESCRIPTION
## Background

A new tenant's egress allowlist is empty by default, and the gateway is **default-deny** for egress. So even after a tenant configures an LLM credential (BYOK), the agent's LLM calls get blocked because the provider host isn't in the allowlist — "set it up but can't use it".

The upstream hosts for known LLM providers are platform-controlled and deterministic (derived from the `_PROVIDER_TEMPLATES` / anthropic / bedrock routing logic, not free-text user input), so conceptually they are a platform-level policy. This PR adds a **platform-managed allow layer** at the gateway so BYOK works out of the box, while the tenant allowlist still governs MCP and any custom egress.

## Changes

- **`reverse_proxy.py`**: add `known_provider_endpoints()` / `is_known_provider_host()`, deriving `(host, port)` from the same routing source the proxy actually dials; honours `*_BASE_URL` overrides automatically; Bedrock matched by its region-templated shape (`bedrock-runtime.<region>.amazonaws.com`); HTTPS only.
- **`safety_call.py`**: `EgressSafetyCaller` gains a `platform_allow` predicate, checked in `decide()` **ahead of the `seeded` gate** so provider egress does not depend on the tenant rule snapshot (BYOK keeps working during degraded startup); allow decisions are still audited.
- **`gateway.py`**: wire `platform_allow=is_known_provider_host` and log the active endpoints.

## Scope control (security)

The platform allow is **scoped to the credential proxy only (`mode == "reverse"`)** — that path's host is server-derived from the matched provider template, so it is trusted. The forward proxy and DNS resolver carry an **agent-controlled** host (the CONNECT target / queried name) and are **not** short-circuited; they fall through to the tenant allowlist + default-deny, preserving that guarantee for these hosts on the agent-controlled paths.

## Not changed

`fetch_all_egress_rules`, `policy_cache`, schema, migrations, orchestrator, frontend — gateway-side only, small blast radius.

## Tests

- `tests/egress/test_provider_hosts.py`: matcher unit tests (each provider / bedrock region / case + trailing dot / wrong port / unknown host / lookalike suffix / `*_BASE_URL` override).
- `tests/egress/test_safety_call.py`: platform-allow behaviour (short-circuit allow, works during degraded startup, miss falls through to tenant rules, audited), plus **forward / dns negative tests** that pin the scope.
- All DB-independent tests pass; ruff clean.

https://claude.ai/code/session_012qa5WgeXRuXxEPZbvxwwDZ