### PR TITLE
fix(k8s): make the agent DNS path work end-to-end (close helm-test false-green)

### DIFF
--- a/deploy/charts/rolemesh/templates/egress-gateway.yaml
+++ b/deploy/charts/rolemesh/templates/egress-gateway.yaml
@@ -15,6 +15,17 @@ policies reference it as a peer).
 */ -}}
 {{- $tag := default .Chart.AppVersion .Values.egressGateway.image.tag -}}
 {{- $dnsPort := .Values.egressGateway.dnsContainerPort | int -}}
+{{- /* Cluster DNS domain shared with the orchestrator's
+       ROLEMESH_K8S_CLUSTER_DOMAIN (agent search domains), so the FQDNs
+       agents query equal the ones allowlisted here. */ -}}
+{{- $clusterDomain := .Values.clusterDomain | default "cluster.local" -}}
+{{- /* Internal Service FQDNs an agent legitimately resolves: NATS (it
+       dials nats://nats:4222) and the gateway itself (HTTP(S)_PROXY /
+       MCP proxy host). Agents resolve short names that glibc expands to
+       these FQDNs via the search domains; the resolver's allowlist is
+       keyed on the FQDN. Merged with any operator-supplied extras. */ -}}
+{{- $internalDns := list (printf "%s.%s.svc.%s" (include "rolemesh.natsServiceName" .) .Release.Namespace $clusterDomain) (printf "egress-gateway.%s.svc.%s" .Release.Namespace $clusterDomain) -}}
+{{- $dnsAllow := concat $internalDns (.Values.egressGateway.dnsAllowlistExtra | default list) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -109,6 +120,19 @@ spec:
             # set here for the K8s binding to be correct.
             - name: EGRESS_GATEWAY_DNS_PORT
               value: {{ $dnsPort | quote }}
+            # Recursive DNS upstream. On K8s this MUST be the cluster's
+            # kube-dns ClusterIP — the source default (8.8.8.8,1.1.1.1) is
+            # public and cannot resolve cluster-internal Service names, so
+            # agent -> nats resolution would NXDOMAIN. Required (no safe
+            # universal default; kube-dns IP is per-cluster, see values).
+            - name: EGRESS_UPSTREAM_DNS
+              value: {{ required "egressGateway.upstreamDns is REQUIRED on K8s — set it to your cluster's kube-dns ClusterIP (kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}'). See values.yaml." .Values.egressGateway.upstreamDns | quote }}
+            # Platform DNS allowlist: the internal Service FQDNs agents
+            # resolve, chart-templated so operators never hand-copy them.
+            # Without this the resolver default-denies (empty allowlist +
+            # enforce mode) and every agent lookup NXDOMAINs.
+            - name: EGRESS_DNS_ALLOWLIST
+              value: {{ join "," $dnsAllow | quote }}
             - name: EGRESS_TOKEN_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/charts/rolemesh/templates/networkpolicy.yaml
+++ b/deploy/charts/rolemesh/templates/networkpolicy.yaml
@@ -16,6 +16,12 @@ DO NOT template these names or the agent selector off the release name.
 */ -}}
 {{- $natsSvc := include "rolemesh.natsServiceName" . -}}
 {{- $kubeDnsNs := .Values.networkPolicy.kubeDns.namespace -}}
+{{- /* Single source of truth for the gateway's DNS container port: the
+       same value the Service targetPort and the container env use
+       (egress-gateway.yaml). NetworkPolicy egress matches the POST-DNAT
+       backend container port, NOT the Service port — so this MUST be the
+       container port (1053), not 53. */ -}}
+{{- $gwDnsPort := .Values.egressGateway.dnsContainerPort | int -}}
 ---
 # 1. agent-default-deny: every agent pod, all ingress + egress denied.
 #    Standalone so the "default deny" invariant is independently verifiable.
@@ -52,15 +58,18 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # -> egress gateway: DNS (53 udp+tcp -> Service maps to container 1053),
-    #    credential proxy / healthz (3001), forward proxy (3128).
+    # -> egress gateway: DNS (container port {{ $gwDnsPort }} — the
+    #    Service maps 53 -> {{ $gwDnsPort }}, but NetworkPolicy matches the
+    #    backend container port post-DNAT, so this MUST be {{ $gwDnsPort }}
+    #    not 53; mirrors gateway-policy's ingress below), credential proxy
+    #    / healthz (3001), forward proxy (3128).
     - to:
         - podSelector:
             matchLabels:
               app.kubernetes.io/component: egress-gateway
       ports:
-        - { protocol: UDP, port: 53 }
-        - { protocol: TCP, port: 53 }
+        - { protocol: UDP, port: {{ $gwDnsPort }} }
+        - { protocol: TCP, port: {{ $gwDnsPort }} }
         - { protocol: TCP, port: 3001 }
         - { protocol: TCP, port: 3128 }
     # -> NATS (4222): agent lifecycle + protocol traffic rides NATS.
@@ -97,8 +106,8 @@ spec:
             matchLabels:
               app.kubernetes.io/component: orchestrator
       ports:
-        - { protocol: UDP, port: 1053 }
-        - { protocol: TCP, port: 1053 }
+        - { protocol: UDP, port: {{ $gwDnsPort }} }
+        - { protocol: TCP, port: {{ $gwDnsPort }} }
         - { protocol: TCP, port: 3001 }
         - { protocol: TCP, port: 3128 }
   egress:

--- a/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
+++ b/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
@@ -88,8 +88,18 @@ spec:
           env:
             - name: ROLEMESH_CONTAINER_RUNTIME
               value: "k8s"
+            # Sourced from the Downward API rather than templated so the
+            # agent pods the orchestrator spawns (and their DNS search
+            # domains, built from this) always track the pod's REAL
+            # namespace — it cannot drift from the install namespace.
             - name: ROLEMESH_K8S_NAMESPACE
-              value: {{ .Release.Namespace | quote }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # Cluster DNS domain for agent pod search domains (matches the
+            # FQDNs the gateway DNS allowlist is keyed on, below).
+            - name: ROLEMESH_K8S_CLUSTER_DOMAIN
+              value: {{ .Values.clusterDomain | default "cluster.local" | quote }}
             - name: ROLEMESH_K8S_DATA_PVC
               value: "rolemesh-data"
             - name: ROLEMESH_K8S_IMAGE_PULL_SECRET

--- a/deploy/charts/rolemesh/templates/tests/connectivity-probe.yaml
+++ b/deploy/charts/rolemesh/templates/tests/connectivity-probe.yaml
@@ -1,0 +1,126 @@
+{{- /*
+helm test connectivity probe — the POSITIVE counterpart to deny-probe.
+
+deny-probe proves an agent CANNOT reach the public internet. It does not
+exercise the path an agent actually needs to WORK: resolve the short name
+`nats` through the gateway resolver and connect to NATS. That path was a
+false-green for a long time (helm test + "Infrastructure verified" both
+passed while agents could not resolve `nats` at all), because it depends
+on four things lining up that nothing tested together:
+
+  * agent-allow-egress allowing the gateway's DNS CONTAINER port (1053),
+    not the Service port 53 (NetworkPolicy matches the backend port);
+  * the gateway DNS allowlist containing nats's internal FQDN;
+  * the gateway's recursive upstream being kube-dns, not public DNS;
+  * the agent pod carrying cluster DNS search domains so `nats` expands
+    to its FQDN under dnsPolicy: None.
+
+This probe reproduces the REAL agent DNS setup (a helm-test pod defaults
+to dnsPolicy: ClusterFirst and would resolve via kube-dns directly,
+testing none of the above), so it must hard-code the same dnsConfig the
+orchestrator's K8sRuntime stamps on agent pods: dnsPolicy None +
+nameservers=[gateway ClusterIP] + the cluster search domains. Labeled
+role=agent so it is subject to the agent NetworkPolicies.
+
+It resolves the SHORT name `nats` (exercising the search domains) and
+reads the NATS INFO banner (proving it really reached NATS at the
+protocol level, not just opened a TCP port). A failure here fails
+`helm test` with a message pointing at which link broke.
+*/ -}}
+{{- $clusterDomain := .Values.clusterDomain | default "cluster.local" -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "rolemesh.fullname" . }}-connectivity-probe
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rolemesh.labels" . | nindent 4 }}
+    # Subjects the probe to the agent NetworkPolicies — must match
+    # AGENT_ROLE_LABEL/VALUE, exactly like a real agent pod.
+    rolemesh.io/role: agent
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  # Mirror K8sRuntime's agent dnsConfig (src/rolemesh/container/
+  # k8s_runtime.py spec_to_pod_manifest): force resolution through the
+  # gateway and supply the cluster search domains short names need.
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - {{ required "egressGateway.clusterIP is required" .Values.egressGateway.clusterIP | quote }}
+    searches:
+      - {{ printf "%s.svc.%s" .Release.Namespace $clusterDomain | quote }}
+      - {{ printf "svc.%s" $clusterDomain | quote }}
+      - {{ $clusterDomain | quote }}
+    options:
+      - { name: ndots, value: "5" }
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: probe
+      image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      command:
+        - python
+        - -c
+        - |
+          import socket, sys
+
+          # 1. Resolve the SHORT name. glibc appends the search domains
+          #    (dnsConfig above) and asks the gateway resolver, which must
+          #    allowlist the FQDN and forward to kube-dns. This is the link
+          #    the old false-green missed.
+          try:
+              infos = socket.getaddrinfo("nats", 4222, type=socket.SOCK_STREAM)
+              addr = infos[0][4]
+          except OSError as exc:
+              print(
+                  "FAIL: could not resolve short name 'nats' via the gateway "
+                  f"resolver ({exc}). Check: agent-allow-egress DNS port == "
+                  "gateway container port (not 53); EGRESS_DNS_ALLOWLIST has "
+                  "the nats FQDN; EGRESS_UPSTREAM_DNS points at kube-dns; "
+                  "agent dnsConfig has search domains.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          print(f"resolved nats -> {addr}")
+
+          # 2. Connect and read the NATS INFO banner — proves we reached
+          #    NATS at the protocol level (agent-allow-egress :4222), not
+          #    just any open port.
+          try:
+              with socket.create_connection(addr, timeout=10) as sock:
+                  sock.settimeout(10)
+                  banner = sock.recv(64)
+          except OSError as exc:
+              print(
+                  f"FAIL: resolved nats but could not connect to {addr} "
+                  f"({exc}). Check agent-allow-egress allows :4222 to NATS.",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          if not banner.startswith(b"INFO"):
+              print(
+                  f"FAIL: connected to {addr} but it did not speak NATS "
+                  f"(banner={banner!r}).",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          print("PASS: agent resolved 'nats' via the gateway and reached NATS.")
+          sys.exit(0)

--- a/deploy/charts/rolemesh/values-kind.yaml
+++ b/deploy/charts/rolemesh/values-kind.yaml
@@ -45,6 +45,9 @@ egressGateway:
   # Inside kind's default Service CIDR (10.96.0.0/12). kube-dns is .10;
   # .53 is free and mnemonic (DNS port). MUST match EGRESS_GATEWAY_DNS_IP.
   clusterIP: "10.96.0.53"
+  # kind's kube-dns ClusterIP — the gateway's recursive upstream, so
+  # agents can resolve nats / the gateway (and external names) through it.
+  upstreamDns: "10.96.0.10"
   resources:
     requests:
       cpu: 50m

--- a/deploy/charts/rolemesh/values.yaml
+++ b/deploy/charts/rolemesh/values.yaml
@@ -22,6 +22,14 @@
 #   pod-security.kubernetes.io/enforce: restricted
 # (kind/RKE2 docs in deploy/kind/README and the RKE2 doc show how.)
 
+# -- Cluster DNS domain ------------------------------------------------------
+# The cluster's DNS domain. Feeds BOTH the agent pod DNS search domains
+# (orchestrator ROLEMESH_K8S_CLUSTER_DOMAIN) and the gateway's internal DNS
+# allowlist FQDNs, so the names agents query equal the names allowlisted.
+# Default fits stock clusters (kind/EKS/GKE/RKE2); override only if your
+# cluster was built with a custom domain.
+clusterDomain: cluster.local
+
 # -- Images ------------------------------------------------------------------
 # tag "" falls back to Chart.appVersion (see _helpers rolemesh.imageTag).
 image:
@@ -94,6 +102,18 @@ egressGateway:
   # so the privileged port 53 is unreachable inside the pod). The Service
   # maps the well-known 53 -> 1053. Do not change without changing both.
   dnsContainerPort: 1053
+  # Recursive DNS upstream for the gateway resolver. REQUIRED on K8s: set
+  # to the cluster's kube-dns ClusterIP so cluster-internal Service names
+  # (nats, the gateway) resolve. The source default (8.8.8.8,1.1.1.1) is
+  # public and cannot see internal names. Discover it with:
+  #   kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}'
+  # Typically the Service CIDR's .10 (kind: 10.96.0.10; EKS: 10.100.0.10).
+  upstreamDns: ""  # REQUIRED — e.g. "10.96.0.10"
+  # Extra DNS allowlist entries appended to the chart-templated internal
+  # Service FQDNs (nats, gateway). Exact names or "*.suffix". Tenant-custom
+  # egress destinations the agent must resolve directly go here; MCP/LLM
+  # upstreams are resolved by the gateway, not the agent, so they do NOT.
+  dnsAllowlistExtra: []
   resources:
     requests:
       cpu: 100m
@@ -101,12 +121,12 @@ egressGateway:
     limits:
       cpu: "1"
       memory: 512Mi
-  # Egress gateway extra env (DNS allowlist/mode, upstream base URLs).
-  # These mirror the compose pass-through set.
+  # Egress gateway extra env (provider base-URL overrides etc.), mirroring
+  # the compose pass-through set. NOTE: EGRESS_UPSTREAM_DNS and
+  # EGRESS_DNS_ALLOWLIST are first-class knobs above (upstreamDns /
+  # dnsAllowlistExtra) — set those, not extraEnv, so the chart keeps them
+  # consistent with the agent search domains.
   extraEnv: {}
-    # EGRESS_UPSTREAM_DNS: "8.8.8.8"
-    # EGRESS_DNS_ALLOWLIST: "api.anthropic.com,api.openai.com"
-    # EGRESS_DNS_MODE: "allowlist"
     # ANTHROPIC_BASE_URL: ""
     # OPENAI_BASE_URL: ""
     # GOOGLE_BASE_URL: ""

--- a/src/rolemesh/container/k8s_runtime.py
+++ b/src/rolemesh/container/k8s_runtime.py
@@ -222,6 +222,7 @@ def spec_to_pod_manifest(
     image_pull_secret: str = "",
     image_pull_policy: str = "IfNotPresent",
     runtime_class: str = "",
+    cluster_domain: str = "cluster.local",
 ) -> dict[str, Any]:
     """Map a ContainerSpec to a bare-Pod manifest (docs/21 §4.4).
 
@@ -314,7 +315,22 @@ def spec_to_pod_manifest(
     # default (kube-dns) — appropriate only for non-agent pods.
     if spec.dns:
         pod_spec["dnsPolicy"] = "None"
-        pod_spec["dnsConfig"] = {"nameservers": list(spec.dns)}
+        dns_config: dict[str, Any] = {"nameservers": list(spec.dns)}
+        # dnsPolicy: None carries NO default search domains. Without them a
+        # short Service name like "nats" (NATS_URL is nats://nats:4222,
+        # byte-identical to compose) is sent to the gateway resolver bare
+        # and kube-dns NXDOMAINs it. Mirror kubelet's ClusterFirst search
+        # path + ndots=5 so getaddrinfo("nats") expands to the FQDN
+        # nats.<ns>.svc.<domain> before it leaves the pod — which the
+        # gateway's DNS allowlist (chart-templated) is keyed on.
+        if namespace and cluster_domain:
+            dns_config["searches"] = [
+                f"{namespace}.svc.{cluster_domain}",
+                f"svc.{cluster_domain}",
+                cluster_domain,
+            ]
+            dns_config["options"] = [{"name": "ndots", "value": "5"}]
+        pod_spec["dnsConfig"] = dns_config
 
     # extra_hosts -> hostAliases. On K8s the metadata blackhole duty is
     # carried by the default-deny NetworkPolicy, but the mapping is kept
@@ -653,6 +669,7 @@ class K8sRuntime:
         core = self._ensure_core()
         from rolemesh.core.config import (
             DATA_DIR,
+            ROLEMESH_K8S_CLUSTER_DOMAIN,
             ROLEMESH_K8S_DATA_PVC,
             ROLEMESH_K8S_IMAGE_PULL_POLICY,
             ROLEMESH_K8S_IMAGE_PULL_SECRET,
@@ -668,6 +685,7 @@ class K8sRuntime:
             image_pull_secret=ROLEMESH_K8S_IMAGE_PULL_SECRET,
             image_pull_policy=ROLEMESH_K8S_IMAGE_PULL_POLICY,
             runtime_class=ROLEMESH_K8S_RUNTIME_CLASS,
+            cluster_domain=ROLEMESH_K8S_CLUSTER_DOMAIN,
         )
 
         await self._delete_and_wait_gone(spec.name, ROLEMESH_K8S_NAMESPACE)

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -141,6 +141,11 @@ ROLEMESH_CONTAINER_RUNTIME: str = os.environ.get("ROLEMESH_CONTAINER_RUNTIME", "
 #   ROLEMESH_K8S_RUNTIME_CLASS    RuntimeClass used when a spec asks for the
 #                                 gVisor OCI runtime (spec.runtime="runsc");
 #                                 empty = the conventional name "gvisor"
+#   ROLEMESH_K8S_CLUSTER_DOMAIN   cluster DNS domain (default "cluster.local").
+#                                 Used to build the agent pod's DNS search
+#                                 domains so short Service names (e.g. "nats")
+#                                 resolve under dnsPolicy: None (see
+#                                 k8s_runtime.spec_to_pod_manifest).
 ROLEMESH_K8S_NAMESPACE: str = os.environ.get("ROLEMESH_K8S_NAMESPACE", "rolemesh")
 ROLEMESH_K8S_DATA_PVC: str = os.environ.get("ROLEMESH_K8S_DATA_PVC", "rolemesh-data")
 ROLEMESH_K8S_IMAGE_PULL_SECRET: str = os.environ.get("ROLEMESH_K8S_IMAGE_PULL_SECRET", "")
@@ -148,6 +153,9 @@ ROLEMESH_K8S_IMAGE_PULL_POLICY: str = os.environ.get(
     "ROLEMESH_K8S_IMAGE_PULL_POLICY", "IfNotPresent"
 )
 ROLEMESH_K8S_RUNTIME_CLASS: str = os.environ.get("ROLEMESH_K8S_RUNTIME_CLASS", "")
+ROLEMESH_K8S_CLUSTER_DOMAIN: str = os.environ.get(
+    "ROLEMESH_K8S_CLUSTER_DOMAIN", "cluster.local"
+)
 
 # OCI runtime selection (R1). "runc" is the default; "runsc" enables gVisor
 # syscall-level sandboxing and requires runsc to be registered in

--- a/tests/container/test_k8s_runtime.py
+++ b/tests/container/test_k8s_runtime.py
@@ -422,6 +422,40 @@ def test_dns_forces_resolver_via_dnspolicy_none() -> None:
     assert pod_spec["dnsConfig"]["nameservers"] == ["172.28.100.53"]
 
 
+def test_dns_config_carries_cluster_search_domains() -> None:
+    """dnsPolicy None must supply search domains + ndots itself.
+
+    dnsPolicy: None carries NO default search path, so a short Service
+    name like "nats" is sent bare and kube-dns NXDOMAINs it — the agent
+    then cannot reach NATS at all. The manifest must mirror kubelet's
+    ClusterFirst search list (<ns>.svc.<domain>, svc.<domain>, <domain>)
+    + ndots=5 so getaddrinfo("nats") expands to the FQDN.
+
+    Mutation caught: omitting searches/options (the original bug) leaves
+    every short-name lookup failing; this asserts both are present and
+    namespace/cluster-domain-templated.
+    """
+    spec = ContainerSpec(name="a", image="img", dns=["172.28.100.53"])
+    dns_config = _manifest(spec, namespace="troposai", cluster_domain="cluster.local")[
+        "spec"
+    ]["dnsConfig"]
+    assert dns_config["searches"] == [
+        "troposai.svc.cluster.local",
+        "svc.cluster.local",
+        "cluster.local",
+    ]
+    assert {"name": "ndots", "value": "5"} in dns_config["options"]
+
+
+def test_dns_search_honours_custom_cluster_domain() -> None:
+    """A non-default cluster domain flows into every search entry."""
+    spec = ContainerSpec(name="a", image="img", dns=["10.0.0.10"])
+    searches = _manifest(spec, namespace="ns1", cluster_domain="k8s.internal")["spec"][
+        "dnsConfig"
+    ]["searches"]
+    assert searches == ["ns1.svc.k8s.internal", "svc.k8s.internal", "k8s.internal"]
+
+
 def test_no_dns_keeps_cluster_default() -> None:
     """Empty spec.dns must NOT pin dnsPolicy None (would break the gateway pod).
 


### PR DESCRIPTION
## What

Makes the Kubernetes **agent DNS path actually work end to end**. An agent resolving the short name `nats` through the gateway resolver and connecting to NATS was never exercised: `helm test` only ran the deny probe (agent can't reach the internet) and the in-cluster lifecycle smoke spawned agents that exited immediately. So both `helm test` and the orchestrator's `Infrastructure verified` were green **while a real agent could not resolve `nats` at all** — a false green.

Four issues, surfaced by the downstream **tropos** project and all reproduced on rolemesh `main`. The root causes are all in rolemesh (chart + one source bug), so downstreams inherit the fix after a version bump; the only per-cluster value they supply is `egressGateway.upstreamDns` (their kube-dns ClusterIP).

## The four fixes

| # | Layer | Problem | Fix |
|---|-------|---------|-----|
| #2 | chart | `agent-allow-egress` allowed the gateway DNS **Service** port 53, but NetworkPolicy matches the post-DNAT **container** port (1053) | Route both DNS ports — and `gateway-policy` ingress — through the single `egressGateway.dnsContainerPort` value so they can't drift |
| #3 | chart | resolver default-denies (empty allowlist + `enforce`) → every agent lookup NXDOMAINs | Template `EGRESS_DNS_ALLOWLIST` from the internal Service FQDNs the chart already knows (`nats`, gateway), merged with `egressGateway.dnsAllowlistExtra` |
| #4 | chart | upstream defaults to public DNS, which can't resolve cluster names | Add required `egressGateway.upstreamDns` (kube-dns ClusterIP); `values-kind` sets `10.96.0.10` |
| #5 | **source** | `K8sRuntime` set `dnsPolicy:None` + nameservers but **no `searches`**, so short names never expand | Add cluster search domains + `ndots=5` (`ROLEMESH_K8S_CLUSTER_DOMAIN`); orchestrator now sources `ROLEMESH_K8S_NAMESPACE` from the **Downward API** so search domains and allowlist FQDNs share one namespace by construction |

Plus **#1**: a positive `helm-test` **connectivity probe** that reproduces the real agent `dnsConfig`, resolves the short name `nats`, and reads the NATS `INFO` banner — the counterpart the deny probe never covered. This is what closes the false green.

## Validation (kind + Calico)

- `helm install` clean; orchestrator logs `Infrastructure verified`.
- **`helm test` — both probes Succeed**: `deny-probe` (isolation intact, no regression) and the new `connectivity-probe` (agent resolves `nats` → reaches NATS).
- A **real `K8sRuntime`-spawned agent** resolves `nats` → NATS ClusterIP and reads the `INFO {"serve...` banner (exit 0) — proves the genuine spawn path, not just the templated probe.
- 54 k8s unit tests (2 new for search domains) + `mypy --strict` clean; full host suite green except the 3 pre-existing `webui` xdist flakes (pass serially).

## Note for downstream (tropos)

After bumping to include this, tropos only needs to set `egressGateway.upstreamDns` to its cluster's kube-dns ClusterIP and confirm its namespace — everything else (port, search domains, internal allowlist) is inherited with zero config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
