### PR TITLE
fix(egress): resolve internal DNS names via the platform resolver

### DIFF
--- a/deploy/charts/rolemesh/templates/NOTES.txt
+++ b/deploy/charts/rolemesh/templates/NOTES.txt
@@ -12,9 +12,16 @@ RoleMesh has been installed as release {{ .Release.Name }} in namespace {{ .Rele
 
      helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
 
-   The deny probe pod (labeled rolemesh.io/role=agent) tries to reach the
-   public internet and MUST be blocked. If `helm test` fails, your CNI is
-   not enforcing policy — DO NOT run real agents. Use Calico/Cilium.
+   `helm test` runs two paired probes (both labeled rolemesh.io/role=agent):
+     * deny-probe — MUST be BLOCKED reaching the public internet (proves the
+       CNI enforces isolation; a successful connect is a false green).
+     * connectivity-probe — MUST resolve `nats`/`egress-gateway` through the
+       gateway and CONNECT to nats:4222 + gateway:3001, while an external
+       name stays blocked (proves the golden path: the agent can actually
+       reach the bus, not just that the YAML looks right). This is the
+       in-cluster, repeatable check that the DNS internal-name exemption +
+       the agent egress NetworkPolicy rules work on the real CNI.
+   If either fails, DO NOT run real agents. Use Calico/Cilium.
 
    NOTE (docs/21 §4.2): swapping the CNI AFTER install is unguarded — the
    startup verify checks policy OBJECTS exist, not that they are enforced.

--- a/deploy/charts/rolemesh/templates/egress-gateway.yaml
+++ b/deploy/charts/rolemesh/templates/egress-gateway.yaml
@@ -109,6 +109,11 @@ spec:
             # set here for the K8s binding to be correct.
             - name: EGRESS_GATEWAY_DNS_PORT
               value: {{ $dnsPort | quote }}
+            # Cluster DNS domain for the internal-name exemption suffix
+            # (egress/dns_internal.py). Single source of truth shared with
+            # the orchestrator and the connectivity-probe: .Values.clusterDomain.
+            - name: ROLEMESH_K8S_CLUSTER_DOMAIN
+              value: {{ .Values.clusterDomain | default "cluster.local" | quote }}
             - name: EGRESS_TOKEN_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/charts/rolemesh/templates/networkpolicy.yaml
+++ b/deploy/charts/rolemesh/templates/networkpolicy.yaml
@@ -16,6 +16,7 @@ DO NOT template these names or the agent selector off the release name.
 */ -}}
 {{- $natsSvc := include "rolemesh.natsServiceName" . -}}
 {{- $kubeDnsNs := .Values.networkPolicy.kubeDns.namespace -}}
+{{- $dnsPort := .Values.egressGateway.dnsContainerPort | int -}}
 ---
 # 1. agent-default-deny: every agent pod, all ingress + egress denied.
 #    Standalone so the "default deny" invariant is independently verifiable.
@@ -35,7 +36,7 @@ spec:
     - Egress
   # No ingress/egress rules == deny all.
 ---
-# 2. agent-allow-egress: agent -> gateway (53 udp+tcp, 3001, 3128) and
+# 2. agent-allow-egress: agent -> gateway (DNS, 3001, 3128) and
 #    agent -> NATS (4222) ONLY. kube-dns is deliberately NOT allowed:
 #    agents resolve every name through the gateway resolver (docs/21 §6.3).
 apiVersion: networking.k8s.io/v1
@@ -52,8 +53,17 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # -> egress gateway: DNS (53 udp+tcp -> Service maps to container 1053),
-    #    credential proxy / healthz (3001), forward proxy (3128).
+    # -> egress gateway: DNS, credential proxy / healthz (3001), forward
+    #    proxy (3128).
+    #
+    # DNS: the agent's nameserver is the gateway Service ClusterIP:53,
+    # which DNATs to the gateway pod's dnsContainerPort ({{ $dnsPort }};
+    # PSA restricted forbids binding 53). A NetworkPolicy port is the
+    # DESTINATION POD port, so CNIs that evaluate egress post-DNAT (Calico,
+    # Cilium) see {{ $dnsPort }} while pre-DNAT ones see 53. Allow BOTH so
+    # agent DNS works regardless of the CNI's DNAT ordering — the
+    # gateway-policy ingress (below) admits only {{ $dnsPort }}, so the
+    # gateway is reached on its real port either way.
     - to:
         - podSelector:
             matchLabels:
@@ -61,6 +71,8 @@ spec:
       ports:
         - { protocol: UDP, port: 53 }
         - { protocol: TCP, port: 53 }
+        - { protocol: UDP, port: {{ $dnsPort }} }
+        - { protocol: TCP, port: {{ $dnsPort }} }
         - { protocol: TCP, port: 3001 }
         - { protocol: TCP, port: 3128 }
     # -> NATS (4222): agent lifecycle + protocol traffic rides NATS.

--- a/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
+++ b/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
@@ -96,6 +96,12 @@ spec:
               value: {{ .Values.image.pullSecret | quote }}
             - name: ROLEMESH_K8S_RUNTIME_CLASS
               value: {{ .Values.orchestrator.runtimeClass | quote }}
+            # Single source of truth for the cluster DNS domain: the agent
+            # pod search domains (here, via k8s_runtime), the gateway's
+            # internal-name exemption suffix, and the connectivity-probe
+            # search domains all derive from .Values.clusterDomain.
+            - name: ROLEMESH_K8S_CLUSTER_DOMAIN
+              value: {{ .Values.clusterDomain | default "cluster.local" | quote }}
             # Startup guard (main._ensure_container_system_running) reads
             # this even in k8s mode; the pod mapping ignores it. Keep
             # non-empty.

--- a/deploy/charts/rolemesh/templates/tests/connectivity-probe.yaml
+++ b/deploy/charts/rolemesh/templates/tests/connectivity-probe.yaml
@@ -1,0 +1,136 @@
+{{- /*
+helm test connectivity probe (docs/21 §6.3) — the POSITIVE-path partner of
+deny-probe.yaml. deny-probe proves the CNI BLOCKS what it must; this proves
+it PASSES what it must, end-to-end, on the real cluster.
+
+It is the permanent, repeatable closure of the "T-NET-3 never runs on real
+infra" false-green: a pod carrying the agent role label + the exact agent
+dnsConfig (dnsPolicy None, resolver pinned at the gateway, cluster search +
+ndots:5 — mirrors k8s_runtime.spec_to_pod_manifest, whose output is locked
+by tests/container/test_k8s_runtime.py) that:
+
+  1. RESOLVES internal names (nats, egress-gateway) — short names complete
+     via the search list and route through the gateway's internal-name
+     exemption to kube-dns (egress/dns_internal.py).
+  2. CONNECTS to nats:4222 and the gateway:3001. Resolution is not reach:
+     these are separate NetworkPolicy egress rules, and the 53-vs-1053 bug
+     proved a YAML port that "looks right" can still be dropped by the CNI.
+     A bare gethostbyname would not have caught it; a real TCP connect does.
+  3. Confirms the DNS-exfil tripwire still bites — a non-allowlisted
+     external name must NOT resolve.
+
+Runs in-cluster, so it reaches ClusterIPs natively (no host route hack) and
+is portable to kind and RKE2 alike. Any failure exits non-zero -> helm test
+fails. Host-search-domain pollution (an exfil-class regression) is
+environment-specific and is locked by the dns_internal unit tests instead.
+*/ -}}
+{{- $clusterDomain := .Values.clusterDomain | default "cluster.local" -}}
+{{- $gwIP := required "egressGateway.clusterIP is REQUIRED for the connectivity probe (= EGRESS_GATEWAY_DNS_IP)." .Values.egressGateway.clusterIP -}}
+{{- $nats := include "rolemesh.natsServiceName" . -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "rolemesh.fullname" . }}-connectivity-probe
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rolemesh.labels" . | nindent 4 }}
+    # Subjects the probe to the agent NetworkPolicies, exactly like a real
+    # agent. MUST match AGENT_ROLE_LABEL/VALUE.
+    rolemesh.io/role: agent
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  # Mirrors k8s_runtime.spec_to_pod_manifest: dnsPolicy None pins the agent
+  # resolver at the gateway and supplies the cluster search list + ndots:5,
+  # so a short `nats` completes to its FQDN and routes through the gateway
+  # exemption. If these drift from the runtime's output, the probe's
+  # resolution stops matching real agents — and test_k8s_runtime guards the
+  # runtime side.
+  dnsPolicy: None
+  dnsConfig:
+    nameservers:
+      - {{ $gwIP | quote }}
+    searches:
+      - {{ printf "%s.svc.%s" .Release.Namespace $clusterDomain | quote }}
+      - {{ printf "svc.%s" $clusterDomain | quote }}
+      - {{ $clusterDomain | quote }}
+    options:
+      - name: ndots
+        value: "5"
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: probe
+      image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      env:
+        - name: NATS_HOST
+          value: {{ $nats | quote }}
+      command:
+        - python
+        - -c
+        - |
+          import json, os, socket, sys
+
+          results = {}
+          ok = True
+
+          def expect_resolves(name):
+              global ok
+              try:
+                  results["resolve " + name] = socket.gethostbyname(name)
+              except OSError as exc:
+                  results["resolve " + name] = "FAILED (%s)" % type(exc).__name__
+                  ok = False
+
+          def expect_connects(host, port):
+              global ok
+              try:
+                  with socket.create_connection((host, port), timeout=8):
+                      results["connect %s:%d" % (host, port)] = "OK"
+              except OSError as exc:
+                  results["connect %s:%d" % (host, port)] = "FAILED (%s)" % type(exc).__name__
+                  ok = False
+
+          def expect_blocked(name):
+              global ok
+              try:
+                  ip = socket.gethostbyname(name)
+                  results["resolve " + name] = "RESOLVED %s (should be blocked!)" % ip
+                  ok = False
+              except OSError:
+                  results["resolve " + name] = "blocked as required"
+
+          nats = os.environ["NATS_HOST"]
+          # 1. internal names resolve via gateway exemption -> kube-dns.
+          expect_resolves(nats)
+          expect_resolves("egress-gateway")
+          # 2. and the agent actually REACHES them — separate NetworkPolicy
+          #    egress rules, proven on the real CNI, not just resolved.
+          expect_connects(nats, 4222)
+          expect_connects("egress-gateway", 3001)
+          # 3. the DNS-exfil tripwire still bites.
+          expect_blocked("contract-denied.example.com")
+
+          print(json.dumps(results, indent=2))
+          if not ok:
+              print("FAIL: golden-path connectivity probe", file=sys.stderr)
+              sys.exit(1)
+          print("PASS: internal names resolve + reachable (NATS, gateway); "
+                "external blocked")

--- a/deploy/charts/rolemesh/values.yaml
+++ b/deploy/charts/rolemesh/values.yaml
@@ -23,11 +23,13 @@
 # (kind/RKE2 docs in deploy/kind/README and the RKE2 doc show how.)
 
 # -- Cluster DNS domain ------------------------------------------------------
-# The cluster's DNS domain (kubeadm/kind/RKE2 default "cluster.local"). Used
-# by the connectivity-probe helm test to build the agent search domains; it
-# MUST equal the orchestrator's ROLEMESH_K8S_CLUSTER_DOMAIN (which the agent
-# pod search domains are derived from). Override only on a cluster that set
-# kubelet --cluster-domain to something else.
+# The cluster's DNS domain (kubeadm/kind/RKE2 default "cluster.local"). SINGLE
+# SOURCE OF TRUTH: the chart injects it as ROLEMESH_K8S_CLUSTER_DOMAIN into the
+# orchestrator (which stamps agent pod search domains) and the gateway (the
+# internal-name exemption suffix), and the connectivity-probe helm test builds
+# its search domains from it — so all three stay consistent. Override only on a
+# cluster whose kubelet sets --cluster-domain to something other than
+# cluster.local.
 clusterDomain: cluster.local
 
 # -- Images ------------------------------------------------------------------

--- a/deploy/charts/rolemesh/values.yaml
+++ b/deploy/charts/rolemesh/values.yaml
@@ -22,6 +22,14 @@
 #   pod-security.kubernetes.io/enforce: restricted
 # (kind/RKE2 docs in deploy/kind/README and the RKE2 doc show how.)
 
+# -- Cluster DNS domain ------------------------------------------------------
+# The cluster's DNS domain (kubeadm/kind/RKE2 default "cluster.local"). Used
+# by the connectivity-probe helm test to build the agent search domains; it
+# MUST equal the orchestrator's ROLEMESH_K8S_CLUSTER_DOMAIN (which the agent
+# pod search domains are derived from). Override only on a cluster that set
+# kubelet --cluster-domain to something else.
+clusterDomain: cluster.local
+
 # -- Images ------------------------------------------------------------------
 # tag "" falls back to Chart.appVersion (see _helpers rolemesh.imageTag).
 image:

--- a/docs/16-egress-control-architecture.md
+++ b/docs/16-egress-control-architecture.md
@@ -231,9 +231,26 @@ Why platform-level is sufficient — and why the list stays empty:
   the **gateway** resolves it on its own egress-side resolver path,
   which this policy does not touch. Per-tenant access control happens
   at the CONNECT / reverse-proxy layer, unchanged.
-- Container names (`nats`, `egress-gateway`) are answered locally by
-  Docker's embedded DNS (127.0.0.11); only external names are
-  forwarded to the gateway resolver.
+- Internal names (`nats`, `egress-gateway`, and on Kubernetes anything
+  under `*.cluster.local`) are resolved by the platform's own resolver,
+  not the gateway's allowlist. The two runtimes reach the same outcome by
+  different routes:
+  - **Docker**: the agent's resolver is the embedded DNS (`127.0.0.11`),
+    which answers container names locally and forwards only external names
+    to the gateway (its configured upstream). Internal names never reach
+    the gateway resolver.
+  - **Kubernetes**: pods have no per-container embedded DNS — `dnsPolicy:
+    None` pins the agent's resolver straight at the gateway — so the
+    gateway itself **exempts** internal names from the allowlist and
+    forwards them to kube-dns. It derives the internal-name set and that
+    resolver from its OWN `/etc/resolv.conf`, so the same code is correct
+    on both runtimes with no per-runtime branching
+    (`src/rolemesh/egress/dns_internal.py`).
+
+  Either way it is **not** an exfil channel: the platform resolver is
+  authoritative for these names and never forwards them to a public
+  upstream, so an attacker's DNS server can never receive them. Only
+  external names are evaluated against `EGRESS_DNS_ALLOWLIST`.
 - Therefore every query that reaches this resolver comes from code
   bypassing the proxy convention — a tool missing proxy config, or a
   DNS-exfiltration attempt. Allowing a name here rescues no legitimate
@@ -373,7 +390,7 @@ If item 1 fails = EC-1 as a whole is pointless.
 - **Business logic** moves to `src/rolemesh/egress/reverse_proxy.py`
 - `credential_proxy.py` keeps a thin re-export, **all public APIs (`start_credential_proxy / register_mcp_server / set_token_vault`, etc.) retain their paths** — external imports unchanged
 - The Gateway process is containerized, listening on the same 3001 port (inside the Gateway container)
-- Agents access it via `http://egress-gateway:3001/...` (Docker's built-in DNS resolves the container name)
+- Agents access it via `http://egress-gateway:3001/...`; the container name `egress-gateway` is resolved by the platform resolver (Docker embedded DNS / kube-dns), not the allowlist — see "DNS plane" above
 
 **Migrate, not rewrite** — business logic (credential selection, provider registration, token vault) is preserved as-is.
 

--- a/docs/21-container-runtime-decoupling.md
+++ b/docs/21-container-runtime-decoupling.md
@@ -314,6 +314,31 @@ build infrastructure — that is itself a test of "declarative".
 Acceptance: all green on local Ubuntu docker (incl. runsc); all green on kind
 (Calico) on the same machine; one suite, zero runtime branches.
 
+The positive K8s golden path (internal names resolve through the gateway
+exemption AND the agent reaches the bus) has a second, in-cluster home: the
+`connectivity-probe` helm test (paired with `deny-probe`). Unlike the pytest
+contract suite — whose `verify_infrastructure` pre-flight hits the gateway
+ClusterIP:3001 from the test process and so cannot run from OUTSIDE the
+cluster (a host route to the Service CIDR is a non-portable hack, not a
+fix) — the probe runs as a pod, reaches ClusterIPs natively, and gives a
+repeatable regression guard on kind and RKE2 alike. It resolves
+`nats`/`egress-gateway` and TCP-connects to nats:4222 + gateway:3001 (the
+53-vs-1053 NetworkPolicy bug proved resolution ≠ reachability — connect,
+don't just resolve), and confirms an external name stays blocked.
+
+### Known limitations
+
+- **Internal SRV/TXT stay refused.** The internal-name exemption runs after
+  the A/AAAA/CNAME qtype gate, so SRV/TXT for internal names are still
+  REFUSED. Sufficient today (NATS dials an A record); revisit only if an
+  internal flow genuinely needs SRV.
+- **The pytest contract suite's k8s mode needs cluster-network reach.** Its
+  `verify_infrastructure` pre-flight assumes the runner can reach the
+  gateway ClusterIP, true on an in-cluster/RKE2 node but not from a kind
+  host. Until that pre-flight grows an in-cluster mode, the `helm test`
+  connectivity-probe is the portable positive-path guard. (Tracked as a
+  follow-up; not blocking.)
+
 ## 10. Deployment
 
 ### 10.1 Local: `deploy/compose/compose.yaml` (replaces process-style README)

--- a/docs/21-container-runtime-decoupling.md
+++ b/docs/21-container-runtime-decoupling.md
@@ -216,12 +216,29 @@ the §3 mapping philosophy each side uses its own mechanism:
 - K8s: container listens on 1053, Service maps 53 -> 1053; the namespace is
   fully PSA `restricted`.
 
-Upstream policy (rev4 addition, P2 work item): agents resolve internal
-service names (`nats`, `egress-gateway`) through the gateway resolver too.
-Its recursive upstream differs: Docker forwards to Docker embedded DNS
-(127.0.0.11); K8s forwards to kube-dns (read from the gateway's own
-resolv.conf — the gateway keeps the default dnsPolicy). Contract case T-NET
-locks: agent resolves `nats` via gateway; non-allowlisted domains NXDOMAIN.
+Internal-name resolution (rev5). Internal names (`nats`, `egress-gateway`,
+and `*.cluster.local` on K8s) resolve via the platform's own resolver, by
+different routes per runtime:
+
+- Docker: the agent's resolver is the embedded DNS (127.0.0.11), which
+  answers container names locally and forwards only external names to the
+  gateway. Internal names never reach the gateway resolver — no exemption
+  needed. (This is why the empty-allowlist default works on Docker but
+  broke on K8s when tropos first ran a full agent round-trip there.)
+- K8s: `dnsPolicy: None` pins the agent's resolver straight at the gateway,
+  so the gateway itself EXEMPTS internal names from the allowlist and
+  forwards them to kube-dns. It reads both the internal-name set and the
+  kube-dns address from its OWN `/etc/resolv.conf` (the gateway keeps the
+  default ClusterFirst dnsPolicy), so the same code is correct on both
+  runtimes with no docker/k8s fork — `src/rolemesh/egress/dns_internal.py`.
+  Only suffixes within the cluster domain are exempt; an inherited host
+  search domain is not, or it would reopen the exfil channel. The exemption
+  is the partner of the agent pod's `dnsConfig` search domains + `ndots:5`
+  (§3): the search list turns a short `nats` into
+  `nats.<ns>.svc.cluster.local`, which the exemption then routes to kube-dns.
+
+Contract case T-NET-3 locks the behaviour: the agent resolves `nats` and the
+gateway, while a non-allowlisted external domain NXDOMAINs.
 
 ### 6.4 gVisor
 

--- a/src/rolemesh/container/k8s_runtime.py
+++ b/src/rolemesh/container/k8s_runtime.py
@@ -77,6 +77,19 @@ REQUIRED_COMPONENT_NETWORK_POLICIES: tuple[str, ...] = (
 # different name.
 _DEFAULT_GVISOR_RUNTIME_CLASS = "gvisor"
 
+# Cluster DNS domain (docs/21 §6.3). Agents run with dnsPolicy None, which
+# drops the kubelet-injected resolv.conf entirely, so the agent pod must
+# carry the cluster search domains itself or a short name like ``nats``
+# is never completed to ``nats.<ns>.svc.cluster.local``. Overridable for
+# clusters that customised --cluster-domain.
+_CLUSTER_DOMAIN = os.environ.get("ROLEMESH_K8S_CLUSTER_DOMAIN", "cluster.local")
+
+# Matches the kubelet ClusterFirst default. Names with fewer than this many
+# dots get the search list appended before being tried absolute — so a
+# 1-dot internal name resolves via search, and only genuinely-qualified
+# external names skip it.
+_NDOTS = "5"
+
 _INSTALL_HINT = (
     "The Kubernetes container backend requires the optional "
     "kubernetes_asyncio dependency. Install it with: uv sync --extra k8s"
@@ -312,9 +325,25 @@ def spec_to_pod_manifest(
     # DNS forced through the gateway resolver (docs/21 §3): dnsPolicy None
     # replaces docker's HostConfig.Dns. Empty spec.dns keeps the cluster
     # default (kube-dns) — appropriate only for non-agent pods.
+    #
+    # dnsPolicy None drops the kubelet resolv.conf wholesale, so the search
+    # domains + ndots must be supplied here. Without them a short internal
+    # name (``nats``) is sent absolute and never completes to its FQDN; the
+    # gateway resolver, in turn, routes anything under cluster.local to
+    # kube-dns (the internal-name exemption — egress/dns_internal.py). The
+    # two are partners: searches turn ``nats`` into a cluster.local FQDN,
+    # the exemption then forwards that FQDN to kube-dns.
     if spec.dns:
         pod_spec["dnsPolicy"] = "None"
-        pod_spec["dnsConfig"] = {"nameservers": list(spec.dns)}
+        pod_spec["dnsConfig"] = {
+            "nameservers": list(spec.dns),
+            "searches": [
+                f"{namespace}.svc.{_CLUSTER_DOMAIN}",
+                f"svc.{_CLUSTER_DOMAIN}",
+                _CLUSTER_DOMAIN,
+            ],
+            "options": [{"name": "ndots", "value": _NDOTS}],
+        }
 
     # extra_hosts -> hostAliases. On K8s the metadata blackhole duty is
     # carried by the default-deny NetworkPolicy, but the mapping is kept

--- a/src/rolemesh/egress/dns_internal.py
+++ b/src/rolemesh/egress/dns_internal.py
@@ -1,0 +1,153 @@
+"""Derive the gateway's internal-name DNS exemption from its own resolv.conf.
+
+The authoritative DNS resolver (``dns_resolver.DnsServer``) blocks every
+name that is not on ``EGRESS_DNS_ALLOWLIST`` — a tripwire against DNS
+exfiltration. But agents must still resolve *internal* names (``nats`` to
+reach the bus, ``egress-gateway`` for the proxies) and, on Kubernetes,
+arbitrary ``*.cluster.local`` service names. Those are not exfil: the
+platform's own resolver is authoritative for them and never forwards them
+to a public upstream, so an attacker's nameserver can never receive them.
+
+This is really the KUBERNETES adapter. On Docker, the agent's resolver is
+the embedded DNS (127.0.0.11); it answers container names (``nats``,
+``egress-gateway``) locally and forwards only external names to the gateway
+(its configured upstream), so internal names never reach the gateway
+resolver and need no exemption. Kubernetes pods have no per-container
+embedded DNS — ``dnsPolicy: None`` pins the agent's resolver straight at
+the gateway — so the gateway must itself recreate that "answer internal
+names from the platform resolver" behaviour. This module derives it,
+runtime-agnostically, from the gateway container's OWN ``/etc/resolv.conf``
+rather than branching on ``ROLEMESH_CONTAINER_RUNTIME``:
+
+  Kubernetes  nameserver = kube-dns ClusterIP
+              search     = <ns>.svc.cluster.local svc.cluster.local cluster.local
+              => internal = any name under the cluster domain. kube-dns is
+                 authoritative for cluster.local and never forwards those
+                 names upstream, so they cannot leak.
+
+  Docker      nameserver = 127.0.0.11 (embedded DNS)
+              search     = (typically an inherited host domain)
+              => internal = single-label names only (a defensive fallback;
+                 real internal names are already answered by the agent's
+                 embedded DNS before reaching the gateway).
+
+Two safety rules keep the exemption from becoming an exfil hole:
+
+  * Only suffixes within ``cluster_domain`` count — an inherited HOST
+    search domain (a dev box's ISP domain, a node's corp domain) must NOT
+    exempt every external name under it. See ``build_internal_exemption``.
+  * Single-label exemption is gated on the Docker embedded-DNS address:
+    kube-dns WOULD forward a bare single label to its own upstream (a
+    leak), whereas ``127.0.0.11`` cannot route a single label anywhere an
+    attacker controls.
+
+Multi-label external names (``secret.attacker.com``) match no internal
+suffix on either runtime and stay on the allowlist path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rolemesh.core.logger import get_logger
+
+from .dns_resolver import InternalMatcher, UpstreamResolver
+
+logger = get_logger()
+
+# Docker's embedded DNS, fixed by Docker at this address. Its presence as
+# the gateway's resolver is what makes single-label names safe to treat as
+# internal (see the module docstring).
+DOCKER_EMBEDDED_DNS = "127.0.0.11"
+
+
+@dataclass(frozen=True)
+class ResolvConf:
+    """The fields of /etc/resolv.conf this module cares about."""
+
+    nameservers: tuple[str, ...] = ()
+    search: tuple[str, ...] = ()
+
+
+def parse_resolv_conf(text: str) -> ResolvConf:
+    """Parse ``nameserver`` and ``search`` / ``domain`` lines.
+
+    Mirrors the libc resolver where it matters: the last ``search`` (or
+    ``domain``) line wins, trailing dots on suffixes are stripped, and
+    comments (``#`` / ``;``) are ignored. Other directives are dropped.
+    """
+    nameservers: list[str] = []
+    search: tuple[str, ...] = ()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line[0] in "#;":
+            continue
+        parts = line.split()
+        if parts[0] == "nameserver" and len(parts) >= 2:
+            nameservers.append(parts[1])
+        elif parts[0] in ("search", "domain") and len(parts) >= 2:
+            search = tuple(p.rstrip(".").lower() for p in parts[1:] if p.strip("."))
+    return ResolvConf(nameservers=tuple(nameservers), search=search)
+
+
+def _is_ipv4(addr: str) -> bool:
+    """True for a dotted-quad. The upstream forwarder is AF_INET only, so
+    IPv6 nameservers (kube-dns dual-stack, link-local) are skipped."""
+    octets = addr.split(".")
+    if len(octets) != 4:
+        return False
+    try:
+        return all(0 <= int(o) <= 255 for o in octets)
+    except ValueError:
+        return False
+
+
+def build_internal_exemption(
+    resolv: ResolvConf,
+    *,
+    cluster_domain: str = "cluster.local",
+) -> tuple[InternalMatcher, list[UpstreamResolver]] | None:
+    """Build ``(is_internal, internal_upstreams)`` from a parsed resolv.conf.
+
+    Only search suffixes WITHIN *cluster_domain* count as internal. This is
+    the load-bearing safety filter: a gateway container often inherits the
+    host's search domain (a dev box's ISP domain, a node's corp domain),
+    and treating that as internal would exempt every external name under it
+    from the allowlist — reopening the exfil channel. The cluster domain is
+    the only suffix the platform's own resolver is authoritative for.
+
+    Returns ``None`` when no exemption can be derived — no usable IPv4
+    nameserver, or nothing that counts as internal — in which case the
+    caller leaves the resolver fail-closed (every name on the allowlist
+    path). Never returns an exemption without a resolver to forward to.
+    """
+    upstreams = [UpstreamResolver(host=ns) for ns in resolv.nameservers if _is_ipv4(ns)]
+    if not upstreams:
+        return None
+
+    cluster_domain = cluster_domain.rstrip(".").lower()
+    suffixes = tuple(s for s in resolv.search if s and (s == cluster_domain or s.endswith("." + cluster_domain)))
+    single_label_internal = DOCKER_EMBEDDED_DNS in resolv.nameservers
+
+    if not suffixes and not single_label_internal:
+        return None
+
+    def is_internal(qname: str) -> bool:
+        name = qname.rstrip(".").lower()
+        if not name:
+            return False
+        if "." not in name:
+            # Bare single label: only internal where the platform resolver
+            # answers such names locally without an upstream hop (Docker).
+            return single_label_internal
+        return any(name == suf or name.endswith("." + suf) for suf in suffixes)
+
+    return is_internal, upstreams
+
+
+__all__ = [
+    "DOCKER_EMBEDDED_DNS",
+    "ResolvConf",
+    "build_internal_exemption",
+    "parse_resolv_conf",
+]

--- a/src/rolemesh/egress/dns_resolver.py
+++ b/src/rolemesh/egress/dns_resolver.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import socket
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -73,6 +74,15 @@ class UpstreamResolver:
     port: int = 53
 
 
+# Predicate over a (trailing-dot-stripped) qname. True for an "internal"
+# name — one the platform's own resolver is authoritative for and will
+# never forward to a public upstream (Kubernetes ``*.cluster.local``,
+# Docker single-label container names). Internal names bypass the
+# allowlist tripwire and are forwarded to ``internal_upstreams`` instead.
+# Derived from the gateway's own /etc/resolv.conf; see ``dns_internal``.
+InternalMatcher = Callable[[str], bool]
+
+
 class DnsServer:
     """Asyncio UDP server that evaluates each query against the platform policy.
 
@@ -86,11 +96,23 @@ class DnsServer:
         *,
         policy: GlobalDnsPolicy,
         upstreams: list[UpstreamResolver],
+        internal_matcher: InternalMatcher | None = None,
+        internal_upstreams: list[UpstreamResolver] | None = None,
     ) -> None:
         if not upstreams:
             raise ValueError("DnsServer requires at least one upstream resolver")
+        # The internal-name exemption is all-or-nothing: a matcher with no
+        # upstream to forward to (or an upstream with no matcher) is a
+        # wiring bug, not a degraded mode — fail loud at boot rather than
+        # silently NXDOMAIN every internal name. Both unset (the default)
+        # disables the exemption: every name flows through the allowlist,
+        # the original fail-closed behaviour.
+        if bool(internal_matcher) != bool(internal_upstreams):
+            raise ValueError("internal_matcher and internal_upstreams must be set together")
         self._policy = policy
         self._upstreams = list(upstreams)
+        self._internal_matcher = internal_matcher
+        self._internal_upstreams = list(internal_upstreams or ())
         self._transport: asyncio.DatagramTransport | None = None
 
     async def serve(self, host: str, port: int) -> None:
@@ -155,6 +177,31 @@ class DnsServer:
             respond(_build_error(query, _RCODE_REFUSED))
             return
 
+        # Internal-name exemption (docs/16 "DNS plane"). Names the
+        # platform's own resolver is authoritative for — Kubernetes
+        # ``*.cluster.local``, Docker single-label container names — skip
+        # the allowlist tripwire entirely and forward to that resolver.
+        # This is not an exfil channel: the internal resolver never
+        # forwards these names to a public upstream, so an attacker's
+        # nameserver can never receive them. Without it an agent cannot
+        # resolve ``nats`` to reach the bus. The qtype gate above still
+        # applies, so internal SRV/TXT stay refused. Logged at DEBUG: with
+        # ndots:5 every external lookup first probes the search domains, so
+        # this path is high-volume and must not flood the tripwire's logs.
+        if self._internal_matcher is not None and self._internal_matcher(qname):
+            logger.debug(
+                "dns: internal name forwarded to platform resolver",
+                source=source_addr[0],
+                qname=qname,
+                qtype=qtype,
+            )
+            response_data = await self._resolve_internal(data)
+            if response_data is None:
+                respond(_build_error(query, _RCODE_SERVFAIL))
+                return
+            respond(response_data)
+            return
+
         # Platform-wide policy: same answer for every source. The qname
         # is redacted in logs past the registered domain — exfil
         # attempts put the payload in the leftmost labels, and this
@@ -196,19 +243,26 @@ class DnsServer:
         respond(response_data)
 
     async def _resolve_upstream(self, data: bytes) -> bytes | None:
-        """Forward the raw query to the first upstream that responds.
+        """Forward an allowlisted external query to the public upstreams."""
+        return await self._forward(data, self._upstreams)
+
+    async def _resolve_internal(self, data: bytes) -> bytes | None:
+        """Forward an internal-name query to the platform's own resolver."""
+        return await self._forward(data, self._internal_upstreams)
+
+    async def _forward(self, data: bytes, upstreams: list[UpstreamResolver]) -> bytes | None:
+        """Forward the raw query to the first of *upstreams* that responds.
 
         Run resolvers in parallel with a 2-second budget. Raw-packet
         forwarding preserves client flags (EDNS0, CD, AD) verbatim.
         """
+
         async def _query(up: UpstreamResolver) -> bytes:
             return await _udp_query(up.host, up.port, data, timeout_s=2.0)
 
-        tasks = [asyncio.create_task(_query(up)) for up in self._upstreams]
+        tasks = [asyncio.create_task(_query(up)) for up in upstreams]
         try:
-            done, _pending = await asyncio.wait(
-                tasks, return_when=asyncio.FIRST_COMPLETED, timeout=2.5
-            )
+            done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED, timeout=2.5)
         finally:
             for t in tasks:
                 if not t.done():

--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -61,8 +61,9 @@ from rolemesh.core.config import (
 )
 from rolemesh.core.logger import get_logger
 
+from .dns_internal import build_internal_exemption, parse_resolv_conf
 from .dns_policy import GlobalDnsPolicy
-from .dns_resolver import DnsServer, UpstreamResolver
+from .dns_resolver import DnsServer, InternalMatcher, UpstreamResolver
 from .forward_proxy import ForwardProxy
 from .mcp_cache import (
     apply_snapshot_to_registry,
@@ -113,6 +114,55 @@ _SNAPSHOT_RETRY_INITIAL_S = 1.0
 _SNAPSHOT_RETRY_MAX_S = 30.0
 
 
+def _derive_internal_exemption(
+    resolv_path: str = "/etc/resolv.conf",
+) -> tuple[InternalMatcher | None, list[UpstreamResolver] | None]:
+    """Build the internal-name DNS exemption from the gateway's own
+    resolv.conf (egress/dns_internal.py — runtime-agnostic: kube-dns on
+    K8s, 127.0.0.11 on Docker).
+
+    Returns ``(None, None)`` — exemption disabled, every name stays on the
+    allowlist path — when resolv.conf is unreadable or yields nothing
+    internal. That is fail-closed but degraded: internal names like
+    ``nats`` will NXDOMAIN, so the failure is logged at WARNING with the
+    parsed contents for an operator to diagnose.
+    """
+    try:
+        with open(resolv_path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as exc:
+        logger.warning(
+            "dns: cannot read resolv.conf for internal-name exemption — "
+            "agents may fail to resolve internal services (nats)",
+            path=resolv_path,
+            error=str(exc),
+        )
+        return None, None
+
+    resolv = parse_resolv_conf(text)
+    # Same knob the orchestrator stamps the agent pod search domains with
+    # (k8s_runtime._CLUSTER_DOMAIN), so the two cannot disagree about what
+    # "internal" means.
+    cluster_domain = os.environ.get("ROLEMESH_K8S_CLUSTER_DOMAIN", "cluster.local")
+    exemption = build_internal_exemption(resolv, cluster_domain=cluster_domain)
+    if exemption is None:
+        logger.warning(
+            "dns: no internal-name exemption derived from resolv.conf — "
+            "agents may fail to resolve internal services (nats)",
+            nameservers=list(resolv.nameservers),
+            search=list(resolv.search),
+        )
+        return None, None
+
+    matcher, internal_upstreams = exemption
+    logger.info(
+        "dns: internal-name exemption active",
+        internal_upstreams=[f"{u.host}:{u.port}" for u in internal_upstreams],
+        cluster_domain=cluster_domain,
+    )
+    return matcher, internal_upstreams
+
+
 def _parse_upstream_dns(raw: str) -> list[UpstreamResolver]:
     """Split "8.8.8.8,1.1.1.1:5353" into UpstreamResolver records.
 
@@ -154,13 +204,10 @@ async def _seed_rules_with_retry(
     while True:
         attempt += 1
         try:
-            snapshot = await fetch_snapshot_via_nats(
-                nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S
-            )
+            snapshot = await fetch_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
         except Exception as exc:  # noqa: BLE001 — any RPC failure means "retry"
             logger.warning(
-                "gateway: rule snapshot fetch failed — policy plane stays "
-                "default-deny, retrying",
+                "gateway: rule snapshot fetch failed — policy plane stays default-deny, retrying",
                 attempt=attempt,
                 retry_in_s=delay,
                 error=str(exc),
@@ -185,14 +232,18 @@ async def _cancel_task(task: asyncio.Task[Any]) -> None:
 
 
 async def main() -> None:
-    upstream_dns = _parse_upstream_dns(
-        os.environ.get("EGRESS_UPSTREAM_DNS", _UPSTREAM_DNS_DEFAULT)
-    )
+    upstream_dns = _parse_upstream_dns(os.environ.get("EGRESS_UPSTREAM_DNS", _UPSTREAM_DNS_DEFAULT))
 
     # Platform DNS policy. Loaded before any network setup so a config
     # typo (bad EGRESS_DNS_MODE) kills the boot immediately — same
     # fail-closed posture as the token-authority secret check below.
     dns_policy = GlobalDnsPolicy.from_env()
+
+    # Internal-name exemption: internal service names (nats, the gateway,
+    # *.cluster.local) bypass the allowlist and forward to the platform's
+    # own resolver. Derived from the gateway's own resolv.conf so the same
+    # code is correct on Docker and K8s (egress/dns_internal.py).
+    internal_matcher, internal_upstreams = _derive_internal_exemption()
 
     # Import nats-py lazily so unit tests importing this module don't
     # require the dependency. The gateway Dockerfile pins it, so
@@ -277,15 +328,12 @@ async def main() -> None:
         # instead of crash-looping the gateway over a transient NATS
         # blip on the orchestrator side.
         try:
-            mcp_entries = await fetch_mcp_snapshot_via_nats(
-                nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S
-            )
+            mcp_entries = await fetch_mcp_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
             apply_snapshot_to_registry(mcp_entries)
             logger.info("gateway: MCP registry seeded", count=len(mcp_entries))
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "gateway: MCP snapshot fetch failed — continuing with empty "
-                "registry; live change events will refill",
+                "gateway: MCP snapshot fetch failed — continuing with empty registry; live change events will refill",
                 error=str(exc),
             )
         mcp_sub = await subscribe_mcp_changes(nats_client)
@@ -353,6 +401,8 @@ async def main() -> None:
         dns = DnsServer(
             policy=dns_policy,
             upstreams=upstream_dns,
+            internal_matcher=internal_matcher,
+            internal_upstreams=internal_upstreams,
         )
         await dns.serve("0.0.0.0", EGRESS_GATEWAY_DNS_PORT)
 

--- a/tests/container/test_k8s_runtime.py
+++ b/tests/container/test_k8s_runtime.py
@@ -422,6 +422,25 @@ def test_dns_forces_resolver_via_dnspolicy_none() -> None:
     assert pod_spec["dnsConfig"]["nameservers"] == ["172.28.100.53"]
 
 
+def test_dns_config_carries_cluster_search_and_ndots() -> None:
+    """dnsPolicy None drops the kubelet resolv.conf, so the agent pod must
+    bring the cluster search domains + ndots:5 itself — without them a short
+    name like ``nats`` is sent absolute and never completes to its FQDN, so
+    the gateway's cluster.local exemption never fires (docs/21 §6.3).
+
+    Mutation caught: omitting searches, or dropping ndots below the search
+    depth, silently breaks internal-name resolution.
+    """
+    spec = ContainerSpec(name="a", image="img", dns=["172.28.100.53"])
+    dns_config = _manifest(spec, namespace="team-x")["spec"]["dnsConfig"]
+    assert dns_config["searches"] == [
+        "team-x.svc.cluster.local",
+        "svc.cluster.local",
+        "cluster.local",
+    ]
+    assert {"name": "ndots", "value": "5"} in dns_config["options"]
+
+
 def test_no_dns_keeps_cluster_default() -> None:
     """Empty spec.dns must NOT pin dnsPolicy None (would break the gateway pod).
 

--- a/tests/egress/test_dns_internal.py
+++ b/tests/egress/test_dns_internal.py
@@ -1,0 +1,198 @@
+"""Internal-name exemption derivation from the gateway's resolv.conf.
+
+The security-critical property under test: a name is exempt from the DNS
+allowlist iff the platform's own resolver is authoritative for it and will
+not forward it to a public upstream. Get the boundary wrong in either
+direction and you have a regression — too narrow breaks ``nats`` (the bus
+is unreachable), too wide reopens the DNS-exfil channel the allowlist
+exists to close. The tests therefore lead with the adversarial cases:
+names crafted to *look* internal, and the runtime asymmetry on bare
+single labels.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from rolemesh.egress.dns_internal import (
+    DOCKER_EMBEDDED_DNS,
+    ResolvConf,
+    build_internal_exemption,
+    parse_resolv_conf,
+)
+
+# Representative resolv.conf bodies. K8s pods get the cluster search list +
+# a kube-dns ClusterIP; Docker containers get the embedded DNS and no
+# (useful) search domain.
+_K8S = textwrap.dedent(
+    """
+    nameserver 10.96.0.10
+    search rolemesh.svc.cluster.local svc.cluster.local cluster.local
+    options ndots:5
+    """
+)
+_DOCKER = f"nameserver {DOCKER_EMBEDDED_DNS}\n"
+# A real dev-box gateway: embedded DNS + the HOST's inherited ISP search
+# domain. The host domain must never become an allowlist exemption.
+_DOCKER_DEV = f"nameserver {DOCKER_EMBEDDED_DNS}\nsearch hsd1.ca.comcast.net\n"
+# A cluster that also injects a corp search domain alongside cluster.local.
+_K8S_WITH_HOST = "nameserver 10.96.0.10\nsearch rolemesh.svc.cluster.local cluster.local corp.example.com\n"
+
+
+def _matcher(text: str):
+    exemption = build_internal_exemption(parse_resolv_conf(text))
+    assert exemption is not None, f"expected an exemption from:\n{text}"
+    is_internal, upstreams = exemption
+    return is_internal, upstreams
+
+
+# --------------------------------------------------------------------------
+# parse_resolv_conf
+# --------------------------------------------------------------------------
+
+
+def test_parse_collects_nameservers_in_order() -> None:
+    resolv = parse_resolv_conf("nameserver 10.0.0.1\nnameserver 10.0.0.2\n")
+    assert resolv.nameservers == ("10.0.0.1", "10.0.0.2")
+
+
+def test_parse_last_search_line_wins_like_libc() -> None:
+    # glibc keeps only the final search directive, not the union.
+    resolv = parse_resolv_conf("search first.local\nsearch a.local b.local\n")
+    assert resolv.search == ("a.local", "b.local")
+
+
+def test_parse_treats_domain_directive_as_search() -> None:
+    resolv = parse_resolv_conf("domain corp.example.\n")
+    assert resolv.search == ("corp.example",)
+
+
+def test_parse_ignores_comments_and_blank_lines() -> None:
+    resolv = parse_resolv_conf("# a comment\n; another\n\nnameserver 10.0.0.1\n")
+    assert resolv.nameservers == ("10.0.0.1",)
+    assert resolv.search == ()
+
+
+# --------------------------------------------------------------------------
+# Adversarial: names crafted to look internal must NOT be exempt
+# --------------------------------------------------------------------------
+
+
+def test_suffix_spoof_with_internal_as_prefix_is_external() -> None:
+    # The classic exfil dressing: put the authoritative suffix early and
+    # the attacker apex last. Must be evaluated as external (-> allowlist).
+    is_internal, _ = _matcher(_K8S)
+    assert is_internal("cluster.local.attacker.com") is False
+    assert is_internal("nats.svc.cluster.local.evil.example") is False
+
+
+def test_label_glued_to_suffix_without_a_dot_is_external() -> None:
+    # "evilcluster.local" shares letters with "cluster.local" but is not a
+    # dotted subdomain of it — must not be exempt.
+    is_internal, _ = _matcher(_K8S)
+    assert is_internal("evilcluster.local") is False
+
+
+def test_external_apex_is_external_under_k8s() -> None:
+    is_internal, _ = _matcher(_K8S)
+    assert is_internal("api.anthropic.com") is False
+    assert is_internal("secret-payload.evil.test") is False
+
+
+def test_inherited_host_search_domain_is_not_internal() -> None:
+    # REGRESSION: a Docker gateway inherits the host's ISP search domain.
+    # Treating it as internal would forward `secret.<host-domain>` to the
+    # host resolver, bypassing the allowlist tripwire. It must stay
+    # external; only the single-label container path remains internal.
+    is_internal, _ = _matcher(_DOCKER_DEV)
+    assert is_internal("secret-payload.hsd1.ca.comcast.net") is False
+    assert is_internal("nats") is True
+
+
+def test_non_cluster_suffix_filtered_even_behind_kube_dns() -> None:
+    # A cluster injecting a corp domain alongside cluster.local: only the
+    # cluster domain is authoritative-local, so corp names stay external.
+    is_internal, _ = _matcher(_K8S_WITH_HOST)
+    assert is_internal("nats.rolemesh.svc.cluster.local") is True
+    assert is_internal("intranet.corp.example.com") is False
+
+
+# --------------------------------------------------------------------------
+# Runtime asymmetry on bare single labels (the heart of the design)
+# --------------------------------------------------------------------------
+
+
+def test_bare_single_label_is_internal_on_docker() -> None:
+    # Docker embedded DNS answers `nats` locally; a single label has no
+    # public delegation, so treating it as internal cannot leak.
+    is_internal, _ = _matcher(_DOCKER)
+    assert is_internal("nats") is True
+    assert is_internal("egress-gateway") is True
+
+
+def test_bare_single_label_is_external_on_k8s() -> None:
+    # kube-dns WOULD forward a bare single label to its own upstream, so on
+    # K8s a single label must stay on the allowlist path (fail-closed).
+    # Short internal names arrive as FQDNs anyway, via ndots:5 search.
+    is_internal, _ = _matcher(_K8S)
+    assert is_internal("nats") is False
+
+
+def test_dotted_external_name_is_external_on_docker() -> None:
+    # The embedded DNS forwards multi-label unknowns to the host resolver,
+    # so a dotted name must NOT be exempt — it goes through the allowlist.
+    is_internal, _ = _matcher(_DOCKER)
+    assert is_internal("secret.attacker.com") is False
+
+
+# --------------------------------------------------------------------------
+# Internal names that MUST resolve
+# --------------------------------------------------------------------------
+
+
+def test_cluster_local_names_are_internal_on_k8s() -> None:
+    is_internal, _ = _matcher(_K8S)
+    assert is_internal("nats.rolemesh.svc.cluster.local") is True
+    assert is_internal("egress-gateway.rolemesh.svc.cluster.local") is True
+    # Cross-namespace name matches the broad `cluster.local` suffix.
+    assert is_internal("postgres.other.svc.cluster.local") is True
+    # The bare apex itself.
+    assert is_internal("cluster.local") is True
+
+
+def test_matching_is_case_insensitive_and_dot_tolerant() -> None:
+    is_internal, _ = _matcher(_K8S)
+    assert is_internal("NATS.Rolemesh.SVC.Cluster.Local") is True
+    # Fully-qualified form with the root dot.
+    assert is_internal("nats.rolemesh.svc.cluster.local.") is True
+
+
+def test_internal_upstream_is_the_resolv_nameserver() -> None:
+    _, k8s_up = _matcher(_K8S)
+    assert [(u.host, u.port) for u in k8s_up] == [("10.96.0.10", 53)]
+    _, docker_up = _matcher(_DOCKER)
+    assert [(u.host, u.port) for u in docker_up] == [(DOCKER_EMBEDDED_DNS, 53)]
+
+
+# --------------------------------------------------------------------------
+# No exemption => fail-closed (None), never a blanket forward
+# --------------------------------------------------------------------------
+
+
+def test_no_nameserver_yields_no_exemption() -> None:
+    assert build_internal_exemption(ResolvConf(search=("cluster.local",))) is None
+
+
+def test_ipv6_only_nameserver_yields_no_exemption() -> None:
+    # The forwarder is AF_INET only; an unusable upstream must not produce
+    # an exemption that then SERVFAILs every internal name.
+    resolv = parse_resolv_conf("nameserver fd00::a\nsearch cluster.local\n")
+    assert build_internal_exemption(resolv) is None
+
+
+def test_kube_dns_without_search_does_not_blanket_forward() -> None:
+    # A kube-dns-like nameserver with no search list and no embedded-DNS
+    # marker must NOT enable the exemption — otherwise every name would be
+    # forwarded to a resolver that recurses to the public internet.
+    resolv = parse_resolv_conf("nameserver 10.96.0.10\n")
+    assert build_internal_exemption(resolv) is None

--- a/tests/egress/test_dns_resolver.py
+++ b/tests/egress/test_dns_resolver.py
@@ -19,11 +19,16 @@ Invariants pinned:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import dnslib
 import pytest
 
 from rolemesh.egress.dns_policy import GlobalDnsPolicy
 from rolemesh.egress.dns_resolver import DnsServer, UpstreamResolver
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 pytestmark = pytest.mark.asyncio
 
@@ -41,27 +46,47 @@ def _rcode(packet: bytes) -> str:
 
 
 class _Harness:
-    """DnsServer with the upstream leg replaced by a canned answer."""
+    """DnsServer with both upstream legs replaced by canned answers.
 
-    def __init__(self, policy: GlobalDnsPolicy, *, upstream_answers: bool = True) -> None:
+    ``upstream_calls`` / ``internal_calls`` record which leg fired, so a
+    test can assert not just the rcode but that an exfil name never even
+    reached a forwarder, and an internal name reached the *internal* one.
+    """
+
+    def __init__(
+        self,
+        policy: GlobalDnsPolicy,
+        *,
+        upstream_answers: bool = True,
+        internal_matcher: Callable[[str], bool] | None = None,
+    ) -> None:
         self.server = DnsServer(
             policy=policy,
             upstreams=[UpstreamResolver(host="192.0.2.1")],  # TEST-NET, never dialed
+            internal_matcher=internal_matcher,
+            internal_upstreams=(
+                [UpstreamResolver(host="127.0.0.11")] if internal_matcher else None
+            ),
         )
         self.upstream_calls: list[bytes] = []
+        self.internal_calls: list[bytes] = []
         self.responses: list[bytes] = []
+
+        def _answer(data: bytes) -> bytes:
+            reply = dnslib.DNSRecord.parse(data).reply()
+            reply.add_answer(*dnslib.RR.fromZone("resolved.test. 60 A 198.51.100.7"))
+            return reply.pack()
 
         async def _fake_upstream(data: bytes) -> bytes | None:
             self.upstream_calls.append(data)
-            if not upstream_answers:
-                return None
-            reply = dnslib.DNSRecord.parse(data).reply()
-            reply.add_answer(
-                *dnslib.RR.fromZone("resolved.test. 60 A 198.51.100.7")
-            )
-            return reply.pack()
+            return _answer(data) if upstream_answers else None
+
+        async def _fake_internal(data: bytes) -> bytes | None:
+            self.internal_calls.append(data)
+            return _answer(data)
 
         self.server._resolve_upstream = _fake_upstream  # type: ignore[method-assign]
+        self.server._resolve_internal = _fake_internal  # type: ignore[method-assign]
 
     async def ask(self, qname: str, qtype: str) -> None:
         await self.server._handle_packet(
@@ -111,3 +136,66 @@ async def test_multi_question_packet_refused() -> None:
     await h.server._handle_packet(record.pack(), _SOURCE, h.responses.append)
     assert [_rcode(r) for r in h.responses] == ["REFUSED"]
     assert h.upstream_calls == []
+
+
+# --------------------------------------------------------------------------
+# Internal-name exemption: internal forwarded, external still tripwired.
+# The matcher here calls anything ending in ".svc.internal" internal.
+# --------------------------------------------------------------------------
+
+_INTERNAL = lambda name: name.endswith(".svc.internal")  # noqa: E731
+
+
+async def test_internal_name_forwarded_despite_empty_allowlist() -> None:
+    # The whole point: with the steady-state EMPTY allowlist + enforce, an
+    # internal name must still resolve — via the INTERNAL leg, never the
+    # external one, never the allowlist.
+    h = _Harness(GlobalDnsPolicy(), internal_matcher=_INTERNAL)
+    await h.ask("nats.svc.internal", "A")
+    assert [_rcode(r) for r in h.responses] == ["NOERROR"]
+    assert len(h.internal_calls) == 1
+    assert h.upstream_calls == []
+
+
+async def test_external_name_still_nxdomain_when_exemption_active() -> None:
+    # Turning the exemption on must not punch a hole for external names:
+    # a non-matching, non-allowlisted name is still blocked, and reaches
+    # NEITHER forwarder (the attacker's NS records no hit).
+    h = _Harness(GlobalDnsPolicy(), internal_matcher=_INTERNAL)
+    await h.ask("secret-payload.attacker.com", "A")
+    assert [_rcode(r) for r in h.responses] == ["NXDOMAIN"]
+    assert h.internal_calls == []
+    assert h.upstream_calls == []
+
+
+async def test_internal_txt_refused_by_qtype_gate_before_exemption() -> None:
+    # The qtype gate runs before the exemption, so an internal name cannot
+    # be used to smuggle a TXT/SRV tunnel through the internal resolver.
+    h = _Harness(GlobalDnsPolicy(), internal_matcher=_INTERNAL)
+    await h.ask("nats.svc.internal", "TXT")
+    assert [_rcode(r) for r in h.responses] == ["REFUSED"]
+    assert h.internal_calls == []
+    assert h.upstream_calls == []
+
+
+async def test_allowlisted_external_uses_external_leg_not_internal() -> None:
+    # An allowlisted external name still goes out the EXTERNAL upstream even
+    # when the exemption is wired — the two legs must not cross.
+    h = _Harness(
+        GlobalDnsPolicy(patterns=("*.corp.test",)), internal_matcher=_INTERNAL
+    )
+    await h.ask("metrics.corp.test", "A")
+    assert [_rcode(r) for r in h.responses] == ["NOERROR"]
+    assert len(h.upstream_calls) == 1
+    assert h.internal_calls == []
+
+
+async def test_matcher_and_upstream_must_be_wired_together() -> None:
+    # An exemption half-configured is a deploy bug that would silently
+    # NXDOMAIN every internal name — fail loud at construction instead.
+    policy = GlobalDnsPolicy()
+    ext = [UpstreamResolver(host="192.0.2.1")]
+    with pytest.raises(ValueError):
+        DnsServer(policy=policy, upstreams=ext, internal_matcher=_INTERNAL)
+    with pytest.raises(ValueError):
+        DnsServer(policy=policy, upstreams=ext, internal_upstreams=ext)

--- a/tests/egress/test_dns_resolver_sockets.py
+++ b/tests/egress/test_dns_resolver_sockets.py
@@ -1,0 +1,118 @@
+"""End-to-end socket test of the internal-name exemption.
+
+Unlike test_dns_resolver.py (which stubs the forwarder methods), this binds
+a REAL ``DnsServer`` on a UDP socket and drives it with real DNS packets,
+so the full ``_handle_packet -> _resolve_internal -> _udp_query`` path runs
+over the wire. It is the no-cluster stand-in for the Kubernetes leg of
+contract case T-NET-3: an internal ``*.cluster.local`` name is forwarded to
+a stub kube-dns and resolves, while an external name is NXDOMAINed without
+either upstream being touched.
+
+The stubs record which upstream actually received each query, so the test
+proves the routing — not just the rcode. A green here plus the live-gateway
+``nats -> NOERROR`` probe (Docker embedded DNS leg) covers both runtimes'
+forwarding without standing up a cluster.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import dnslib
+import pytest
+
+from rolemesh.egress.dns_policy import GlobalDnsPolicy
+from rolemesh.egress.dns_resolver import DnsServer, UpstreamResolver
+
+pytestmark = pytest.mark.asyncio
+
+
+class _StubResolver(asyncio.DatagramProtocol):
+    """A canned upstream that answers every A query with one fixed record
+    and remembers the qnames it was asked, so a test can assert routing."""
+
+    def __init__(self, answer_ip: str) -> None:
+        self._answer_ip = answer_ip
+        self.received: list[str] = []
+        self._transport: asyncio.DatagramTransport | None = None
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        self._transport = transport  # type: ignore[assignment]
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        query = dnslib.DNSRecord.parse(data)
+        self.received.append(str(query.q.qname).rstrip("."))
+        reply = query.reply()
+        reply.add_answer(
+            *dnslib.RR.fromZone(f"{query.q.qname} 30 A {self._answer_ip}")
+        )
+        assert self._transport is not None
+        self._transport.sendto(reply.pack(), addr)
+
+
+async def _bind(proto: _StubResolver) -> tuple[asyncio.DatagramTransport, int]:
+    loop = asyncio.get_running_loop()
+    transport, _ = await loop.create_datagram_endpoint(
+        lambda: proto, local_addr=("127.0.0.1", 0)
+    )
+    port = transport.get_extra_info("socket").getsockname()[1]
+    return transport, port
+
+
+async def _ask(resolver_port: int, qname: str) -> dnslib.DNSRecord:
+    """Send one real A query to 127.0.0.1:resolver_port and parse the reply."""
+    loop = asyncio.get_running_loop()
+    recv: asyncio.Future[bytes] = loop.create_future()
+
+    class _Client(asyncio.DatagramProtocol):
+        def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+            if not recv.done():
+                recv.set_result(data)
+
+    transport, _ = await loop.create_datagram_endpoint(
+        _Client, remote_addr=("127.0.0.1", resolver_port)
+    )
+    try:
+        transport.sendto(dnslib.DNSRecord.question(qname, "A").pack())
+        data = await asyncio.wait_for(recv, timeout=2.0)
+    finally:
+        transport.close()
+    return dnslib.DNSRecord.parse(data)
+
+
+def _is_cluster_local(name: str) -> bool:
+    n = name.rstrip(".").lower()
+    return n == "cluster.local" or n.endswith(".cluster.local")
+
+
+async def test_internal_cluster_local_forwarded_to_kube_dns_over_udp() -> None:
+    kube_dns = _StubResolver("10.96.0.99")
+    external = _StubResolver("203.0.113.1")  # must never be hit by internal
+    kube_t, kube_port = await _bind(kube_dns)
+    ext_t, ext_port = await _bind(external)
+
+    server = DnsServer(
+        policy=GlobalDnsPolicy(),  # empty allowlist + enforce (steady state)
+        upstreams=[UpstreamResolver(host="127.0.0.1", port=ext_port)],
+        internal_matcher=_is_cluster_local,
+        internal_upstreams=[UpstreamResolver(host="127.0.0.1", port=kube_port)],
+    )
+    await server.serve("127.0.0.1", 0)
+    server_port = server._transport.get_extra_info("socket").getsockname()[1]  # type: ignore[union-attr]
+    try:
+        # Internal name: resolves via kube-dns, NEVER via the external leg.
+        internal = await _ask(server_port, "nats.rolemesh.svc.cluster.local")
+        assert dnslib.RCODE.get(internal.header.rcode) == "NOERROR"
+        assert str(internal.rr[0].rdata) == "10.96.0.99"
+        assert kube_dns.received == ["nats.rolemesh.svc.cluster.local"]
+        assert external.received == []
+
+        # External name: blocked at the allowlist, reaching NEITHER upstream.
+        ext = await _ask(server_port, "secret-payload.attacker.com")
+        assert dnslib.RCODE.get(ext.header.rcode) == "NXDOMAIN"
+        assert external.received == []
+        assert kube_dns.received == ["nats.rolemesh.svc.cluster.local"]
+    finally:
+        server.close()
+        kube_t.close()
+        ext_t.close()


### PR DESCRIPTION
## Problem

Agent pods on **Kubernetes** run `dnsPolicy: None` with their resolver pinned solely at the egress gateway. Internal names (`nats`, `egress-gateway`, `*.cluster.local`) therefore reach the gateway resolver and were `NXDOMAIN`ed by the empty-by-default `EGRESS_DNS_ALLOWLIST` — an agent could not even resolve `nats` to connect to the bus. This surfaced when a downstream project first ran a full agent round-trip on K8s.

On **Docker** it never surfaced: the agent's embedded DNS (`127.0.0.11`) answers container names locally and only forwards *external* names to the gateway, so the gateway never sees internal names. The fix recreates that embedded-DNS behaviour on the gateway for K8s — symmetric, no `docker|k8s` branch.

This realises the long-stated intent in `docs/16` ("DNS plane") and the existing contract case **T-NET-3**, which were never exercised on real infra.

## Changes

- **`dns_resolver`** — `DnsServer` gains an internal-name exemption: names matched by `internal_matcher` skip the allowlist tripwire and forward to `internal_upstreams` (the platform's own resolver). Both unset keeps the original fail-closed behaviour; the `A/AAAA/CNAME` qtype gate still runs first.
- **`dns_internal`** (new) — derive both the internal-name set and that resolver from the gateway's **own `/etc/resolv.conf`**, so the same code is correct on every runtime. Two safety rules keep it from becoming an exfil hole:
  - Only suffixes within `cluster_domain` are exempt — an inherited host search domain (observed on kind: `hsd1.ca.comcast.net`) cannot become an allowlist bypass.
  - Single-label exemption is gated on the Docker embedded-DNS address.
- **`gateway`** — build the exemption at boot from `/etc/resolv.conf`.
- **`k8s_runtime`** — agent pod `dnsConfig` now carries the cluster search domains + `ndots:5` (`dnsPolicy: None` drops the kubelet resolv.conf, so a short `nats` never completed to its FQDN).
- **chart `networkpolicy`** — `agent-allow-egress` permits DNS to the gateway on **both 53 and 1053** (NetworkPolicy ports are the destination *pod* port; CNIs enforcing egress post-DNAT see 1053). Allowing both covers either DNAT ordering.
- **chart `tests/connectivity-probe.yaml`** (new) — the in-cluster, repeatable golden-path guard (see below).
- **docs/16, docs/21** — aligned with the implemented mechanism + known limitations.

## Test plan

- **88 unit tests** (incl. adversarial: suffix-spoofing, inherited host-domain pollution, single-label runtime asymmetry, qtype gate before exemption, all-or-nothing wiring).
- **Socket-level integration** (`test_dns_resolver_sockets.py`): real UDP through `DnsServer` — `*.cluster.local` forwarded to a stub kube-dns and resolves; external `NXDOMAIN`, neither upstream touched.
- **Docker compose**: network contract suite 6/6, no regression.
- **kind + Calico (live cluster), `helm test` exit 0** — the new `connectivity-probe` (paired with `deny-probe`) runs **in-cluster**, so it reaches ClusterIPs natively (no host-route hack; portable to kind + RKE2). It resolves `nats` → the real Service ClusterIP via the exemption → kube-dns and `egress-gateway` → the gateway ClusterIP, **TCP-connects to `nats:4222` and `gateway:3001`** (the 53-vs-1053 bug proved resolution ≠ reachability — connect, don't just resolve), and confirms `contract-denied.example.com` stays blocked. This is the permanent closure of the "T-NET-3 never runs on real infra" false-green.

## Known limitations (documented in docs/21)

- Internal **SRV/TXT stay refused** — the exemption runs after the A/AAAA/CNAME qtype gate. Sufficient today (NATS dials an A record).
- The **pytest contract suite's k8s mode needs cluster-network reach** (its `verify_infrastructure` pre-flight hits the gateway ClusterIP from the test process). The `helm test` connectivity-probe is the portable positive-path guard until that pre-flight grows an in-cluster mode.

## Out of scope (separate branch)

Response-IP filtering (DNS rebinding / CNAME pointing at internal or metadata IPs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
