### PR TITLE
feat(compose): Keycloak OIDC stack for end-to-end oidc auth

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,0 +1,149 @@
+# RoleMesh compose stacks
+
+The base stack (`compose.yaml`) runs RoleMesh with `AUTH_MODE=external` (the
+default). An **optional** override (`compose.keycloak.yaml`) layers a Keycloak
+OIDC IdP on top and switches auth to `AUTH_MODE=oidc` for end-to-end OIDC
+testing (the foundation for promptfoo BOLA/BFLA/RBAC red-teaming).
+
+The override is purely additive — leave it out and you get the original
+external-auth stack unchanged.
+
+---
+
+## Keycloak / OIDC stack (dev & test only)
+
+### What it provides
+
+| Item | Value |
+|------|-------|
+| Realm | `rolemesh` |
+| Client (confidential) | `rolemesh-web` |
+| Client secret | `rolemesh-web-dev-secret` |
+| Keycloak admin console | http://localhost:8081 (admin / admin) |
+| Discovery (host) | http://localhost:8081/realms/rolemesh/.well-known/openid-configuration |
+| Discovery (in-container) | http://keycloak:8080/realms/rolemesh/.well-known/openid-configuration |
+| WebUI | http://localhost:8080 |
+
+### Test users
+
+All passwords are `Passw0rd!`. `tenant_id` is an opaque external id; RoleMesh
+JIT-creates a local tenant `oidc-<tenant_id>` on first login, so `t1` and `t2`
+become two isolated tenants with no pre-seeding.
+
+| Username | Password | tenant_id | role | Purpose |
+|----------|----------|-----------|------|---------|
+| `owner@t1`  | `Passw0rd!` | `t1` | `owner`  | tenant 1 admin |
+| `member@t1` | `Passw0rd!` | `t1` | `member` | tenant 1 low-priv (BFLA/RBAC tests) |
+| `owner@t2`  | `Passw0rd!` | `t2` | `owner`  | tenant 2 (cross-tenant / BOLA tests) |
+
+> `role` must be exactly `owner` / `admin` / `member`. RoleMesh's adapter
+> rejects any other value and silently falls back to `member`. The
+> platform-plane `platform_admin` role is **not** mappable via OIDC by design.
+
+### Claim mapping (the make-or-break contract)
+
+RoleMesh reads two **flat, top-level String claims** from the **ID token**. The
+realm ships a User-Attribute protocol mapper (attached to the `rolemesh-web`
+client) for each:
+
+| User attribute (Keycloak) | Token claim | RoleMesh env | Consumed by |
+|---------------------------|-------------|--------------|-------------|
+| `tenant_id` | `tenant_id` | `OIDC_CLAIM_TENANT_ID=tenant_id` | `map_tenant_id` → tenant binding |
+| `role`      | `role`      | `OIDC_CLAIM_ROLE=role`           | `map_role` → owner/admin/member |
+
+Both mappers have **Add to ID token = on** because RoleMesh validates the
+**id_token** (not the access_token — see "Token contract" below).
+
+### Start it
+
+From the repo root (the base `.env` keys — `WS_TICKET_SECRET`,
+`ROLEMESH_HOST_DATA_DIR`, `DOCKER_GID`, `EGRESS_TOKEN_SECRET` — are still
+required by the base stack):
+
+```bash
+docker compose --env-file .env \
+  -f deploy/compose/compose.yaml \
+  -f deploy/compose/compose.keycloak.yaml up -d
+```
+
+Wait ~20s for the realm import (`docker logs rolemesh-keycloak | grep Imported`),
+then run the acceptance check:
+
+```bash
+deploy/compose/keycloak/e2e-verify.sh
+```
+
+It fetches a token per user, hits the protected `GET /api/v1/auth/me`, and
+asserts: role/tenant claims mapped, t1 users share a tenant, t2 is separate,
+and an access_token is rejected.
+
+### Log in as a user (browser)
+
+Open http://localhost:8080, click login, authenticate as e.g. `owner@t1` /
+`Passw0rd!`. The SPA runs the PKCE flow against Keycloak and lands you in
+tenant `oidc-t1` as an owner.
+
+### Get a token programmatically (for promptfoo)
+
+```bash
+# Prints an id_token (NOT an access_token — see contract below).
+deploy/compose/keycloak/get-token.sh owner@t1
+
+# Use it as a bearer:
+TOKEN=$(deploy/compose/keycloak/get-token.sh owner@t1)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/auth/me
+```
+
+Raw form (what a promptfoo custom provider does — note `scope=openid` and that
+we read `.id_token`):
+
+```bash
+curl -s http://localhost:8081/realms/rolemesh/protocol/openid-connect/token \
+  -d grant_type=password -d scope=openid \
+  -d client_id=rolemesh-web -d client_secret=rolemesh-web-dev-secret \
+  -d username=owner@t1 -d password='Passw0rd!' | jq -r .id_token
+```
+
+### 🔑 Token contract: use the **id_token**, not the access_token
+
+RoleMesh's `OIDCAuthProvider.authenticate()` validates the bearer as an
+**id_token** with `aud == client_id` (`rolemesh-web`). A Keycloak access_token
+defaults to `aud=["account"]` and is rejected with **401**. Always send the
+`id_token`. (This is consistent with RoleMesh's design: the IdP is trusted for
+authentication only; all authorization is internal — see
+`docs/6-auth-architecture.md`.)
+
+### Switch back to external auth
+
+Just drop the override file:
+
+```bash
+docker compose --env-file .env -f deploy/compose/compose.yaml up -d
+```
+
+---
+
+## Gotchas baked into this stack
+
+These are pre-solved in `compose.keycloak.yaml` / `rolemesh-realm.json`; listed
+so you don't undo them:
+
+- **Image is pinned to `keycloak:25.0`.** The hostname env vars use the v1
+  option names. Keycloak 26 (hostname v2) removed `KC_HOSTNAME_PORT` /
+  `KC_HOSTNAME_STRICT_BACKCHANNEL`; bumping the tag without switching to v2
+  syntax (`KC_HOSTNAME=http://localhost:8081`,
+  `KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true`) breaks startup.
+- **`OIDC_DISCOVERY_URL` must stay `http://keycloak:8080/...`** (the in-network
+  name). `KC_HOSTNAME_STRICT_BACKCHANNEL=false` makes Keycloak return
+  backchannel endpoints (`jwks_uri`, `token_endpoint`) on the request host, so
+  containers fetch keys from a reachable address while `iss` stays the fixed
+  frontend URL. Pointing discovery at `localhost:8081` to "match iss" would
+  make `jwks_uri` unreachable from the containers and break all validation.
+- **Keycloak is on host port 8081** (8080 belongs to the WebUI).
+- **`redirect_uri` points at the WebUI** (`localhost:8080/oauth2/callback`),
+  **discovery points at Keycloak** — don't swap them.
+- **`OIDC_COOKIE_SECURE=false`** for plain-HTTP dev, or the browser drops the
+  refresh cookie.
+- The client has **Direct Access Grants enabled** (ROPG) and **S256 PKCE
+  forced**; the realm token lifespan is **30 min** so a long red-team run
+  doesn't 401 mid-suite. All dev-only.

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -73,9 +73,11 @@ then run the acceptance check:
 deploy/compose/keycloak/e2e-verify.sh
 ```
 
-It fetches a token per user, hits the protected `GET /api/v1/auth/me`, and
-asserts: role/tenant claims mapped, t1 users share a tenant, t2 is separate,
-and an access_token is rejected.
+It fetches a token per user, hits the protected `GET /api/v1/me`, asserts the
+role/tenant claims mapped (t1 users share a tenant, t2 is separate), then
+proves data-layer isolation: `owner@t1` creates a coworker, `owner@t1` sees it
+in `GET /api/v1/coworkers`, `owner@t2` does not (and gets 404 fetching it by
+id). Finally it asserts an access_token is rejected.
 
 ### Log in as a user (browser)
 
@@ -91,7 +93,7 @@ deploy/compose/keycloak/get-token.sh owner@t1
 
 # Use it as a bearer:
 TOKEN=$(deploy/compose/keycloak/get-token.sh owner@t1)
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/auth/me
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/me
 ```
 
 Raw form (what a promptfoo custom provider does — note `scope=openid` and that

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -130,13 +130,14 @@ docker compose --env-file .env -f deploy/compose/compose.yaml up -d
 These are pre-solved in `compose.keycloak.yaml` / `rolemesh-realm.json`; listed
 so you don't undo them:
 
-- **Image is pinned to `keycloak:25.0`.** The hostname env vars use the v1
-  option names. Keycloak 26 (hostname v2) removed `KC_HOSTNAME_PORT` /
-  `KC_HOSTNAME_STRICT_BACKCHANNEL`; bumping the tag without switching to v2
-  syntax (`KC_HOSTNAME=http://localhost:8081`,
-  `KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true`) breaks startup.
+- **Image is pinned to the exact patch `keycloak:25.0.6`** (not the floating
+  `:25.0`). The hostname env vars use **v2 syntax** (`KC_HOSTNAME` = a full URL
+  + `KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true`), which is the default on 25.0.6 /
+  26.x. The older v1 options (`KC_HOSTNAME_PORT`,
+  `KC_HOSTNAME_STRICT_BACKCHANNEL`) are silently ignored here — do not
+  reintroduce them. Keep the tag and the syntax in lockstep when bumping.
 - **`OIDC_DISCOVERY_URL` must stay `http://keycloak:8080/...`** (the in-network
-  name). `KC_HOSTNAME_STRICT_BACKCHANNEL=false` makes Keycloak return
+  name). `KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true` makes Keycloak return
   backchannel endpoints (`jwks_uri`, `token_endpoint`) on the request host, so
   containers fetch keys from a reachable address while `iss` stays the fixed
   frontend URL. Pointing discovery at `localhost:8081` to "match iss" would

--- a/deploy/compose/compose.keycloak.yaml
+++ b/deploy/compose/compose.keycloak.yaml
@@ -22,13 +22,16 @@
 # (iss=localhost:8081) would fail validation against a discovery doc fetched at
 # keycloak:8080 — login would break.
 #
-# Fix (Keycloak 25 / hostname v1):
-#   * KC_HOSTNAME + KC_HOSTNAME_PORT pin the FRONTEND issuer/authorize URLs to
-#     http://localhost:8081 — stable for both browser and backchannel.
-#   * KC_HOSTNAME_STRICT_BACKCHANNEL=false (the load-bearing line) lets the
+# Fix (Keycloak hostname v2 — the default on 25.0.6, which the floating ":25.0"
+# tag resolves to; the older v1 options KC_HOSTNAME_PORT /
+# KC_HOSTNAME_STRICT_BACKCHANNEL are ignored here and must NOT be used):
+#   * KC_HOSTNAME = full FRONTEND URL http://localhost:8081 — pins the
+#     issuer/authorize URLs, stable for both browser and backchannel.
+#   * KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true (the load-bearing line) lets the
 #     BACKCHANNEL endpoints (jwks_uri, token_endpoint) follow the request host,
 #     so a container fetching discovery at keycloak:8080 gets jwks_uri =
-#     http://keycloak:8080/...  — reachable from inside the network.
+#     http://keycloak:8080/...  — reachable from inside the network. Without it,
+#     jwks_uri stays http://localhost:8081 and is unreachable from containers.
 #
 # Hard coupling: OIDC_DISCOVERY_URL below MUST stay http://keycloak:8080/...
 # Do NOT "fix" it to localhost:8081 to match iss — iss already matches (pinned
@@ -37,20 +40,20 @@
 
 services:
   keycloak:
-    # Pinned to 25.0: the hostname env vars below are the v1 option names.
-    # Keycloak 26 removed KC_HOSTNAME_PORT / KC_HOSTNAME_STRICT_BACKCHANNEL
-    # (hostname v2) — do NOT bump the tag without switching to v2 syntax
-    # (KC_HOSTNAME=http://localhost:8081, KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true).
-    image: quay.io/keycloak/keycloak:25.0
+    # Pinned to an EXACT patch (not the floating ":25.0", which resolves to
+    # 25.0.6 and defaults to hostname v2). The env vars below are v2 syntax;
+    # keep tag and syntax in lockstep when bumping. On 26.x the same v2 vars
+    # apply, but re-verify the user-profile import (rolemesh-realm.json).
+    image: quay.io/keycloak/keycloak:25.0.6
     container_name: rolemesh-keycloak
     command: ["start-dev", "--import-realm"]
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KC_HOSTNAME: localhost
-      KC_HOSTNAME_PORT: "8081"
+      # Hostname v2: full frontend URL + dynamic backchannel (see header note).
+      KC_HOSTNAME: http://localhost:8081
+      KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
       KC_HOSTNAME_STRICT: "false"
-      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
     ports:

--- a/deploy/compose/compose.keycloak.yaml
+++ b/deploy/compose/compose.keycloak.yaml
@@ -1,0 +1,113 @@
+# RoleMesh + Keycloak OIDC override (dev/test only).
+#
+# Layers a Keycloak IdP onto the base stack and flips webui + orchestrator
+# into AUTH_MODE=oidc. The base compose.yaml is unchanged and still defaults
+# to AUTH_MODE=external, so this file is purely additive — omit it to get the
+# original stack back.
+#
+# Run from the repo root (note BOTH -f flags, base first):
+#
+#   docker compose --env-file .env \
+#     -f deploy/compose/compose.yaml \
+#     -f deploy/compose/compose.keycloak.yaml up -d
+#
+# Then wait ~20s for the realm import and run:
+#   deploy/compose/keycloak/e2e-verify.sh
+#
+# ── Why the hostname settings below matter (the classic Keycloak-in-docker
+#    trap) ──────────────────────────────────────────────────────────────────
+# The browser reaches Keycloak at http://localhost:8081 (published port) while
+# the webui/orchestrator containers reach it at http://keycloak:8080 (service
+# name). If issuer/jwks_uri were host-dependent, tokens minted for the browser
+# (iss=localhost:8081) would fail validation against a discovery doc fetched at
+# keycloak:8080 — login would break.
+#
+# Fix (Keycloak 25 / hostname v1):
+#   * KC_HOSTNAME + KC_HOSTNAME_PORT pin the FRONTEND issuer/authorize URLs to
+#     http://localhost:8081 — stable for both browser and backchannel.
+#   * KC_HOSTNAME_STRICT_BACKCHANNEL=false (the load-bearing line) lets the
+#     BACKCHANNEL endpoints (jwks_uri, token_endpoint) follow the request host,
+#     so a container fetching discovery at keycloak:8080 gets jwks_uri =
+#     http://keycloak:8080/...  — reachable from inside the network.
+#
+# Hard coupling: OIDC_DISCOVERY_URL below MUST stay http://keycloak:8080/...
+# Do NOT "fix" it to localhost:8081 to match iss — iss already matches (pinned
+# above), and pointing discovery at localhost:8081 would make jwks_uri
+# unreachable from the containers and break ALL token validation.
+
+services:
+  keycloak:
+    # Pinned to 25.0: the hostname env vars below are the v1 option names.
+    # Keycloak 26 removed KC_HOSTNAME_PORT / KC_HOSTNAME_STRICT_BACKCHANNEL
+    # (hostname v2) — do NOT bump the tag without switching to v2 syntax
+    # (KC_HOSTNAME=http://localhost:8081, KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true).
+    image: quay.io/keycloak/keycloak:25.0
+    container_name: rolemesh-keycloak
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: "8081"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      # 8081 on the host (8080 is taken by webui). Container still listens on
+      # 8080, which is the address the other services use (keycloak:8080).
+      - "8081:8080"
+    volumes:
+      - ./keycloak/rolemesh-realm.json:/opt/keycloak/data/import/rolemesh-realm.json:ro
+    networks:
+      - default
+    healthcheck:
+      # UBI9 /bin/sh is bash, so /dev/tcp works. Probes the management health
+      # port (9000, enabled by KC_HEALTH_ENABLED). Best-effort: dependents use
+      # service_started (the RoleMesh OIDC provider fetches discovery lazily on
+      # first login, so they need not wait for Keycloak to be ready to boot).
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000 && printf 'GET /health/ready HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q UP <&3"]
+      interval: 10s
+      timeout: 5s
+      retries: 24
+      start_period: 20s
+
+  webui:
+    depends_on:
+      keycloak:
+        condition: service_started
+    environment:
+      AUTH_MODE: oidc
+      # Containers reach Keycloak by service name; see the coupling note above.
+      OIDC_DISCOVERY_URL: http://keycloak:8080/realms/rolemesh/.well-known/openid-configuration
+      OIDC_CLIENT_ID: rolemesh-web
+      OIDC_CLIENT_SECRET: rolemesh-web-dev-secret
+      # Audience left empty -> defaults to client_id. Keycloak id_token aud is
+      # the client_id, so it validates with zero extra mappers.
+      OIDC_AUDIENCE: ""
+      # redirect_uri is browser-facing -> the host-published webui address.
+      OIDC_REDIRECT_URI: http://localhost:8080/oauth2/callback
+      # offline_access is requested so the browser flow gets a refresh_token
+      # (webui silent-refresh / session continuity). Not needed by promptfoo.
+      OIDC_SCOPES: "openid profile email offline_access"
+      # Flat top-level String claims emitted by the realm's user-attribute
+      # mappers. These names MUST match claim.name in rolemesh-realm.json.
+      OIDC_CLAIM_TENANT_ID: tenant_id
+      OIDC_CLAIM_ROLE: role
+      # Dev is plain HTTP -> the refresh cookie cannot be Secure or the
+      # browser silently drops it.
+      OIDC_COOKIE_SECURE: "false"
+      OIDC_COOKIE_SAMESITE: lax
+
+  orchestrator:
+    depends_on:
+      keycloak:
+        condition: service_started
+    environment:
+      # The orchestrator needs the OIDC config too: without a discovery URL +
+      # client_id it never subscribes the egress token responder (see the base
+      # compose comment on the orchestrator OIDC_* block).
+      AUTH_MODE: oidc
+      OIDC_DISCOVERY_URL: http://keycloak:8080/realms/rolemesh/.well-known/openid-configuration
+      OIDC_CLIENT_ID: rolemesh-web
+      OIDC_CLIENT_SECRET: rolemesh-web-dev-secret

--- a/deploy/compose/keycloak/e2e-verify.sh
+++ b/deploy/compose/keycloak/e2e-verify.sh
@@ -3,10 +3,13 @@
 # gate (pytest does not exercise a live IdP). It:
 #   1. waits for the realm to be served,
 #   2. fetches an id_token per test user via ROPG,
-#   3. calls the protected GET /api/v1/auth/me and asserts the role + tenant
-#      claims mapped correctly,
-#   4. asserts cross-tenant isolation (t1 users share a tenant; t2 differs),
-#   5. asserts an access_token is REJECTED (proves the id_token contract).
+#   3. calls the protected GET /api/v1/me and asserts the role + tenant claims
+#      mapped correctly,
+#   4. asserts identity-layer cross-tenant separation (t1 users share a tenant;
+#      t2 differs),
+#   5. asserts DATA-layer (RLS) isolation: owner@t1 creates a coworker, owner@t1
+#      lists it, owner@t2 cannot see it and gets 404 fetching it by id,
+#   6. asserts an access_token is REJECTED (proves the id_token contract).
 #
 # Exit 0 = all green. Requires curl + jq. Run after `docker compose ... up -d`.
 #
@@ -22,7 +25,7 @@ PASSWORD="${PASSWORD:-Passw0rd!}"
 
 TOKEN_URL="${KC_BASE_URL}/realms/${REALM}/protocol/openid-connect/token"
 DISCOVERY_URL="${KC_BASE_URL}/realms/${REALM}/.well-known/openid-configuration"
-ME_URL="${ROLEMESH_BASE_URL}/api/v1/auth/me"
+API="${ROLEMESH_BASE_URL}/api/v1"
 
 pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
@@ -37,8 +40,21 @@ token() {
     | jq -r ".${kind}_token"
 }
 
-# me <id_token> -> prints the /me JSON (or fails the curl)
-me() { curl -sf -H "Authorization: Bearer $1" "$ME_URL"; }
+# api <method> <token> <path> [json-body]  -> prints "<http_code>\n<body>"
+# Uses -s (not -f) so we can assert on status codes including 401/404.
+api() {
+  local method="$1" tok="$2" path="$3" body="${4:-}"
+  if [ -n "$body" ]; then
+    curl -s -w '\n%{http_code}' -X "$method" \
+      -H "Authorization: Bearer $tok" -H 'Content-Type: application/json' \
+      -d "$body" "${API}${path}"
+  else
+    curl -s -w '\n%{http_code}' -X "$method" \
+      -H "Authorization: Bearer $tok" "${API}${path}"
+  fi
+}
+code() { printf '%s' "$1" | tail -n1; }      # last line = http code
+json() { printf '%s' "$1" | sed '$d'; }      # everything but last line = body
 
 echo "==> 1. Waiting for Keycloak realm '${REALM}' ..."
 for i in $(seq 1 60); do
@@ -48,34 +64,67 @@ for i in $(seq 1 60); do
 done
 pass "discovery reachable at ${DISCOVERY_URL}"
 
-echo "==> 2/3. Tokens + claim mapping via GET /api/v1/auth/me"
-OWNER_T1=$(me "$(token owner@t1 id)")
-MEMBER_T1=$(me "$(token member@t1 id)")
-OWNER_T2=$(me "$(token owner@t2 id)")
+echo "==> 2. Fetch id_tokens (ROPG)"
+ID_OWNER_T1=$(token owner@t1 id)
+ID_MEMBER_T1=$(token member@t1 id)
+ID_OWNER_T2=$(token owner@t2 id)
+[ -n "$ID_OWNER_T1" ] && [ "$ID_OWNER_T1" != null ] || fail "no id_token for owner@t1 (is directAccessGrants enabled?)"
+pass "id_tokens issued for all three users"
 
-r_owner_t1=$(jq -r .role <<<"$OWNER_T1")
-r_member_t1=$(jq -r .role <<<"$MEMBER_T1")
-r_owner_t2=$(jq -r .role <<<"$OWNER_T2")
-[ "$r_owner_t1"  = owner  ] || fail "owner@t1 role=$r_owner_t1 (want owner)"
-[ "$r_member_t1" = member ] || fail "member@t1 role=$r_member_t1 (want member)"
-[ "$r_owner_t2"  = owner  ] || fail "owner@t2 role=$r_owner_t2 (want owner)"
+echo "==> 3. Claim mapping via GET /api/v1/me"
+ME_OWNER_T1=$(json "$(api GET "$ID_OWNER_T1" /me)")
+ME_MEMBER_T1=$(json "$(api GET "$ID_MEMBER_T1" /me)")
+ME_OWNER_T2=$(json "$(api GET "$ID_OWNER_T2" /me)")
+
+[ "$(jq -r .role <<<"$ME_OWNER_T1")"  = owner  ] || fail "owner@t1 role != owner (claim mapping broken)"
+[ "$(jq -r .role <<<"$ME_MEMBER_T1")" = member ] || fail "member@t1 role != member"
+[ "$(jq -r .role <<<"$ME_OWNER_T2")"  = owner  ] || fail "owner@t2 role != owner"
 pass "role claim mapped: owner@t1=owner, member@t1=member, owner@t2=owner"
 
-t_owner_t1=$(jq -r .tenant_id <<<"$OWNER_T1")
-t_member_t1=$(jq -r .tenant_id <<<"$MEMBER_T1")
-t_owner_t2=$(jq -r .tenant_id <<<"$OWNER_T2")
-[ -n "$t_owner_t1" ] && [ "$t_owner_t1" != null ] || fail "owner@t1 has empty tenant_id (claim mapping broken)"
+T1=$(jq -r .tenant_id <<<"$ME_OWNER_T1")
+T1_MEMBER=$(jq -r .tenant_id <<<"$ME_MEMBER_T1")
+T2=$(jq -r .tenant_id <<<"$ME_OWNER_T2")
+[ -n "$T1" ] && [ "$T1" != null ] || fail "owner@t1 tenant_id empty (tenant claim mapping broken)"
 
-echo "==> 4. Cross-tenant isolation"
-[ "$t_owner_t1" = "$t_member_t1" ] || fail "t1 users in different tenants ($t_owner_t1 vs $t_member_t1)"
-pass "owner@t1 and member@t1 share tenant $t_owner_t1"
-[ "$t_owner_t1" != "$t_owner_t2" ] || fail "t1 and t2 collapsed into one tenant ($t_owner_t1)"
-pass "owner@t2 is a separate tenant $t_owner_t2 (cross-tenant boundary holds)"
+echo "==> 4. Identity-layer cross-tenant separation"
+[ "$T1" = "$T1_MEMBER" ] || fail "t1 users in different tenants ($T1 vs $T1_MEMBER)"
+pass "owner@t1 and member@t1 share tenant $T1"
+[ "$T1" != "$T2" ] || fail "t1 and t2 collapsed into one tenant ($T1)"
+pass "owner@t2 is a separate tenant $T2"
 
-echo "==> 5. Negative: access_token must be rejected (id_token-only contract)"
+echo "==> 5. Data-layer (RLS) isolation via /api/v1/coworkers"
+# Unique-ish folder per run so a re-run doesn't collide on UNIQUE(tenant_id,folder).
+FOLDER="e2e-iso-$$"
+CREATE=$(api POST "$ID_OWNER_T1" /coworkers "{\"name\":\"e2e-iso\",\"folder\":\"${FOLDER}\"}")
+[ "$(code "$CREATE")" = 201 ] || fail "owner@t1 create coworker -> $(code "$CREATE") (want 201); body: $(json "$CREATE")"
+CW_ID=$(jq -r .id <<<"$(json "$CREATE")")
+pass "owner@t1 created coworker $CW_ID"
+
+# Ensure cleanup even if a later assertion fails.
+cleanup() { api DELETE "$ID_OWNER_T1" "/coworkers/${CW_ID}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+LIST_T1=$(api GET "$ID_OWNER_T1" /coworkers)
+[ "$(code "$LIST_T1")" = 200 ] || fail "owner@t1 list coworkers -> $(code "$LIST_T1") (want 200)"
+jq -e --arg id "$CW_ID" '.items[]? | select(.id==$id)' <<<"$(json "$LIST_T1")" >/dev/null \
+  || fail "owner@t1 cannot see its own coworker $CW_ID in the list"
+pass "owner@t1 sees its coworker in GET /coworkers (tenant data reachable, not empty)"
+
+LIST_T2=$(api GET "$ID_OWNER_T2" /coworkers)
+[ "$(code "$LIST_T2")" = 200 ] || fail "owner@t2 list coworkers -> $(code "$LIST_T2") (want 200)"
+if jq -e --arg id "$CW_ID" '.items[]? | select(.id==$id)' <<<"$(json "$LIST_T2")" >/dev/null; then
+  fail "CROSS-TENANT LEAK: owner@t2 sees owner@t1's coworker $CW_ID"
+fi
+pass "owner@t2 does NOT see owner@t1's coworker (RLS cross-tenant isolation holds)"
+
+GET_T2=$(api GET "$ID_OWNER_T2" "/coworkers/${CW_ID}")
+[ "$(code "$GET_T2")" = 404 ] || fail "owner@t2 GET t1's coworker by id -> $(code "$GET_T2") (want 404 BOLA)"
+pass "owner@t2 GET t1's coworker by id -> 404 (direct-object BOLA blocked)"
+
+echo "==> 6. Negative: access_token must be rejected (id_token-only contract)"
 ACCESS_T1=$(token owner@t1 access)
-code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $ACCESS_T1" "$ME_URL")
-[ "$code" = 401 ] || fail "access_token unexpectedly accepted (HTTP $code; want 401)"
+RESP=$(api GET "$ACCESS_T1" /me)
+[ "$(code "$RESP")" = 401 ] || fail "access_token unexpectedly accepted ($(code "$RESP"); want 401)"
 pass "access_token rejected with 401 as expected"
 
 echo

--- a/deploy/compose/keycloak/e2e-verify.sh
+++ b/deploy/compose/keycloak/e2e-verify.sh
@@ -95,7 +95,9 @@ pass "owner@t2 is a separate tenant $T2"
 echo "==> 5. Data-layer (RLS) isolation via /api/v1/coworkers"
 # Unique-ish folder per run so a re-run doesn't collide on UNIQUE(tenant_id,folder).
 FOLDER="e2e-iso-$$"
-CREATE=$(api POST "$ID_OWNER_T1" /coworkers "{\"name\":\"e2e-iso\",\"folder\":\"${FOLDER}\"}")
+# agent_backend is a required CoworkerCreate field (Literal["claude","pi"]) and
+# the schema is extra="forbid", so name+folder alone returns 422.
+CREATE=$(api POST "$ID_OWNER_T1" /coworkers "{\"name\":\"e2e-iso\",\"folder\":\"${FOLDER}\",\"agent_backend\":\"claude\"}")
 [ "$(code "$CREATE")" = 201 ] || fail "owner@t1 create coworker -> $(code "$CREATE") (want 201); body: $(json "$CREATE")"
 CW_ID=$(jq -r .id <<<"$(json "$CREATE")")
 pass "owner@t1 created coworker $CW_ID"

--- a/deploy/compose/keycloak/e2e-verify.sh
+++ b/deploy/compose/keycloak/e2e-verify.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# End-to-end acceptance for the Keycloak OIDC integration. This is the real
+# gate (pytest does not exercise a live IdP). It:
+#   1. waits for the realm to be served,
+#   2. fetches an id_token per test user via ROPG,
+#   3. calls the protected GET /api/v1/auth/me and asserts the role + tenant
+#      claims mapped correctly,
+#   4. asserts cross-tenant isolation (t1 users share a tenant; t2 differs),
+#   5. asserts an access_token is REJECTED (proves the id_token contract).
+#
+# Exit 0 = all green. Requires curl + jq. Run after `docker compose ... up -d`.
+#
+# Env overrides: KC_BASE_URL, ROLEMESH_BASE_URL, REALM, CLIENT_ID, CLIENT_SECRET
+set -euo pipefail
+
+KC_BASE_URL="${KC_BASE_URL:-http://localhost:8081}"
+ROLEMESH_BASE_URL="${ROLEMESH_BASE_URL:-http://localhost:8080}"
+REALM="${REALM:-rolemesh}"
+CLIENT_ID="${CLIENT_ID:-rolemesh-web}"
+CLIENT_SECRET="${CLIENT_SECRET:-rolemesh-web-dev-secret}"
+PASSWORD="${PASSWORD:-Passw0rd!}"
+
+TOKEN_URL="${KC_BASE_URL}/realms/${REALM}/protocol/openid-connect/token"
+DISCOVERY_URL="${KC_BASE_URL}/realms/${REALM}/.well-known/openid-configuration"
+ME_URL="${ROLEMESH_BASE_URL}/api/v1/auth/me"
+
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+
+# token <username> <id|access>  -> prints the requested token
+token() {
+  local user="$1" kind="$2"
+  curl -sf "$TOKEN_URL" \
+    -d grant_type=password -d scope=openid \
+    -d client_id="$CLIENT_ID" -d client_secret="$CLIENT_SECRET" \
+    -d username="$user" -d password="$PASSWORD" \
+    | jq -r ".${kind}_token"
+}
+
+# me <id_token> -> prints the /me JSON (or fails the curl)
+me() { curl -sf -H "Authorization: Bearer $1" "$ME_URL"; }
+
+echo "==> 1. Waiting for Keycloak realm '${REALM}' ..."
+for i in $(seq 1 60); do
+  if curl -sf "$DISCOVERY_URL" >/dev/null 2>&1; then break; fi
+  [ "$i" = 60 ] && fail "realm discovery never came up at ${DISCOVERY_URL}"
+  sleep 2
+done
+pass "discovery reachable at ${DISCOVERY_URL}"
+
+echo "==> 2/3. Tokens + claim mapping via GET /api/v1/auth/me"
+OWNER_T1=$(me "$(token owner@t1 id)")
+MEMBER_T1=$(me "$(token member@t1 id)")
+OWNER_T2=$(me "$(token owner@t2 id)")
+
+r_owner_t1=$(jq -r .role <<<"$OWNER_T1")
+r_member_t1=$(jq -r .role <<<"$MEMBER_T1")
+r_owner_t2=$(jq -r .role <<<"$OWNER_T2")
+[ "$r_owner_t1"  = owner  ] || fail "owner@t1 role=$r_owner_t1 (want owner)"
+[ "$r_member_t1" = member ] || fail "member@t1 role=$r_member_t1 (want member)"
+[ "$r_owner_t2"  = owner  ] || fail "owner@t2 role=$r_owner_t2 (want owner)"
+pass "role claim mapped: owner@t1=owner, member@t1=member, owner@t2=owner"
+
+t_owner_t1=$(jq -r .tenant_id <<<"$OWNER_T1")
+t_member_t1=$(jq -r .tenant_id <<<"$MEMBER_T1")
+t_owner_t2=$(jq -r .tenant_id <<<"$OWNER_T2")
+[ -n "$t_owner_t1" ] && [ "$t_owner_t1" != null ] || fail "owner@t1 has empty tenant_id (claim mapping broken)"
+
+echo "==> 4. Cross-tenant isolation"
+[ "$t_owner_t1" = "$t_member_t1" ] || fail "t1 users in different tenants ($t_owner_t1 vs $t_member_t1)"
+pass "owner@t1 and member@t1 share tenant $t_owner_t1"
+[ "$t_owner_t1" != "$t_owner_t2" ] || fail "t1 and t2 collapsed into one tenant ($t_owner_t1)"
+pass "owner@t2 is a separate tenant $t_owner_t2 (cross-tenant boundary holds)"
+
+echo "==> 5. Negative: access_token must be rejected (id_token-only contract)"
+ACCESS_T1=$(token owner@t1 access)
+code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $ACCESS_T1" "$ME_URL")
+[ "$code" = 401 ] || fail "access_token unexpectedly accepted (HTTP $code; want 401)"
+pass "access_token rejected with 401 as expected"
+
+echo
+printf '\033[32mAll checks passed.\033[0m RoleMesh is authenticating against Keycloak in oidc mode.\n'

--- a/deploy/compose/keycloak/get-token.sh
+++ b/deploy/compose/keycloak/get-token.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Fetch an id_token for a RoleMesh test user from Keycloak via the Resource
+# Owner Password Grant (ROPG). This is what a promptfoo custom provider uses to
+# authenticate programmatically.
+#
+# IMPORTANT: prints the id_token, NOT the access_token. RoleMesh validates the
+# bearer as an id_token (aud == client_id); a Keycloak access_token has
+# aud=["account"] and would be rejected with 401.
+#
+# Usage:
+#   ./get-token.sh                 # owner@t1 by default
+#   ./get-token.sh member@t1
+#   ./get-token.sh owner@t2 'Passw0rd!'
+#
+# Env overrides: KC_BASE_URL, REALM, CLIENT_ID, CLIENT_SECRET
+set -euo pipefail
+
+USER_NAME="${1:-owner@t1}"
+PASSWORD="${2:-Passw0rd!}"
+KC_BASE_URL="${KC_BASE_URL:-http://localhost:8081}"
+REALM="${REALM:-rolemesh}"
+CLIENT_ID="${CLIENT_ID:-rolemesh-web}"
+CLIENT_SECRET="${CLIENT_SECRET:-rolemesh-web-dev-secret}"
+
+curl -sf "${KC_BASE_URL}/realms/${REALM}/protocol/openid-connect/token" \
+  -d grant_type=password \
+  -d scope=openid \
+  -d client_id="${CLIENT_ID}" \
+  -d client_secret="${CLIENT_SECRET}" \
+  -d username="${USER_NAME}" \
+  -d password="${PASSWORD}" \
+  | jq -r .id_token

--- a/deploy/compose/keycloak/rolemesh-realm.json
+++ b/deploy/compose/keycloak/rolemesh-realm.json
@@ -1,0 +1,131 @@
+{
+  "realm": "rolemesh",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "accessTokenLifespan": 1800,
+  "accessTokenLifespanForImplicitFlow": 1800,
+  "ssoSessionIdleTimeout": 3600,
+  "ssoSessionMaxLifespan": 36000,
+  "components": {
+    "org.keycloak.userprofile.UserProfileProvider": [
+      {
+        "name": "Declarative User Profile",
+        "providerId": "declarative-user-profile",
+        "subComponents": {},
+        "config": {
+          "kc.user.profile.config": [
+            "{\"unmanagedAttributePolicy\":\"ENABLED\"}"
+          ]
+        }
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "rolemesh-web",
+      "name": "RoleMesh WebUI",
+      "description": "Confidential client for RoleMesh: browser PKCE login + ROPG for programmatic (promptfoo) token issuance.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "rolemesh-web-dev-secret",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "implicitFlowEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/oauth2/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:8080"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:8080/*"
+      },
+      "protocolMappers": [
+        {
+          "name": "tenant_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "tenant_id",
+            "claim.name": "tenant_id",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "multivalued": "false"
+          }
+        },
+        {
+          "name": "role",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "role",
+            "claim.name": "role",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "multivalued": "false"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "owner@t1",
+      "email": "owner@t1.example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Owner",
+      "lastName": "TenantOne",
+      "attributes": {
+        "tenant_id": ["t1"],
+        "role": ["owner"]
+      },
+      "credentials": [
+        { "type": "password", "value": "Passw0rd!", "temporary": false }
+      ]
+    },
+    {
+      "username": "member@t1",
+      "email": "member@t1.example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Member",
+      "lastName": "TenantOne",
+      "attributes": {
+        "tenant_id": ["t1"],
+        "role": ["member"]
+      },
+      "credentials": [
+        { "type": "password", "value": "Passw0rd!", "temporary": false }
+      ]
+    },
+    {
+      "username": "owner@t2",
+      "email": "owner@t2.example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Owner",
+      "lastName": "TenantTwo",
+      "attributes": {
+        "tenant_id": ["t2"],
+        "role": ["owner"]
+      },
+      "credentials": [
+        { "type": "password", "value": "Passw0rd!", "temporary": false }
+      ]
+    }
+  ]
+}

--- a/deploy/compose/keycloak/rolemesh-realm.json
+++ b/deploy/compose/keycloak/rolemesh-realm.json
@@ -17,7 +17,7 @@
         "subComponents": {},
         "config": {
           "kc.user.profile.config": [
-            "{\"unmanagedAttributePolicy\":\"ENABLED\"}"
+            "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}],\"unmanagedAttributePolicy\":\"ENABLED\"}"
           ]
         }
       }


### PR DESCRIPTION
## What

Adds an **optional** Keycloak IdP to the compose stack so RoleMesh can run
end-to-end under `AUTH_MODE=oidc` — the prerequisite for promptfoo
BOLA/BFLA/RBAC red-teaming against real role/tenant/scope boundaries. The
`oidc` provider code already existed but had never been run end-to-end because
no IdP was deployed.

**Purely additive** — the base `compose.yaml` is untouched and still defaults to
`AUTH_MODE=external`. Omit the override file to get the original stack back. No
Python changes.

## Files (5 new)

| File | Purpose |
|------|---------|
| `deploy/compose/compose.keycloak.yaml` | Keycloak service + override flipping webui/orchestrator to `AUTH_MODE=oidc` with full `OIDC_*` wiring |
| `deploy/compose/keycloak/rolemesh-realm.json` | Reproducible realm import: confidential client `rolemesh-web` (S256 PKCE + Direct Access Grants), 30-min token lifespan, user-attribute mappers emitting flat `tenant_id`/`role` String claims into the **ID token**, 3 test users across 2 tenants |
| `deploy/compose/keycloak/get-token.sh` | ROPG helper that prints an **id_token** (the bearer RoleMesh validates) |
| `deploy/compose/keycloak/e2e-verify.sh` | Live acceptance: claim mapping, identity + RLS cross-tenant isolation, BOLA block, id_token-only contract |
| `deploy/compose/README.md` | One-page run / login / claim-map / token-fetch guide + contract notes |

## Key design contract

RoleMesh's `OIDCAuthProvider.authenticate()` validates the bearer as an
**id_token** (`aud == client_id`), consistent with its "AuthN external, AuthZ
internal" design (`docs/6-auth-architecture.md`). A Keycloak access_token has
`aud=["account"]` and is rejected with 401. **Always use the id_token** — both
the browser flow and `get-token.sh`/promptfoo. `e2e-verify.sh` asserts the
access_token is rejected as a guardrail.

## Test users

All passwords `Passw0rd!`. RoleMesh JIT-creates a local tenant `oidc-<tenant_id>`
on first login, so `t1`/`t2` become isolated tenants with no pre-seeding.

| Username | tenant_id | role |
|----------|-----------|------|
| `owner@t1`  | `t1` | `owner`  |
| `member@t1` | `t1` | `member` |
| `owner@t2`  | `t2` | `owner`  |

## How to run

```bash
docker compose --env-file .env \
  -f deploy/compose/compose.yaml \
  -f deploy/compose/compose.keycloak.yaml up -d
# wait ~20s for realm import, then:
deploy/compose/keycloak/e2e-verify.sh
```

## Verification

`e2e-verify.sh` — **6 phases / 11 assertions, confirmed green on a Docker
host**: OIDC auth, role + tenant claim mapping, identity-layer cross-tenant
separation, RLS data-layer isolation (owner@t1 creates a coworker; owner@t2
cannot see it and gets 404 by id), and access_token rejection.

The Keycloak image is pinned to the exact patch **`25.0.6`** with hostname
**v2** syntax (`KC_HOSTNAME=http://localhost:8081` +
`KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true`) so tag and config can't drift — this
keeps `iss` stable for the browser while backchannel `jwks_uri`/`token_endpoint`
stay reachable in-network (`OIDC_DISCOVERY_URL` must remain `keycloak:8080`).

## Scope notes

- Dev/test only: H2 in-memory Keycloak, plaintext secrets, no HA/persistence.
- No changes to the auth abstraction; no MCP work (that's `feat/3-mcp-servers`);
  no promptfoo. Compose changes kept small and localized to avoid conflicts.
- `pytest tests/ -k auth` cannot regress: zero Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJaGRSoGAwm955w7BAEeP)_