### PR TITLE
fix(claude-backend): end input stream when a turn settles so run_prompt returns

### DIFF
--- a/src/agent_runner/claude_backend.py
+++ b/src/agent_runner/claude_backend.py
@@ -551,6 +551,22 @@ class ClaudeBackend:
                         is_final=False,
                         usage=usage,
                     ))
+                    # End the turn once this batch is fully answered. In
+                    # multi-turn streaming mode the SDK keeps query() reading
+                    # from the persistent MessageStream, so after the last
+                    # ResultMessage the async-for would block forever waiting
+                    # for more input — run_prompt never returns and the NATS
+                    # bridge never publishes the batch-final (is_final=True)
+                    # marker, leaking the orchestrator's turn slot until the
+                    # watchdog. Closing the input ends the turn deterministically.
+                    # Guard on has_pending() so a follow-up already queued (or
+                    # pushed before the SDK's next input read) is still drained
+                    # and answered first — MessageStream.__aiter__ drains the
+                    # queue before honoring _done. Cross-turn continuity rides
+                    # options.resume + resume-session-at, not this stream, so
+                    # closing it per-turn is safe; abort() owns its own end().
+                    if not self._aborting and not stream.has_pending():
+                        stream.end()
 
         aborted = False
         try:

--- a/src/agent_runner/message_stream.py
+++ b/src/agent_runner/message_stream.py
@@ -40,6 +40,17 @@ class MessageStream:
         self._done = True
         self._event.set()
 
+    def has_pending(self) -> bool:
+        """True while user messages are queued but not yet consumed by the SDK.
+
+        Used by the backend to decide whether a turn is fully answered: after a
+        ResultMessage, an empty queue means there is no follow-up to keep the
+        multi-turn stream open for, so the input can be ended. ``__aiter__``
+        drains the queue before honoring ``end()``, so a follow-up that races
+        in right after this check is still delivered, never lost.
+        """
+        return bool(self._queue)
+
     async def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
         while True:
             while self._queue:

--- a/tests/test_agent_runner/test_claude_turn_ends.py
+++ b/tests/test_agent_runner/test_claude_turn_ends.py
@@ -1,0 +1,120 @@
+"""Regression: ClaudeBackend.run_prompt must RETURN after a turn settles.
+
+Root cause it guards (slot-leak hunt): ClaudeBackend feeds query() a persistent
+MessageStream to support in-turn follow-ups, which puts the SDK in multi-turn
+streaming mode — query() stays open reading the input iterator. The "end the
+turn = close the input" contract was only honored in abort(); on normal
+completion neither stream.end() nor a break happened, so after the last
+ResultMessage the async-for blocked forever, run_prompt never returned, and the
+NATS bridge never published the batch-final is_final=True marker → the
+orchestrator's turn slot leaked until the 7-min watchdog.
+
+Fix: after a ResultMessage, when no follow-up is queued, ClaudeBackend calls
+stream.end(). These tests drive run_prompt with a faked SDK query() (the real
+claude_agent_sdk only exists inside containers) and assert run_prompt RETURNS —
+a wait_for timeout here means the hang regressed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+# Stub claude_agent_sdk BEFORE importing claude_backend (container-only dep).
+_fake_sdk = types.ModuleType("claude_agent_sdk")
+_fake_sdk.ClaudeAgentOptions = type(  # type: ignore[attr-defined]
+    "ClaudeAgentOptions", (), {"__init__": lambda self, **kw: None}
+)
+_fake_sdk.HookMatcher = type(  # type: ignore[attr-defined]
+    "HookMatcher", (), {"__init__": lambda self, **kw: setattr(self, "hooks", kw.get("hooks"))}
+)
+_fake_sdk.ToolUseBlock = type("ToolUseBlock", (), {})  # type: ignore[attr-defined]
+_fake_sdk.query = lambda **kw: iter(())  # type: ignore[attr-defined]
+_fake_sdk.create_sdk_mcp_server = lambda **kw: object()  # type: ignore[attr-defined]
+_fake_sdk.tool = lambda *a, **kw: (lambda fn: fn)  # type: ignore[attr-defined]
+sys.modules.setdefault("claude_agent_sdk", _fake_sdk)
+
+
+from agent_runner import claude_backend  # noqa: E402
+from agent_runner.backend import ResultEvent  # noqa: E402
+
+
+class ResultMessage:
+    """Fake SDK ResultMessage (matched by type(...).__name__ == 'ResultMessage')."""
+
+    def __init__(self, result: str, session_id: str = "sess-1") -> None:
+        self.result = result
+        self.session_id = session_id
+        # No `usage`/`model` attrs → _build_usage_snapshot returns None.
+
+
+def _make_backend() -> tuple[Any, list[Any]]:
+    """A ClaudeBackend wired with just enough state for run_prompt, plus a
+    listener that records emitted events."""
+    backend = claude_backend.ClaudeBackend()
+    backend._init = SimpleNamespace(
+        system_prompt=None, mcp_servers=None, user_id=None, is_scheduled_task=False
+    )
+    backend._mcp_server = object()
+    backend._sdk_hooks = {}
+    backend._sdk_env = {}
+    events: list[Any] = []
+
+    async def listener(event: Any) -> None:
+        events.append(event)
+
+    backend.subscribe(listener)
+    return backend, events
+
+
+async def test_run_prompt_returns_when_no_follow_up(monkeypatch: Any) -> None:
+    """One reply, no follow-up: the SDK query() blocks on the input iterator
+    after the ResultMessage; the fix's stream.end() must let it finish so
+    run_prompt returns (pre-fix this hangs forever)."""
+
+    async def fake_query(*, prompt: Any, options: Any) -> Any:
+        # Mirror the SDK contract: read each user message from the input
+        # iterator and answer it. When the input ends (stream.end()), the
+        # async-for terminates and the generator returns.
+        async for _ in prompt:
+            yield ResultMessage(result="hello back")
+
+    monkeypatch.setattr(claude_backend, "query", fake_query)
+    backend, events = _make_backend()
+
+    await asyncio.wait_for(backend.run_prompt("hi"), timeout=2.0)
+
+    results = [e for e in events if isinstance(e, ResultEvent)]
+    assert len(results) == 1
+    assert results[0].text == "hello back"
+    assert results[0].is_final is False  # batch-final marker is the bridge's job
+
+
+async def test_queued_follow_up_answered_then_returns(monkeypatch: Any) -> None:
+    """A follow-up queued during the turn must still be answered (has_pending()
+    keeps the stream open), and then run_prompt must return — proving the fix
+    both preserves in-turn follow-ups and no longer hangs."""
+
+    pushed = False
+
+    async def fake_query(*, prompt: Any, options: Any) -> Any:
+        nonlocal pushed
+        async for _ in prompt:
+            if not pushed:
+                # Queue a follow-up BEFORE replying to the first message, so
+                # the backend sees has_pending()==True after the first
+                # ResultMessage and does NOT end the stream yet.
+                pushed = True
+                prompt.push("second question")
+            yield ResultMessage(result="answer")
+
+    monkeypatch.setattr(claude_backend, "query", fake_query)
+    backend, events = _make_backend()
+
+    await asyncio.wait_for(backend.run_prompt("first question"), timeout=2.0)
+
+    results = [e for e in events if isinstance(e, ResultEvent)]
+    assert len(results) == 2, "the queued follow-up must be answered, not dropped"


### PR DESCRIPTION
## Problem

On the **Claude** backend, a web turn completes and the reply reaches the user, but the agent process never finishes the turn: its log freezes at `Session initialized` and no batch-final marker is ever published. Downstream this leaks the orchestrator's per-coworker turn slot — a 3rd concurrent conversation to the same coworker is blocked ~5–7 min until the `TURN_INACTIVITY_TIMEOUT` watchdog reaps the (non-exited) container. **Pi is unaffected.**

## Root cause

`ClaudeBackend.run_prompt` feeds `query()` a persistent `MessageStream` (async-iterable) to keep the SDK in **multi-turn streaming mode**, so `handle_follow_up` can `push()` a follow-up into the *same* turn. The SDK therefore keeps `query()` open, reading from that input iterator.

But the contract "end the turn = close the input stream" was only honored in `abort()`. On normal completion neither `stream.end()` nor a `break` ran, so after the last `ResultMessage`:

```
async for message in query(prompt=stream)  →  MessageStream.__aiter__:
    queue empty + _done=False  →  await self._event.wait()   # blocks forever
```

→ `_consume_query` never returns → `run_prompt` never returns → the agent_runner bridge never publishes `ContainerOutput(status="success", is_final=True)`. That marker is exactly what the orchestrator's `_on_output` turns into `notify_idle()` (the turn-slot release), so on the Claude path the slot is never released by the normal route.

Pi avoids this because `PiBackend.run_prompt` awaits a bounded `session.prompt()` that returns.

## Fix

After each `ResultMessage`, when no follow-up is queued, call `stream.end()`:

```python
if not self._aborting and not stream.has_pending():
    stream.end()
```

- **No lost follow-ups**: `MessageStream.__aiter__` drains the queue *before* honoring `_done`, so a follow-up that races in after the check is still answered. `has_pending()` (new) keeps the stream open when one is already queued.
- **Cross-turn continuity is unaffected**: it rides `options.resume` + `resume-session-at`, not this stream — so closing the input per-turn is safe. Every new NATS message starts a fresh `run_prompt` that resumes the same SDK session.
- **`abort()` still owns its own `end()`**; the `_aborting` guard keeps the two paths from colliding.

This is a pre-existing ClaudeBackend bug, independent of the concurrency rework; it's the upstream cause that makes the slot-follows-turn release fire on the Claude path.

## Tests

`tests/test_agent_runner/test_claude_turn_ends.py` (offline — stubs the container-only `claude_agent_sdk` and drives `run_prompt` with a faked `query()`):

- `test_run_prompt_returns_when_no_follow_up` — asserts `run_prompt` **returns** (pre-fix it hangs → `wait_for` timeout) and emits one `ResultEvent`.
- `test_queued_follow_up_answered_then_returns` — a follow-up queued mid-turn is still answered (2 `ResultEvent`s) and then `run_prompt` returns.

`ruff` clean. Full Docker/NATS round-trip (real agent emits `is_final` → orchestrator `notify_idle`) still to be confirmed on a Docker stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7HqqhQtwzR9N6vnwuxfyy)_