### PR TITLE
feat(webui-react): MCP servers registry page — CRUD + binding-aware delete (spec Part D)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -32,6 +32,10 @@ export type Model = components['schemas']['Model'];
 export type ModelProvider = components['schemas']['ModelProvider'];
 export type CredentialResponse = components['schemas']['CredentialResponse'];
 export type MCPServer = components['schemas']['MCPServer'];
+export type MCPServerCreate = components['schemas']['MCPServerCreate'];
+export type MCPServerUpdate = components['schemas']['MCPServerUpdate'];
+export type MCPType = components['schemas']['MCPType'];
+export type MCPAuthMode = components['schemas']['MCPAuthMode'];
 export type SkillSummary = components['schemas']['SkillSummary'];
 export type ApprovalRequest = components['schemas']['ApprovalRequest'];
 
@@ -241,6 +245,41 @@ export class ApiClient {
     });
     if (!resp.ok) throw await this.parseError(resp);
     return ((await resp.json()) as components['schemas']['MCPServerPage']).items;
+  }
+
+  async createMCPServer(body: MCPServerCreate): Promise<MCPServer> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/mcp-servers`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as MCPServer;
+  }
+
+  async updateMCPServer(id: string, body: MCPServerUpdate): Promise<MCPServer> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/mcp-servers/${encodeURIComponent(id)}`,
+      {
+        method: 'PATCH',
+        headers: this.headers({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as MCPServer;
+  }
+
+  /** Hard-delete an MCP server. 204 on success; 409 RESOURCE_IN_USE
+   *  when the server is still bound to any coworker — the backend is
+   *  the authoritative gate (the page's client-side count is advisory
+   *  only). The 409 body carries `details.coworker_ids`. */
+  async deleteMCPServer(id: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/mcp-servers/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
   }
 
   async listSkills(): Promise<SkillSummary[]> {

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -68,6 +68,46 @@ export function useMCPServers(enabled: boolean) {
   });
 }
 
+// ---- MCP server registry page (Part D) ----
+
+/** The registry list (its own key — the wizard's catalogue hook above
+ *  swallows errors; this page wants to surface a list-load failure). */
+export function useMCPServerRegistry() {
+  return useQuery({
+    queryKey: ['mcp-servers'],
+    queryFn: () => getApiClient().listMCPServers(),
+  });
+}
+
+/** Client-derived per-server bound-coworker counts (spec D.1, Lit
+ *  parity): the backend doesn't surface a count on MCPServer, so we
+ *  list coworkers and fan out their binding reads. A failed read
+ *  renders as 0 (never blocks). Shares the ['coworkers'] key and the
+ *  per-coworker binding keys with the coworker wizard's step-4
+ *  pre-fill, so the cache is reused. Returns Map<mcpServerId, count>. */
+export function useMCPUsageCounts(enabled: boolean) {
+  return useQuery({
+    queryKey: ['mcp-usage-counts'],
+    enabled,
+    queryFn: async () => {
+      const api = getApiClient();
+      const coworkers = await api.listCoworkers();
+      const results = await Promise.allSettled(
+        coworkers.map((c) => api.listCoworkerMCPServers(c.id)),
+      );
+      const counts = new Map<string, number>();
+      for (const r of results) {
+        if (r.status !== 'fulfilled') continue;
+        for (const binding of r.value) {
+          const id = binding.mcp_server_id;
+          counts.set(id, (counts.get(id) ?? 0) + 1);
+        }
+      }
+      return counts;
+    },
+  });
+}
+
 export function useSkills(enabled: boolean) {
   return useQuery({
     queryKey: ['skills'],

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -22,6 +22,12 @@ const CoworkersPage = lazy(() =>
   })),
 );
 
+const MCPServersPage = lazy(() =>
+  import('../features/settings/mcp-servers/mcp-servers-page').then((m) => ({
+    default: m.MCPServersPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -40,6 +46,14 @@ export function AppRoutes() {
         element={
           <Suspense fallback={null}>
             <CoworkersPage />
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/mcp-servers/*"
+        element={
+          <Suspense fallback={null}>
+            <MCPServersPage />
           </Suspense>
         }
       />

--- a/web-react/src/components/confirm-dialog.tsx
+++ b/web-react/src/components/confirm-dialog.tsx
@@ -17,6 +17,7 @@ export function ConfirmDialog({
   confirmLabel,
   busyLabel,
   busy,
+  disableConfirm = false,
   onConfirm,
   onCancel,
 }: {
@@ -25,6 +26,9 @@ export function ConfirmDialog({
   confirmLabel: string;
   busyLabel: string;
   busy: boolean;
+  /** Blocks the confirm action while the dialog stays open (e.g. a
+   *  binding-aware delete block). Cancel/ESC/scrim still dismiss. */
+  disableConfirm?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }) {
@@ -66,7 +70,11 @@ export function ConfirmDialog({
           <button className="btn-ghost" disabled={busy} onClick={onCancel}>
             Cancel
           </button>
-          <button className="btn-danger" disabled={busy} onClick={onConfirm}>
+          <button
+            className="btn-danger"
+            disabled={busy || disableConfirm}
+            onClick={onConfirm}
+          >
             {busy ? busyLabel : confirmLabel}
           </button>
         </div>

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -262,3 +262,223 @@
   font-weight: 600;
   z-index: 9;
 }
+
+/* ============ settings page chrome (shared by ≥2 settings pages) ============ */
+.page {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  max-width: 72rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.5rem 2rem 0.5rem;
+  height: 100%;
+}
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+.page-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+.page-sub {
+  margin-top: 2px;
+  color: var(--rm-text-muted);
+  font-size: 0.875rem;
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--rm-action);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+.back-link:hover {
+  color: var(--rm-action-hover);
+}
+.back-link svg {
+  width: 14px;
+  height: 14px;
+}
+.page-search {
+  padding: 12px 0;
+  flex-shrink: 0;
+}
+.grid-scroll {
+  flex: 1 1 0%;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding: 2px 0.5rem 1rem 2px;
+}
+.grid-empty {
+  padding-top: 3rem;
+  display: flex;
+}
+
+/* manage-card action footer (shared: coworkers + mcp-servers) */
+.card.manage .desc {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+.card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--rm-border);
+  margin-top: 4px;
+  padding-top: 10px;
+}
+.icon-acts {
+  display: inline-flex;
+  gap: 2px;
+}
+.icon-acts .icon-btn {
+  padding: 5px;
+}
+.icon-acts .icon-btn:hover {
+  background: var(--rm-nav-hover);
+}
+.icon-acts .icon-btn.on {
+  color: var(--rm-app-bg);
+  background: var(--rm-action);
+}
+.icon-acts .icon-btn.danger {
+  color: var(--rm-danger);
+}
+.icon-acts .icon-btn.danger:hover {
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+}
+.icon-acts .icon-btn:disabled {
+  color: var(--rm-text-muted);
+  cursor: default;
+  background: none;
+}
+.icon-acts .icon-btn svg {
+  width: 15px;
+  height: 15px;
+}
+.row-error {
+  font-size: 12px;
+  color: var(--rm-danger);
+  margin-top: 6px;
+}
+
+/* ============ dialog form primitives (shared by wizard + mcp dialog) ============ */
+.wiz-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1rem 2px;
+}
+.wiz-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--rm-border);
+  padding-top: 10px;
+  flex-shrink: 0;
+}
+.wiz-foot .actions {
+  display: inline-flex;
+  gap: 8px;
+  margin-left: auto;
+}
+.wiz-err {
+  color: var(--rm-danger);
+  font-size: 0.8125rem;
+}
+.field {
+  margin-bottom: 14px;
+}
+.field label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+.field .hint {
+  font-size: 12px;
+  color: var(--rm-text-muted);
+  margin-top: 4px;
+}
+.field .hint.invalid {
+  color: var(--rm-danger);
+}
+.field input[type="text"],
+.field textarea,
+.field select {
+  width: 100%;
+  font-family: var(--font-base);
+  font-size: 0.875rem;
+  color: var(--rm-text);
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  padding: 8px 10px;
+}
+.field textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+.field input:focus-visible,
+.field textarea:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid var(--rm-action);
+  outline-offset: -1px;
+}
+.field input:disabled {
+  background: var(--rm-card-bg);
+  color: var(--rm-text-muted);
+  cursor: not-allowed;
+}
+.opt-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  font-family: var(--font-base);
+  color: var(--rm-text);
+}
+.opt-card:hover {
+  outline: 1px solid var(--rm-action-hover);
+  outline-offset: -1px;
+}
+.opt-card.selected {
+  border-color: var(--rm-action);
+  background: var(--rm-info-bg);
+}
+.opt-card.locked {
+  opacity: 0.45;
+  cursor: not-allowed;
+  outline: none;
+}
+.opt-card .t {
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+.opt-card .d {
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  margin-top: 2px;
+}

--- a/web-react/src/features/settings/coworkers/coworker-wizard.tsx
+++ b/web-react/src/features/settings/coworkers/coworker-wizard.tsx
@@ -633,7 +633,7 @@ export function CoworkerWizard({
             );
           })}
         </div>
-        <div className="wiz-body">
+        <div className="wiz-body wizard">
           {cataloguesLoading ? (
             <div className="hint">Loading…</div>
           ) : backendsQ.isError || modelsQ.isError ? (

--- a/web-react/src/features/settings/coworkers/coworkers.css
+++ b/web-react/src/features/settings/coworkers/coworkers.css
@@ -1,74 +1,11 @@
-/* Coworkers page + wizard CSS — transcribed from the v4 prototype
- * (page chrome, manage-card variant, wizard stepper/form primitives,
- * review rows). Shared primitives (.dlg/.card/.masonry/buttons/toast)
- * live in components/ui.css. */
+/* Coworkers page + wizard CSS — the coworker-SPECIFIC bits only.
+ * Shared primitives live in components/ui.css: the dialog/card/button
+ * families, page chrome (.page/.page-head/.back-link/.grid-scroll),
+ * the manage-card action footer (.card-actions/.icon-acts/.row-error),
+ * and the dialog form primitives (.field/.opt-card/.wiz-body/foot/err).
+ * Anything below is used by coworkers alone. */
 
-/* page chrome */
-.page {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  max-width: 72rem;
-  width: 100%;
-  margin: 0 auto;
-  padding: 1.5rem 2rem 0.5rem;
-  height: 100%;
-}
-.page-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-shrink: 0;
-}
-.page-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 700;
-}
-.page-sub {
-  margin-top: 2px;
-  color: var(--rm-text-muted);
-  font-size: 0.875rem;
-}
-.back-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 6px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  color: var(--rm-action);
-  font-size: 0.8125rem;
-  font-weight: 700;
-}
-.back-link:hover {
-  color: var(--rm-action-hover);
-}
-.back-link svg {
-  width: 14px;
-  height: 14px;
-}
-.page-search {
-  padding: 12px 0;
-  flex-shrink: 0;
-}
-.grid-scroll {
-  flex: 1 1 0%;
-  min-height: 0;
-  overflow-y: auto;
-  scrollbar-gutter: stable;
-  padding: 2px 0.5rem 1rem 2px;
-}
-.grid-empty {
-  padding-top: 3rem;
-  display: flex;
-}
-
-/* manage-card variant */
+/* manage-card: visibility/status pills + ownership tag + open-chat */
 .pills {
   display: flex;
   flex-wrap: wrap;
@@ -107,20 +44,6 @@
   font-size: 12px;
   color: var(--rm-text-muted);
 }
-.card.manage .desc {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-}
-.card-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-top: 1px solid var(--rm-border);
-  margin-top: 4px;
-  padding-top: 10px;
-}
 .open-chat {
   display: inline-flex;
   align-items: center;
@@ -140,46 +63,11 @@
   width: 14px;
   height: 14px;
 }
-.icon-acts {
-  display: inline-flex;
-  gap: 2px;
-}
-.icon-acts .icon-btn {
-  padding: 5px;
-}
-.icon-acts .icon-btn:hover {
-  background: var(--rm-nav-hover);
-}
-.icon-acts .icon-btn.on {
-  color: var(--rm-app-bg);
-  background: var(--rm-action);
-}
-.icon-acts .icon-btn.danger {
-  color: var(--rm-danger);
-}
-.icon-acts .icon-btn.danger:hover {
-  background: var(--rm-danger-bg);
-  color: var(--rm-danger);
-}
-.icon-acts .icon-btn:disabled {
-  color: var(--rm-text-muted);
-  cursor: default;
-  background: none;
-}
-.icon-acts .icon-btn svg {
-  width: 15px;
-  height: 15px;
-}
 .view-only {
   font-size: 12px;
   font-weight: 700;
   color: var(--rm-text-muted);
   text-transform: uppercase;
-}
-.row-error {
-  font-size: 12px;
-  color: var(--rm-danger);
-  margin-top: 6px;
 }
 
 /* wizard: stepper (tab-bar idiom) */
@@ -231,6 +119,10 @@
   display: inline;
 }
 
+/* wizard body: partial-commit banner + wizard-only min-height */
+.wiz-body.wizard {
+  min-height: 220px;
+}
 .wiz-banner {
   margin-top: 8px;
   border-left: 3px solid var(--rm-danger);
@@ -245,73 +137,8 @@
   color: var(--rm-text);
   margin-top: 4px;
 }
-.wiz-body {
-  flex: 1 1 auto;
-  min-height: 220px;
-  overflow-y: auto;
-  padding: 1rem 2px;
-}
-.wiz-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-top: 1px solid var(--rm-border);
-  padding-top: 10px;
-  flex-shrink: 0;
-}
-.wiz-err {
-  color: var(--rm-danger);
-  font-size: 0.8125rem;
-}
-.wiz-foot .actions {
-  display: inline-flex;
-  gap: 8px;
-  margin-left: auto;
-}
 
-/* form primitives */
-.field {
-  margin-bottom: 14px;
-}
-.field label {
-  display: block;
-  font-size: 0.8125rem;
-  font-weight: 700;
-  margin-bottom: 4px;
-}
-.field .hint {
-  font-size: 12px;
-  color: var(--rm-text-muted);
-  margin-top: 4px;
-}
-.field .hint.invalid {
-  color: var(--rm-danger);
-}
-.field input[type="text"],
-.field textarea {
-  width: 100%;
-  font-family: var(--font-base);
-  font-size: 0.875rem;
-  color: var(--rm-text);
-  border: 1px solid var(--rm-text-muted);
-  border-radius: 4px;
-  background: var(--rm-app-bg);
-  padding: 8px 10px;
-}
-.field textarea {
-  min-height: 96px;
-  resize: vertical;
-}
-.field input:focus-visible,
-.field textarea:focus-visible {
-  outline: 2px solid var(--rm-action);
-  outline-offset: -1px;
-}
-.field input:disabled {
-  background: var(--rm-card-bg);
-  color: var(--rm-text-muted);
-  cursor: not-allowed;
-}
+/* wizard form: engine lock note, model provider groups, check rows */
 .lock-note {
   background: var(--rm-card-bg);
   border: 1px solid var(--rm-border);
@@ -324,43 +151,6 @@
 .lock-note code {
   font-family: ui-monospace, monospace;
   color: var(--rm-text);
-}
-
-/* option cards / checkbox rows */
-.opt-card {
-  display: block;
-  width: 100%;
-  text-align: left;
-  cursor: pointer;
-  border: 1px solid var(--rm-border);
-  border-radius: 4px;
-  background: var(--rm-app-bg);
-  padding: 10px 12px;
-  margin-bottom: 8px;
-  font-family: var(--font-base);
-  color: var(--rm-text);
-}
-.opt-card:hover {
-  outline: 1px solid var(--rm-action-hover);
-  outline-offset: -1px;
-}
-.opt-card.selected {
-  border-color: var(--rm-action);
-  background: var(--rm-info-bg);
-}
-.opt-card.locked {
-  opacity: 0.45;
-  cursor: not-allowed;
-  outline: none;
-}
-.opt-card .t {
-  font-weight: 700;
-  font-size: 0.875rem;
-}
-.opt-card .d {
-  font-size: 0.8125rem;
-  color: var(--rm-text-muted);
-  margin-top: 2px;
 }
 .group-h {
   font-size: 12px;

--- a/web-react/src/features/settings/mcp-servers/auth-modes.ts
+++ b/web-react/src/features/settings/mcp-servers/auth-modes.ts
@@ -1,0 +1,35 @@
+// Auth-mode catalogue for the MCP dialog (spec D.2 / D-M2). The enum
+// will grow — new modes land as a data-only addition here with zero
+// layout work; the dialog renders the select + dynamic hint from this
+// list. Semantics mirror the wire `MCPAuthMode` docs in openapi.yaml.
+
+import type { MCPAuthMode } from '../../../api/client';
+
+export interface AuthModeOption {
+  id: MCPAuthMode;
+  label: string;
+  description: string;
+}
+
+export const AUTH_MODES: readonly AuthModeOption[] = [
+  {
+    id: 'service',
+    label: 'Service',
+    description:
+      'A shared service credential from the vault — the credential proxy injects it; agents never see it.',
+  },
+  {
+    id: 'user',
+    label: 'User',
+    description: "The requesting user's own credential is used for each call.",
+  },
+  {
+    id: 'both',
+    label: 'Both',
+    description: 'User credential when present, service credential as fallback.',
+  },
+];
+
+export function authModeDescription(mode: MCPAuthMode): string {
+  return AUTH_MODES.find((m) => m.id === mode)?.description ?? '';
+}

--- a/web-react/src/features/settings/mcp-servers/delete-error.test.ts
+++ b/web-react/src/features/settings/mcp-servers/delete-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../../api/client';
+import { deleteErrText } from './delete-error';
+
+describe('deleteErrText', () => {
+  it('renders a 409 RESOURCE_IN_USE as a coworker count from details', () => {
+    const err = new ApiError(
+      409,
+      { code: 'RESOURCE_IN_USE', message: 'in use', details: { coworker_ids: ['a', 'b', 'c'] } },
+      'in use',
+    );
+    expect(deleteErrText(err)).toBe(
+      'In use by 3 coworkers — unbind it from each before deleting.',
+    );
+  });
+
+  it('singularizes at one bound coworker', () => {
+    const err = new ApiError(
+      409,
+      { code: 'RESOURCE_IN_USE', message: 'in use', details: { coworker_ids: ['a'] } },
+      'in use',
+    );
+    expect(deleteErrText(err)).toContain('In use by 1 coworker —');
+  });
+
+  it('falls back to the message when 409 has no coworker_ids', () => {
+    const err = new ApiError(409, { code: 'CONFLICT', message: 'boom' }, 'boom');
+    expect(deleteErrText(err)).toBe('boom');
+  });
+
+  it('uses the message for non-409 ApiErrors and plain errors', () => {
+    expect(deleteErrText(new ApiError(500, { code: 'X', message: 'server' }, 'server'))).toBe(
+      'server',
+    );
+    expect(deleteErrText(new Error('network'))).toBe('network');
+  });
+});

--- a/web-react/src/features/settings/mcp-servers/delete-error.ts
+++ b/web-react/src/features/settings/mcp-servers/delete-error.ts
@@ -1,0 +1,19 @@
+// Delete-failure message formatter (spec D.3). A 409 RESOURCE_IN_USE
+// carries `details.coworker_ids` — render the count (Lit parity),
+// never dump the raw open `details` object. Everything else falls back
+// to the message. Pure so the 409-surfacing path is unit-testable.
+
+import { ApiError } from '../../../api/client';
+
+export function deleteErrText(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 409 && err.body?.details) {
+      const ids = (err.body.details as Record<string, unknown>).coworker_ids;
+      if (Array.isArray(ids)) {
+        return `In use by ${ids.length} coworker${ids.length === 1 ? '' : 's'} — unbind it from each before deleting.`;
+      }
+    }
+    return err.body?.message ?? `${err.status}`;
+  }
+  return (err as Error).message ?? 'delete failed';
+}

--- a/web-react/src/features/settings/mcp-servers/mcp-server-card.test.tsx
+++ b/web-react/src/features/settings/mcp-servers/mcp-server-card.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MCPServerCard } from './mcp-server-card';
+import type { MCPServer } from '../../../api/client';
+
+function server(overrides: Partial<MCPServer> = {}): MCPServer {
+  return {
+    id: 'mcp1',
+    tenant_id: 't1',
+    name: 'records',
+    type: 'http',
+    url: 'http://records.internal/mcp',
+    auth_mode: 'service',
+    description: 'Records MCP server',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  } as MCPServer;
+}
+
+function renderCard(s: MCPServer, usageCount: number) {
+  return render(
+    <MCPServerCard
+      server={s}
+      usageCount={usageCount}
+      rowError={null}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe('MCPServerCard', () => {
+  it('renders the provider line, monospace url, and description', () => {
+    renderCard(server(), 0);
+    expect(screen.getByText('http · auth: service')).toBeTruthy();
+    expect(screen.getByText('http://records.internal/mcp').className).toContain('mono');
+    expect(screen.getByText('Records MCP server')).toBeTruthy();
+  });
+
+  it('shows the bound usage text (info-blue) when N>0', () => {
+    renderCard(server(), 3);
+    const usage = screen.getByText('Used by 3 coworkers');
+    expect(usage.className).toContain('bound');
+  });
+
+  it('shows the unbound text (muted) when N=0', () => {
+    renderCard(server(), 0);
+    const usage = screen.getByText('Not bound to any coworker');
+    expect(usage.className).not.toContain('bound');
+  });
+
+  it('singularizes "coworker" at N=1', () => {
+    renderCard(server(), 1);
+    expect(screen.getByText('Used by 1 coworker')).toBeTruthy();
+  });
+
+  it('has no visibility/ownership pills (tenant infrastructure)', () => {
+    renderCard(server(), 0);
+    expect(document.querySelector('.pills')).toBeNull();
+    expect(screen.queryByText('View only')).toBeNull();
+  });
+});

--- a/web-react/src/features/settings/mcp-servers/mcp-server-card.tsx
+++ b/web-react/src/features/settings/mcp-servers/mcp-server-card.tsx
@@ -1,0 +1,57 @@
+// MCPServerCard — one registry row (spec D.1). Same manage-card family
+// as the coworkers page, but no visibility/ownership (tenant
+// infrastructure — the whole page is gated by its nav capability, not
+// per-row). The URL is the key operational datum, rendered monospace.
+
+import { Pencil, Trash2 } from 'lucide-react';
+import type { MCPServer } from '../../../api/client';
+
+export function MCPServerCard({
+  server,
+  usageCount,
+  rowError,
+  onEdit,
+  onDelete,
+}: {
+  server: MCPServer;
+  usageCount: number;
+  rowError: string | null;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const bound = usageCount > 0;
+  return (
+    <div className="card manage">
+      <div className="card-content">
+        <div>
+          <div className="provider">
+            {server.type} · auth: {server.auth_mode}
+          </div>
+          <div className="name">{server.name}</div>
+        </div>
+        <div className="mono">{server.url}</div>
+        {server.description ? <div className="desc">{server.description}</div> : null}
+        <div className="card-actions">
+          <span className={`usage${bound ? ' bound' : ''}`}>
+            {bound
+              ? `Used by ${usageCount} coworker${usageCount === 1 ? '' : 's'}`
+              : 'Not bound to any coworker'}
+          </span>
+          <span className="icon-acts">
+            <button className="icon-btn" title="Edit MCP server" onClick={onEdit}>
+              <Pencil />
+            </button>
+            <button
+              className="icon-btn danger"
+              title="Delete MCP server"
+              onClick={onDelete}
+            >
+              <Trash2 />
+            </button>
+          </span>
+        </div>
+        {rowError ? <div className="row-error">{rowError}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/mcp-servers/mcp-server-dialog.test.tsx
+++ b/web-react/src/features/settings/mcp-servers/mcp-server-dialog.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MCPServerDialog } from './mcp-server-dialog';
+import { authModeDescription } from './auth-modes';
+
+function renderDialog() {
+  const onSaved = vi.fn();
+  const onClose = vi.fn();
+  render(<MCPServerDialog editing={null} onClose={onClose} onSaved={onSaved} />);
+  return { onSaved, onClose };
+}
+
+afterEach(cleanup);
+
+describe('MCPServerDialog', () => {
+  it('gates Create on name AND url (defaults cover type/auth_mode)', () => {
+    renderDialog();
+    const create = screen.getByText('Create') as HTMLButtonElement;
+    expect(create.disabled).toBe(true); // empty name + url
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. records-mcp'), {
+      target: { value: 'records' },
+    });
+    expect(create.disabled).toBe(true); // url still empty
+
+    fireEvent.change(
+      screen.getByPlaceholderText('http://records-mcp.rolemesh-system.svc:8080/mcp'),
+      { target: { value: 'http://records.internal/mcp' } },
+    );
+    expect(create.disabled).toBe(false);
+  });
+
+  it('auth-mode hint updates with the selected mode', () => {
+    renderDialog();
+    // default is service
+    expect(screen.getByText(authModeDescription('service'))).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Auth mode'), {
+      target: { value: 'both' },
+    });
+    expect(screen.getByText(authModeDescription('both'))).toBeTruthy();
+  });
+
+  it('transport option-cards toggle the selected class', () => {
+    renderDialog();
+    const sse = screen.getByText('sse').closest('button')!;
+    const http = screen.getByText('http').closest('button')!;
+    expect(http.className).toContain('selected'); // default http
+    expect(sse.className).not.toContain('selected');
+    fireEvent.click(sse);
+    expect(sse.className).toContain('selected');
+    expect(http.className).not.toContain('selected');
+  });
+});

--- a/web-react/src/features/settings/mcp-servers/mcp-server-dialog.tsx
+++ b/web-react/src/features/settings/mcp-servers/mcp-server-dialog.tsx
@@ -1,0 +1,222 @@
+// MCPServerDialog — create AND edit in one component (spec D.2;
+// behavioral reference web/src/components/mcp-server-dialog.ts). No
+// wizard — a single 560px form. Fields: name, transport (inline
+// option-cards http/sse), url (monospace), auth mode (select + dynamic
+// hint), description (optional).
+//
+// extra_headers / tool_reversibility are API-only (D-M1) — the Lit
+// dialog defers them too. Submit gates on name + url non-empty;
+// type/auth_mode always carry defaults (http/service) so the looser
+// gate still satisfies the wire-required set.
+
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  ApiError,
+  getApiClient,
+  type MCPServer,
+  type MCPServerCreate,
+  type MCPType,
+} from '../../../api/client';
+import { BrandMark } from '../../../components/brand-mark';
+import { AUTH_MODES, authModeDescription } from './auth-modes';
+
+interface DialogForm {
+  name: string;
+  type: MCPType;
+  url: string;
+  auth_mode: MCPServerCreate['auth_mode'];
+  description: string;
+}
+
+function formFromServer(s: MCPServer): DialogForm {
+  return {
+    name: s.name,
+    type: s.type,
+    url: s.url,
+    auth_mode: s.auth_mode,
+    description: s.description ?? '',
+  };
+}
+
+const EMPTY: DialogForm = {
+  name: '',
+  type: 'http',
+  url: '',
+  auth_mode: 'service',
+  description: '',
+};
+
+const TRANSPORTS: MCPType[] = ['http', 'sse'];
+
+export function MCPServerDialog({
+  editing,
+  onClose,
+  onSaved,
+}: {
+  editing: MCPServer | null;
+  onClose: () => void;
+  /** Fired on success with a toast line; parent refreshes the list. */
+  onSaved: (toast: string) => void;
+}) {
+  const isEdit = editing !== null;
+  const [form, setForm] = useState<DialogForm>(() =>
+    editing ? formFromServer(editing) : EMPTY,
+  );
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onClose]);
+
+  const canSubmit = form.name.trim() !== '' && form.url.trim() !== '' && !busy;
+
+  async function submit() {
+    if (!canSubmit) return;
+    setBusy(true);
+    setErr(null);
+    const body = {
+      name: form.name.trim(),
+      type: form.type,
+      url: form.url.trim(),
+      auth_mode: form.auth_mode,
+      description: form.description.trim() || null,
+    };
+    try {
+      const api = getApiClient();
+      const saved = isEdit
+        ? await api.updateMCPServer(editing.id, body)
+        : await api.createMCPServer(body);
+      onSaved(
+        isEdit
+          ? `Saved changes to ${saved.name}`
+          : `Registered ${saved.name} — egress gateway hot-reloaded`,
+      );
+      onClose();
+    } catch (e) {
+      setErr(
+        e instanceof ApiError ? (e.body?.message ?? `${e.status}`) : (e as Error).message,
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div className="dlg mcp" role="dialog" aria-modal="true" aria-label="MCP server">
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">
+              {isEdit ? `Edit ${editing.name}` : 'New MCP server'}
+            </h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body">
+          <div className="field">
+            <label htmlFor="mcp-name">Name</label>
+            <input
+              id="mcp-name"
+              type="text"
+              maxLength={200}
+              placeholder="e.g. records-mcp"
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            />
+          </div>
+          <div className="field">
+            <label>Transport</label>
+            <div className="transport-row">
+              {TRANSPORTS.map((t) => (
+                <button
+                  key={t}
+                  className={`opt-card${form.type === t ? ' selected' : ''}`}
+                  onClick={() => setForm((f) => ({ ...f, type: t }))}
+                >
+                  <div className="t">{t}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="field">
+            <label htmlFor="mcp-url">URL</label>
+            <input
+              id="mcp-url"
+              type="text"
+              className="mono"
+              placeholder="http://records-mcp.rolemesh-system.svc:8080/mcp"
+              value={form.url}
+              onChange={(e) => setForm((f) => ({ ...f, url: e.target.value }))}
+            />
+            <div className="hint">
+              Every call is routed through the egress gateway and credential proxy —
+              the URL must be reachable from the cluster, not from your browser.
+            </div>
+          </div>
+          <div className="field">
+            <label htmlFor="mcp-auth">Auth mode</label>
+            <select
+              id="mcp-auth"
+              value={form.auth_mode}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  auth_mode: e.target.value as DialogForm['auth_mode'],
+                }))
+              }
+            >
+              {AUTH_MODES.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+            <div className="hint">{authModeDescription(form.auth_mode)}</div>
+          </div>
+          <div className="field">
+            <label htmlFor="mcp-desc">
+              Description{' '}
+              <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+                (optional)
+              </span>
+            </label>
+            <textarea
+              id="mcp-desc"
+              style={{ minHeight: 64 }}
+              value={form.description}
+              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+            />
+          </div>
+        </div>
+        <div className="wiz-foot">
+          {err ? <span className="wiz-err" role="alert">{err}</span> : <span />}
+          <span className="actions">
+            <button className="btn-ghost" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+            <button className="btn-primary" disabled={!canSubmit} onClick={() => void submit()}>
+              {busy ? (isEdit ? 'Saving…' : 'Creating…') : isEdit ? 'Save changes' : 'Create'}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/mcp-servers/mcp-servers-page.tsx
+++ b/web-react/src/features/settings/mcp-servers/mcp-servers-page.tsx
@@ -1,0 +1,206 @@
+// MCPServersPage — tenant-scoped MCP registry (spec Part D). Reuses
+// Part C's page chrome, manage-card family, and shared confirm dialog.
+// No visibility/ownership on this resource — the whole page is gated
+// by the `mcp.configure` nav capability (Part A §5.1), so no per-row
+// capability split.
+//
+// Usage counts are client-derived (D.1, Lit parity) via the shared
+// query — see useMCPUsageCounts. The delete-block is advisory; the
+// backend's 409 RESOURCE_IN_USE is the authoritative gate.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowLeft, Plus, Search } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { getApiClient, type MCPServer } from '../../../api/client';
+import { useMCPServerRegistry, useMCPUsageCounts } from '../../../api/queries';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { deleteErrText } from './delete-error';
+import { MCPServerCard } from './mcp-server-card';
+import { MCPServerDialog } from './mcp-server-dialog';
+import './mcp-servers.css';
+
+export function MCPServersPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const registryQ = useMCPServerRegistry();
+  const usageQ = useMCPUsageCounts(true);
+  const counts = usageQ.data ?? new Map<string, number>();
+
+  const [query, setQuery] = useState('');
+  const [dialog, setDialog] = useState<{ open: boolean; editing: MCPServer | null }>(
+    { open: false, editing: null },
+  );
+  const [deleteTarget, setDeleteTarget] = useState<MCPServer | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  const rows = registryQ.data ?? [];
+  const q = query.trim().toLowerCase();
+  const visible = useMemo(
+    () =>
+      rows.filter(
+        (s) =>
+          !q ||
+          `${s.name} ${s.url} ${s.description ?? ''}`.toLowerCase().includes(q),
+      ),
+    [rows, q],
+  );
+
+  function refreshAfterMutation() {
+    void queryClient.invalidateQueries({ queryKey: ['mcp-servers'] });
+    // Bindings didn't change on create/edit, but a fresh count is cheap
+    // and keeps the page authoritative after a delete elsewhere.
+    void queryClient.invalidateQueries({ queryKey: ['mcp-usage-counts'] });
+  }
+
+  async function performDelete() {
+    const s = deleteTarget;
+    if (!s || deleteBusy) return;
+    setDeleteBusy(true);
+    setRowErrors((e) => ({ ...e, [s.id]: '' }));
+    try {
+      await getApiClient().deleteMCPServer(s.id);
+      refreshAfterMutation();
+      showToast(`Deleted ${s.name}`);
+    } catch (err) {
+      // Close on error too — the per-row line surfaces the message
+      // (incl. the 409 in-use case if the advisory block was stale).
+      setRowErrors((e) => ({ ...e, [s.id]: deleteErrText(err) }));
+    } finally {
+      setDeleteBusy(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  const deleteBlockCount = deleteTarget ? (counts.get(deleteTarget.id) ?? 0) : 0;
+  const deleteBlocked = deleteBlockCount > 0;
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">MCP servers</h1>
+          <div className="page-sub">
+            Tenant-scoped registry — changes hot-reload to the egress gateway.
+          </div>
+        </div>
+        <button
+          className="btn-primary"
+          onClick={() => setDialog({ open: true, editing: null })}
+        >
+          <Plus />
+          New MCP server
+        </button>
+      </div>
+      <div className="page-search">
+        <div className="search-field">
+          <input
+            type="text"
+            placeholder="Search MCP servers"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <span className="search-ic">
+            <Search />
+          </span>
+        </div>
+      </div>
+      <div className="grid-scroll">
+        {registryQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : registryQ.isError ? (
+          <div className="row-error">Failed to load MCP servers — retry from the sidebar.</div>
+        ) : rows.length === 0 ? (
+          <div className="grid-empty">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <div style={{ fontSize: '1rem', fontWeight: 700 }}>No MCP servers yet.</div>
+              <div className="page-sub" style={{ marginTop: 4 }}>
+                Register one to make its tools available to coworkers.
+              </div>
+              <button
+                className="btn-primary"
+                style={{ marginTop: '1rem' }}
+                onClick={() => setDialog({ open: true, editing: null })}
+              >
+                New MCP server
+              </button>
+            </div>
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="page-sub">No MCP servers match your search.</div>
+        ) : (
+          <div className="masonry">
+            {visible.map((s) => (
+              <MCPServerCard
+                key={s.id}
+                server={s}
+                usageCount={counts.get(s.id) ?? 0}
+                rowError={rowErrors[s.id] || null}
+                onEdit={() => setDialog({ open: true, editing: s })}
+                onDelete={() => setDeleteTarget(s)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {dialog.open ? (
+        <MCPServerDialog
+          editing={dialog.editing}
+          onClose={() => setDialog({ open: false, editing: null })}
+          onSaved={(msg) => {
+            refreshAfterMutation();
+            showToast(msg);
+          }}
+        />
+      ) : null}
+
+      {deleteTarget ? (
+        <ConfirmDialog
+          title={`Delete MCP server “${deleteTarget.name}”?`}
+          confirmLabel="Delete"
+          busyLabel="Deleting…"
+          busy={deleteBusy}
+          disableConfirm={deleteBlocked}
+          onConfirm={() => void performDelete()}
+          onCancel={() => {
+            if (!deleteBusy) setDeleteTarget(null);
+          }}
+        >
+          {deleteBlocked ? (
+            <>
+              This MCP server is bound to <b>{deleteBlockCount}</b> coworker
+              {deleteBlockCount === 1 ? '' : 's'}. Unbind it from{' '}
+              {deleteBlockCount === 1 ? 'that coworker' : 'each one'} before deleting.
+            </>
+          ) : (
+            <>This cannot be undone.</>
+          )}
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? <div className="toast">{toast}</div> : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/mcp-servers/mcp-servers.css
+++ b/web-react/src/features/settings/mcp-servers/mcp-servers.css
@@ -1,0 +1,35 @@
+/* MCP servers page — the MCP-SPECIFIC bits only. Shared primitives
+ * (page chrome, .card/.card.manage, .card-actions/.icon-acts/.row-error,
+ * dialog family, .field/.opt-card/.wiz-body/foot/err, toast) live in
+ * components/ui.css. */
+
+/* card: monospace URL (the key operational datum) + usage line */
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+  color: var(--rm-text);
+  word-break: break-all;
+}
+.usage {
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  font-weight: 600;
+}
+.usage.bound {
+  color: var(--rm-info-text);
+}
+
+/* create/edit dialog: 560px, inline transport option-cards */
+.dlg.mcp {
+  width: 560px;
+}
+.transport-row {
+  display: flex;
+  gap: 8px;
+}
+.transport-row .opt-card {
+  flex: 1;
+  margin-bottom: 0;
+  text-align: center;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
Third child branch of the React webui effort: **Part D — MCP servers page** of the v5 spec handoff, filling `features/settings/mcp-servers/` per the §1.1 growth rule (own ~9 KB lazy chunk, static route above `/manage/:slug`). Behavioral reference: the Lit `mcp-servers-page.ts` / `mcp-server-dialog.ts`, per the v5 behavior-parity rule (visuals follow the prototype; behavior follows Lit).

## What's in

- **Page** (`#/manage/mcp-servers`): back-to-chat, header + `New MCP server`, subtitle stating the operational contract (registry writes hot-reload to the egress gateway), search over name + url + description, 3-column masonry, loading/empty/search-empty states, toast. **No visibility/ownership** — tenant infrastructure, so no pills, no per-row capability split; the whole page is gated by the `mcp.configure` nav capability (Part A §5.1).
- **Card**: same manage-card family as coworkers. Provider line `{type} · auth: {auth_mode}` (uppercase muted), name, **monospace break-all URL** (the key operational datum, visually distinct), description, usage line — info-blue `Used by N coworkers` when bound / muted `Not bound to any coworker` — plus edit/delete icons and a per-row delete-error line.
- **Dialog** (create AND edit, one component, 560px, no wizard): name, transport as inline option-cards `http`/`sse`, monospace URL with the egress-gateway hint, auth mode as a `<select>` + **dynamic hint driven by one `AUTH_MODES` constant** (D-M2: the enum will grow, so new modes are a data-only addition), optional description. Submit gates on name + url non-empty (defaults `http`/`service` cover the wire-required `type`/`auth_mode`). Create toast: `Registered {name} — egress gateway hot-reloaded`.
- **Delete** (binding-aware block, spec D.3): shared `ConfirmDialog` (now with a `disableConfirm` prop). Usage count > 0 → Delete disabled + `This MCP server is bound to N coworkers. Unbind it from each one before deleting.`; count = 0 → `This cannot be undone.` The client count is **advisory** — the backend's `409 RESOURCE_IN_USE` is the authoritative gate; on 409 the per-row error is derived from `details.coworker_ids` (Lit parity — never dumps the raw open `details` object).
- **Usage counts** (client-derived, Lit parity, D.1): list coworkers → fan out per-coworker binding reads via `Promise.allSettled` (a failed read renders as 0, never blocks) → count by `mcp_server_id`. Shares the `['coworkers']` + per-coworker binding query keys with the coworker wizard's step-4 pre-fill, so the cache is reused.
- **Client**: `createMCPServer` / `updateMCPServer` / `deleteMCPServer` lifted verbatim from the Lit client (method names identical, §11).
- **Refactor** (separate commit): hoisted the genuinely-shared settings primitives (page chrome, manage-card action footer, dialog form primitives) from `coworkers.css` into the globally-loaded `components/ui.css`. Part D needs them, and leaving them in `coworkers.css` would create a hidden load-order dependency (mcp cards break if the coworkers page never mounts) and violate sibling-isolation. No visual change — coworkers page rebuilt and re-verified.

## Not in scope (per spec)

`extra_headers` / `tool_reversibility` editing (D-M1 — API-only, as in the Lit dialog); no connection test/health probe (nothing on the wire — a contract PR if wanted); no per-server tool listing (runtime concern).

## Verification

- 103 vitest tests green (15 new: dialog submit gating, auth-mode dynamic hint, transport option-card toggle, card usage rendering incl. singular/plural + no-pills, and the 409 `details.coworker_ids` surfacing path); tsc strict, all three lints, `openapi:check`, production build all clean. MCP page is its own ~9 KB lazy chunk.
- End-to-end against a mock v1 backend (extended with MCP CRUD + 409-on-bound) with Playwright: list renders correct usage counts (records bound = 1, files = 0) → create (transport cards, auth-mode hint updates, monospace URL) → new card appears with the hot-reload toast → delete **blocked** on the bound server (Delete disabled + unbind copy) → delete **succeeds** on the unbound one. Zero app console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_