### PR TITLE
fix(compose): wire OIDC env into orchestrator for user-mode MCP tokens

### DIFF
--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -242,6 +242,15 @@ services:
       CREDENTIAL_VAULT_KEY:
       AUTH_MODE:
       ROLEMESH_TOKEN_SECRET:
+      # OIDC discovery + client creds. The orchestrator needs these (not
+      # just webui): create_vault_from_env() returns None without a
+      # discovery URL + client_id, so under AUTH_MODE=oidc the orchestrator
+      # would never subscribe the egress.token.access.request responder and
+      # the gateway's RemoteTokenVault RPC would get "no responders" — every
+      # user-mode MCP request then forwards an empty Authorization header.
+      OIDC_DISCOVERY_URL:
+      OIDC_CLIENT_ID:
+      OIDC_CLIENT_SECRET:
       ROLEMESH_ENV:
       BOOTSTRAP_USERS:
       WEBUI_BASE_URL:

--- a/docs/6-auth-architecture-cn.md
+++ b/docs/6-auth-architecture-cn.md
@@ -112,6 +112,15 @@ OIDC_AUTO_ASSIGN_TO_ALL=true                    # new users get all coworkers
 ROLEMESH_TOKEN_SECRET=<any-secret>              # Fernet encryption key derivation
 ```
 
+> **两个进程都需要 OIDC env。** `create_vault_from_env()` 在 orchestrator
+> 和 webui 两个进程里都会跑，缺 `OIDC_DISCOVERY_URL` + `OIDC_CLIENT_ID`
+> 时返回 `None`。如果只给 webui 配，orchestrator 就永远不会订阅
+> `egress.token.access.request` 这个 responder，gateway 的
+> `RemoteTokenVault` RPC 会拿到 "no responders"，于是每个 user-mode MCP
+> 请求转发出去的 `Authorization` 头都是空的。务必把
+> `OIDC_DISCOVERY_URL` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET`（以及
+> `ROLEMESH_TOKEN_SECRET`）同时配到这两个服务上。
+
 OIDC 模式下角色解析的优先级：直接角色 claim → 分组映射 → 作用域映射 → 兜底为 "member"。
 
 ### Builtin 模式（占位实现）

--- a/docs/6-auth-architecture.md
+++ b/docs/6-auth-architecture.md
@@ -112,6 +112,15 @@ OIDC_AUTO_ASSIGN_TO_ALL=true                    # new users get all coworkers
 ROLEMESH_TOKEN_SECRET=<any-secret>              # Fernet encryption key derivation
 ```
 
+> **Both processes need the OIDC env.** `create_vault_from_env()` runs in
+> the orchestrator *and* the webui process, and returns `None` without
+> `OIDC_DISCOVERY_URL` + `OIDC_CLIENT_ID`. If only webui gets them, the
+> orchestrator never subscribes the `egress.token.access.request`
+> responder, the gateway's `RemoteTokenVault` RPC gets "no responders",
+> and every user-mode MCP request forwards an empty `Authorization` header.
+> Wire `OIDC_DISCOVERY_URL` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` (and
+> `ROLEMESH_TOKEN_SECRET`) into both services.
+
 OIDC mode role resolution priority: direct role claim → group mapping → scope mapping → fallback "member".
 
 ### Builtin Mode (Stub)


### PR DESCRIPTION
## Problem

Under `AUTH_MODE=oidc`, any user-mode MCP request gets forwarded with an **empty `Authorization` header**, breaking per-user MCP token forwarding end to end.

Root cause is a config gap in the dev compose stack, not application code:

- `create_vault_from_env()` (`src/rolemesh/auth/token_vault.py:222`) returns `None` when `OIDC_DISCOVERY_URL` or `OIDC_CLIENT_ID` is unset. Its docstring already notes that **both** the orchestrator and webui processes must call it at startup.
- `deploy/compose/compose.yaml` only declared the `OIDC_*` pass-through keys on the **webui** service. The **orchestrator** service had `AUTH_MODE` / `ROLEMESH_TOKEN_SECRET` but none of the three `OIDC_*` keys.
- So in the orchestrator process `_vault` stays `None` (`src/rolemesh/main.py:1825`), the `if _vault is not None:` guard at `main.py:1948` is skipped, and `start_token_responder` never runs — the `token responder subscribed | subject=egress.token.access.request` log never appears.
- The egress gateway's `RemoteTokenVault.get_fresh_access_token` then RPCs `egress.token.access.request` and gets `nats: no responders available` → returns `None` → upstream injects no/empty `Authorization`.

## Fix

- Add `OIDC_DISCOVERY_URL` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` to the orchestrator `environment:` block (mirroring webui), with an inline comment explaining the responder dependency.
- Document in `docs/6-auth-architecture.md` (+ `-cn`) that both processes must receive the OIDC env, to prevent the config from drifting again.

## Scope / notes

- Purely additive compose + docs change; no application code touched.
- Default `AUTH_MODE=external` is unaffected (vault is intentionally `None` there). The bug only surfaces when an operator actually enables OIDC user-mode MCP.
- This is a generic RoleMesh defect (discovered downstream in tropos). Deploying the fix still requires restarting the orchestrator so it picks up the new env.

## Validation

- `compose.yaml` parses; orchestrator now exposes `OIDC_DISCOVERY_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`.

https://claude.ai/code/session_01GgiyEymTGvLEnnUxrhhyrP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgiyEymTGvLEnnUxrhhyrP)_