### PR TITLE
test: make container + nats-bridge tests self-supply their environment

### DIFF
--- a/tests/container/test_runner.py
+++ b/tests/container/test_runner.py
@@ -464,9 +464,18 @@ class TestMetadataBlackholeAndNetwork:
         assert spec.extra_hosts.get("metadata.google.internal") == "127.0.0.1"
 
     def test_custom_network_name_applied_from_config(self) -> None:
-        with patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"):
+        # Pin the bridge name: a developer .env with an empty
+        # CONTAINER_NETWORK_NAME leaks into os.environ via
+        # rolemesh.bootstrap's load_dotenv whenever another test module
+        # imports rolemesh.main/webui.main first, which would null this out.
+        with (
+            patch(
+                "rolemesh.container.runner.CONTAINER_NETWORK_NAME",
+                "rolemesh-agent-net",
+            ),
+            patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),
+        ):
             spec = build_container_spec([], "c", "j")
-        # Default config points at rolemesh-agent-net unless CONTAINER_NETWORK_NAME='' is set.
         assert spec.network_name == "rolemesh-agent-net"
 
     def test_empty_network_name_yields_none(self) -> None:
@@ -486,7 +495,12 @@ class TestComputeEgressRouting:
     def test_routing_with_token(self) -> None:
         from rolemesh.container import runner
 
-        with patch.object(runner, "EGRESS_GATEWAY_DNS_IP", "172.20.0.2"):
+        # Pin the bridge name against developer-.env pollution (see
+        # test_custom_network_name_applied_from_config).
+        with (
+            patch.object(runner, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+            patch.object(runner, "EGRESS_GATEWAY_DNS_IP", "172.20.0.2"),
+        ):
             r = compute_egress_routing("TOK")
 
         assert r.proxy_base == "http://egress-gateway:3001"

--- a/tests/container/test_startup_order.py
+++ b/tests/container/test_startup_order.py
@@ -52,7 +52,13 @@ async def test_startup_verifies_infrastructure_in_order() -> None:
     parent.attach_mock(rt.verify_infrastructure, "verify_infrastructure")
     parent.attach_mock(rt.cleanup_orphans, "cleanup_orphans")
 
-    with patch.object(main_module, "get_runtime", return_value=rt):
+    # Pin the bridge name: a developer .env with an empty
+    # CONTAINER_NETWORK_NAME leaks into os.environ via rolemesh.bootstrap
+    # and would otherwise trip the empty-value guard before verification.
+    with (
+        patch.object(main_module, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
+        patch.object(main_module, "get_runtime", return_value=rt),
+    ):
         await main_module._ensure_container_system_running()
 
     call_order = [c[0] for c in parent.mock_calls if c[0]]
@@ -91,7 +97,10 @@ async def test_startup_fail_closed_when_verification_fails() -> None:
         side_effect=RuntimeError("agent network does not exist")
     )
 
+    # Pin the bridge name so the empty-value guard doesn't fire before
+    # verify_infrastructure (developer-.env pollution; see module siblings).
     with (
+        patch.object(main_module, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
         patch.object(main_module, "get_runtime", return_value=rt),
         pytest.raises(RuntimeError, match="agent network does not exist"),
     ):

--- a/tests/test_agent_runner/test_nats_bridge.py
+++ b/tests/test_agent_runner/test_nats_bridge.py
@@ -387,13 +387,14 @@ class TestChannel4CloseSignal:
 class TestChannel5And6ToolPublishes:
     async def test_send_message_tool_publishes_to_nats(self, nats_conn: tuple) -> None:
         """send_message tool publishes to agent.{id}.messages via real NATS."""
-        _nc, js = nats_conn
+        nc, js = nats_conn
         job_id = _unique_job_id()
 
         sub = await js.subscribe(f"agent.{job_id}.messages")
 
         ctx = ToolContext(
             js=js,
+            nc=nc,
             job_id=job_id,
             chat_jid="chat-1",
             group_folder="grp",
@@ -418,13 +419,14 @@ class TestChannel5And6ToolPublishes:
 
     async def test_schedule_task_tool_publishes_to_nats(self, nats_conn: tuple) -> None:
         """schedule_task tool publishes to agent.{id}.tasks via real NATS."""
-        _nc, js = nats_conn
+        nc, js = nats_conn
         job_id = _unique_job_id()
 
         sub = await js.subscribe(f"agent.{job_id}.tasks")
 
         ctx = ToolContext(
             js=js,
+            nc=nc,
             job_id=job_id,
             chat_jid="chat-1",
             group_folder="grp",


### PR DESCRIPTION
## What

Two test-hygiene fixes so the suite is hermetic regardless of a developer's local `.env` or cross-module import order. No production code changes — tests only (3 files, +31/-6).

## Bug 1 — `CONTAINER_NETWORK_NAME` pollution (4 tests, flaky under full-suite ordering)

**Root cause (reproduced):** a local `.env` with an empty `CONTAINER_NETWORK_NAME=` leaks into `os.environ` via `rolemesh.bootstrap`'s `load_dotenv(override=False)` as soon as any test imports `rolemesh.main`/`webui.main`. `core.config` (frozen at import) then reads `''` instead of the `"rolemesh-agent-net"` default. Four tests that relied on the default fail when import order puts `rolemesh.main` first; they pass when run alone.

Affected:
- `test_runner.py::TestMetadataBlackholeAndNetwork::test_custom_network_name_applied_from_config`
- `test_runner.py::TestComputeEgressRouting::test_routing_with_token`
- `test_startup_order.py::test_startup_verifies_infrastructure_in_order`
- `test_startup_order.py::test_startup_fail_closed_when_verification_fails`

**Fix:** pin the bridge name in each test (patching the importing module's binding), matching the existing pattern in `test_verify_infrastructure.py`. Product behaviour — empty value = hard startup error — is intentional and unchanged; this is a test-isolation fix, not a config change.

## Bug 2 — `ToolContext` missing required `nc` (2 tests)

**Root cause:** `nc` became a required field in Frontdesk v1.2 (guarded by `test_nc_is_a_required_field`), but two `nats_bridge` constructions still omitted it, failing at construction time with `TypeError`.

**Fix:** pass `nc=nc` from the fixture connection (`_nc, js` → `nc, js`). Verified these are the only two of the suite's eight `ToolContext(` sites missing `nc`.

## Verification

- Bug 1: `CONTAINER_NETWORK_NAME="" pytest tests/container/test_runner.py tests/container/test_startup_order.py` → **55 passed** (was 4 failed / 51 passed). Clean env → **55 passed**.
- Bug 2: `ruff` clean; both tests collect under the `integration` marker; `test_tool_context.py` guard → **9 passed**. (Tests themselves require a NATS testcontainer not available in this environment; the failure they fixed is a construction-time `TypeError` independent of NATS reachability.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014SF11iL8qtGjKuKLj9a7gj)_