### PR TITLE
feat(webui-react): Coworkers page — CRUD, 6-step wizard, share, delete (spec Part C)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -14,11 +14,25 @@ import { getStoredToken } from '../lib/oidc-auth';
 export type ApiPaths = paths;
 
 export type BackendName = components['schemas']['BackendName'];
+export type Backend = components['schemas']['Backend'];
+export type BackendList = Backend[];
 export type Coworker = components['schemas']['Coworker'];
+export type CoworkerCreate = components['schemas']['CoworkerCreate'];
+export type CoworkerUpdate = components['schemas']['CoworkerUpdate'];
+export type CoworkerMCPBindingCreate =
+  components['schemas']['CoworkerMCPBindingCreate'];
+export type CoworkerMCPBindingResponse =
+  components['schemas']['CoworkerMCPBindingResponse'];
+export type CoworkerSkillBinding =
+  components['schemas']['CoworkerSkillBinding'];
 export type Conversation = components['schemas']['Conversation'];
 export type Message = components['schemas']['Message'];
 export type Me = components['schemas']['Me'];
 export type Model = components['schemas']['Model'];
+export type ModelProvider = components['schemas']['ModelProvider'];
+export type CredentialResponse = components['schemas']['CredentialResponse'];
+export type MCPServer = components['schemas']['MCPServer'];
+export type SkillSummary = components['schemas']['SkillSummary'];
 export type ApprovalRequest = components['schemas']['ApprovalRequest'];
 
 export type ErrorResponseBody =
@@ -136,6 +150,183 @@ export class ApiClient {
     });
     if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as Model[];
+  }
+
+  // ------------------------------------------------------------------
+  // Coworker management (Part C). Method names identical to the Lit
+  // client (spec §11) — lift, don't rewrite.
+  // ------------------------------------------------------------------
+
+  async getBackends(): Promise<BackendList> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/backends`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as BackendList;
+  }
+
+  async createCoworker(body: CoworkerCreate): Promise<Coworker> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/coworkers`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Coworker;
+  }
+
+  /** Patch selected fields on a coworker. Backend treats ABSENT keys
+   *  as "leave alone"; explicit nulls follow the per-field rules in
+   *  webui/schemas_v1.CoworkerUpdate (note: `model_id: null` to CLEAR
+   *  is currently rejected by the handler — omit the key instead). */
+  async updateCoworker(id: string, body: CoworkerUpdate): Promise<Coworker> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}`,
+      {
+        method: 'PATCH',
+        headers: this.headers({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Coworker;
+  }
+
+  /** Hard-delete a coworker. Backend uses DB ON DELETE CASCADE to drop
+   *  conversations / runs / messages — there is no soft-delete path. */
+  async deleteCoworker(id: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  /** Flip a coworker's visibility to `shared` (tenant-wide). Real
+   *  authorization is the ownership escape server-side (a member may
+   *  share only what they created). Idempotent. */
+  async shareCoworker(id: string): Promise<Coworker> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}/share`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Coworker;
+  }
+
+  /** Flip a coworker's visibility back to `private`. */
+  async unshareCoworker(id: string): Promise<Coworker> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}/unshare`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Coworker;
+  }
+
+  async listCredentials(): Promise<CredentialResponse[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/credentials`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as CredentialResponse[];
+  }
+
+  async listMCPServers(): Promise<MCPServer[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/mcp-servers?limit=200`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return ((await resp.json()) as components['schemas']['MCPServerPage']).items;
+  }
+
+  async listSkills(): Promise<SkillSummary[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/skills?limit=200`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return ((await resp.json()) as components['schemas']['SkillSummaryPage'])
+      .items;
+  }
+
+  /** List MCP-server bindings for a coworker (wizard edit pre-fill). */
+  async listCoworkerMCPServers(
+    coworkerId: string,
+  ): Promise<CoworkerMCPBindingResponse[]> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/mcp-servers`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as CoworkerMCPBindingResponse[];
+  }
+
+  async bindCoworkerMCPServer(
+    coworkerId: string,
+    body: CoworkerMCPBindingCreate,
+  ): Promise<CoworkerMCPBindingResponse> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/mcp-servers`,
+      {
+        method: 'POST',
+        headers: this.headers({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as CoworkerMCPBindingResponse;
+  }
+
+  /** Remove a single MCP-server binding (path takes the MCP SERVER id,
+   *  not a separate binding id — the junction is keyed by the pair). */
+  async unbindCoworkerMCPServer(
+    coworkerId: string,
+    mcpServerId: string,
+  ): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}` +
+        `/mcp-servers/${encodeURIComponent(mcpServerId)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  async listCoworkerSkills(coworkerId: string): Promise<CoworkerSkillBinding[]> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/skills`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as CoworkerSkillBinding[];
+  }
+
+  async enableCoworkerSkill(
+    coworkerId: string,
+    skillId: string,
+  ): Promise<CoworkerSkillBinding> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}` +
+        `/skills/${encodeURIComponent(skillId)}`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as CoworkerSkillBinding;
+  }
+
+  async disableCoworkerSkill(
+    coworkerId: string,
+    skillId: string,
+  ): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}` +
+        `/skills/${encodeURIComponent(skillId)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
   }
 }
 

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -35,3 +35,43 @@ export function useMessages(chatId: string | null) {
     enabled: !!chatId,
   });
 }
+
+// ---- coworker-wizard catalogues (Part C) ----
+//
+// Credentials / MCP servers / skills degrade to [] on failure (same
+// catch-to-empty policy as the Lit wizard's loadCatalogues) — e.g. a
+// member without `credential.byok.manage` gets a 403 on the
+// credentials read; the wizard then renders those models as locked
+// rather than erroring out.
+
+export function useBackends(enabled: boolean) {
+  return useQuery({
+    queryKey: ['backends'],
+    queryFn: () => getApiClient().getBackends(),
+    enabled,
+  });
+}
+
+export function useCredentials(enabled: boolean) {
+  return useQuery({
+    queryKey: ['credentials'],
+    queryFn: () => getApiClient().listCredentials().catch(() => []),
+    enabled,
+  });
+}
+
+export function useMCPServers(enabled: boolean) {
+  return useQuery({
+    queryKey: ['mcp-servers'],
+    queryFn: () => getApiClient().listMCPServers().catch(() => []),
+    enabled,
+  });
+}
+
+export function useSkills(enabled: boolean) {
+  return useQuery({
+    queryKey: ['skills'],
+    queryFn: () => getApiClient().listSkills().catch(() => []),
+    enabled,
+  });
+}

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -14,6 +14,14 @@ const SettingsPage = lazy(() =>
   })),
 );
 
+// Grown settings pages get their own lazy chunk keyed by slug (§1.1
+// settings growth rule) — the static route ranks above /manage/:slug.
+const CoworkersPage = lazy(() =>
+  import('../features/settings/coworkers/coworkers-page').then((m) => ({
+    default: m.CoworkersPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -27,6 +35,14 @@ export function AppRoutes() {
   return (
     <Routes>
       <Route path="/" element={<ChatPage />} />
+      <Route
+        path="/manage/coworkers/*"
+        element={
+          <Suspense fallback={null}>
+            <CoworkersPage />
+          </Suspense>
+        }
+      />
       <Route
         path="/manage/:slug/*"
         element={

--- a/web-react/src/components/confirm-dialog.test.tsx
+++ b/web-react/src/components/confirm-dialog.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ConfirmDialog } from './confirm-dialog';
+
+function renderDialog(busy = false) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <ConfirmDialog
+      title="Delete coworker “Mira”?"
+      confirmLabel="Delete"
+      busyLabel="Deleting…"
+      busy={busy}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    >
+      body copy
+    </ConfirmDialog>,
+  );
+  return { onConfirm, onCancel };
+}
+
+afterEach(cleanup);
+
+describe('ConfirmDialog', () => {
+  it('renders an alertdialog with title, body, and both actions', () => {
+    renderDialog();
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(screen.getByText('body copy')).toBeTruthy();
+    expect(screen.getByText('Cancel')).toBeTruthy();
+    expect(screen.getByText('Delete')).toBeTruthy();
+  });
+
+  it('confirm fires onConfirm; cancel and ESC fire onCancel', () => {
+    const { onConfirm, onCancel } = renderDialog();
+    fireEvent.click(screen.getByText('Delete'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText('Cancel'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
+  it('busy state shows the busy label and makes every dismiss path inert', () => {
+    const { onConfirm, onCancel } = renderDialog(true);
+    const confirm = screen.getByText('Deleting…') as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+    fireEvent.click(confirm); // double-submit guard
+    expect(onConfirm).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Cancel'));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/web-react/src/components/confirm-dialog.tsx
+++ b/web-react/src/components/confirm-dialog.tsx
@@ -1,0 +1,76 @@
+// ConfirmDialog — the shared destructive-action confirm (spec §C.5;
+// behavioral reference web/src/components/confirm-dialog.ts). Lives in
+// components/ because delete confirms recur on every settings page
+// (the ≥2-consumers admission rule, pre-satisfied).
+//
+// Busy semantics: while `busy`, the confirm button shows `busyLabel`
+// and BOTH dismiss paths (cancel button, scrim, ESC, X) are inert —
+// double-submit and mid-flight dismissal are guarded here, not in the
+// caller.
+
+import { useEffect, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+export function ConfirmDialog({
+  title,
+  children,
+  confirmLabel,
+  busyLabel,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  title: string;
+  children: ReactNode;
+  confirmLabel: string;
+  busyLabel: string;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onCancel();
+    }
+    // Capture phase so an open confirm wins over page-level ESC
+    // handlers (asides, wizard) — prototype's dismissal priority.
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onCancel]);
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onCancel();
+      }}
+    >
+      <div className="dlg small" role="alertdialog" aria-modal="true" aria-label={title}>
+        <div className="dlg-header">
+          <div className="hleft">
+            <h2 className="dlg-title">{title}</h2>
+          </div>
+          <button
+            className="icon-btn"
+            aria-label="Close"
+            disabled={busy}
+            onClick={onCancel}
+          >
+            <X />
+          </button>
+        </div>
+        <div className="confirm-body">{children}</div>
+        <div className="confirm-foot">
+          <button className="btn-ghost" disabled={busy} onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="btn-danger" disabled={busy} onClick={onConfirm}>
+            {busy ? busyLabel : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -1,0 +1,264 @@
+/* Shared UI primitives (loaded globally after tokens/base): the
+ * dialog family, button family, icon button, search field, masonry
+ * grid, the coworker card base, and the toast. Transcribed from the
+ * v4 prototype. Feature CSS adds variants only:
+ *   - .dlg          → 720px base (wizard); .dlg.small 440px (confirm);
+ *                     .dlg.picker 75vw×80vh lives in agent-picker.css
+ *   - .card         → base card; picker adds .pick/.cb, coworkers page
+ *                     adds .manage pills/actions
+ */
+
+/* dialogs */
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--rm-scrim);
+  z-index: 7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.dlg {
+  background: var(--rm-app-bg);
+  border-radius: 8px;
+  box-shadow: var(--rm-elevation-soar);
+  padding: 0.5rem 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  width: 720px;
+  max-width: 92vw;
+  max-height: 86vh;
+  min-height: 0;
+}
+.dlg.small {
+  width: 440px;
+}
+.dlg-header {
+  height: 32px;
+  flex: 0 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+}
+.dlg-header .hleft {
+  display: flex;
+  align-items: center;
+}
+.dlg-brand-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 8px;
+  box-sizing: content-box;
+}
+.dlg-title {
+  margin: 0;
+  color: var(--rm-text);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+/* buttons */
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--rm-action);
+  color: var(--rm-app-bg);
+  border: none;
+  border-radius: 2px;
+  padding: 8px 18px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.btn-primary:hover {
+  background: var(--rm-action-hover);
+}
+.btn-primary:disabled {
+  background: var(--rm-disabled-bg);
+  color: var(--rm-text-muted);
+  cursor: default;
+}
+.btn-primary svg {
+  width: 15px;
+  height: 15px;
+}
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  color: var(--rm-action);
+  font-size: 0.875rem;
+  font-weight: 700;
+  padding: 8px 10px;
+  border-radius: 2px;
+}
+.btn-ghost:hover {
+  color: var(--rm-action-hover);
+}
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--rm-danger);
+  color: var(--rm-app-bg);
+  border: none;
+  border-radius: 2px;
+  padding: 8px 18px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+.btn-danger:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--rm-action);
+  padding: 4px;
+  border-radius: 2px;
+}
+.icon-btn:hover {
+  color: var(--rm-action-hover);
+}
+.icon-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* search field */
+.search-field {
+  position: relative;
+  width: 100%;
+}
+.search-field input {
+  width: 100%;
+  height: 40px;
+  padding: 0 40px 0 12px;
+  font-family: var(--font-base);
+  font-size: 0.875rem;
+  color: var(--rm-text);
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+}
+.search-field input::placeholder {
+  color: var(--rm-text-muted);
+}
+.search-field input:focus-visible {
+  outline: 2px solid var(--rm-action);
+  outline-offset: -1px;
+}
+.search-field .search-ic {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--rm-action);
+  pointer-events: none;
+}
+.search-field .search-ic svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+/* masonry grid + card base (picker family ∪ manage row) */
+.masonry {
+  columns: 3;
+  column-gap: 2rem;
+}
+@media (max-width: 1100px) {
+  .masonry {
+    columns: 2;
+  }
+}
+@media (max-width: 720px) {
+  .masonry {
+    columns: 1;
+  }
+}
+.card {
+  position: relative;
+  width: 100%;
+  display: inline-block;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  overflow: hidden;
+  cursor: pointer;
+  padding: 16px;
+  text-align: left;
+  margin: 0 0 2rem;
+  break-inside: avoid;
+  -webkit-column-break-inside: avoid;
+  font-family: var(--font-base);
+  color: var(--rm-text);
+}
+.card:hover {
+  outline: 1px solid var(--rm-action-hover);
+  outline-offset: -1px;
+}
+.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.card .provider {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--rm-text-muted);
+}
+.card .name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--rm-text);
+  line-height: 1.3;
+}
+.card .desc {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--rm-text);
+}
+
+/* confirm dialog body/footer */
+.confirm-body {
+  padding: 12px 2px 4px;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+.confirm-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 12px;
+}
+
+/* toast */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--rm-nav-text);
+  color: var(--rm-app-bg);
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  z-index: 9;
+}

--- a/web-react/src/features/chat/agent-picker/agent-card.tsx
+++ b/web-react/src/features/chat/agent-picker/agent-card.tsx
@@ -22,7 +22,7 @@ export function AgentCard({
   const modelLabel = model?.display_name ?? coworker.model_id ?? null;
   return (
     <div
-      className={`card${selected ? ' selected' : ''}`}
+      className={`card pick${selected ? ' selected' : ''}`}
       role="radio"
       aria-checked={selected}
       tabIndex={0}

--- a/web-react/src/features/chat/agent-picker/agent-picker-modal.tsx
+++ b/web-react/src/features/chat/agent-picker/agent-picker-modal.tsx
@@ -40,7 +40,9 @@ export function AgentPickerModal({
       `${c.name} ${c.routing_description ?? ''}`.toLowerCase().includes(q),
   );
 
-  const canCreate = hasCapability('coworker.manage');
+  // Creation is gated on `coworker.create` (spec C.2) — `coworker.manage`
+  // is the row-management capability, a different grant.
+  const canCreate = hasCapability('coworker.create');
 
   return (
     <div
@@ -49,7 +51,7 @@ export function AgentPickerModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="dlg" role="dialog" aria-modal="true" aria-label="RoleMesh assistants and agents">
+      <div className="dlg picker" role="dialog" aria-modal="true" aria-label="RoleMesh assistants and agents">
         <div className="dlg-header">
           <div className="hleft">
             <div className="dlg-brand-icon">

--- a/web-react/src/features/chat/agent-picker/agent-picker.css
+++ b/web-react/src/features/chat/agent-picker/agent-picker.css
@@ -1,54 +1,13 @@
-/* Agent picker modal — transcribed from the prototype (.scrim / .dlg /
- * tabs / search / masonry / .card). Geometry per spec Appendix A:
- * 75vw × 80vh, header 32px, tab bar 2rem with 2px orange underline,
- * 3-col masonry, checkbox 18px at 10,10. */
+/* Agent picker modal — picker-specific variants on top of the shared
+ * primitives in components/ui.css (.scrim/.dlg/.card/.masonry/
+ * .search-field/.icon-btn). Geometry per spec Appendix A: 75vw × 80vh,
+ * tab bar 2rem with 2px orange underline, checkbox 18px at 10,10,
+ * picker card content indented 1rem for the checkbox. */
 
-.scrim {
-  position: fixed;
-  inset: 0;
-  background: var(--rm-scrim);
-  z-index: 7;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.dlg {
-  background: var(--rm-app-bg);
-  border-radius: 8px;
-  box-shadow: var(--rm-elevation-soar);
-  padding: 0.5rem 1.5rem 1rem;
-  display: flex;
-  flex-direction: column;
+.dlg.picker {
   width: 75vw;
   height: 80vh;
-  min-height: 0;
-}
-.dlg-header {
-  height: 32px;
-  flex: 0 0 32px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: 0.5rem;
-}
-.dlg-header .hleft {
-  display: flex;
-  align-items: center;
-}
-.dlg-brand-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  padding: 8px;
-  box-sizing: content-box;
-}
-.dlg-title {
-  margin: 0;
-  color: var(--rm-text);
-  font-size: 1rem;
-  font-weight: 700;
+  max-height: 80vh;
 }
 
 .tabs-shell {
@@ -105,41 +64,6 @@
   flex: 0 0 auto;
   padding: 12px 1rem 12px 0;
 }
-.search-field {
-  position: relative;
-  width: 100%;
-}
-.search-field input {
-  width: 100%;
-  height: 40px;
-  padding: 0 40px 0 12px;
-  font-family: var(--font-base);
-  font-size: 0.875rem;
-  color: var(--rm-text);
-  border: 1px solid var(--rm-text-muted);
-  border-radius: 4px;
-  background: var(--rm-app-bg);
-}
-.search-field input::placeholder {
-  color: var(--rm-text-muted);
-}
-.search-field input:focus-visible {
-  outline: 2px solid var(--rm-action);
-  outline-offset: -1px;
-}
-.search-field .search-ic {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--rm-action);
-  pointer-events: none;
-}
-.search-field .search-ic svg {
-  width: 18px;
-  height: 18px;
-  display: block;
-}
 
 .masonry-scroll {
   flex: 1 1 0%;
@@ -148,41 +72,10 @@
   scrollbar-gutter: stable;
   padding-right: 0.5rem;
 }
-.masonry {
-  columns: 3;
-  column-gap: 2rem;
-}
-@media (max-width: 1100px) {
-  .masonry {
-    columns: 2;
-  }
-}
-@media (max-width: 720px) {
-  .masonry {
-    columns: 1;
-  }
-}
 
-.card {
-  position: relative;
-  width: 100%;
-  display: inline-block;
-  border: 1px solid var(--rm-border);
-  border-radius: 4px;
-  background: var(--rm-card-bg);
-  overflow: hidden;
-  cursor: pointer;
-  padding: 16px;
-  text-align: left;
-  margin: 0 0 2rem;
-  break-inside: avoid;
-  -webkit-column-break-inside: avoid;
-  font-family: var(--font-base);
-  color: var(--rm-text);
-}
-.card:hover {
-  outline: 1px solid var(--rm-action-hover);
-  outline-offset: -1px;
+/* picker card variant: checkbox visual + indented content */
+.card.pick .card-content {
+  padding-left: 1rem;
 }
 .card .cb {
   position: absolute;
@@ -195,7 +88,7 @@
   background: var(--rm-app-bg);
   pointer-events: none;
 }
-.card:hover .cb {
+.card.pick:hover .cb {
   border-color: var(--rm-action-hover);
 }
 .card.selected .cb {
@@ -213,33 +106,25 @@
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
 }
-.card-content {
+.badges {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding-left: 1rem;
+  flex-wrap: wrap;
+  gap: 4px;
 }
-.card .provider {
+.badge {
+  display: inline-flex;
+  text-transform: capitalize;
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
   font-size: 12px;
   font-weight: 700;
-  text-transform: uppercase;
-  color: var(--rm-text-muted);
-}
-.card .name {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: var(--rm-text);
-  line-height: 1.3;
+  padding: 2px 8px;
+  border-radius: 2px;
 }
 .card .profile {
   color: var(--rm-text-muted);
   font-size: 1rem;
   line-height: 1.5;
-}
-.card .desc {
-  font-size: 1rem;
-  line-height: 1.5;
-  color: var(--rm-text);
 }
 .tab-empty {
   padding: 32px 0;

--- a/web-react/src/features/chat/chat.css
+++ b/web-react/src/features/chat/chat.css
@@ -181,19 +181,9 @@
   margin-top: 0.75rem;
   font-size: 1rem;
 }
-.btn-primary {
-  background: var(--rm-action);
-  color: var(--rm-app-bg);
-  border: none;
-  border-radius: 2px;
-  padding: 8px 18px;
-  font-size: 0.875rem;
-  font-weight: 700;
-  cursor: pointer;
+/* .btn-primary base lives in components/ui.css */
+.empty-state .btn-primary {
   margin-top: 1rem;
-}
-.btn-primary:hover {
-  background: var(--rm-action-hover);
 }
 
 /* status bar — reference statusBar region (§5.4): active-agent line
@@ -338,24 +328,7 @@
   width: 18px;
   height: 18px;
 }
-.icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--rm-action);
-  padding: 4px;
-  border-radius: 2px;
-}
-.icon-btn:hover {
-  color: var(--rm-action-hover);
-}
-.icon-btn svg {
-  width: 18px;
-  height: 18px;
-}
+/* .icon-btn base lives in components/ui.css */
 
 /* right asides (recall + debug) */
 .aside-panel {

--- a/web-react/src/features/settings/coworkers/coworker-card.test.tsx
+++ b/web-react/src/features/settings/coworkers/coworker-card.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { CoworkerCard } from './coworker-card';
+import { setMe } from '../../../lib/capabilities';
+import type { Coworker, Me } from '../../../api/client';
+
+function me(capabilities: string[], userId = 'u1'): Me {
+  return {
+    user_id: userId,
+    tenant_id: 't1',
+    role: 'member',
+    plane: 'tenant',
+    capabilities,
+  };
+}
+
+function coworker(overrides: Partial<Coworker> = {}): Coworker {
+  return {
+    id: 'cw1',
+    tenant_id: 't1',
+    name: 'Portfolio Manager',
+    folder: 'pm',
+    agent_backend: 'claude',
+    status: 'active',
+    max_concurrent_containers: 1,
+    visibility: 'private',
+    permissions: {},
+    created_at: '2026-07-01T00:00:00Z',
+    created_by_user_id: 'someone-else',
+    system_prompt: 'Handles portfolio intents',
+    ...overrides,
+  } as Coworker;
+}
+
+function renderCard(c: Coworker) {
+  return render(
+    <CoworkerCard
+      coworker={c}
+      modelsById={new Map()}
+      shareBusy={false}
+      rowError={null}
+      onOpenChat={vi.fn()}
+      onToggleShare={vi.fn()}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  setMe(null);
+});
+
+// Pins the ownership escape (spec C.2): row management = the
+// `coworker.manage` capability OR ownership of the row — mirrored via
+// the copied canManage/isOwnResource helpers, never re-derived.
+describe('CoworkerCard capability rendering', () => {
+  it('member WITHOUT coworker.manage sees VIEW ONLY on others’ rows', () => {
+    setMe(me(['coworker.use']));
+    renderCard(coworker({ created_by_user_id: 'someone-else' }));
+    expect(screen.getByText('View only')).toBeTruthy();
+    expect(screen.queryByTitle('Edit coworker')).toBeNull();
+  });
+
+  it('member WITHOUT coworker.manage gets full icons on their OWN row', () => {
+    setMe(me(['coworker.use'], 'u1'));
+    renderCard(coworker({ created_by_user_id: 'u1' }));
+    expect(screen.queryByText('View only')).toBeNull();
+    expect(screen.getByTitle('Edit coworker')).toBeTruthy();
+    expect(screen.getByTitle('Delete coworker')).toBeTruthy();
+  });
+
+  it('manager gets icons on any row; ownership tag reflects the creator', () => {
+    setMe(me(['coworker.manage']));
+    renderCard(coworker({ created_by_user_id: 'someone-else' }));
+    expect(screen.getByTitle('Edit coworker')).toBeTruthy();
+    expect(screen.getByText('Shared by another member')).toBeTruthy();
+  });
+
+  it('system-created rows (null creator) are never "own"', () => {
+    setMe(me(['coworker.use'], 'u1'));
+    renderCard(coworker({ created_by_user_id: null }));
+    expect(screen.getByText('View only')).toBeTruthy();
+    expect(screen.getByText('Shared by another member')).toBeTruthy();
+  });
+
+  it('share toggle exposes aria-pressed and the shared pill', () => {
+    setMe(me(['coworker.manage']));
+    renderCard(coworker({ visibility: 'shared' }));
+    const share = screen.getByTitle('Make private');
+    expect(share.getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByText('shared')).toBeTruthy();
+  });
+});

--- a/web-react/src/features/settings/coworkers/coworker-card.tsx
+++ b/web-react/src/features/settings/coworkers/coworker-card.tsx
@@ -1,0 +1,114 @@
+// CoworkerCard — one manage row (spec §C.1 card anatomy, same card
+// family as the agent picker). Row management renders only where
+// `canManage(c, 'coworker.manage')` holds — the capability OR
+// ownership of the row (the backend's ownership escape, mirrored via
+// the copied helpers; never re-derived). Others see VIEW ONLY.
+//
+// All three action icons stopPropagation — card body click means
+// Open chat.
+
+import { ArrowRight, Pencil, Trash2, Users } from 'lucide-react';
+import type { Coworker, Model } from '../../../api/client';
+import { canManage, isOwnResource } from '../../../lib/capabilities';
+import { coworkerSubtitle } from '../../../lib/coworker-label';
+
+export function CoworkerCard({
+  coworker,
+  modelsById,
+  shareBusy,
+  rowError,
+  onOpenChat,
+  onToggleShare,
+  onEdit,
+  onDelete,
+}: {
+  coworker: Coworker;
+  modelsById: Map<string, Model>;
+  shareBusy: boolean;
+  rowError: string | null;
+  onOpenChat: () => void;
+  onToggleShare: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const c = coworker;
+  const manageable = canManage(c, 'coworker.manage');
+  const shared = c.visibility === 'shared';
+  return (
+    <div
+      className="card manage"
+      role="button"
+      tabIndex={0}
+      onClick={onOpenChat}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onOpenChat();
+      }}
+    >
+      <div className="card-content">
+        <div>
+          <div className="provider">{coworkerSubtitle(c, modelsById)}</div>
+          <div className="name">{c.name}</div>
+        </div>
+        <div className="pills">
+          <span className={`pill pill-${c.visibility}`}>{c.visibility}</span>
+          <span className={`pill pill-${c.status}`}>{c.status}</span>
+          <span className="own-tag">
+            {isOwnResource(c) ? 'Created by you' : 'Shared by another member'}
+          </span>
+        </div>
+        {c.system_prompt ? <div className="desc">{c.system_prompt}</div> : null}
+        <div className="card-actions">
+          <button
+            className="open-chat"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenChat();
+            }}
+          >
+            Open chat
+            <ArrowRight />
+          </button>
+          {manageable ? (
+            <span className="icon-acts">
+              <button
+                className={`icon-btn${shared ? ' on' : ''}`}
+                aria-pressed={shared}
+                disabled={shareBusy}
+                title={shared ? 'Make private' : 'Share with everyone in this workspace'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleShare();
+                }}
+              >
+                <Users />
+              </button>
+              <button
+                className="icon-btn"
+                title="Edit coworker"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+              >
+                <Pencil />
+              </button>
+              <button
+                className="icon-btn danger"
+                title="Delete coworker"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+              >
+                <Trash2 />
+              </button>
+            </span>
+          ) : (
+            <span className="view-only">View only</span>
+          )}
+        </div>
+        {rowError ? <div className="row-error">{rowError}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/coworkers/coworker-wizard.test.ts
+++ b/web-react/src/features/settings/coworkers/coworker-wizard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { emptyDraft, isStepValid, type WizardDraft } from './coworker-wizard';
+
+function draft(overrides: Partial<WizardDraft>): WizardDraft {
+  return { ...emptyDraft(), ...overrides };
+}
+
+// Pins the per-step advance gates (spec C.4 table). Note the deliberate
+// divergence from the Lit wizard: the Model step is optional (Backend
+// default) — if that gate ever tightens again, this test is the flag.
+describe('isStepValid', () => {
+  it('gates Identity on non-empty name AND a valid slug', () => {
+    expect(isStepValid(0, draft({}))).toBe(false);
+    expect(isStepValid(0, draft({ name: 'Mira', folder: '' }))).toBe(false);
+    expect(isStepValid(0, draft({ name: 'Mira', folder: 'Bad Slug' }))).toBe(false);
+    expect(isStepValid(0, draft({ name: 'Mira', folder: 'mira' }))).toBe(true);
+  });
+
+  it('gates Engine on a backend pick', () => {
+    expect(isStepValid(1, draft({}))).toBe(false);
+    expect(isStepValid(1, draft({ backend: 'claude' }))).toBe(true);
+  });
+
+  it('leaves Model optional (Backend default) and Tools/Skills/Review free', () => {
+    const d = draft({ modelId: null, mcpServerIds: [], skillIds: [] });
+    expect(isStepValid(2, d)).toBe(true);
+    expect(isStepValid(3, d)).toBe(true);
+    expect(isStepValid(4, d)).toBe(true);
+    expect(isStepValid(5, d)).toBe(true);
+  });
+});

--- a/web-react/src/features/settings/coworkers/coworker-wizard.test.ts
+++ b/web-react/src/features/settings/coworkers/coworker-wizard.test.ts
@@ -1,13 +1,34 @@
 import { describe, expect, it } from 'vitest';
 import { emptyDraft, isStepValid, type WizardDraft } from './coworker-wizard';
+import type { ProviderGroup } from '../../../lib/models-grouping';
+import type { Model } from '../../../api/client';
 
 function draft(overrides: Partial<WizardDraft>): WizardDraft {
   return { ...emptyDraft(), ...overrides };
 }
 
-// Pins the per-step advance gates (spec C.4 table). Note the deliberate
-// divergence from the Lit wizard: the Model step is optional (Backend
-// default) — if that gate ever tightens again, this test is the flag.
+function model(id: string): Model {
+  return {
+    id,
+    provider: 'anthropic',
+    model_id: id,
+    model_family: 'claude',
+    display_name: id,
+    is_active: true,
+  } as Model;
+}
+
+function group(hasCredential: boolean, ids: string[]): ProviderGroup {
+  return {
+    provider: 'anthropic',
+    hasCredential,
+    credentialUpdatedAt: null,
+    models: ids.map(model),
+  };
+}
+
+// Pins the per-step advance gates (spec C.4 table, D-C4 resolved:
+// Lit parity — the Model step is REQUIRED, no "Backend default" card).
 describe('isStepValid', () => {
   it('gates Identity on non-empty name AND a valid slug', () => {
     expect(isStepValid(0, draft({}))).toBe(false);
@@ -21,9 +42,25 @@ describe('isStepValid', () => {
     expect(isStepValid(1, draft({ backend: 'claude' }))).toBe(true);
   });
 
-  it('leaves Model optional (Backend default) and Tools/Skills/Review free', () => {
-    const d = draft({ modelId: null, mcpServerIds: [], skillIds: [] });
-    expect(isStepValid(2, d)).toBe(true);
+  it('Model REQUIRES a pick — a null model (incl. legacy edit seeds) blocks', () => {
+    const groups = [group(true, ['m-1'])];
+    expect(isStepValid(2, draft({ modelId: null }), groups)).toBe(false);
+  });
+
+  it('Model requires the provider to be credentialed', () => {
+    const d = draft({ modelId: 'm-1' });
+    expect(isStepValid(2, d, [group(false, ['m-1'])])).toBe(false);
+    expect(isStepValid(2, d, [group(true, ['m-1'])])).toBe(true);
+  });
+
+  it('Model must be in the backend-filtered visible set', () => {
+    // e.g. engine switched and the old pick fell out of the groups.
+    const d = draft({ modelId: 'm-gone' });
+    expect(isStepValid(2, d, [group(true, ['m-1'])])).toBe(false);
+  });
+
+  it('leaves Tools/Skills/Review free', () => {
+    const d = draft({ mcpServerIds: [], skillIds: [] });
     expect(isStepValid(3, d)).toBe(true);
     expect(isStepValid(4, d)).toBe(true);
     expect(isStepValid(5, d)).toBe(true);

--- a/web-react/src/features/settings/coworkers/coworker-wizard.tsx
+++ b/web-react/src/features/settings/coworkers/coworker-wizard.tsx
@@ -1,0 +1,665 @@
+// CoworkerWizard — create AND edit in one component (spec §C.4;
+// behavioral reference web/src/components/coworker-wizard.ts).
+//
+// Six steps (pinned order): Identity · Engine · Model · Tools ·
+// Skills · Review. Stepper reuses the tab-bar idiom — completed steps
+// are blue + ✓ and clickable, current gets the orange underline.
+//
+// Deliberate divergence from the Lit wizard, per spec C.4 + the v4
+// prototype: the Model step is OPTIONAL — the first card is
+// `Backend default` (model_id = null; the runtime resolves its default
+// model, the documented pre-v1.1 semantics). The Lit wizard requires a
+// credentialed model pick; flip `isStepValid` case 2 if that stricter
+// gate is ever wanted back.
+//
+// Edit-mode locks (contract-enforced — CoworkerUpdate has neither
+// `folder` nor `agent_backend`): slug read-only with hint; engine
+// lock-note with the other cards dimmed + disabled.
+//
+// Submit ordering (ported from Lit): coworker POST/PATCH first, then
+// the MCP/skill binding diffs sequentially; partial failures DON'T
+// roll back — a banner pinned above the stepper lists what failed and
+// the wizard stays open. Full-success create navigates into chat with
+// the new coworker (`/?agent_id={id}` — creation's purpose is to talk
+// to it); full-success edit closes + toasts.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ApiError,
+  getApiClient,
+  type BackendName,
+  type Coworker,
+  type Model,
+} from '../../../api/client';
+import {
+  useBackends,
+  useCredentials,
+  useMCPServers,
+  useModels,
+  useSkills,
+} from '../../../api/queries';
+import { BrandMark } from '../../../components/brand-mark';
+import { groupModelsByProvider } from '../../../lib/models-grouping';
+import { isValidSlug, slugify } from './use-slug';
+
+export const WIZARD_STEPS = [
+  'Identity',
+  'Engine',
+  'Model',
+  'Tools',
+  'Skills',
+  'Review',
+] as const;
+
+export interface WizardDraft {
+  name: string;
+  folder: string;
+  slugTouched: boolean;
+  instructions: string;
+  backend: BackendName | null;
+  modelId: string | null;
+  mcpServerIds: string[];
+  skillIds: string[];
+}
+
+export function emptyDraft(): WizardDraft {
+  return {
+    name: '',
+    folder: '',
+    slugTouched: false,
+    instructions: '',
+    backend: null,
+    modelId: null,
+    mcpServerIds: [],
+    skillIds: [],
+  };
+}
+
+/** Per-step advance gate (spec C.4 table). Exported for tests. */
+export function isStepValid(step: number, d: WizardDraft): boolean {
+  switch (step) {
+    case 0:
+      return d.name.trim().length > 0 && isValidSlug(d.folder);
+    case 1:
+      return d.backend !== null;
+    default:
+      return true; // Model optional (Backend default) · Tools/Skills/Review free
+  }
+}
+
+interface SubmitFailure {
+  message: string;
+  mcpFailures: string[];
+  skillFailures: string[];
+}
+
+function draftFromCoworker(c: Coworker): WizardDraft {
+  return {
+    name: c.name,
+    folder: c.folder,
+    slugTouched: true,
+    instructions: c.system_prompt ?? '',
+    backend: c.agent_backend,
+    modelId: c.model_id ?? null,
+    mcpServerIds: [],
+    skillIds: [],
+  };
+}
+
+export function CoworkerWizard({
+  editing,
+  onClose,
+  onSaved,
+}: {
+  /** null → create flow; a row → edit flow with locks + binding diff. */
+  editing: Coworker | null;
+  onClose: () => void;
+  /** Fired whenever server state changed (edit success, partial
+   *  commit) so the page can refresh its list; carries a toast line
+   *  on full-success edit. */
+  onSaved: (toast: string | null) => void;
+}) {
+  const isEdit = editing !== null;
+  const [step, setStep] = useState(0);
+  const [draft, setDraft] = useState<WizardDraft>(() =>
+    editing ? draftFromCoworker(editing) : emptyDraft(),
+  );
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<SubmitFailure | null>(null);
+  const navigate = useNavigate();
+
+  // Catalogues (credentials/MCP/skills degrade to [] — see queries.ts).
+  const backendsQ = useBackends(true);
+  const modelsQ = useModels();
+  const credentialsQ = useCredentials(true);
+  const mcpServersQ = useMCPServers(true);
+  const skillsQ = useSkills(true);
+
+  // Edit mode: seed bindings from the coworker's current state
+  // (failures degrade to empty — the wizard stays usable for
+  // identity/model edits). The originals feed the submit diff.
+  const [originals, setOriginals] = useState<{ mcp: string[]; skills: string[] }>(
+    { mcp: [], skills: [] },
+  );
+  useEffect(() => {
+    if (!editing) return;
+    let cancelled = false;
+    void (async () => {
+      const [mcpResult, skillResult] = await Promise.allSettled([
+        getApiClient().listCoworkerMCPServers(editing.id),
+        getApiClient().listCoworkerSkills(editing.id),
+      ]);
+      if (cancelled) return;
+      const mcpIds =
+        mcpResult.status === 'fulfilled'
+          ? mcpResult.value.map((b) => b.mcp_server_id)
+          : [];
+      const skillIds =
+        skillResult.status === 'fulfilled'
+          ? skillResult.value
+              .filter((b) => b.enabled !== false)
+              .map((b) => b.skill_id)
+          : [];
+      setOriginals({ mcp: mcpIds, skills: skillIds });
+      setDraft((d) => ({ ...d, mcpServerIds: mcpIds, skillIds }));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [editing]);
+
+  // ESC closes (unless mid-submit). Capture so the page-level ESC
+  // handlers don't race.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onClose]);
+
+  const selectedBackend = useMemo(
+    () => backendsQ.data?.find((b) => b.name === draft.backend) ?? null,
+    [backendsQ.data, draft.backend],
+  );
+  const modelGroups = useMemo(
+    () =>
+      groupModelsByProvider(
+        modelsQ.data ?? [],
+        credentialsQ.data ?? [],
+        selectedBackend,
+      ),
+    [modelsQ.data, credentialsQ.data, selectedBackend],
+  );
+  const selectedModel: Model | null =
+    (draft.modelId && modelsQ.data?.find((m) => m.id === draft.modelId)) || null;
+
+  const canAdvance = isStepValid(step, draft);
+
+  async function handleSubmit(): Promise<void> {
+    if (busy) return;
+    setBusy(true);
+    setFailure(null);
+    const api = getApiClient();
+
+    let coworker: Coworker;
+    try {
+      if (editing) {
+        coworker = await api.updateCoworker(editing.id, {
+          name: draft.name.trim(),
+          // Omit (never null) when unset — the handler rejects
+          // `model_id: null` as a clear (see client.ts note).
+          model_id: draft.modelId ?? undefined,
+          system_prompt: draft.instructions.trim() || null,
+        });
+      } else {
+        coworker = await api.createCoworker({
+          name: draft.name.trim(),
+          folder: draft.folder,
+          agent_backend: draft.backend!,
+          model_id: draft.modelId,
+          system_prompt: draft.instructions.trim() || null,
+          // Not surfaced in the wizard (D-C2) — Lit-locked defaults.
+          max_concurrent_containers: 2,
+          is_frontdesk: false,
+        });
+      }
+    } catch (err) {
+      setFailure({
+        message:
+          err instanceof ApiError
+            ? `${err.status} — ${err.message}`
+            : (err as Error).message,
+        mcpFailures: [],
+        skillFailures: [],
+      });
+      setBusy(false);
+      return;
+    }
+
+    // Binding plan: create = all selections; edit = deltas only.
+    // Partial failures don't roll back (Lit commit ordering).
+    const oldMcp = new Set(isEdit ? originals.mcp : []);
+    const newMcp = new Set(draft.mcpServerIds);
+    const mcpToAdd = draft.mcpServerIds.filter((id) => !oldMcp.has(id));
+    const mcpToRemove = isEdit
+      ? originals.mcp.filter((id) => !newMcp.has(id))
+      : [];
+    const oldSkill = new Set(isEdit ? originals.skills : []);
+    const newSkill = new Set(draft.skillIds);
+    const skillToAdd = draft.skillIds.filter((id) => !oldSkill.has(id));
+    const skillToRemove = isEdit
+      ? originals.skills.filter((id) => !newSkill.has(id))
+      : [];
+
+    const mcpFailures: string[] = [];
+    for (const id of mcpToAdd) {
+      try {
+        // null = all tools enabled (Lit locked decision #9).
+        await api.bindCoworkerMCPServer(coworker.id, {
+          mcp_server_id: id,
+          enabled_tools: null,
+        });
+      } catch {
+        mcpFailures.push(id);
+      }
+    }
+    for (const id of mcpToRemove) {
+      try {
+        await api.unbindCoworkerMCPServer(coworker.id, id);
+      } catch {
+        mcpFailures.push(id);
+      }
+    }
+    const skillFailures: string[] = [];
+    for (const id of skillToAdd) {
+      try {
+        await api.enableCoworkerSkill(coworker.id, id);
+      } catch {
+        skillFailures.push(id);
+      }
+    }
+    for (const id of skillToRemove) {
+      try {
+        await api.disableCoworkerSkill(coworker.id, id);
+      } catch {
+        skillFailures.push(id);
+      }
+    }
+
+    setBusy(false);
+
+    if (mcpFailures.length || skillFailures.length) {
+      // Partial success — keep the wizard open so the user sees what
+      // happened; the list still refreshes behind it.
+      const total = mcpFailures.length + skillFailures.length;
+      setFailure({
+        message: `Coworker ${isEdit ? 'updated' : 'created'}, but ${total} binding${total > 1 ? 's' : ''} failed. You can finish wiring it up by editing it again.`,
+        mcpFailures,
+        skillFailures,
+      });
+      onSaved(null);
+      return;
+    }
+
+    if (isEdit) {
+      onSaved(`Saved changes to ${coworker.name}`);
+      onClose();
+      return;
+    }
+    // Create success — go talk to it. Full-reload navigation keeps the
+    // ?agent_id contract identical to the Lit wizard.
+    location.href = `${location.pathname}?agent_id=${encodeURIComponent(coworker.id)}#/`;
+  }
+
+  function renderIdentity() {
+    const slugInvalid = draft.name.trim() !== '' && !isValidSlug(draft.folder);
+    return (
+      <>
+        <div className="field">
+          <label htmlFor="wiz-name">Name</label>
+          <input
+            id="wiz-name"
+            type="text"
+            maxLength={200}
+            placeholder="e.g. Portfolio Manager"
+            value={draft.name}
+            onChange={(e) => {
+              const name = e.target.value;
+              setDraft((d) => ({
+                ...d,
+                name,
+                folder: !isEdit && !d.slugTouched ? slugify(name) : d.folder,
+              }));
+            }}
+          />
+        </div>
+        <div className="field">
+          <label htmlFor="wiz-slug">Slug (workspace folder)</label>
+          <input
+            id="wiz-slug"
+            type="text"
+            maxLength={64}
+            disabled={isEdit}
+            value={draft.folder}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, folder: e.target.value, slugTouched: true }))
+            }
+          />
+          <div className={`hint${slugInvalid ? ' invalid' : ''}`}>
+            {isEdit
+              ? 'The slug is fixed for the lifetime of a coworker — it names the container mount path.'
+              : slugInvalid
+                ? 'Slug must start with a letter or digit and may contain a–z, 0–9, _ or -.'
+                : 'Auto-derived from the name; letters, digits, - and _ only.'}
+          </div>
+        </div>
+        <div className="field">
+          <label htmlFor="wiz-instructions">Instructions</label>
+          <textarea
+            id="wiz-instructions"
+            placeholder="What this coworker does, its tone, and its boundaries…"
+            value={draft.instructions}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, instructions: e.target.value }))
+            }
+          />
+          <div className="hint">Becomes the coworker's system prompt.</div>
+        </div>
+      </>
+    );
+  }
+
+  function renderEngine() {
+    return (
+      <>
+        {isEdit ? (
+          <div className="lock-note">
+            Engine is fixed at <code>{draft.backend}</code> for the lifetime of a
+            coworker. Delete + recreate if you really need a different one.
+          </div>
+        ) : null}
+        {(backendsQ.data ?? []).map((b) => {
+          const selected = draft.backend === b.name;
+          const locked = isEdit && !selected;
+          return (
+            <button
+              key={b.name}
+              className={`opt-card${selected ? ' selected' : ''}${locked ? ' locked' : ''}`}
+              disabled={isEdit}
+              onClick={() => {
+                if (isEdit) return;
+                // Reset the model — the previous pick may not fit the
+                // new backend's compatibility matrix.
+                setDraft((d) => ({ ...d, backend: b.name, modelId: null }));
+              }}
+            >
+              <div className="t" style={{ textTransform: 'capitalize' }}>
+                {b.name}
+              </div>
+              <div className="d">{b.description}</div>
+              <div className="d">
+                Providers: {b.supported_providers.join(', ')} · Families:{' '}
+                {b.supported_model_families
+                  ? b.supported_model_families.join(', ')
+                  : 'any'}
+              </div>
+            </button>
+          );
+        })}
+      </>
+    );
+  }
+
+  function renderModel() {
+    return (
+      <>
+        <button
+          className={`opt-card${draft.modelId === null ? ' selected' : ''}`}
+          onClick={() => setDraft((d) => ({ ...d, modelId: null }))}
+        >
+          <div className="t">Backend default</div>
+          <div className="d">
+            Let the {draft.backend ?? 'engine'} runtime pick its default model
+          </div>
+        </button>
+        {modelGroups.map((g) => (
+          <div key={g.provider}>
+            <div className="group-h">{g.provider}</div>
+            {g.models.map((m) => {
+              const inactive = !m.is_active;
+              if (!g.hasCredential || inactive) {
+                return (
+                  <div key={m.id} className="opt-card locked">
+                    <div className="cred-missing">
+                      <div className="t">{m.display_name}</div>
+                      {inactive ? (
+                        <span className="warn" style={{ cursor: 'default' }}>
+                          Inactive in the catalogue
+                        </span>
+                      ) : (
+                        // D-C1: link out to the credentials page instead
+                        // of the Lit wizard's nested credential dialog.
+                        <button
+                          className="warn"
+                          onClick={() => {
+                            onClose();
+                            navigate('/manage/credentials');
+                          }}
+                        >
+                          No credential — add one under Settings → Credentials
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              }
+              return (
+                <button
+                  key={m.id}
+                  className={`opt-card${draft.modelId === m.id ? ' selected' : ''}`}
+                  onClick={() => setDraft((d) => ({ ...d, modelId: m.id }))}
+                >
+                  <div className="t">{m.display_name}</div>
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  function renderCheckList(kind: 'tools' | 'skills') {
+    const selectedIds = kind === 'tools' ? draft.mcpServerIds : draft.skillIds;
+    const rows =
+      kind === 'tools'
+        ? (mcpServersQ.data ?? []).map((s) => ({
+            id: s.id,
+            title: s.name,
+            detail: s.url,
+          }))
+        : (skillsQ.data ?? []).map((s) => ({
+            id: s.id,
+            title: s.name,
+            detail: s.description,
+          }));
+    function toggle(id: string) {
+      setDraft((d) => {
+        const key = kind === 'tools' ? 'mcpServerIds' : 'skillIds';
+        const cur = d[key];
+        const next = cur.includes(id)
+          ? cur.filter((x) => x !== id)
+          : [...cur, id];
+        return { ...d, [key]: next };
+      });
+    }
+    return (
+      <>
+        <div className="hint" style={{ marginBottom: 10 }}>
+          {kind === 'tools'
+            ? 'MCP servers this coworker may call. Every call still passes the credential proxy, egress gateway, and safety pipeline.'
+            : 'Skills the coworker loads at run time.'}
+        </div>
+        {rows.length === 0 ? (
+          <div className="hint">
+            {kind === 'tools' ? 'No MCP servers configured yet.' : 'No skills yet.'}
+          </div>
+        ) : (
+          rows.map((r) => (
+            <button
+              key={r.id}
+              className={`check-row${selectedIds.includes(r.id) ? ' selected' : ''}`}
+              onClick={() => toggle(r.id)}
+            >
+              <span className="cb" />
+              <span>
+                <div className="rt">{r.title}</div>
+                <div className="rd">{r.detail}</div>
+              </span>
+            </button>
+          ))
+        )}
+      </>
+    );
+  }
+
+  function renderReview() {
+    const mcpNames = draft.mcpServerIds.map(
+      (id) => mcpServersQ.data?.find((s) => s.id === id)?.name ?? id,
+    );
+    const skillNames = draft.skillIds.map(
+      (id) => skillsQ.data?.find((s) => s.id === id)?.name ?? id,
+    );
+    const rows: [string, ReactNode][] = [
+      ['Name', draft.name],
+      ['Slug', <code key="s">{draft.folder}</code>],
+      ['Engine', draft.backend ?? '—'],
+      ['Model', selectedModel?.display_name ?? 'Backend default'],
+      ['MCP servers', mcpNames.length ? mcpNames.join(', ') : '—'],
+      ['Skills', skillNames.length ? skillNames.join(', ') : '—'],
+      ['Instructions', draft.instructions || '—'],
+    ];
+    return (
+      <>
+        {rows.map(([k, v]) => (
+          <div key={k as string} className="review-row">
+            <span className="k">{k}</span>
+            <span className="v">{v}</span>
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  const bodyByStep = [
+    renderIdentity,
+    renderEngine,
+    renderModel,
+    () => renderCheckList('tools'),
+    () => renderCheckList('skills'),
+    renderReview,
+  ];
+  const isLast = step === WIZARD_STEPS.length - 1;
+  const cataloguesLoading = backendsQ.isLoading || modelsQ.isLoading;
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div className="dlg" role="dialog" aria-modal="true" aria-label="Coworker wizard">
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">
+              {isEdit ? `Edit ${editing.name}` : 'New coworker'}
+            </h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        {failure ? (
+          <div className="wiz-banner" role="alert">
+            {failure.message}
+            {failure.mcpFailures.length ? (
+              <div className="detail">
+                Tool bindings failed: {failure.mcpFailures.join(', ')}
+              </div>
+            ) : null}
+            {failure.skillFailures.length ? (
+              <div className="detail">
+                Skills failed: {failure.skillFailures.join(', ')}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="stepper">
+          {WIZARD_STEPS.map((label, i) => {
+            const cls = i === step ? 'current' : i < step ? 'done' : '';
+            return (
+              <button
+                key={label}
+                className={`step ${cls}`}
+                disabled={i >= step}
+                onClick={() => {
+                  if (i < step) setStep(i);
+                }}
+              >
+                <span className="tick">✓</span>
+                {label}
+              </button>
+            );
+          })}
+        </div>
+        <div className="wiz-body">
+          {cataloguesLoading ? (
+            <div className="hint">Loading…</div>
+          ) : backendsQ.isError || modelsQ.isError ? (
+            <div className="wiz-err">Failed to load catalogues — close and retry.</div>
+          ) : (
+            bodyByStep[step]()
+          )}
+        </div>
+        <div className="wiz-foot">
+          {step > 0 ? (
+            <button className="btn-ghost" disabled={busy} onClick={() => setStep(step - 1)}>
+              Back
+            </button>
+          ) : (
+            <span />
+          )}
+          <span className="actions">
+            <button
+              className="btn-primary"
+              disabled={!canAdvance || busy || cataloguesLoading}
+              onClick={() => {
+                if (isLast) void handleSubmit();
+                else setStep(step + 1);
+              }}
+            >
+              {isLast
+                ? busy
+                  ? isEdit
+                    ? 'Saving…'
+                    : 'Creating…'
+                  : isEdit
+                    ? 'Save changes'
+                    : 'Create coworker'
+                : 'Next'}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/coworkers/coworker-wizard.tsx
+++ b/web-react/src/features/settings/coworkers/coworker-wizard.tsx
@@ -5,12 +5,13 @@
 // Skills · Review. Stepper reuses the tab-bar idiom — completed steps
 // are blue + ✓ and clickable, current gets the orange underline.
 //
-// Deliberate divergence from the Lit wizard, per spec C.4 + the v4
-// prototype: the Model step is OPTIONAL — the first card is
-// `Backend default` (model_id = null; the runtime resolves its default
-// model, the documented pre-v1.1 semantics). The Lit wizard requires a
-// credentialed model pick; flip `isStepValid` case 2 if that stricter
-// gate is ever wanted back.
+// Model step is REQUIRED — Lit parity per D-C4 (spec v5): a model must
+// be picked, its provider must hold a credential, and it must survive
+// the backend compatibility filter. No "Backend default" card (the
+// v4 draft's citation for one was wrong); with zero credentialed
+// providers the wizard cannot complete — the credential link-out
+// (D-C1) is the intended path. Editing a legacy null-model coworker
+// forces the user to converge on a model before advancing.
 //
 // Edit-mode locks (contract-enforced — CoworkerUpdate has neither
 // `folder` nor `agent_backend`): slug read-only with hint; engine
@@ -41,7 +42,10 @@ import {
   useSkills,
 } from '../../../api/queries';
 import { BrandMark } from '../../../components/brand-mark';
-import { groupModelsByProvider } from '../../../lib/models-grouping';
+import {
+  groupModelsByProvider,
+  type ProviderGroup,
+} from '../../../lib/models-grouping';
 import { isValidSlug, slugify } from './use-slug';
 
 export const WIZARD_STEPS = [
@@ -77,15 +81,29 @@ export function emptyDraft(): WizardDraft {
   };
 }
 
-/** Per-step advance gate (spec C.4 table). Exported for tests. */
-export function isStepValid(step: number, d: WizardDraft): boolean {
+/** Per-step advance gate (spec C.4 table, D-C4 Lit parity). Exported
+ *  for tests. `modelGroups` is the backend-filtered, credential-
+ *  annotated projection (models-grouping.ts) the Model step renders —
+ *  the gate and the visible set stay one source. */
+export function isStepValid(
+  step: number,
+  d: WizardDraft,
+  modelGroups: readonly ProviderGroup[] = [],
+): boolean {
   switch (step) {
     case 0:
       return d.name.trim().length > 0 && isValidSlug(d.folder);
     case 1:
       return d.backend !== null;
+    case 2:
+      // Model REQUIRED: picked + provider credentialed + in the
+      // backend-filtered visible set (mirrors the Lit isStepValid).
+      if (!d.modelId) return false;
+      return modelGroups.some(
+        (g) => g.hasCredential && g.models.some((m) => m.id === d.modelId),
+      );
     default:
-      return true; // Model optional (Backend default) · Tools/Skills/Review free
+      return true; // Tools/Skills optional · Review free
   }
 }
 
@@ -198,7 +216,7 @@ export function CoworkerWizard({
   const selectedModel: Model | null =
     (draft.modelId && modelsQ.data?.find((m) => m.id === draft.modelId)) || null;
 
-  const canAdvance = isStepValid(step, draft);
+  const canAdvance = isStepValid(step, draft, modelGroups);
 
   async function handleSubmit(): Promise<void> {
     if (busy) return;
@@ -418,15 +436,9 @@ export function CoworkerWizard({
   function renderModel() {
     return (
       <>
-        <button
-          className={`opt-card${draft.modelId === null ? ' selected' : ''}`}
-          onClick={() => setDraft((d) => ({ ...d, modelId: null }))}
-        >
-          <div className="t">Backend default</div>
-          <div className="d">
-            Let the {draft.backend ?? 'engine'} runtime pick its default model
-          </div>
-        </button>
+        {modelGroups.length === 0 ? (
+          <div className="hint">No models compatible with this engine.</div>
+        ) : null}
         {modelGroups.map((g) => (
           <div key={g.provider}>
             <div className="group-h">{g.provider}</div>
@@ -539,7 +551,7 @@ export function CoworkerWizard({
       ['Name', draft.name],
       ['Slug', <code key="s">{draft.folder}</code>],
       ['Engine', draft.backend ?? '—'],
-      ['Model', selectedModel?.display_name ?? 'Backend default'],
+      ['Model', selectedModel?.display_name ?? '—'],
       ['MCP servers', mcpNames.length ? mcpNames.join(', ') : '—'],
       ['Skills', skillNames.length ? skillNames.join(', ') : '—'],
       ['Instructions', draft.instructions || '—'],

--- a/web-react/src/features/settings/coworkers/coworkers-page.tsx
+++ b/web-react/src/features/settings/coworkers/coworkers-page.tsx
@@ -1,0 +1,246 @@
+// CoworkersPage — the manage surface (spec Part C §C.1): list + search
+// + card grid + wizard + delete confirm. Replaces the stub route per
+// the §1.1 settings growth rule. Behavioral reference:
+// web/src/components/coworkers-page.ts.
+//
+// Mutations invalidate the ['coworkers'] query — the SAME key the chat
+// picker reads, so a created coworker appears in the picker with no
+// extra wiring (spec §C.6).
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowLeft, Plus, Search } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  ApiError,
+  getApiClient,
+  type Coworker,
+} from '../../../api/client';
+import { useCoworkers, useModels } from '../../../api/queries';
+import { BrandMark } from '../../../components/brand-mark';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { hasCapability } from '../../../lib/capabilities';
+import { modelsByIdMap } from '../../../lib/coworker-label';
+import { CoworkerCard } from './coworker-card';
+import { CoworkerWizard } from './coworker-wizard';
+import './coworkers.css';
+
+function errText(err: unknown): string {
+  return err instanceof ApiError
+    ? `${err.status} — ${err.body?.message ?? err.message}`
+    : ((err as Error).message ?? 'request failed');
+}
+
+export function CoworkersPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const coworkersQ = useCoworkers();
+  const modelsQ = useModels();
+  const modelsById = useMemo(
+    () => modelsByIdMap(modelsQ.data ?? []),
+    [modelsQ.data],
+  );
+
+  const [query, setQuery] = useState('');
+  const [wizard, setWizard] = useState<{ open: boolean; editing: Coworker | null }>(
+    { open: false, editing: null },
+  );
+  const [deleteTarget, setDeleteTarget] = useState<Coworker | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [shareBusy, setShareBusy] = useState<ReadonlySet<string>>(new Set());
+  // Per-row error line for delete/share failures — errors stay on the
+  // row, never a toast-only surface (spec §C.1).
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  const canCreate = hasCapability('coworker.create');
+  const rows = coworkersQ.data ?? [];
+  const q = query.trim().toLowerCase();
+  const visible = rows.filter(
+    (c) => !q || `${c.name} ${c.system_prompt ?? ''}`.toLowerCase().includes(q),
+  );
+
+  function openChat(c: Coworker) {
+    // chat reads ?agent_id from the real location.search — same URL
+    // contract (and same full-navigation pattern) as the Lit page.
+    location.href = `${location.pathname}?agent_id=${encodeURIComponent(c.id)}#/`;
+  }
+
+  async function toggleShare(c: Coworker) {
+    if (shareBusy.has(c.id)) return;
+    setShareBusy((s) => new Set(s).add(c.id));
+    setRowErrors((e) => ({ ...e, [c.id]: '' }));
+    try {
+      const api = getApiClient();
+      const updated =
+        c.visibility === 'shared'
+          ? await api.unshareCoworker(c.id)
+          : await api.shareCoworker(c.id);
+      // Patch the row in place so the pill + tooltip flip without a
+      // full refetch (Lit's optimistic-from-response pattern).
+      queryClient.setQueryData<Coworker[]>(['coworkers'], (cur) =>
+        (cur ?? []).map((r) => (r.id === updated.id ? updated : r)),
+      );
+      showToast(
+        updated.visibility === 'shared'
+          ? `${updated.name} is now shared with the workspace`
+          : `${updated.name} is now private`,
+      );
+    } catch (err) {
+      setRowErrors((e) => ({ ...e, [c.id]: errText(err) }));
+    } finally {
+      setShareBusy((s) => {
+        const next = new Set(s);
+        next.delete(c.id);
+        return next;
+      });
+    }
+  }
+
+  async function performDelete() {
+    const c = deleteTarget;
+    if (!c || deleteBusy) return;
+    setDeleteBusy(true);
+    setRowErrors((e) => ({ ...e, [c.id]: '' }));
+    try {
+      await getApiClient().deleteCoworker(c.id);
+      await queryClient.invalidateQueries({ queryKey: ['coworkers'] });
+      showToast(`Deleted ${c.name}`);
+    } catch (err) {
+      // Close on error too — the per-row line surfaces the message;
+      // leaving the modal up would trap the user under it.
+      setRowErrors((e) => ({ ...e, [c.id]: errText(err) }));
+    } finally {
+      setDeleteBusy(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  function onWizardSaved(toastMsg: string | null) {
+    void queryClient.invalidateQueries({ queryKey: ['coworkers'] });
+    if (toastMsg) showToast(toastMsg);
+  }
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Coworkers</h1>
+          <div className="page-sub">
+            Create and manage the agents your workspace can chat with.
+          </div>
+        </div>
+        {canCreate ? (
+          <button
+            className="btn-primary"
+            onClick={() => setWizard({ open: true, editing: null })}
+          >
+            <Plus />
+            New coworker
+          </button>
+        ) : null}
+      </div>
+      <div className="page-search">
+        <div className="search-field">
+          <input
+            type="text"
+            placeholder="Search coworkers"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <span className="search-ic">
+            <Search />
+          </span>
+        </div>
+      </div>
+      <div className="grid-scroll">
+        {coworkersQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : coworkersQ.isError ? (
+          <div className="row-error">Failed to load coworkers — retry from the sidebar.</div>
+        ) : rows.length === 0 ? (
+          <div className="grid-empty">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <BrandMark size={128} />
+              <div style={{ marginTop: '0.75rem', fontSize: '1rem' }}>
+                No coworkers yet.
+              </div>
+              {canCreate ? (
+                <button
+                  className="btn-primary"
+                  style={{ marginTop: '1rem' }}
+                  onClick={() => setWizard({ open: true, editing: null })}
+                >
+                  New coworker
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="page-sub">No coworkers match your search.</div>
+        ) : (
+          <div className="masonry">
+            {visible.map((c) => (
+              <CoworkerCard
+                key={c.id}
+                coworker={c}
+                modelsById={modelsById}
+                shareBusy={shareBusy.has(c.id)}
+                rowError={rowErrors[c.id] || null}
+                onOpenChat={() => openChat(c)}
+                onToggleShare={() => void toggleShare(c)}
+                onEdit={() => setWizard({ open: true, editing: c })}
+                onDelete={() => setDeleteTarget(c)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {wizard.open ? (
+        <CoworkerWizard
+          editing={wizard.editing}
+          onClose={() => setWizard({ open: false, editing: null })}
+          onSaved={onWizardSaved}
+        />
+      ) : null}
+
+      {deleteTarget ? (
+        <ConfirmDialog
+          title={`Delete coworker “${deleteTarget.name}”?`}
+          confirmLabel="Delete"
+          busyLabel="Deleting…"
+          busy={deleteBusy}
+          onConfirm={() => void performDelete()}
+          onCancel={() => {
+            if (!deleteBusy) setDeleteTarget(null);
+          }}
+        >
+          This permanently removes <b>{deleteTarget.name}</b> and unbinds its MCP
+          servers and skills. This can't be undone.
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? <div className="toast">{toast}</div> : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/coworkers/coworkers.css
+++ b/web-react/src/features/settings/coworkers/coworkers.css
@@ -1,0 +1,464 @@
+/* Coworkers page + wizard CSS — transcribed from the v4 prototype
+ * (page chrome, manage-card variant, wizard stepper/form primitives,
+ * review rows). Shared primitives (.dlg/.card/.masonry/buttons/toast)
+ * live in components/ui.css. */
+
+/* page chrome */
+.page {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  max-width: 72rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.5rem 2rem 0.5rem;
+  height: 100%;
+}
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+.page-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+.page-sub {
+  margin-top: 2px;
+  color: var(--rm-text-muted);
+  font-size: 0.875rem;
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--rm-action);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+.back-link:hover {
+  color: var(--rm-action-hover);
+}
+.back-link svg {
+  width: 14px;
+  height: 14px;
+}
+.page-search {
+  padding: 12px 0;
+  flex-shrink: 0;
+}
+.grid-scroll {
+  flex: 1 1 0%;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding: 2px 0.5rem 1rem 2px;
+}
+.grid-empty {
+  padding-top: 3rem;
+  display: flex;
+}
+
+/* manage-card variant */
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.pill {
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 2px;
+  text-transform: capitalize;
+}
+.pill-shared {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.pill-private {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.pill-active {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.pill-paused {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.pill-disabled {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.own-tag {
+  font-size: 12px;
+  color: var(--rm-text-muted);
+}
+.card.manage .desc {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+.card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--rm-border);
+  margin-top: 4px;
+  padding-top: 10px;
+}
+.open-chat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--rm-action);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+.open-chat:hover {
+  color: var(--rm-action-hover);
+}
+.open-chat svg {
+  width: 14px;
+  height: 14px;
+}
+.icon-acts {
+  display: inline-flex;
+  gap: 2px;
+}
+.icon-acts .icon-btn {
+  padding: 5px;
+}
+.icon-acts .icon-btn:hover {
+  background: var(--rm-nav-hover);
+}
+.icon-acts .icon-btn.on {
+  color: var(--rm-app-bg);
+  background: var(--rm-action);
+}
+.icon-acts .icon-btn.danger {
+  color: var(--rm-danger);
+}
+.icon-acts .icon-btn.danger:hover {
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+}
+.icon-acts .icon-btn:disabled {
+  color: var(--rm-text-muted);
+  cursor: default;
+  background: none;
+}
+.icon-acts .icon-btn svg {
+  width: 15px;
+  height: 15px;
+}
+.view-only {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--rm-text-muted);
+  text-transform: uppercase;
+}
+.row-error {
+  font-size: 12px;
+  color: var(--rm-danger);
+  margin-top: 6px;
+}
+
+/* wizard: stepper (tab-bar idiom) */
+.stepper {
+  border-bottom: 1px solid var(--rm-border);
+  margin-top: 8px;
+  display: flex;
+  gap: 4px;
+  height: 2rem;
+  flex-shrink: 0;
+}
+.step {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  border: none;
+  padding: 0 12px;
+  height: 2rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--rm-text-muted);
+  cursor: default;
+}
+.step.done {
+  color: var(--rm-action);
+  cursor: pointer;
+}
+.step.done:hover {
+  color: var(--rm-action-hover);
+}
+.step.current {
+  color: var(--rm-text);
+}
+.step.current::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--rm-tab-active);
+}
+.step .tick {
+  display: none;
+}
+.step.done .tick {
+  display: inline;
+}
+
+.wiz-banner {
+  margin-top: 8px;
+  border-left: 3px solid var(--rm-danger);
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+  border-radius: 2px;
+  padding: 8px 12px;
+  font-size: 0.8125rem;
+  flex-shrink: 0;
+}
+.wiz-banner .detail {
+  color: var(--rm-text);
+  margin-top: 4px;
+}
+.wiz-body {
+  flex: 1 1 auto;
+  min-height: 220px;
+  overflow-y: auto;
+  padding: 1rem 2px;
+}
+.wiz-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--rm-border);
+  padding-top: 10px;
+  flex-shrink: 0;
+}
+.wiz-err {
+  color: var(--rm-danger);
+  font-size: 0.8125rem;
+}
+.wiz-foot .actions {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+/* form primitives */
+.field {
+  margin-bottom: 14px;
+}
+.field label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.field .hint {
+  font-size: 12px;
+  color: var(--rm-text-muted);
+  margin-top: 4px;
+}
+.field .hint.invalid {
+  color: var(--rm-danger);
+}
+.field input[type="text"],
+.field textarea {
+  width: 100%;
+  font-family: var(--font-base);
+  font-size: 0.875rem;
+  color: var(--rm-text);
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  padding: 8px 10px;
+}
+.field textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+.field input:focus-visible,
+.field textarea:focus-visible {
+  outline: 2px solid var(--rm-action);
+  outline-offset: -1px;
+}
+.field input:disabled {
+  background: var(--rm-card-bg);
+  color: var(--rm-text-muted);
+  cursor: not-allowed;
+}
+.lock-note {
+  background: var(--rm-card-bg);
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  margin-bottom: 12px;
+}
+.lock-note code {
+  font-family: ui-monospace, monospace;
+  color: var(--rm-text);
+}
+
+/* option cards / checkbox rows */
+.opt-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  font-family: var(--font-base);
+  color: var(--rm-text);
+}
+.opt-card:hover {
+  outline: 1px solid var(--rm-action-hover);
+  outline-offset: -1px;
+}
+.opt-card.selected {
+  border-color: var(--rm-action);
+  background: var(--rm-info-bg);
+}
+.opt-card.locked {
+  opacity: 0.45;
+  cursor: not-allowed;
+  outline: none;
+}
+.opt-card .t {
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+.opt-card .d {
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  margin-top: 2px;
+}
+.group-h {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--rm-text-muted);
+  margin: 12px 0 6px;
+}
+.check-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  font-family: var(--font-base);
+  color: var(--rm-text);
+}
+.check-row:hover {
+  outline: 1px solid var(--rm-action-hover);
+  outline-offset: -1px;
+}
+.check-row .cb {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  border: 2px solid var(--rm-action);
+  border-radius: 2px;
+  background: var(--rm-app-bg);
+  position: relative;
+}
+.check-row.selected .cb {
+  background: var(--rm-action);
+}
+.check-row.selected .cb::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: -0.5px;
+  width: 4px;
+  height: 8px;
+  border-style: solid;
+  border-color: var(--rm-app-bg);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+.check-row .rt {
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+.check-row .rd {
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+}
+.cred-missing {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.cred-missing .warn {
+  font-size: 12px;
+  color: var(--rm-warn-text);
+  font-weight: 700;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: right;
+  padding: 0;
+  font-family: var(--font-base);
+}
+.cred-missing .warn:hover {
+  text-decoration: underline;
+}
+
+/* review */
+.review-row {
+  display: flex;
+  gap: 12px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--rm-border);
+  font-size: 0.875rem;
+}
+.review-row .k {
+  width: 140px;
+  flex-shrink: 0;
+  color: var(--rm-text-muted);
+  font-weight: 700;
+}
+.review-row .v {
+  flex: 1;
+}
+.review-row .v code {
+  font-family: ui-monospace, monospace;
+}

--- a/web-react/src/features/settings/coworkers/use-slug.test.ts
+++ b/web-react/src/features/settings/coworkers/use-slug.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isValidSlug, slugify } from './use-slug';
+
+describe('slugify', () => {
+  it('lowers, dashes non-slug chars, collapses runs', () => {
+    expect(slugify('Portfolio Manager')).toBe('portfolio-manager');
+    expect(slugify('SEC — EDGAR!! Agent')).toBe('sec-edgar-agent');
+  });
+
+  it('trims leading non-alphanumerics and trailing dashes', () => {
+    expect(slugify('---Mira')).toBe('mira');
+    expect(slugify('Mira?!')).toBe('mira');
+  });
+
+  it('keeps digits as a valid first char and caps at 64', () => {
+    expect(slugify('42 helpers')).toBe('42-helpers');
+    expect(slugify('x'.repeat(80)).length).toBeLessThanOrEqual(64);
+  });
+
+  it('produces valid slugs for typical names', () => {
+    for (const name of ['Portfolio Manager', 'Mira', 'Data_Analyst 2']) {
+      expect(isValidSlug(slugify(name))).toBe(true);
+    }
+  });
+});
+
+describe('isValidSlug', () => {
+  it('accepts contract-shaped slugs', () => {
+    expect(isValidSlug('portfolio-manager')).toBe(true);
+    expect(isValidSlug('a')).toBe(true);
+    expect(isValidSlug('42_helpers')).toBe(true);
+  });
+
+  it('rejects empty, leading dash, uppercase, illegal chars, overlong', () => {
+    expect(isValidSlug('')).toBe(false);
+    expect(isValidSlug('-lead')).toBe(false);
+    expect(isValidSlug('Upper')).toBe(false);
+    expect(isValidSlug('has space')).toBe(false);
+    expect(isValidSlug('a'.repeat(65))).toBe(false);
+  });
+});

--- a/web-react/src/features/settings/coworkers/use-slug.ts
+++ b/web-react/src/features/settings/coworkers/use-slug.ts
@@ -1,0 +1,28 @@
+// Slug derive/validate logic — ported from the top of
+// web/src/components/coworker-wizard.ts (kept byte-equivalent so the
+// two SPAs derive identical folders from identical names). Pure module
+// colocated with the wizard per the §1.1 settings growth rule.
+//
+// The slug names the coworker's container mount path; the regex
+// mirrors the contract's `CoworkerCreate.folder` pattern. It is
+// immutable after create (`CoworkerUpdate` has no `folder` field).
+
+export function slugify(name: string): string {
+  const lowered = name.toLowerCase();
+  // Replace any char that's not a-z 0-9 _ - with -.
+  const replaced = lowered.replace(/[^a-z0-9_-]+/g, '-');
+  // Collapse runs of `-`.
+  const collapsed = replaced.replace(/-+/g, '-');
+  // Trim leading non-alphanumeric (per backend regex). Numbers OK as
+  // first char per `^[a-z0-9][a-z0-9_-]{0,63}$`.
+  const trimmed = collapsed.replace(/^[^a-z0-9]+/, '');
+  // Trim trailing `-` for tidiness (regex allows trailing `-` but it
+  // looks weird as a derived slug).
+  return trimmed.replace(/-+$/, '').slice(0, 64);
+}
+
+const SLUG_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function isValidSlug(s: string): boolean {
+  return SLUG_RE.test(s);
+}

--- a/web-react/src/lib/PORTED.md
+++ b/web-react/src/lib/PORTED.md
@@ -12,6 +12,7 @@ header. Keep them in sync manually until workspace extraction.
 | `ws/v1_client.ts` (+test) | `ws/v1_client.ts` | cf6b0f1 |
 | `ws/ws-client-base.ts` (+test) | `ws/ws-client-base.ts` | cf6b0f1 |
 | `ws/connection-state.ts` (+test) | `ws/connection-state.ts` | cf6b0f1 |
+| `lib/models-grouping.ts` (+test) | `services/models-grouping.ts` | 5d3650e |
 
 Ported (adapted, not verbatim — source noted in the file header):
 

--- a/web-react/src/lib/models-grouping.test.ts
+++ b/web-react/src/lib/models-grouping.test.ts
@@ -1,0 +1,200 @@
+// Copied from web/src/services/models-grouping.test.ts @ 5d3650e; keep in sync manually until workspace extraction.
+// Behavioural tests for groupModelsByProvider().
+//
+// These pin the *contract* the wizard and Models page consume, not
+// the internal grouping algorithm. They were authored before reading
+// the implementation: any test that fails here represents either a
+// contract violation or a spec drift the caller will see in the UI.
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  Backend,
+  CredentialResponse,
+  Model,
+  ModelProvider,
+} from '../api/client.js';
+import { groupModelsByProvider } from './models-grouping.js';
+
+function model(
+  id: string,
+  provider: ModelProvider,
+  family: Model['model_family'],
+  opts: { active?: boolean } = {},
+): Model {
+  return {
+    id: `00000000-0000-0000-0000-${id.padStart(12, '0')}`,
+    provider,
+    model_id: id,
+    model_family: family,
+    display_name: `${provider}/${id}`,
+    is_active: opts.active ?? true,
+  };
+}
+
+function cred(provider: ModelProvider, updatedAt = '2026-05-20T00:00:00Z'): CredentialResponse {
+  return {
+    provider,
+    mode: 'byok',
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  };
+}
+
+const claudeBackend: Backend = {
+  name: 'claude',
+  description: 'Claude Agent SDK',
+  supported_providers: ['anthropic'],
+  supported_model_families: ['claude'],
+};
+
+const piBackend: Backend = {
+  name: 'pi',
+  description: 'Pi',
+  supported_providers: ['anthropic', 'openai', 'google', 'bedrock'],
+  // null means "any family" per the OpenAPI contract.
+  supported_model_families: null,
+};
+
+describe('groupModelsByProvider', () => {
+  it('returns empty when no models', () => {
+    expect(groupModelsByProvider([], [])).toEqual([]);
+  });
+
+  it('groups models under their provider with hasCredential reflecting the cred list', () => {
+    const models = [
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('gpt-4o', 'openai', 'gpt'),
+      model('gemini-2-pro', 'google', 'gemini'),
+    ];
+    const groups = groupModelsByProvider(models, [cred('anthropic')]);
+    const byProvider = Object.fromEntries(groups.map((g) => [g.provider, g]));
+    expect(byProvider.anthropic?.hasCredential).toBe(true);
+    expect(byProvider.openai?.hasCredential).toBe(false);
+    expect(byProvider.google?.hasCredential).toBe(false);
+  });
+
+  it('exposes credentialUpdatedAt when credential present, null otherwise', () => {
+    const groups = groupModelsByProvider(
+      [model('claude-opus-4-7', 'anthropic', 'claude'), model('gpt-4o', 'openai', 'gpt')],
+      [cred('anthropic', '2026-05-21T10:00:00Z')],
+    );
+    const ant = groups.find((g) => g.provider === 'anthropic')!;
+    const oai = groups.find((g) => g.provider === 'openai')!;
+    expect(ant.credentialUpdatedAt).toBe('2026-05-21T10:00:00Z');
+    expect(oai.credentialUpdatedAt).toBe(null);
+  });
+
+  it('sorts provider groups alphabetically', () => {
+    const models = [
+      model('gpt-4o', 'openai', 'gpt'),
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('gemini-2-pro', 'google', 'gemini'),
+      model('claude-on-bedrock', 'bedrock', 'claude'),
+    ];
+    const groups = groupModelsByProvider(models, []);
+    expect(groups.map((g) => g.provider)).toEqual([
+      'anthropic',
+      'bedrock',
+      'google',
+      'openai',
+    ]);
+  });
+
+  it('sorts models within a group alphabetically by model_id', () => {
+    const models = [
+      model('claude-sonnet-4-6', 'anthropic', 'claude'),
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('claude-haiku-4-5', 'anthropic', 'claude'),
+    ];
+    const groups = groupModelsByProvider(models, []);
+    expect(groups[0]!.models.map((m) => m.model_id)).toEqual([
+      'claude-haiku-4-5',
+      'claude-opus-4-7',
+      'claude-sonnet-4-6',
+    ]);
+  });
+
+  it('drops models whose provider is not in backend.supported_providers', () => {
+    const models = [
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('gpt-4o', 'openai', 'gpt'),
+    ];
+    const groups = groupModelsByProvider(models, [], claudeBackend);
+    expect(groups.map((g) => g.provider)).toEqual(['anthropic']);
+  });
+
+  it('drops models whose family is not in backend.supported_model_families', () => {
+    // Claude backend supports anthropic provider AND only `claude`
+    // family. A hypothetical anthropic+gpt model should be dropped.
+    const models = [
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('weird-anthropic-gpt', 'anthropic', 'gpt'),
+    ];
+    const groups = groupModelsByProvider(models, [], claudeBackend);
+    expect(groups[0]!.models.map((m) => m.model_id)).toEqual(['claude-opus-4-7']);
+  });
+
+  it('treats null supported_model_families as "any family"', () => {
+    const models = [
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('gpt-4o', 'openai', 'gpt'),
+      model('gemini-2-pro', 'google', 'gemini'),
+    ];
+    const groups = groupModelsByProvider(models, [], piBackend);
+    // All providers + families pass when family allowlist is null.
+    expect(groups.length).toBe(3);
+  });
+
+  it('drops provider groups that go empty after backend filter', () => {
+    const models = [model('gpt-4o', 'openai', 'gpt')];
+    const groups = groupModelsByProvider(models, [cred('anthropic')], claudeBackend);
+    // OpenAI gets filtered out by claudeBackend; anthropic has no
+    // models — group should not appear just because the credential is
+    // present.
+    expect(groups).toEqual([]);
+  });
+
+  it('keeps inactive models — callers post-filter for "hide inactive"', () => {
+    const models = [
+      model('claude-opus-4-7', 'anthropic', 'claude'),
+      model('claude-legacy', 'anthropic', 'claude', { active: false }),
+    ];
+    const groups = groupModelsByProvider(models, []);
+    expect(groups[0]!.models.map((m) => m.model_id)).toEqual([
+      'claude-legacy',
+      'claude-opus-4-7',
+    ]);
+  });
+
+  it('does not mutate the input arrays', () => {
+    const models = [
+      model('z-second', 'anthropic', 'claude'),
+      model('a-first', 'anthropic', 'claude'),
+    ];
+    const original = models.map((m) => m.model_id);
+    groupModelsByProvider(models, []);
+    expect(models.map((m) => m.model_id)).toEqual(original);
+  });
+
+  it('hasCredential=true even when the group has zero models for that provider after filter', () => {
+    // Edge: if cred is present but no models survive the filter,
+    // the group itself is gone. Verify behaviour matches the docs.
+    const models = [model('gpt-4o', 'openai', 'gpt')];
+    const groups = groupModelsByProvider(models, [cred('openai')], claudeBackend);
+    // openai dropped by claude backend → no group at all.
+    expect(groups).toEqual([]);
+  });
+
+  it('handles multiple credentials including ones with no matching provider models', () => {
+    // Tenant has bedrock + anthropic creds but only ships an openai
+    // model. Bedrock + anthropic should not produce empty groups.
+    const models = [model('gpt-4o', 'openai', 'gpt')];
+    const groups = groupModelsByProvider(
+      models,
+      [cred('bedrock'), cred('anthropic')],
+    );
+    expect(groups.map((g) => g.provider)).toEqual(['openai']);
+    expect(groups[0]!.hasCredential).toBe(false);
+  });
+});

--- a/web-react/src/lib/models-grouping.ts
+++ b/web-react/src/lib/models-grouping.ts
@@ -1,0 +1,80 @@
+// Copied from web/src/services/models-grouping.ts @ 5d3650e; keep in sync manually until workspace extraction.
+// Provider-grouped model catalog projection.
+//
+// Single source of truth for "which providers have a credential and
+// which models live under each" — consumed by both <rm-models-page>
+// (read-only catalog) and the v2-B coworker wizard (model picker
+// with inline credential unlock).
+//
+// Rules (v2-B locked):
+//   - Groups are sorted by provider name (alphabetical).
+//   - Models inside a group are sorted by `model_id` (alphabetical).
+//   - When a `backend` is supplied, models whose `provider` is not
+//     in `backend.supported_providers` are dropped entirely. If
+//     `backend.supported_model_families` is non-null, only models
+//     whose `model_family` is in that list survive. A `null` family
+//     list means "any family the provider offers" (Pi today).
+//   - Inactive models (`is_active=false`) are *kept* — the wizard
+//     wants to surface them as disabled rather than hide them so an
+//     operator can see what their tenant has access to. Callers that
+//     want them hidden can post-filter on `is_active`.
+//   - Empty provider groups (no models surviving the backend filter)
+//     are dropped. They are not useful to surface.
+
+import type {
+  Backend,
+  CredentialResponse,
+  Model,
+  ModelProvider,
+} from '../api/client.js';
+
+export interface ProviderGroup {
+  provider: ModelProvider;
+  hasCredential: boolean;
+  /** ISO timestamp from the credential's `updated_at`, or null when
+   *  the tenant has no credential for this provider. */
+  credentialUpdatedAt: string | null;
+  models: Model[];
+}
+
+export function groupModelsByProvider(
+  models: readonly Model[],
+  credentials: readonly CredentialResponse[],
+  backend?: Backend | null,
+): ProviderGroup[] {
+  const credByProvider = new Map<ModelProvider, CredentialResponse>();
+  for (const c of credentials) credByProvider.set(c.provider, c);
+
+  const allowedProviders = backend
+    ? new Set<ModelProvider>(backend.supported_providers)
+    : null;
+  // null `supported_model_families` means "any family" per OpenAPI.
+  const allowedFamilies = backend?.supported_model_families
+    ? new Set(backend.supported_model_families)
+    : null;
+
+  const buckets = new Map<ModelProvider, Model[]>();
+  for (const m of models) {
+    if (allowedProviders && !allowedProviders.has(m.provider)) continue;
+    if (allowedFamilies && !allowedFamilies.has(m.model_family)) continue;
+    let bucket = buckets.get(m.provider);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(m.provider, bucket);
+    }
+    bucket.push(m);
+  }
+
+  const providers = [...buckets.keys()].sort();
+  return providers.map((provider) => {
+    const cred = credByProvider.get(provider) ?? null;
+    const bucket = buckets.get(provider)!;
+    bucket.sort((a, b) => a.model_id.localeCompare(b.model_id));
+    return {
+      provider,
+      hasCredential: cred !== null,
+      credentialUpdatedAt: cred?.updated_at ?? null,
+      models: bucket,
+    };
+  });
+}

--- a/web-react/src/main.tsx
+++ b/web-react/src/main.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import { App } from './app/App';
 import './styles/base.css';
+import './components/ui.css';
 
 // No <StrictMode>: the chat bootstrap is imperative (it may POST a
 // conversation as part of resolving a default chat_id) and dev-mode

--- a/web-react/src/styles/tokens.css
+++ b/web-react/src/styles/tokens.css
@@ -25,6 +25,15 @@
   --rm-nav-hover: #F6F9FF;
   --rm-gradient: linear-gradient(135deg, #3080E4 0%, #69A9FF 52%, #8DD3FF 100%);
 
+  /* state pills + destructive actions (Part C §C.1) */
+  --rm-success-bg: #E7F3E7;
+  --rm-success-text: #1C821C;
+  --rm-warn-bg: #FDEBD9;
+  --rm-warn-text: #B25E00;
+  --rm-danger: #E00606;
+  --rm-danger-bg: #FBE6E6;
+  --rm-disabled-bg: #EBEBEB;
+
   /* brand mark (two-diamond placeholder, D-3) */
   --rm-mark-primary: #307FE2;
   --rm-mark-secondary: #000000;


### PR DESCRIPTION
Second child branch of the React webui effort: **Part C — Coworkers page** of the spec handoff (implemented against v4, updated to **v5's D-C4 resolution** in commit 24d4204), filling the `features/settings/coworkers/` slug folder per the §1.1 settings growth rule (own lazy chunk, static route above `/manage/:slug`). Behavioral reference: the Lit `coworkers-page.ts` / `coworker-wizard.ts` / `confirm-dialog.ts`, per the v5 project-wide behavior-parity rule (visuals follow the prototype; behavior follows Lit).

## What's in

- **Page** (`#/manage/coworkers`): back-to-chat link, header + `New coworker` (gated on `coworker.create`), search over name+instructions, 3-column masonry of manage cards, loading/empty/search-empty states, toast.
- **Cards**: picker card family + visibility/status pills (`shared` green / `private` gray / `active` green / `paused` amber / `disabled` gray), ownership tag, `Open chat →` (card body click too), share/edit/delete icon actions with stopPropagation. Rows where `canManage(c, 'coworker.manage')` fails show `VIEW ONLY` — the ownership escape comes from the copied capability helpers, never re-derived (tested: a member gets icons on their own rows only; null-creator rows never count as own).
- **Share toggle**: per-row in-flight guard, optimistic row patch from the response, per-row error line (errors never toast-only).
- **Delete**: shared `components/confirm-dialog.tsx` (`alertdialog`, `Deleting…` busy label, double-submit + mid-flight-dismissal guards, tested); failure closes the dialog and surfaces on the row (Lit parity).
- **Wizard** (create AND edit, one component): 6 pinned steps with the tab-bar stepper idiom (done = blue + ✓ clickable, current = orange underline); slug auto-derives from the name until touched (`use-slug.ts` ported from the Lit wizard + tests); per-step gates (`isStepValid` exported + tested); edit locks — slug read-only, engine lock-note with dimmed cards (both contract-enforced: `CoworkerUpdate` has neither `folder` nor `agent_backend`); provider-grouped Model step via the copied `models-grouping.ts`, credential-missing cards link out to `#/manage/credentials` (D-C1); submit = POST/PATCH first, then sequential binding diffs — partial failures keep the wizard open with a pinned banner (Lit commit ordering); full-success create navigates into chat with the new coworker, edit closes + refreshes + toasts.
- **Model step is REQUIRED — D-C4 (spec v5, Lit parity)**: a model must be picked, its provider credentialed, and it must survive the backend compatibility filter; switching Engine resets the pick; editing a legacy null-model coworker must converge on a model before advancing. The v4 draft's `Backend default` card shipped briefly and was reverted in 24d4204 (its Lit citation was wrong — locked decision #10 concerns `max_concurrent_containers`, not models). With zero credentialed providers the wizard cannot complete; the credential link-out is the intended path.
- **Foundations**: 7 new tokens (success/warn/danger/disabled); ~15 client methods lifted verbatim from the Lit client; shared dialog/button/card primitives extracted to `components/ui.css` (720px base / `.picker` 75vw / `.small` 440px) with agent-picker.css and chat.css deduped onto it; wizard catalogue query hooks with the Lit catch-to-empty policy for credentials/MCP/skills; picker empty-state CTA gate corrected to `coworker.create` (§C.2).

## Verification

- 91 vitest tests green (33 new: slug derive/validate, wizard step gates incl. the required-model / credentialed-provider / visible-set / engine-reset cases, ownership-escape rendering, confirm-dialog busy guards); tsc strict, all three lints, `openapi:check`, production build all clean. Coworkers page ships as its own ~18 KB lazy chunk; the chat bundle grew ~4 KB (client methods only).
- End-to-end against a mock v1 backend with Playwright: create (auto-slug `data-analyst-2`, engine → model with a locked no-credential provider group visible → tools → skills → review) → lands in chat with the new coworker → **appears in the chat picker with no extra wiring** (shared `['coworkers']` query key, §C.6) → edit (rename saved; slug disabled + engine lock verified) → share toggle (pill flips + toast) → delete (confirm → card gone). D-C4 gate verified separately: no default card, Next disabled until a credentialed pick, engine-switch reset re-blocks. Zero app console errors.

## Not in scope (per spec)

Nested credential/MCP creation dialogs (D-C1 — arrive with those settings PRs), advanced create fields (D-C2), status pause/disable controls (D-C3, display-only like Lit), server-side search/pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh