### PR TITLE
fix(egress): stop mcp-proxy dropping injected auth/X-Actor on 307

### DIFF
--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -298,6 +298,25 @@ def get_mcp_registry() -> dict[str, tuple[str, dict[str, str], str]]:
     return dict(_mcp_registry)
 
 
+def _collapse_trailing_slash(path: str) -> str:
+    """Drop a redundant trailing slash from an MCP upstream path.
+
+    FastMCP/Starlette mount the MCP app at ``/mcp`` and 307-redirect
+    ``/mcp/`` → ``/mcp``. A server registered with a trailing slash (the
+    common case — see ``redteam/seed.py``) therefore triggers a redirect
+    on *every* call. Collapsing the redundant slash here serves the
+    request directly and removes that round-trip at the source. The
+    redirect-follow in ``_stream_upstream`` remains the general safety
+    net for any *other* redirect a server may emit.
+
+    The root path ``/`` is preserved — stripping it would change the
+    request target rather than just normalising a spurious slash.
+    """
+    if len(path) > 1 and path.endswith("/"):
+        return path.rstrip("/") or "/"
+    return path
+
+
 # ---------------------------------------------------------------------------
 # Safety hook
 # ---------------------------------------------------------------------------
@@ -405,9 +424,21 @@ async def start_credential_proxy(
         target_url: str,
         headers: dict[str, str],
         body: bytes,
+        *,
+        follow_redirects: bool = False,
     ) -> web.StreamResponse:
+        # ``follow_redirects`` is opt-in per route. The LLM provider path
+        # leaves it False: those endpoints are exact and a 3xx there is
+        # suspicious, so we pass the redirect straight back. The MCP path
+        # turns it on (see ``handle_mcp_proxy``) so that the per-server
+        # ``extra_headers`` we inject — Authorization / X-Actor-* — are
+        # re-sent on the redirected hop instead of being lost. aiohttp
+        # preserves those headers across a *same-origin* redirect (it only
+        # drops Authorization when the origin changes), which is exactly
+        # the FastMCP ``/mcp/`` → ``/mcp`` case.
         async with session.request(
-            method, target_url, headers=headers, data=body or None, allow_redirects=False,
+            method, target_url, headers=headers, data=body or None,
+            allow_redirects=follow_redirects,
         ) as upstream_resp:
             resp_headers = {k: v for k, v in upstream_resp.headers.items() if k.lower() not in _SKIP_RESPONSE_HEADERS}
             response = web.StreamResponse(status=upstream_resp.status, headers=resp_headers)
@@ -548,7 +579,11 @@ async def start_credential_proxy(
         rest = request.match_info.get("path_info", "")
         identity, server_name, upstream_path = _resolve(request, first_seg, rest)
 
-        remaining_path = "/" + upstream_path
+        # Collapse a redundant trailing slash (``/mcp/`` → ``/mcp``) so the
+        # FastMCP/Starlette 307 redirect never fires in the common case;
+        # _stream_upstream still follows any other redirect with the
+        # injected headers re-sent.
+        remaining_path = _collapse_trailing_slash("/" + upstream_path)
         if request.query_string:
             remaining_path += "?" + request.query_string
 
@@ -590,7 +625,10 @@ async def start_credential_proxy(
         body = await request.read()
 
         try:
-            return await _stream_upstream(request, request.method, target_url, fwd_headers, body)
+            return await _stream_upstream(
+                request, request.method, target_url, fwd_headers, body,
+                follow_redirects=True,
+            )
         except (ConnectionResetError, OSError, RuntimeError, ValueError) as exc:
             logger.error("MCP proxy upstream error", server=server_name, error=str(exc))
             return web.Response(status=502, text="MCP proxy: Bad Gateway")

--- a/tests/egress/test_reverse_proxy_mcp_redirect.py
+++ b/tests/egress/test_reverse_proxy_mcp_redirect.py
@@ -1,0 +1,190 @@
+"""Reverse-proxy MCP redirect / injected-header survival.
+
+Regression for the bug where an MCP server whose ``/mcp/`` endpoint
+307-redirects to ``/mcp`` (FastMCP/Starlette default) lost the
+per-server ``extra_headers`` the gateway injects — Authorization +
+X-Actor-* — because the gateway used ``allow_redirects=False`` and
+passed the bare 307 back to the agent's MCP client, whose follow-up
+request went out *without* the injected headers and got a 401.
+
+The fix has two layers, both exercised here:
+
+  * fix B (``_collapse_trailing_slash``): a registered ``…/mcp/`` path is
+    normalised to ``/mcp`` so the redirect never fires in the common
+    case — the upstream is dialled directly.
+  * fix A (``follow_redirects=True``): for any *other* redirect a server
+    emits, the gateway follows it and the injected headers ride along
+    (aiohttp preserves Authorization on a same-origin redirect).
+
+Driven through a real aiohttp test server (no Docker), mirroring
+``test_reverse_proxy_token_routing.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from rolemesh.egress.reverse_proxy import (
+    get_mcp_registry,
+    register_mcp_server,
+    start_credential_proxy,
+    unregister_mcp_server,
+)
+from rolemesh.egress.token_identity import Identity, TokenAuthority
+
+pytestmark = pytest.mark.asyncio
+
+_SECRET = "mcp-redirect-test-secret-16+chars"
+_SERVICE_TOKEN = "Bearer test-token-redteam"
+_ACTOR_ID = "userA"
+_ACTOR_ROLE = "member"
+
+
+class _FakeCredResolver:
+    async def resolve(self, tenant_id: str, provider: str) -> dict[str, Any]:
+        return {"api_key": "sk-test"}
+
+
+class _Recorder:
+    """Captures every request the stub MCP upstream actually served."""
+
+    def __init__(self) -> None:
+        self.served: list[tuple[str, dict[str, str]]] = []
+
+
+async def _make_mcp_upstream(recorder: _Recorder) -> TestServer:
+    """Stub MCP server: ``/redir`` 307s to ``/mcp``; ``/mcp`` requires the
+    injected ``Bearer test-token-`` auth header (mirrors the red-team
+    JWT-prefix middleware) and records what it saw."""
+
+    async def redir(request: web.Request) -> web.Response:
+        return web.Response(status=307, headers={"Location": "/mcp"})
+
+    async def mcp(request: web.Request) -> web.Response:
+        recorder.served.append((request.path, dict(request.headers)))
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer test-token-"):
+            return web.Response(status=401, text="Unauthorized")
+        return web.Response(status=200, text="ok")
+
+    app = web.Application()
+    app.router.add_route("*", "/redir", redir)
+    app.router.add_route("*", "/mcp", mcp)
+    server = TestServer(app)
+    await server.start_server()
+    return server
+
+
+def _identity(tenant: str = "t1") -> Identity:
+    return Identity(tenant, "cow", "usr", "conv", "job1", "rolemesh-x-1")
+
+
+async def _client(proxy_runner: web.AppRunner) -> TestClient:
+    client = TestClient(TestServer(proxy_runner.app))
+    await client.start_server()
+    return client
+
+
+async def _proxy(authority: TokenAuthority) -> web.AppRunner:
+    return await start_credential_proxy(
+        0,
+        credential_resolver=_FakeCredResolver(),  # type: ignore[arg-type]
+        token_authority=authority,
+    )
+
+
+def _register(origin: str) -> None:
+    register_mcp_server(
+        "srv",
+        origin,
+        headers={
+            "Authorization": _SERVICE_TOKEN,
+            "X-Actor-Id": _ACTOR_ID,
+            "X-Actor-Role": _ACTOR_ROLE,
+        },
+        auth_mode="service",
+    )
+
+
+async def test_redirect_preserves_injected_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fix A: an upstream redirect is followed by the gateway and the
+    injected Authorization + X-Actor headers ride along, so the agent
+    sees 200 — not the bare 307 that used to leak through unauthenticated.
+    """
+    recorder = _Recorder()
+    upstream = await _make_mcp_upstream(recorder)
+    origin = str(upstream._root).rstrip("/")
+    authority = TokenAuthority(secret=_SECRET, ttl_seconds=3600)
+    runner = await _proxy(authority)
+    client = await _client(runner)
+    _register(origin)
+    try:
+        token = authority.mint(_identity())
+        # Hit a path that genuinely redirects (not the trailing-slash
+        # case fix B pre-empts) so the redirect-follow is exercised.
+        resp = await client.post(f"/mcp-proxy/{token}/srv/redir", data=b"{}")
+        assert resp.status == 200
+        assert await resp.text() == "ok"
+
+        # The final (post-redirect) request reached /mcp WITH the injected
+        # service token and actor headers.
+        assert recorder.served, "upstream /mcp was never reached"
+        path, headers = recorder.served[-1]
+        assert path == "/mcp"
+        assert headers.get("Authorization") == _SERVICE_TOKEN
+        assert headers.get("X-Actor-Id") == _ACTOR_ID
+        assert headers.get("X-Actor-Role") == _ACTOR_ROLE
+    finally:
+        unregister_mcp_server("srv")
+        await client.close()
+        await runner.cleanup()
+        await upstream.close()
+
+
+async def test_trailing_slash_collapsed_no_redirect() -> None:
+    """fix B: a request to ``/mcp/`` is normalised to ``/mcp`` so the
+    upstream is dialled directly — a single served request, no redirect
+    round-trip — and the injected headers are present."""
+    recorder = _Recorder()
+    upstream = await _make_mcp_upstream(recorder)
+    origin = str(upstream._root).rstrip("/")
+    authority = TokenAuthority(secret=_SECRET, ttl_seconds=3600)
+    runner = await _proxy(authority)
+    client = await _client(runner)
+    _register(origin)
+    try:
+        token = authority.mint(_identity())
+        resp = await client.post(f"/mcp-proxy/{token}/srv/mcp/", data=b"{}")
+        assert resp.status == 200
+
+        # Exactly one served request, straight to /mcp — the trailing
+        # slash was collapsed before dialling, so no 307 was needed.
+        assert len(recorder.served) == 1
+        path, headers = recorder.served[0]
+        assert path == "/mcp"
+        assert headers.get("Authorization") == _SERVICE_TOKEN
+        assert headers.get("X-Actor-Id") == _ACTOR_ID
+    finally:
+        unregister_mcp_server("srv")
+        await client.close()
+        await runner.cleanup()
+        await upstream.close()
+
+
+async def test_collapse_trailing_slash_unit() -> None:
+    from rolemesh.egress.reverse_proxy import _collapse_trailing_slash
+
+    assert _collapse_trailing_slash("/mcp/") == "/mcp"
+    assert _collapse_trailing_slash("/mcp") == "/mcp"
+    assert _collapse_trailing_slash("/mcp//") == "/mcp"
+    # Root must be preserved, not emptied.
+    assert _collapse_trailing_slash("/") == "/"
+    assert _collapse_trailing_slash("") == ""
+    # Registry stays clean across the test module.
+    assert "srv" not in get_mcp_registry()


### PR DESCRIPTION
## Problem

An MCP server whose `/mcp/` endpoint **307-redirects to `/mcp`** (the FastMCP/Starlette default for a trailing slash) caused the egress gateway's reverse mcp-proxy to leak the bare redirect back to the agent's MCP client. The client's follow-up request went out through a path that does **not** inject the per-server `extra_headers`, so the upstream saw no `Authorization: Bearer test-token-*` / `X-Actor-*` and returned **401**. The agent then **silently dropped that server's tools** — no exception, no log warning.

Impact:
- **Silent**: the agent simply "sees no tools" and degrades to built-in read/bash.
- **Universal**: any real customer MCP registered as `…/mcp/` is affected, not just red-team targets.
- **Security-relevant**: it bypasses the entire `auth_mode=service` / `X-Actor` identity-injection layer.

### Precise chain

1. agent MCP client → `POST /mcp-proxy/<token>/files-mcp/mcp/`
2. `handle_mcp_proxy` injects `server_headers` and dials `http://files-mcp:9101/mcp/`
3. `_stream_upstream` used `allow_redirects=False` → the upstream **307 + Location** is passed straight back, `Location` unrewritten
4. client follows the absolute `Location` via its forward proxy (or a bare connection), which injects **no** per-server headers → upstream 401

## Fix

Two layers in `reverse_proxy.py`:

- **B — `_collapse_trailing_slash`**: normalise a registered `…/mcp/` path to `/mcp` before dialling, so the redirect never fires in the common case and the upstream is reached directly (root `/` preserved).
- **A — `follow_redirects=True` on the MCP path**: for any *other* redirect a server emits, the gateway follows it itself, so the injected headers ride along. Verified against aiohttp 3.14.1 source: `Authorization` is dropped **only on a cross-origin** redirect; a same-origin `/mcp/` → `/mcp` redirect **preserves** it, and `X-Actor-*` are never in the drop list. The LLM provider path keeps `allow_redirects=False` unchanged.

## Tests

New no-Docker test `tests/egress/test_reverse_proxy_mcp_redirect.py`:
- redirect-follow preserves the injected `Authorization` + `X-Actor-*` (agent gets 200, not a leaked 307)
- trailing-slash collapse → a single served request straight to `/mcp`, no 307 round-trip
- `_collapse_trailing_slash` unit cases

`ruff check` clean; new tests + the existing token-routing regression pass (6/6); egress non-integration suite 182 passed. (The DB-credential / credential-resolver collection errors are pre-existing and Docker-dependent — testcontainers cannot reach the Docker socket in this environment — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011L1VdsNstrZ8RFhwuZ1byi

---
_Generated by [Claude Code](https://claude.ai/code/session_011L1VdsNstrZ8RFhwuZ1byi)_