### PR TITLE
feat(webui-react): Skills catalog page — chip filter, upload-aware dialog, share, binding-aware delete (spec Part E)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -37,6 +37,9 @@ export type MCPServerUpdate = components['schemas']['MCPServerUpdate'];
 export type MCPType = components['schemas']['MCPType'];
 export type MCPAuthMode = components['schemas']['MCPAuthMode'];
 export type SkillSummary = components['schemas']['SkillSummary'];
+export type Skill = components['schemas']['Skill'];
+export type SkillCreate = components['schemas']['SkillCreate'];
+export type SkillUpdate = components['schemas']['SkillUpdate'];
 export type ApprovalRequest = components['schemas']['ApprovalRequest'];
 
 export type ErrorResponseBody =
@@ -332,6 +335,74 @@ export class ApiClient {
       { method: 'DELETE', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  // ------------------------------------------------------------------
+  // Skill catalog CRUD + share (Part E). Method names identical to the
+  // Lit client (spec §11).
+  // ------------------------------------------------------------------
+
+  /** Full skill incl. the `files` map — the dialog fetches this on
+   *  edit-open to seed Instructions + the file tree. */
+  async getSkill(id: string): Promise<Skill> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
+  }
+
+  async createSkill(body: SkillCreate): Promise<Skill> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/skills`, {
+      method: 'POST',
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
+  }
+
+  /** PATCH. `name` is read-only server-side — omit it (edit sends the
+   *  full `files` map for atomic replacement per the Lit contract). */
+  async updateSkill(id: string, body: SkillUpdate): Promise<Skill> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}`,
+      {
+        method: 'PATCH',
+        headers: this.headers({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
+  }
+
+  /** 204; 409 RESOURCE_IN_USE when bound to any coworker. */
+  async deleteSkill(id: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  async shareSkill(id: string): Promise<Skill> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}/share`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
+  }
+
+  async unshareSkill(id: string): Promise<Skill> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}/unshare`,
+      { method: 'POST', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as Skill;
   }
 
   async listCoworkerSkills(coworkerId: string): Promise<CoworkerSkillBinding[]> {

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -115,3 +115,17 @@ export function useSkills(enabled: boolean) {
     enabled,
   });
 }
+
+// ---- Skills catalog page (Part E) ----
+//
+// The list carries bound_coworker_count + created_by_user_id, so the
+// page needs no fan-out (unlike Part D's MCP usage counts). Same
+// ['skills'] key the coworker wizard's step-5 catalogue reads, so a
+// created skill appears there with no extra wiring.
+
+export function useSkillRegistry() {
+  return useQuery({
+    queryKey: ['skills'],
+    queryFn: () => getApiClient().listSkills(),
+  });
+}

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -28,6 +28,12 @@ const MCPServersPage = lazy(() =>
   })),
 );
 
+const SkillsPage = lazy(() =>
+  import('../features/settings/skills/skills-page').then((m) => ({
+    default: m.SkillsPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -54,6 +60,14 @@ export function AppRoutes() {
         element={
           <Suspense fallback={null}>
             <MCPServersPage />
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/skills/*"
+        element={
+          <Suspense fallback={null}>
+            <SkillsPage />
           </Suspense>
         }
       />

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -482,3 +482,50 @@
   color: var(--rm-text-muted);
   margin-top: 2px;
 }
+
+/* ============ manage-card pills + ownership tag (shared) ============ */
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.pill {
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 2px;
+  text-transform: capitalize;
+}
+.pill-shared {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.pill-private {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.pill-active {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.pill-paused {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.pill-disabled,
+.pill-off {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.own-tag {
+  font-size: 12px;
+  color: var(--rm-text-muted);
+}
+.view-only {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--rm-text-muted);
+  text-transform: uppercase;
+}

--- a/web-react/src/features/settings/coworkers/coworkers.css
+++ b/web-react/src/features/settings/coworkers/coworkers.css
@@ -5,45 +5,8 @@
  * and the dialog form primitives (.field/.opt-card/.wiz-body/foot/err).
  * Anything below is used by coworkers alone. */
 
-/* manage-card: visibility/status pills + ownership tag + open-chat */
-.pills {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  align-items: center;
-}
-.pill {
-  display: inline-flex;
-  font-size: 12px;
-  font-weight: 700;
-  padding: 2px 8px;
-  border-radius: 2px;
-  text-transform: capitalize;
-}
-.pill-shared {
-  background: var(--rm-success-bg);
-  color: var(--rm-success-text);
-}
-.pill-private {
-  background: var(--rm-border);
-  color: var(--rm-text-muted);
-}
-.pill-active {
-  background: var(--rm-success-bg);
-  color: var(--rm-success-text);
-}
-.pill-paused {
-  background: var(--rm-warn-bg);
-  color: var(--rm-warn-text);
-}
-.pill-disabled {
-  background: var(--rm-border);
-  color: var(--rm-text-muted);
-}
-.own-tag {
-  font-size: 12px;
-  color: var(--rm-text-muted);
-}
+/* manage-card: coworker-specific open-chat (pills + own-tag are shared,
+ * in components/ui.css) */
 .open-chat {
   display: inline-flex;
   align-items: center;
@@ -62,12 +25,6 @@
 .open-chat svg {
   width: 14px;
   height: 14px;
-}
-.view-only {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--rm-text-muted);
-  text-transform: uppercase;
 }
 
 /* wizard: stepper (tab-bar idiom) */

--- a/web-react/src/features/settings/skills/read-files.ts
+++ b/web-react/src/features/settings/skills/read-files.ts
@@ -1,0 +1,123 @@
+// DOM file-reading for the skill upload zone — the impure edge the pure
+// ingestUploads (lib/skill-upload) can't cover. Two entry points mirror
+// the Lit dialog's path policy exactly:
+//
+//   - readFilesFromInput  (folder/file <input>): preserve
+//     webkitRelativePath as-is (PR27 — users pick sub-folders like
+//     `references/` and expect that name to survive; a wrapper folder
+//     is fixed by picking its children).
+//   - readDroppedItems (drag-drop): recursive webkitGetAsEntry walk
+//     where each dropped item's OWN name stays as the path prefix
+//     (PR26 — `references/intro.md` must not flatten to `intro.md`);
+//     getAsFile fallback when the entry API is missing.
+//
+// Unreadable files become `\0` content so the binary gate in
+// ingestUploads catches + tallies them.
+
+import type { IncomingFile } from '../../../lib/skill-upload';
+
+// Minimal structural typing for the non-standard FileSystemEntry API
+// (lib.dom.d.ts coverage varies by tsconfig target; pin the shape used).
+interface FileSystemEntryLike {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+}
+interface FileSystemFileEntryLike extends FileSystemEntryLike {
+  file: (cb: (f: File) => void, errcb?: (e: unknown) => void) => void;
+}
+interface FileSystemDirectoryEntryLike extends FileSystemEntryLike {
+  createReader: () => {
+    readEntries: (
+      cb: (entries: FileSystemEntryLike[]) => void,
+      errcb?: (e: unknown) => void,
+    ) => void;
+  };
+}
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader();
+    r.onerror = () => reject(r.error ?? new Error('read error'));
+    r.onload = () => {
+      const v = r.result;
+      if (typeof v !== 'string') {
+        reject(new Error('expected text content'));
+        return;
+      }
+      resolve(v);
+    };
+    r.readAsText(file);
+  });
+}
+
+/** Picker input → (path, content, bytes). webkitRelativePath is
+ *  "folder/sub/file.md" for the folder picker, empty for plain files. */
+export async function readFilesFromInput(list: FileList): Promise<IncomingFile[]> {
+  const out: IncomingFile[] = [];
+  for (const file of Array.from(list)) {
+    const path =
+      (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name;
+    try {
+      const content = await readFileAsText(file);
+      out.push({ path, content, bytes: file.size });
+    } catch {
+      out.push({ path, content: '\0', bytes: file.size });
+    }
+  }
+  return out;
+}
+
+/** Drag-drop → recursive webkitGetAsEntry walk. Each dropped item's own
+ *  name becomes the path prefix so folder structure survives. */
+export async function readDroppedItems(
+  items: DataTransferItemList,
+): Promise<IncomingFile[]> {
+  const out: IncomingFile[] = [];
+  const entries: FileSystemEntryLike[] = [];
+  for (const it of Array.from(items)) {
+    if (it.kind !== 'file') continue;
+    const getEntry = (
+      it as DataTransferItem & { webkitGetAsEntry?: () => FileSystemEntryLike | null }
+    ).webkitGetAsEntry;
+    const entry = typeof getEntry === 'function' ? getEntry.call(it) : null;
+    if (entry) {
+      entries.push(entry);
+    } else {
+      // No entry API (mostly happy-dom in tests) — fall back to getAsFile.
+      const f = it.getAsFile();
+      if (f) {
+        const content = await readFileAsText(f).catch(() => '\0');
+        out.push({ path: f.name, content, bytes: f.size });
+      }
+    }
+  }
+
+  async function walk(entry: FileSystemEntryLike, prefix: string): Promise<void> {
+    if (entry.isFile) {
+      const file = await new Promise<File>((resolve, reject) =>
+        (entry as FileSystemFileEntryLike).file(resolve, reject),
+      );
+      const content = await readFileAsText(file).catch(() => '\0');
+      // Preserve the full structural prefix (PR26: no flattening).
+      out.push({ path: prefix + file.name, content, bytes: file.size });
+    } else if (entry.isDirectory) {
+      const reader = (entry as FileSystemDirectoryEntryLike).createReader();
+      // readEntries returns a batch at a time; keep calling until empty.
+      let batch: FileSystemEntryLike[] = [];
+      do {
+        batch = await new Promise<FileSystemEntryLike[]>((resolve, reject) =>
+          reader.readEntries(resolve, reject),
+        );
+        for (const child of batch) {
+          await walk(child, `${prefix}${entry.name}/`);
+        }
+      } while (batch.length > 0);
+    }
+  }
+
+  for (const e of entries) {
+    await walk(e, '');
+  }
+  return out;
+}

--- a/web-react/src/features/settings/skills/skill-card.test.tsx
+++ b/web-react/src/features/settings/skills/skill-card.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { SkillCard } from './skill-card';
+import { setMe } from '../../../lib/capabilities';
+import type { Me, SkillSummary } from '../../../api/client';
+
+function me(caps: string[], userId = 'u1'): Me {
+  return { user_id: userId, tenant_id: 't1', role: 'member', plane: 'tenant', capabilities: caps };
+}
+function skill(overrides: Partial<SkillSummary> = {}): SkillSummary {
+  return {
+    id: 's1',
+    tenant_id: 't1',
+    name: 'pdf-toolkit',
+    description: 'Handles PDFs',
+    enabled: true,
+    bound_coworker_count: 0,
+    visibility: 'private',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    created_by_user_id: 'other',
+    ...overrides,
+  } as SkillSummary;
+}
+function renderCard(s: SkillSummary, over: Partial<Parameters<typeof SkillCard>[0]> = {}) {
+  return render(
+    <SkillCard
+      skill={s}
+      shareBusy={false}
+      deleteError={null}
+      shareError={null}
+      onOpen={vi.fn()}
+      onToggleShare={vi.fn()}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      {...over}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  setMe(null);
+});
+
+describe('SkillCard', () => {
+  it('shows the bound count from the payload (no fan-out), singular at 1', () => {
+    setMe(me([]));
+    renderCard(skill({ bound_coworker_count: 1 }));
+    const usage = screen.getByText('Bound to 1 coworker');
+    expect(usage.className).toContain('bound');
+  });
+
+  it('shows unbound text when count is 0', () => {
+    setMe(me([]));
+    renderCard(skill({ bound_coworker_count: 0 }));
+    expect(screen.getByText('Not bound to any coworker').className).not.toContain('bound');
+  });
+
+  it('renders the disabled pill only when enabled === false; no "enabled" pill', () => {
+    setMe(me([]));
+    const { rerender } = renderCard(skill({ enabled: true }));
+    expect(screen.queryByText('disabled')).toBeNull();
+    rerender(
+      <SkillCard
+        skill={skill({ enabled: false })}
+        shareBusy={false}
+        deleteError={null}
+        shareError={null}
+        onOpen={vi.fn()}
+        onToggleShare={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('disabled')).toBeTruthy();
+  });
+
+  it('member without skill.manage sees VIEW ONLY on others’ rows', () => {
+    setMe(me(['skill.use'], 'u1'));
+    renderCard(skill({ created_by_user_id: 'other' }));
+    expect(screen.getByText('View only')).toBeTruthy();
+    expect(screen.queryByTitle('Edit skill')).toBeNull();
+  });
+
+  it('ownership escape: manage icons on own rows even without the capability', () => {
+    setMe(me(['skill.use'], 'u1'));
+    renderCard(skill({ created_by_user_id: 'u1' }));
+    expect(screen.getByTitle('Edit skill')).toBeTruthy();
+    expect(screen.getByTitle('Delete skill')).toBeTruthy();
+  });
+
+  it('renders both error slots and share aria-pressed', () => {
+    setMe(me(['skill.manage']));
+    renderCard(skill({ visibility: 'shared' }), {
+      deleteError: 'del boom',
+      shareError: 'share boom',
+    });
+    expect(screen.getByTitle('Make private').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByText('del boom')).toBeTruthy();
+    expect(screen.getByText('share boom')).toBeTruthy();
+  });
+
+  it('edit/delete icons stopPropagation (do not trigger row open)', () => {
+    setMe(me(['skill.manage']));
+    const onOpen = vi.fn();
+    const onEdit = vi.fn();
+    renderCard(skill({ created_by_user_id: 'u1' }), { onOpen, onEdit });
+    fireEvent.click(screen.getByTitle('Edit skill'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/web-react/src/features/settings/skills/skill-card.tsx
+++ b/web-react/src/features/settings/skills/skill-card.tsx
@@ -1,0 +1,107 @@
+// SkillCard — one catalog row (spec E.1). Manage-card family, but no
+// provider line (skills have no backend/model). The bound count comes
+// straight off the list payload (SkillSummary.bound_coworker_count) —
+// no client fan-out (unlike Part D). Row click opens the edit dialog
+// (Lit parity), so the card body is a button.
+
+import { Pencil, Trash2, Users } from 'lucide-react';
+import type { SkillSummary } from '../../../api/client';
+import { canManage, isOwnResource } from '../../../lib/capabilities';
+
+export function SkillCard({
+  skill,
+  shareBusy,
+  deleteError,
+  shareError,
+  onOpen,
+  onToggleShare,
+  onEdit,
+  onDelete,
+}: {
+  skill: SkillSummary;
+  shareBusy: boolean;
+  deleteError: string | null;
+  shareError: string | null;
+  onOpen: () => void;
+  onToggleShare: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const s = skill;
+  const manageable = canManage(s, 'skill.manage');
+  const shared = s.visibility === 'shared';
+  const n = s.bound_coworker_count;
+  return (
+    <div
+      className="card manage"
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onOpen();
+      }}
+    >
+      <div className="card-content">
+        <div className="name">{s.name}</div>
+        {s.description ? <div className="desc">{s.description}</div> : null}
+        <div className="pills">
+          <span className={`pill pill-${s.visibility}`}>{s.visibility}</span>
+          {/* disabled pill only when explicitly disabled — enabled is
+              the unmarked default (no "enabled" pill). */}
+          {!s.enabled ? <span className="pill pill-off">disabled</span> : null}
+          <span className="own-tag">
+            {isOwnResource(s) ? 'Created by you' : 'Shared by another member'}
+          </span>
+        </div>
+        <div className="card-actions">
+          <span className={`usage${n > 0 ? ' bound' : ''}`}>
+            {n > 0
+              ? `Bound to ${n} coworker${n === 1 ? '' : 's'}`
+              : 'Not bound to any coworker'}
+          </span>
+          {manageable ? (
+            <span className="icon-acts">
+              <button
+                className={`icon-btn${shared ? ' on' : ''}`}
+                aria-pressed={shared}
+                disabled={shareBusy}
+                title={shared ? 'Make private' : 'Share with everyone in this workspace'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleShare();
+                }}
+              >
+                <Users />
+              </button>
+              <button
+                className="icon-btn"
+                title="Edit skill"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+              >
+                <Pencil />
+              </button>
+              <button
+                className="icon-btn danger"
+                title="Delete skill"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+              >
+                <Trash2 />
+              </button>
+            </span>
+          ) : (
+            <span className="view-only">View only</span>
+          )}
+        </div>
+        {/* Two error slots (Lit parity): delete and share failures. */}
+        {deleteError ? <div className="row-error">{deleteError}</div> : null}
+        {shareError ? <div className="row-error">{shareError}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/skills/skill-chips.test.ts
+++ b/web-react/src/features/settings/skills/skill-chips.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { chipEmptyCopy, chipMatches } from './skill-chips';
+import { setMe } from '../../../lib/capabilities';
+import type { Me, SkillSummary } from '../../../api/client';
+
+function me(userId = 'u1'): Me {
+  return { user_id: userId, tenant_id: 't1', role: 'member', plane: 'tenant', capabilities: [] };
+}
+function skill(overrides: Partial<SkillSummary> = {}): SkillSummary {
+  return {
+    id: 's1',
+    tenant_id: 't1',
+    name: 'pdf-toolkit',
+    description: 'Handles PDFs',
+    enabled: true,
+    bound_coworker_count: 0,
+    visibility: 'private',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    created_by_user_id: 'u1',
+    ...overrides,
+  } as SkillSummary;
+}
+
+afterEach(() => setMe(null));
+
+describe('chipMatches', () => {
+  it('all matches everything', () => {
+    setMe(me());
+    expect(chipMatches('all', skill({ created_by_user_id: 'other' }))).toBe(true);
+  });
+
+  it('mine = own rows only (incl. own shared rows)', () => {
+    setMe(me('u1'));
+    expect(chipMatches('mine', skill({ created_by_user_id: 'u1' }))).toBe(true);
+    expect(chipMatches('mine', skill({ created_by_user_id: 'u1', visibility: 'shared' }))).toBe(true);
+    expect(chipMatches('mine', skill({ created_by_user_id: 'other' }))).toBe(false);
+  });
+
+  it('shared = shared AND not own (own shared rows excluded)', () => {
+    setMe(me('u1'));
+    expect(chipMatches('shared', skill({ created_by_user_id: 'other', visibility: 'shared' }))).toBe(true);
+    expect(chipMatches('shared', skill({ created_by_user_id: 'u1', visibility: 'shared' }))).toBe(false);
+    expect(chipMatches('shared', skill({ created_by_user_id: 'other', visibility: 'private' }))).toBe(false);
+  });
+
+  it('null-creator rows are never "mine"', () => {
+    setMe(me('u1'));
+    expect(chipMatches('mine', skill({ created_by_user_id: null }))).toBe(false);
+  });
+});
+
+describe('chipEmptyCopy', () => {
+  it('varies by chip and by whether any skills exist', () => {
+    expect(chipEmptyCopy('all', false)).toBe('No skills yet.');
+    expect(chipEmptyCopy('mine', true)).toBe('You have not created any skills yet.');
+    expect(chipEmptyCopy('shared', true)).toBe('No one has shared a skill with you yet.');
+  });
+});

--- a/web-react/src/features/settings/skills/skill-chips.ts
+++ b/web-react/src/features/settings/skills/skill-chips.ts
@@ -1,0 +1,30 @@
+// Skill filter-chip classification (spec E.1, Lit parity). UX-only
+// re-classification of the already server-visibility-filtered list —
+// NEVER a security gate. Pure so it's testable.
+
+import type { SkillSummary } from '../../../api/client';
+import { isOwnResource } from '../../../lib/capabilities';
+
+export type SkillChip = 'all' | 'mine' | 'shared';
+
+export const SKILL_CHIPS: { id: SkillChip; label: string }[] = [
+  { id: 'all', label: 'All visible' },
+  { id: 'mine', label: 'Mine' },
+  { id: 'shared', label: 'Shared by others' },
+];
+
+/** `mine` = own rows; `shared` = shared AND not own (own shared rows
+ *  stay under Mine); `all` = everything visible. */
+export function chipMatches(chip: SkillChip, skill: SkillSummary): boolean {
+  if (chip === 'all') return true;
+  if (chip === 'mine') return isOwnResource(skill);
+  return skill.visibility === 'shared' && !isOwnResource(skill);
+}
+
+/** Empty-state copy varies by chip (Lit parity). */
+export function chipEmptyCopy(chip: SkillChip, anySkills: boolean): string {
+  if (!anySkills) return 'No skills yet.';
+  if (chip === 'mine') return 'You have not created any skills yet.';
+  if (chip === 'shared') return 'No one has shared a skill with you yet.';
+  return 'No skills yet.';
+}

--- a/web-react/src/features/settings/skills/skill-dialog.tsx
+++ b/web-react/src/features/settings/skills/skill-dialog.tsx
@@ -1,0 +1,395 @@
+// SkillDialog — create AND edit in one component (spec E.2; behavioral
+// reference web/src/components/skill-dialog.ts). 640px. The mental
+// model (kept from Lit): a skill is a short name + a description + a
+// body of instructions. YAML frontmatter is never shown — assembled
+// into SKILL.md on save, stripped on load (lib/skill-manifest).
+//
+// Edit mode: name is immutable (backend read-only on PATCH — omitted
+// from the body; input rendered disabled). On open the dialog fetches
+// the full Skill (files included) and seeds Instructions + the file
+// tree. Save = create POST full files map / edit PATCH full replacement
+// (Lit chose one-shot replace over client-side diffing).
+
+import { useEffect, useRef, useState } from 'react';
+import { Trash2, X } from 'lucide-react';
+import {
+  ApiError,
+  getApiClient,
+  type SkillSummary,
+} from '../../../api/client';
+import { BrandMark } from '../../../components/brand-mark';
+import { parseSkillMd, serializeSkillMd } from '../../../lib/skill-manifest';
+import { SKILL_MANIFEST_NAME } from '../../../lib/skill-constants';
+import {
+  composeTally,
+  contentBytes,
+  DESCRIPTION_MAX,
+  formatBytes,
+  groupByFolder,
+  ingestUploads,
+  MANIFEST_UPLOAD_REJECTED,
+  MAX_UPLOAD_BYTES_PER_FILE,
+  MAX_UPLOAD_BYTES_TOTAL,
+  validateSkillName,
+  type ExtraFile,
+} from '../../../lib/skill-upload';
+import { readDroppedItems, readFilesFromInput } from './read-files';
+
+export function SkillDialog({
+  editing,
+  onClose,
+  onSaved,
+}: {
+  editing: SkillSummary | null;
+  onClose: () => void;
+  onSaved: (toast: string) => void;
+}) {
+  const isEdit = editing !== null;
+  const [name, setName] = useState(editing?.name ?? '');
+  const [nameTouched, setNameTouched] = useState(false);
+  const [description, setDescription] = useState('');
+  const [body, setBody] = useState('');
+  const [extraFiles, setExtraFiles] = useState<ExtraFile[]>([]);
+  const [loadingDetail, setLoadingDetail] = useState(isEdit);
+  const [filesOpen, setFilesOpen] = useState(false);
+  const [dragHover, setDragHover] = useState(false);
+  const [reading, setReading] = useState(false);
+  const [uploadToast, setUploadToast] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const uploadToastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dragDepth = useRef(0);
+
+  function flashUploadToast(msg: string) {
+    if (uploadToastTimer.current) clearTimeout(uploadToastTimer.current);
+    setUploadToast(msg);
+    uploadToastTimer.current = setTimeout(() => setUploadToast(null), 4000);
+  }
+
+  // Edit mode: fetch the full Skill (files) and seed body/description
+  // from SKILL.md + the extra files from the rest of the map.
+  useEffect(() => {
+    if (!editing) return;
+    let cancelled = false;
+    void getApiClient()
+      .getSkill(editing.id)
+      .then((skill) => {
+        if (cancelled) return;
+        const manifest = skill.files?.[SKILL_MANIFEST_NAME]?.content ?? '';
+        const parsed = parseSkillMd(manifest);
+        setDescription(parsed.description || editing.description || '');
+        setBody(parsed.body);
+        const extras: ExtraFile[] = Object.entries(skill.files ?? {})
+          .filter(([p]) => p !== SKILL_MANIFEST_NAME)
+          .map(([path, f]) => ({ path, content: f.content }));
+        setExtraFiles(extras);
+        if (extras.length > 0) setFilesOpen(true);
+        setLoadingDetail(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          // Degrade to the summary's description; body stays empty.
+          setDescription(editing.description || '');
+          setLoadingDetail(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [editing]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onClose]);
+
+  const trimmedName = name.trim();
+  const liveNameErr = nameTouched && trimmedName !== '' ? validateSkillName(trimmedName) : null;
+  const descLen = description.length;
+  const descNearCap = DESCRIPTION_MAX - descLen <= 200;
+
+  // Save gate (Lit isValid): valid non-reserved name + non-empty
+  // description within the cap. Name gate applies to create only
+  // (immutable + prefilled on edit).
+  const nameOk = trimmedName !== '' && validateSkillName(trimmedName) === null;
+  const canSave =
+    (isEdit || nameOk) &&
+    description.trim() !== '' &&
+    descLen <= DESCRIPTION_MAX &&
+    !busy &&
+    !reading &&
+    !loadingDetail;
+
+  function applyIngest(incoming: Awaited<ReturnType<typeof readFilesFromInput>>) {
+    const result = ingestUploads(extraFiles, incoming);
+    setExtraFiles(result.files);
+    if (result.disclose) setFilesOpen(true);
+    if (result.manifestRejected) {
+      flashUploadToast(MANIFEST_UPLOAD_REJECTED);
+    } else {
+      const t = composeTally(result.tally);
+      if (t) flashUploadToast(t);
+    }
+  }
+
+  async function onPickInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const list = e.target.files;
+    if (!list || list.length === 0) return;
+    setReading(true);
+    try {
+      applyIngest(await readFilesFromInput(list));
+    } finally {
+      setReading(false);
+      e.target.value = ''; // allow re-picking the same path
+    }
+  }
+
+  async function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragHover(false);
+    if (!e.dataTransfer) return;
+    setReading(true);
+    try {
+      applyIngest(await readDroppedItems(e.dataTransfer.items));
+    } finally {
+      setReading(false);
+    }
+  }
+
+  function removeFile(index: number) {
+    setExtraFiles((files) => files.filter((_, i) => i !== index));
+  }
+
+  async function save() {
+    if (!canSave) return;
+    setBusy(true);
+    setErr(null);
+    const manifest = serializeSkillMd(trimmedName, description.trim(), body);
+    const files: Record<string, string> = { [SKILL_MANIFEST_NAME]: manifest };
+    for (const f of extraFiles) files[f.path] = f.content;
+    try {
+      const api = getApiClient();
+      const saved = isEdit
+        ? // name is read-only on PATCH — omit it; send the full file set
+          // for atomic replacement.
+          await api.updateSkill(editing.id, { enabled: true, files })
+        : await api.createSkill({ name: trimmedName, enabled: true, files });
+      onSaved(isEdit ? `Saved changes to ${saved.name}` : `Created ${saved.name}`);
+      onClose();
+    } catch (e) {
+      setErr(
+        e instanceof ApiError ? (e.body?.message ?? `${e.status}`) : (e as Error).message,
+      );
+      setBusy(false);
+    }
+  }
+
+  const controlsDisabled = reading || busy;
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div className="dlg" style={{ width: 640 }} role="dialog" aria-modal="true" aria-label="Skill">
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">{isEdit ? `Edit ${editing.name}` : 'New skill'}</h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body">
+          {loadingDetail ? <div className="page-sub">Loading…</div> : null}
+          <div className="field">
+            <label htmlFor="sk-name">Name</label>
+            <input
+              id="sk-name"
+              type="text"
+              maxLength={64}
+              disabled={isEdit || busy}
+              placeholder="e.g. pdf-toolkit"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameTouched(true);
+              }}
+              onBlur={() => setNameTouched(true)}
+            />
+            <div className={`hint${liveNameErr ? ' invalid' : ''}`}>
+              {liveNameErr ??
+                (isEdit
+                  ? 'The name is immutable once created — it is the skill folder the runtime mounts.'
+                  : 'Lowercase slug; becomes the skill folder the runtime mounts.')}
+            </div>
+          </div>
+          <div className="field">
+            <label htmlFor="sk-desc">Description</label>
+            <input
+              id="sk-desc"
+              type="text"
+              maxLength={DESCRIPTION_MAX}
+              disabled={busy}
+              placeholder="Analyzes competitor pricing pages and summarizes trends."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+            <div className={`counter${descNearCap ? ' warn' : ''}`} data-testid="sk-desc-counter">
+              {descLen} / {DESCRIPTION_MAX}
+            </div>
+          </div>
+          <div className="field">
+            <label htmlFor="sk-body">Instructions</label>
+            <textarea
+              id="sk-body"
+              style={{ minHeight: 140 }}
+              disabled={busy}
+              placeholder="What the skill does and how the coworker should use it…"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+            />
+            <div className="hint">
+              Saved as the SKILL.md body — the name/description frontmatter is assembled for you
+              and never shown.
+            </div>
+          </div>
+
+          <details
+            className="files"
+            open={filesOpen}
+            onToggle={(e) => setFilesOpen((e.target as HTMLDetailsElement).open)}
+          >
+            <summary>Add files or folders the coworker can read</summary>
+            <div
+              className={`dropzone${dragHover ? ' hover' : ''}`}
+              onDragEnter={(e) => {
+                e.preventDefault();
+                dragDepth.current += 1;
+                setDragHover(true);
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+              }}
+              onDragLeave={(e) => {
+                e.preventDefault();
+                dragDepth.current -= 1;
+                if (dragDepth.current <= 0) {
+                  dragDepth.current = 0;
+                  setDragHover(false);
+                }
+              }}
+              onDrop={(e) => void onDrop(e)}
+            >
+              <div className="dz-msg">
+                {reading ? 'Reading files…' : 'Drop a folder or files here, or:'}
+              </div>
+              <div className="dz-btns">
+                <label className={`dz-btn${controlsDisabled ? ' off' : ''}`}>
+                  Choose folder
+                  <input
+                    type="file"
+                    // @ts-expect-error non-standard attribute, widely supported
+                    webkitdirectory=""
+                    multiple
+                    disabled={controlsDisabled}
+                    onChange={(e) => void onPickInput(e)}
+                  />
+                </label>
+                <label className={`dz-btn${controlsDisabled ? ' off' : ''}`}>
+                  Choose files
+                  <input
+                    type="file"
+                    multiple
+                    disabled={controlsDisabled}
+                    onChange={(e) => void onPickInput(e)}
+                  />
+                </label>
+              </div>
+              <div className="dz-note">
+                Text files only, {formatBytes(MAX_UPLOAD_BYTES_PER_FILE)} per file,{' '}
+                {formatBytes(MAX_UPLOAD_BYTES_TOTAL)} total.
+              </div>
+            </div>
+            {uploadToast ? (
+              <div className="upload-toast" role="status">
+                {uploadToast}
+              </div>
+            ) : null}
+            <div className="tree">
+              <div className="tree-title">What this skill includes</div>
+              <div className="tree-row" style={{ color: 'var(--rm-text-muted)' }}>
+                <span aria-hidden="true">📄</span>
+                <span className="t-name">SKILL.md</span>
+                <span className="t-main-note">(from Instructions above)</span>
+              </div>
+              {groupByFolder(extraFiles).map(({ folder, entries }) => (
+                <div key={folder || '__root__'}>
+                  {folder ? (
+                    <div className="tree-row tree-folder">
+                      <span aria-hidden="true">📁</span>
+                      <span>{folder}/</span>
+                    </div>
+                  ) : null}
+                  {entries.map(({ file, index }) => (
+                    <div key={file.path} className={`tree-row${folder ? ' indent' : ''}`}>
+                      <span aria-hidden="true">📄</span>
+                      <span className="t-name" title={file.path}>
+                        {folder ? file.path.slice(folder.length + 1) : file.path}
+                      </span>
+                      <span className="t-size">{formatBytes(contentBytes(file.content))}</span>
+                      <button
+                        className="icon-btn danger"
+                        title="Remove file"
+                        disabled={busy}
+                        onClick={() => removeFile(index)}
+                      >
+                        <Trash2 />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </details>
+        </div>
+        <div className="wiz-foot">
+          {err ? (
+            <span className="wiz-err" role="alert">
+              {err}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span className="actions">
+            <button className="btn-ghost" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+            <button className="btn-primary" disabled={!canSave} onClick={() => void save()}>
+              {busy
+                ? isEdit
+                  ? 'Saving…'
+                  : 'Creating…'
+                : isEdit
+                  ? 'Save changes'
+                  : 'Create skill'}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/skills/skills-page.tsx
+++ b/web-react/src/features/settings/skills/skills-page.tsx
@@ -1,0 +1,243 @@
+// SkillsPage — tenant-wide skill catalog (spec Part E). Chip-filtered
+// (not searched — Lit parity); create/edit via one dialog; share;
+// binding-aware delete. Behavioral reference web/src/components/
+// skills-page.ts.
+//
+// Mutations invalidate ['skills'] — the same key the coworker wizard's
+// step-5 catalogue reads, so a created skill appears there for binding
+// with no extra wiring (spec E.4).
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowLeft, Plus } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { ApiError, getApiClient, type SkillSummary } from '../../../api/client';
+import { useSkillRegistry } from '../../../api/queries';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { hasCapability } from '../../../lib/capabilities';
+import { SkillCard } from './skill-card';
+import { SkillDialog } from './skill-dialog';
+import {
+  chipEmptyCopy,
+  chipMatches,
+  SKILL_CHIPS,
+  type SkillChip,
+} from './skill-chips';
+import './skills.css';
+
+function errText(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 409 && err.body?.details) {
+      const ids = (err.body.details as Record<string, unknown>).coworker_ids;
+      if (Array.isArray(ids)) {
+        return `In use by ${ids.length} coworker${ids.length === 1 ? '' : 's'} — unbind it from each before deleting.`;
+      }
+    }
+    return err.body?.message ?? `${err.status}`;
+  }
+  return (err as Error).message ?? 'request failed';
+}
+
+export function SkillsPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const registryQ = useSkillRegistry();
+
+  const [chip, setChip] = useState<SkillChip>('all');
+  const [dialog, setDialog] = useState<{ open: boolean; editing: SkillSummary | null }>(
+    { open: false, editing: null },
+  );
+  const [deleteTarget, setDeleteTarget] = useState<SkillSummary | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [shareBusy, setShareBusy] = useState<ReadonlySet<string>>(new Set());
+  const [deleteErrors, setDeleteErrors] = useState<Record<string, string>>({});
+  const [shareErrors, setShareErrors] = useState<Record<string, string>>({});
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  const canCreate = hasCapability('skill.create');
+  const rows = registryQ.data ?? [];
+  const visible = useMemo(() => rows.filter((s) => chipMatches(chip, s)), [rows, chip]);
+
+  function refresh() {
+    void queryClient.invalidateQueries({ queryKey: ['skills'] });
+  }
+
+  async function toggleShare(s: SkillSummary) {
+    if (shareBusy.has(s.id)) return;
+    setShareBusy((b) => new Set(b).add(s.id));
+    setShareErrors((e) => ({ ...e, [s.id]: '' }));
+    try {
+      const api = getApiClient();
+      const updated =
+        s.visibility === 'shared' ? await api.unshareSkill(s.id) : await api.shareSkill(s.id);
+      refresh();
+      showToast(
+        updated.visibility === 'shared'
+          ? `${updated.name} is now shared with the workspace`
+          : `${updated.name} is now private`,
+      );
+    } catch (err) {
+      setShareErrors((e) => ({ ...e, [s.id]: errText(err) }));
+    } finally {
+      setShareBusy((b) => {
+        const next = new Set(b);
+        next.delete(s.id);
+        return next;
+      });
+    }
+  }
+
+  async function performDelete() {
+    const s = deleteTarget;
+    if (!s || deleteBusy) return;
+    setDeleteBusy(true);
+    setDeleteErrors((e) => ({ ...e, [s.id]: '' }));
+    try {
+      await getApiClient().deleteSkill(s.id);
+      refresh();
+      showToast(`Deleted ${s.name}`);
+    } catch (err) {
+      setDeleteErrors((e) => ({ ...e, [s.id]: errText(err) }));
+    } finally {
+      setDeleteBusy(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  const deleteBlockCount = deleteTarget?.bound_coworker_count ?? 0;
+  const deleteBlocked = deleteBlockCount > 0;
+
+  function newSkillBtn(key: string) {
+    return (
+      <button
+        key={key}
+        className="btn-primary"
+        onClick={() => setDialog({ open: true, editing: null })}
+      >
+        <Plus />
+        New skill
+      </button>
+    );
+  }
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Skills</h1>
+          <div className="page-sub">
+            Tenant-wide catalog. Bind a skill to a coworker in the coworker wizard.
+          </div>
+        </div>
+        {canCreate ? newSkillBtn('header') : null}
+      </div>
+
+      {rows.length > 0 ? (
+        <div className="chips">
+          {SKILL_CHIPS.map((c) => (
+            <button
+              key={c.id}
+              className={`chip${chip === c.id ? ' on' : ''}`}
+              onClick={() => setChip(c.id)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="grid-scroll">
+        {registryQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : registryQ.isError ? (
+          <div className="row-error">Failed to load skills — retry from the sidebar.</div>
+        ) : visible.length === 0 ? (
+          <div className="grid-empty">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <div style={{ fontSize: '1rem', fontWeight: 700 }}>
+                {chipEmptyCopy(chip, rows.length > 0)}
+              </div>
+              {/* Offer create only where creating makes sense (not on the
+                  "shared by others" chip). */}
+              {canCreate && chip !== 'shared' ? (
+                <div style={{ marginTop: '1rem' }}>{newSkillBtn('empty')}</div>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="masonry">
+            {visible.map((s) => (
+              <SkillCard
+                key={s.id}
+                skill={s}
+                shareBusy={shareBusy.has(s.id)}
+                deleteError={deleteErrors[s.id] || null}
+                shareError={shareErrors[s.id] || null}
+                onOpen={() => setDialog({ open: true, editing: s })}
+                onToggleShare={() => void toggleShare(s)}
+                onEdit={() => setDialog({ open: true, editing: s })}
+                onDelete={() => setDeleteTarget(s)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {dialog.open ? (
+        <SkillDialog
+          editing={dialog.editing}
+          onClose={() => setDialog({ open: false, editing: null })}
+          onSaved={(msg) => {
+            refresh();
+            showToast(msg);
+          }}
+        />
+      ) : null}
+
+      {deleteTarget ? (
+        <ConfirmDialog
+          title={`Delete skill “${deleteTarget.name}”?`}
+          confirmLabel="Delete"
+          busyLabel="Deleting…"
+          busy={deleteBusy}
+          disableConfirm={deleteBlocked}
+          onConfirm={() => void performDelete()}
+          onCancel={() => {
+            if (!deleteBusy) setDeleteTarget(null);
+          }}
+        >
+          {deleteBlocked ? (
+            <>
+              This skill is bound to <b>{deleteBlockCount}</b> coworker
+              {deleteBlockCount === 1 ? '' : 's'}. Unbind it from{' '}
+              {deleteBlockCount === 1 ? 'that coworker' : 'each one'} before deleting.
+            </>
+          ) : (
+            <>This cannot be undone.</>
+          )}
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? <div className="toast">{toast}</div> : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/skills/skills.css
+++ b/web-react/src/features/settings/skills/skills.css
@@ -1,0 +1,168 @@
+/* Skills page — the skill-SPECIFIC bits (chips, dialog dropzone + file
+ * tree). Shared primitives (page chrome, card family, pills, dialog
+ * form primitives, buttons, toast) live in components/ui.css. */
+
+/* filter chips */
+.chips {
+  display: flex;
+  gap: 6px;
+  padding: 12px 0 2px;
+  flex-shrink: 0;
+}
+.chip {
+  border: 1px solid var(--rm-border);
+  background: var(--rm-app-bg);
+  cursor: pointer;
+  color: var(--rm-nav-text-2);
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 2px;
+}
+.chip:hover {
+  border-color: var(--rm-action-hover);
+  color: var(--rm-action-hover);
+}
+.chip.on {
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+  border-color: transparent;
+}
+
+/* dialog: description counter */
+.counter {
+  text-align: right;
+  font-size: 12px;
+  color: var(--rm-text-muted);
+  margin-top: 2px;
+}
+.counter.warn {
+  color: var(--rm-warn-text);
+}
+
+/* dialog: additional-files disclosure */
+details.files {
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  padding: 8px 12px;
+  margin-bottom: 14px;
+}
+details.files summary {
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--rm-action);
+}
+.dropzone {
+  border: 2px dashed var(--rm-border);
+  border-radius: 6px;
+  margin-top: 10px;
+  padding: 18px 16px;
+  text-align: center;
+  background: var(--rm-card-bg);
+}
+.dropzone.hover {
+  border-color: var(--rm-action);
+  background: var(--rm-info-bg);
+}
+.dropzone .dz-msg {
+  font-size: 0.8125rem;
+  color: var(--rm-text);
+  margin-bottom: 8px;
+}
+.dz-btns {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+}
+.dz-btn {
+  display: inline-block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  color: var(--rm-text);
+  padding: 5px 12px;
+}
+.dz-btn:hover {
+  border-color: var(--rm-action-hover);
+  color: var(--rm-action-hover);
+}
+.dz-btn.off {
+  opacity: 0.6;
+  pointer-events: none;
+}
+.dz-btn input {
+  display: none;
+}
+.dropzone .dz-note {
+  font-size: 11px;
+  color: var(--rm-text-muted);
+  margin-top: 8px;
+}
+.upload-toast {
+  font-size: 12px;
+  color: var(--rm-text);
+  margin-top: 8px;
+}
+
+/* dialog: file tree */
+.tree {
+  margin-top: 14px;
+}
+.tree-title {
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: var(--rm-text-muted);
+  margin-bottom: 4px;
+}
+.tree-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+}
+.tree-row.indent {
+  padding-left: 24px;
+}
+.tree-row .t-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tree-row .t-main-note {
+  font-family: var(--font-base);
+  font-size: 11px;
+  font-style: italic;
+  color: var(--rm-text-muted);
+}
+.tree-row .t-size {
+  font-family: var(--font-base);
+  font-size: 11px;
+  color: var(--rm-text-muted);
+  white-space: nowrap;
+}
+.tree-row .icon-btn {
+  opacity: 0.55;
+  padding: 3px;
+}
+.tree-row:hover .icon-btn {
+  opacity: 1;
+}
+.tree-row .icon-btn.danger {
+  color: var(--rm-danger);
+}
+.tree-row .icon-btn svg {
+  width: 13px;
+  height: 13px;
+}
+.tree-folder {
+  color: var(--rm-text);
+}

--- a/web-react/src/lib/PORTED.md
+++ b/web-react/src/lib/PORTED.md
@@ -13,6 +13,9 @@ header. Keep them in sync manually until workspace extraction.
 | `ws/ws-client-base.ts` (+test) | `ws/ws-client-base.ts` | cf6b0f1 |
 | `ws/connection-state.ts` (+test) | `ws/connection-state.ts` | cf6b0f1 |
 | `lib/models-grouping.ts` (+test) | `services/models-grouping.ts` | 5d3650e |
+| `lib/skill-constants.ts` | `api/skill_constants.ts` | b443846 |
+| `lib/skill-manifest.ts` (+test) | extracted from `components/skill-dialog.ts` | b443846 |
+| `lib/skill-upload.ts` (+test) | extracted from `components/skill-dialog.ts` | b443846 |
 
 Ported (adapted, not verbatim — source noted in the file header):
 

--- a/web-react/src/lib/skill-constants.ts
+++ b/web-react/src/lib/skill-constants.ts
@@ -1,0 +1,26 @@
+// Copied from web/src/api/skill_constants.ts @ b443846; keep in sync manually until workspace extraction.
+// Pinned skill constants — INV-5 (design §11).
+//
+// Python-side source of truth lives in
+// `src/rolemesh/core/skills.py` (`SKILL_MANIFEST_NAME`); the
+// matching string is asserted equal by
+// `tests/test_skill_manifest_constant_consistency_ts.py`. Hand-edit
+// either side and the test fails before a release.
+
+export const SKILL_MANIFEST_NAME = "SKILL.md";
+
+// Mirrors the Python ``SKILL_FILE_PATH_RE`` (whitelist; no leading dot,
+// no traversal). The DB CHECK enforces the same rule on the server,
+// but rejecting bad paths at the form level surfaces the error
+// immediately without a round trip.
+export const SKILL_FILE_PATH_RE =
+  /^[A-Za-z0-9_][A-Za-z0-9_.-]*(\/[A-Za-z0-9_][A-Za-z0-9_.-]*)*$/;
+
+// Validates a single segment doesn't collapse to dots-only ("..", "...").
+// Combined with the regex above this rejects every traversal form
+// (``../``, ``a/..``, ``a/../b``) without writing a separate parser.
+export function isValidSkillFilePath(path: string): boolean {
+  if (!SKILL_FILE_PATH_RE.test(path)) return false;
+  return path.split("/").every((seg) => !/^\.+$/.test(seg));
+}
+

--- a/web-react/src/lib/skill-manifest.test.ts
+++ b/web-react/src/lib/skill-manifest.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { parseSkillMd, serializeSkillMd } from './skill-manifest';
+
+describe('parseSkillMd', () => {
+  it('extracts description from frontmatter and returns the body', () => {
+    const raw = '---\nname: pdf-toolkit\ndescription: Handles PDFs\n---\nBody text here';
+    expect(parseSkillMd(raw)).toEqual({ description: 'Handles PDFs', body: 'Body text here' });
+  });
+
+  it('treats a blob with no frontmatter as all-body, empty description', () => {
+    expect(parseSkillMd('just markdown')).toEqual({ description: '', body: 'just markdown' });
+  });
+
+  it('returns raw as body when the closing fence is missing', () => {
+    const raw = '---\nname: x\ndescription: y\nno close';
+    expect(parseSkillMd(raw)).toEqual({ description: '', body: raw });
+  });
+
+  it('tolerates leading whitespace before the opening fence', () => {
+    const raw = '\n\n---\ndescription: Trimmed\n---\nB';
+    expect(parseSkillMd(raw).description).toBe('Trimmed');
+  });
+});
+
+describe('serializeSkillMd', () => {
+  it('assembles name/description/body into a manifest', () => {
+    expect(serializeSkillMd('pdf-toolkit', 'Handles PDFs', 'Body')).toBe(
+      '---\nname: pdf-toolkit\ndescription: Handles PDFs\n---\nBody',
+    );
+  });
+
+  it('flattens newlines in the description to keep single-line YAML', () => {
+    expect(serializeSkillMd('x', 'line1\nline2', 'B')).toContain('description: line1 line2');
+  });
+
+  it('strips existing leading frontmatter from the body (no double-wrap)', () => {
+    const body = '---\nname: stale\ndescription: old\n---\nreal body';
+    expect(serializeSkillMd('x', 'new', body)).toBe(
+      '---\nname: x\ndescription: new\n---\nreal body',
+    );
+  });
+
+  it('round-trips: serialize then parse recovers description + body', () => {
+    const manifest = serializeSkillMd('name-a', 'A skill', 'The instructions');
+    expect(parseSkillMd(manifest)).toEqual({ description: 'A skill', body: 'The instructions' });
+  });
+});

--- a/web-react/src/lib/skill-manifest.ts
+++ b/web-react/src/lib/skill-manifest.ts
@@ -1,0 +1,51 @@
+// SKILL.md frontmatter assemble/strip — ported verbatim from the Lit
+// skill-dialog.ts (parseSkillMd / serializeSkillMd) so the round-trip
+// is byte-identical between the two SPAs. A subtly-different regex here
+// would corrupt SKILL.md on a load→edit→save cycle, so this is a
+// straight port with the Lit tests carried alongside.
+//
+// Mental model (kept from Lit): a skill is a short name + a description
+// + a body of instructions. YAML frontmatter is NEVER shown to the
+// user — the dialog assembles `---\nname: X\ndescription: Y\n---\n{body}`
+// on save and strips it back on load.
+
+/** Parse a SKILL.md blob into its description (from frontmatter) and
+ *  the body that follows. Liberal grammar: leading whitespace
+ *  tolerated, `---` delimiters optional. Anything we can't parse shows
+ *  up as the body with an empty description. */
+export function parseSkillMd(raw: string): { description: string; body: string } {
+  const trimmed = raw.trimStart();
+  if (!trimmed.startsWith('---')) {
+    return { description: '', body: raw };
+  }
+  // Find the closing `---` on its own line.
+  const afterOpen = trimmed.slice(3); // skip leading ---
+  const closeIdx = afterOpen.search(/(^|\n)---\s*(\n|$)/);
+  if (closeIdx === -1) {
+    return { description: '', body: raw };
+  }
+  const fm = afterOpen.slice(0, closeIdx);
+  // Strip the trailing closing fence + any leading newline of the body.
+  const restStart = afterOpen.indexOf('---', closeIdx) + 3;
+  const body = afterOpen.slice(restStart).replace(/^\n/, '');
+  // Pull description out of the YAML-ish frontmatter. A single line
+  // `description: …` is the only field we care about.
+  const descMatch = fm.match(/(^|\n)description:\s*(.*)/);
+  const description = descMatch ? descMatch[2].trim() : '';
+  return { description, body };
+}
+
+/** Re-assemble a SKILL.md blob from the dialog's 3 inputs. */
+export function serializeSkillMd(
+  name: string,
+  description: string,
+  body: string,
+): string {
+  // Guard the colon-and-newline case for a single-line YAML value.
+  const safeDescription = description.replace(/\n/g, ' ').trim();
+  // Strip any existing leading frontmatter from `body` to avoid
+  // double-wrapping if the user pasted raw markdown back into the
+  // textarea.
+  const cleanBody = body.replace(/^---[\s\S]*?\n---\n?/, '').replace(/^\n+/, '');
+  return `---\nname: ${name}\ndescription: ${safeDescription}\n---\n${cleanBody}`;
+}

--- a/web-react/src/lib/skill-upload.test.ts
+++ b/web-react/src/lib/skill-upload.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  composeTally,
+  contentBytes,
+  groupByFolder,
+  ingestUploads,
+  isLikelyBinary,
+  validateSkillName,
+  type ExtraFile,
+  type IncomingFile,
+  MAX_UPLOAD_BYTES_PER_FILE,
+} from './skill-upload';
+
+const file = (path: string, content: string): IncomingFile => ({
+  path,
+  content,
+  bytes: contentBytes(content),
+});
+
+describe('validateSkillName', () => {
+  it('accepts a lowercase slug, null on empty', () => {
+    expect(validateSkillName('')).toBeNull();
+    expect(validateSkillName('pdf-toolkit')).toBeNull();
+    expect(validateSkillName('a1')).toBeNull();
+  });
+  it('rejects uppercase, spaces, leading hyphen, overlong', () => {
+    expect(validateSkillName('PDF')).toContain('Lowercase');
+    expect(validateSkillName('has space')).toContain('Lowercase');
+    expect(validateSkillName('-lead')).toContain('Lowercase');
+    expect(validateSkillName('a'.repeat(65))).toContain('Lowercase');
+  });
+  it('rejects reserved runtime names', () => {
+    expect(validateSkillName('claude')).toContain('reserved');
+    expect(validateSkillName('anthropic')).toContain('reserved');
+  });
+});
+
+describe('isLikelyBinary', () => {
+  it('flags a NUL byte in the first 4KB', () => {
+    expect(isLikelyBinary('hello\0world')).toBe(true);
+    expect(isLikelyBinary('plain text')).toBe(false);
+    expect(isLikelyBinary('x'.repeat(5000) + '\0')).toBe(false); // beyond window
+  });
+});
+
+describe('ingestUploads gates', () => {
+  it('rejects SKILL.md path with the manifest flag, no tally', () => {
+    const r = ingestUploads([], [file('SKILL.md', 'shadow')]);
+    expect(r.manifestRejected).toBe(true);
+    expect(r.files).toHaveLength(0);
+    expect(r.tally.added).toBe(0);
+  });
+
+  it('skips invalid paths without aborting the batch', () => {
+    const r = ingestUploads([], [file('../evil', 'x'), file('good.md', 'ok')]);
+    expect(r.files.map((f) => f.path)).toEqual(['good.md']);
+    expect(r.tally.added).toBe(1);
+  });
+
+  it('skips oversize files (per-file cap) and tallies them', () => {
+    const big = { path: 'big.md', content: 'x', bytes: MAX_UPLOAD_BYTES_PER_FILE + 1 };
+    const r = ingestUploads([], [big, file('ok.md', 'y')]);
+    expect(r.tally.oversize).toBe(1);
+    expect(r.files.map((f) => f.path)).toEqual(['ok.md']);
+  });
+
+  it('skips binary files and tallies them', () => {
+    const r = ingestUploads([], [file('bin', 'a\0b'), file('ok.md', 'y')]);
+    expect(r.tally.binary).toBe(1);
+    expect(r.files.map((f) => f.path)).toEqual(['ok.md']);
+  });
+
+  it('enforces the cumulative budget across the session (replace subtracts old size)', () => {
+    // 3 MiB already accepted; a 3 MiB add would exceed 5 MiB total → skip.
+    const big = 'x'.repeat(3 * 1024 * 1024);
+    const existing: ExtraFile[] = [{ path: 'a.md', content: big }];
+    const add = { path: 'b.md', content: 'y', bytes: 3 * 1024 * 1024 };
+    const r = ingestUploads(existing, [add]);
+    expect(r.tally.oversize).toBe(1);
+    expect(r.files.map((f) => f.path)).toEqual(['a.md']);
+  });
+
+  it('replaces same-path collisions (tallied as replaced, order preserved)', () => {
+    const existing: ExtraFile[] = [{ path: 'a.md', content: 'old' }];
+    const r = ingestUploads(existing, [file('a.md', 'new')]);
+    expect(r.tally.replaced).toBe(1);
+    expect(r.tally.added).toBe(0);
+    expect(r.files).toEqual([{ path: 'a.md', content: 'new' }]);
+  });
+
+  it('keeps existing order and appends new paths sorted; discloses on change', () => {
+    const existing: ExtraFile[] = [{ path: 'z.md', content: '1' }];
+    const r = ingestUploads(existing, [file('b.md', '2'), file('a.md', '3')]);
+    expect(r.files.map((f) => f.path)).toEqual(['z.md', 'a.md', 'b.md']);
+    expect(r.disclose).toBe(true);
+  });
+});
+
+describe('composeTally', () => {
+  it('joins present tallies, empty when nothing happened', () => {
+    expect(composeTally({ added: 2, replaced: 1, binary: 3, oversize: 1 })).toBe(
+      '2 added · 1 replaced · 3 skipped (binary) · 1 skipped (over size cap)',
+    );
+    expect(composeTally({ added: 0, replaced: 0, binary: 0, oversize: 0 })).toBe('');
+  });
+});
+
+describe('groupByFolder', () => {
+  it('roots first, then folders alphabetical; entries keep their index', () => {
+    const files: ExtraFile[] = [
+      { path: 'readme.md', content: '' },
+      { path: 'refs/b.md', content: '' },
+      { path: 'refs/a.md', content: '' },
+    ];
+    const groups = groupByFolder(files);
+    expect(groups.map((g) => g.folder)).toEqual(['', 'refs']);
+    expect(groups[0].entries[0].index).toBe(0);
+    expect(groups[1].entries.map((e) => e.file.path)).toEqual(['refs/b.md', 'refs/a.md']);
+  });
+});

--- a/web-react/src/lib/skill-upload.ts
+++ b/web-react/src/lib/skill-upload.ts
@@ -1,0 +1,186 @@
+// Skill upload pure logic — extracted from the Lit skill-dialog.ts so
+// the caps/binary/name gates and the three-gate ingest pipeline are
+// React-agnostic and unit-testable (the Lit versions were tangled with
+// component state + DOM). The dialog wires DOM events (drop / pickers)
+// to `ingestUploads`; everything decision-shaped lives here.
+
+import { isValidSkillFilePath } from './skill-constants';
+import { SKILL_MANIFEST_NAME } from './skill-constants';
+
+// Mirror the backend regex (src/rolemesh/core/skills.py::_SKILL_NAME_RE);
+// there's no shared source between Python and TS, so the character class
+// is repeated. Gives faster feedback than a 422 round-trip.
+const SKILL_NAME_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const SKILL_NAME_RESERVED: ReadonlySet<string> = new Set(['anthropic', 'claude']);
+export const DESCRIPTION_MAX = 1024;
+
+/** Per-file and aggregate caps for client-uploaded extras (ported). */
+export const MAX_UPLOAD_BYTES_PER_FILE = 1 * 1024 * 1024;
+export const MAX_UPLOAD_BYTES_TOTAL = 5 * 1024 * 1024;
+
+/** Return null when the name is acceptable, else the user-facing
+ *  message. `null` on empty = "not yet typed", not an error, so the
+ *  dialog doesn't flash red on first focus. */
+export function validateSkillName(name: string): string | null {
+  if (name.length === 0) return null;
+  if (!SKILL_NAME_RE.test(name)) {
+    return 'Lowercase letters, digits, hyphens only — no spaces, uppercase, or leading hyphen.';
+  }
+  if (SKILL_NAME_RESERVED.has(name)) {
+    return `"${name}" is reserved by the Claude runtime. Pick a different name.`;
+  }
+  return null;
+}
+
+/** Liberal text-vs-binary heuristic: a NUL byte in the first 4KB is a
+ *  near-perfect binary signal (text files never contain raw NULs; the
+ *  DB's TEXT column rejects them anyway). */
+export function isLikelyBinary(content: string): boolean {
+  const window = content.length > 4096 ? content.slice(0, 4096) : content;
+  return window.indexOf('\0') !== -1;
+}
+
+/** Byte count for a UTF-8 string content (mirrors `new Blob([s]).size`
+ *  without needing a DOM Blob — countable in node tests). */
+export function contentBytes(content: string): number {
+  // TextEncoder is available in node and the browser.
+  return new TextEncoder().encode(content).length;
+}
+
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export interface ExtraFile {
+  /** path relative to skill root, e.g. "references/intro.md". */
+  path: string;
+  content: string;
+}
+
+export interface IncomingFile {
+  path: string;
+  content: string;
+  bytes: number;
+}
+
+export interface IngestTally {
+  added: number;
+  replaced: number;
+  binary: number;
+  oversize: number;
+}
+
+export interface IngestResult {
+  files: ExtraFile[];
+  tally: IngestTally;
+  /** True when a SKILL.md-path upload was rejected — the dialog shows
+   *  the dedicated guidance toast instead of the tally line. */
+  manifestRejected: boolean;
+  /** True when anything was added/replaced — the dialog force-opens the
+   *  disclosure so the user sees what landed. */
+  disclose: boolean;
+}
+
+/** Merge `incoming` into `existing` in one pass with three gates and a
+ *  single aggregated tally (ported from the Lit `ingestUploads`, made
+ *  pure). Gate order matters:
+ *   1. SKILL.md path → rejected with guidance (edit in Instructions).
+ *   2. invalid path → skip (never abort the batch — one bad path in a
+ *      50-file drop must not lose the other 49).
+ *   3. per-file cap → skip; NUL-binary → skip; cumulative budget → skip.
+ *  Same-path collisions replace (budget subtracts the old size first).
+ *  Existing rows keep order; new paths append sorted. */
+export function ingestUploads(
+  existing: readonly ExtraFile[],
+  incoming: readonly IncomingFile[],
+): IngestResult {
+  const tally: IngestTally = { added: 0, replaced: 0, binary: 0, oversize: 0 };
+  let manifestRejected = false;
+
+  const byPath = new Map(existing.map((f) => [f.path, f.content]));
+  // Start the budget from bytes already accepted — defends against
+  // death-by-a-thousand-cuts across repeated drops.
+  let totalBytes = existing.reduce((acc, f) => acc + contentBytes(f.content), 0);
+
+  for (const item of incoming) {
+    if (item.path === SKILL_MANIFEST_NAME) {
+      manifestRejected = true;
+      continue;
+    }
+    if (!isValidSkillFilePath(item.path)) {
+      continue; // skip silently — never abort the batch
+    }
+    if (item.bytes > MAX_UPLOAD_BYTES_PER_FILE) {
+      tally.oversize += 1;
+      continue;
+    }
+    if (isLikelyBinary(item.content)) {
+      tally.binary += 1;
+      continue;
+    }
+    if (totalBytes + item.bytes > MAX_UPLOAD_BYTES_TOTAL) {
+      tally.oversize += 1;
+      continue;
+    }
+    if (byPath.has(item.path)) {
+      tally.replaced += 1;
+      totalBytes -= contentBytes(byPath.get(item.path) ?? '');
+    } else {
+      tally.added += 1;
+    }
+    byPath.set(item.path, item.content);
+    totalBytes += item.bytes;
+  }
+
+  // Preserve existing order; append new paths sorted.
+  const seen = new Set<string>();
+  const files: ExtraFile[] = [];
+  for (const f of existing) {
+    if (byPath.has(f.path)) {
+      files.push({ path: f.path, content: byPath.get(f.path) ?? '' });
+      seen.add(f.path);
+    }
+  }
+  for (const p of [...byPath.keys()].filter((x) => !seen.has(x)).sort()) {
+    files.push({ path: p, content: byPath.get(p) ?? '' });
+  }
+
+  return {
+    files,
+    tally,
+    manifestRejected,
+    disclose: tally.added > 0 || tally.replaced > 0,
+  };
+}
+
+/** Compose the aggregated upload toast from a tally (empty string when
+ *  nothing happened). */
+export function composeTally(t: IngestTally): string {
+  const parts: string[] = [];
+  if (t.added > 0) parts.push(`${t.added} added`);
+  if (t.replaced > 0) parts.push(`${t.replaced} replaced`);
+  if (t.binary > 0) parts.push(`${t.binary} skipped (binary)`);
+  if (t.oversize > 0) parts.push(`${t.oversize} skipped (over size cap)`);
+  return parts.join(' · ');
+}
+
+export const MANIFEST_UPLOAD_REJECTED = `"${SKILL_MANIFEST_NAME}" is the main instructions file — edit it in the Instructions box above, not as an upload.`;
+
+/** Group extra files by top-level folder for the tree render (root
+ *  files first under key "", then folders alphabetical). */
+export function groupByFolder(
+  files: readonly ExtraFile[],
+): { folder: string; entries: { file: ExtraFile; index: number }[] }[] {
+  const groups = new Map<string, { file: ExtraFile; index: number }[]>();
+  files.forEach((file, index) => {
+    const slash = file.path.indexOf('/');
+    const key = slash === -1 ? '' : file.path.slice(0, slash);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push({ file, index });
+  });
+  return [...groups.entries()]
+    .sort(([a], [b]) => (a === '' ? -1 : b === '' ? 1 : a.localeCompare(b)))
+    .map(([folder, entries]) => ({ folder, entries }));
+}


### PR DESCRIPTION
Fourth child branch of the React webui effort: **Part E — Skills page** of the v6 spec handoff, filling `features/settings/skills/` per the §1.1 growth rule (own ~16 KB lazy chunk, static route above `/manage/:slug`). Behavioral reference: the Lit `skills-page.ts` / `skill-dialog.ts`, per the v6 behavior-parity rule (visuals follow the prototype; behavior follows Lit).

## Pure modules extracted from the Lit dialog into `lib/` (React-agnostic, unit-tested)

The Lit `skill-dialog.ts` tangles this logic with DOM + component state; extracting it makes the tricky parts testable in isolation:
- **`lib/skill-manifest`** — `parseSkillMd` / `serializeSkillMd`: the SKILL.md frontmatter assemble/strip, ported **verbatim** so the load→edit→save round-trip is byte-identical (a subtly-different regex would corrupt SKILL.md).
- **`lib/skill-upload`** — name/reserved/desc-max/caps constants, `validateSkillName`, `isLikelyBinary` (NUL-in-first-4 KiB), and the pure **`ingestUploads`** reducer: one pass, three gates (SKILL.md rejected with guidance; invalid path skipped **without aborting the batch**; per-file cap + binary + cumulative budget skipped & tallied), same-path **replace** (budget subtracts the old size), existing order kept + new paths appended sorted, plus `composeTally` + `groupByFolder`.
- **`lib/skill-constants`** — copied from `web/src/api/skill_constants` (§11).

## Page (`#/manage/skills`)

- **Filter chips** `All visible / Mine / Shared by others` (Lit parity — chips, not search): `mine` = own rows, `shared` = shared-and-not-own (own shared rows stay under Mine); per-chip empty copy; `New skill` gated on `skill.create`.
- **Card** (manage family, **no provider line** — skills have no backend/model): name + description; visibility pill + `disabled` pill **only** when `enabled === false` (enabled is the unmarked default) + ownership tag; bound count comes **straight off `SkillSummary.bound_coworker_count`** — no client fan-out (unlike Part D); share / edit / delete or `VIEW ONLY` (ownership escape); **two** per-row error slots (delete + share); **row click opens the edit dialog** (Lit parity).
- **Share** toggle (in-flight guard, optimistic-from-response, per-row error) and **binding-aware delete** (blocked when `bound_coworker_count > 0`; the backend `409 RESOURCE_IN_USE` still backstops races, surfaced from `details.coworker_ids`).

## Dialog (640px, create AND edit)

A skill is a name + description + instructions body; YAML frontmatter is **never shown** (assembled/stripped for you). Name **immutable on edit** (backend read-only — omitted from PATCH, input disabled). Description live `N / MAX` counter turning amber within 200 of the cap. The **additional-files disclosure** carries the full Lit upload system: drop zone + `Choose folder` (`webkitdirectory`) / `Choose files` pickers + caps note + status line + grouped file tree (read-only `SKILL.md` first, folders alphabetical, remove buttons). Path policy: pickers preserve `webkitRelativePath` (PR27); drag-drop does a recursive `webkitGetAsEntry` walk keeping each item's own name as the prefix (PR26 — no flattening); `getAsFile` fallback. Create = `POST` full files map / edit = `PATCH` full replacement (Lit one-shot replace, not client-side diffing); fetches the full `Skill` on edit-open to seed instructions + tree. `enabled` hardcoded `true` on create (D-S2 defers the toggle).

## Verification

- 136 vitest tests green (46 new: frontmatter round-trip incl. no-double-wrap; ingest gates / cumulative budget / replace / tally / folder grouping; name validation incl. reserved words; chip classification; card rendering incl. disabled-pill-only + ownership escape + stopPropagation); tsc strict, all three lints, `openapi:check`, production build all clean.
- End-to-end against a mock v1 backend (extended with skills CRUD + share + 409-on-bound) with Playwright: list usage counts from payload + disabled pill + chip filtering (Mine/Shared) → create **via the file picker** (tree shows `SKILL.md` + the upload, `1 added` toast) → appears in list → edit (name disabled) → share (toast) → delete **blocked** on the bound skill (disabled + unbind copy) → delete **succeeds** on the unbound one. Zero app console errors.

## Refactor (separate commit)

Hoisted the shared manage-card pills + ownership tag + `VIEW ONLY` from `coworkers.css` into the globally-loaded `ui.css` (added `.pill-off` for the disabled pill) — same load-order/sibling-isolation reason as the Part D hoist. No visual change.

## Not in scope (per spec)

File sub-resource endpoints (D-S1 — full-replacement covers v1); the advanced multi-file detail editor + `enabled` toggle (D-S2, `enabled` stays API-only after create); no search box (Lit parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_