### PR TITLE
Approval policies page (Part H)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -32,6 +32,10 @@ export type Model = components['schemas']['Model'];
 export type ModelProvider = components['schemas']['ModelProvider'];
 export type CredentialResponse = components['schemas']['CredentialResponse'];
 export type CredentialUpsert = components['schemas']['CredentialUpsert'];
+export type ConditionExpr = components['schemas']['ConditionExpr'];
+export type ApprovalPolicy = components['schemas']['ApprovalPolicy'];
+export type ApprovalPolicyCreate = components['schemas']['ApprovalPolicyCreate'];
+export type ApprovalPolicyUpdate = components['schemas']['ApprovalPolicyUpdate'];
 export type MCPServer = components['schemas']['MCPServer'];
 export type MCPServerCreate = components['schemas']['MCPServerCreate'];
 export type MCPServerUpdate = components['schemas']['MCPServerUpdate'];
@@ -240,6 +244,48 @@ export class ApiClient {
     });
     if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as CredentialResponse[];
+  }
+
+  async listApprovalPolicies(): Promise<ApprovalPolicy[]> {
+    // Paged endpoint; request the max window and return the items so
+    // callers keep their array shape (page-through UI is a follow-up).
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/approvals/policies?limit=200`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return ((await resp.json()) as components['schemas']['ApprovalPolicyPage'])
+      .items;
+  }
+
+  async createApprovalPolicy(body: ApprovalPolicyCreate): Promise<ApprovalPolicy> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/approvals/policies`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as ApprovalPolicy;
+  }
+
+  async updateApprovalPolicy(
+    id: string,
+    body: ApprovalPolicyUpdate,
+  ): Promise<ApprovalPolicy> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/approvals/policies/${encodeURIComponent(id)}`,
+      { method: 'PATCH', headers: this.headers(), body: JSON.stringify(body) },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as ApprovalPolicy;
+  }
+
+  async deleteApprovalPolicy(id: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/approvals/policies/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
   }
 
   /** Upsert (create OR rotate) the credential for one provider.

--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -92,6 +92,26 @@ export class ApiClient {
     return new ApiError(resp.status, body, msg);
   }
 
+  /** Body-carrying request helper — EVERY JSON mutation goes through
+   *  here so the Content-Type can never be forgotten. Browsers default
+   *  a string body to `text/plain;charset=UTF-8`, and FastAPI then
+   *  validates the whole body as one string → 422 "Input should be a
+   *  valid dictionary". Owning the JSON.stringify here makes the bug
+   *  class unrepresentable. Throws ApiError on non-2xx. */
+  private async fetchJson(
+    method: 'POST' | 'PATCH' | 'PUT',
+    url: string,
+    body: unknown,
+  ): Promise<Response> {
+    const resp = await fetch(url, {
+      method,
+      headers: this.headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return resp;
+  }
+
   async getMe(): Promise<Me> {
     const resp = await fetch(`${this.baseUrl}/api/v1/me`, {
       method: 'GET',
@@ -130,15 +150,11 @@ export class ApiClient {
     coworkerId: string,
     name?: string | null,
   ): Promise<Conversation> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'POST',
       `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/conversations`,
-      {
-        method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ name: name ?? null }),
-      },
+      { name: name ?? null },
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as Conversation;
   }
 
@@ -179,12 +195,11 @@ export class ApiClient {
   }
 
   async createCoworker(body: CoworkerCreate): Promise<Coworker> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/coworkers`, {
-      method: 'POST',
-      headers: this.headers({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw await this.parseError(resp);
+    const resp = await this.fetchJson(
+      'POST',
+      `${this.baseUrl}/api/v1/coworkers`,
+      body,
+    );
     return (await resp.json()) as Coworker;
   }
 
@@ -193,15 +208,11 @@ export class ApiClient {
    *  webui/schemas_v1.CoworkerUpdate (note: `model_id: null` to CLEAR
    *  is currently rejected by the handler — omit the key instead). */
   async updateCoworker(id: string, body: CoworkerUpdate): Promise<Coworker> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'PATCH',
       `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(id)}`,
-      {
-        method: 'PATCH',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify(body),
-      },
+      body,
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as Coworker;
   }
 
@@ -259,12 +270,11 @@ export class ApiClient {
   }
 
   async createApprovalPolicy(body: ApprovalPolicyCreate): Promise<ApprovalPolicy> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/approvals/policies`, {
-      method: 'POST',
-      headers: this.headers(),
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw await this.parseError(resp);
+    const resp = await this.fetchJson(
+      'POST',
+      `${this.baseUrl}/api/v1/approvals/policies`,
+      body,
+    );
     return (await resp.json()) as ApprovalPolicy;
   }
 
@@ -272,11 +282,11 @@ export class ApiClient {
     id: string,
     body: ApprovalPolicyUpdate,
   ): Promise<ApprovalPolicy> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'PATCH',
       `${this.baseUrl}/api/v1/approvals/policies/${encodeURIComponent(id)}`,
-      { method: 'PATCH', headers: this.headers(), body: JSON.stringify(body) },
+      body,
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as ApprovalPolicy;
   }
 
@@ -294,11 +304,11 @@ export class ApiClient {
     provider: ModelProvider,
     body: CredentialUpsert,
   ): Promise<CredentialResponse> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'PUT',
       `${this.baseUrl}/api/v1/credentials/${encodeURIComponent(provider)}`,
-      { method: 'PUT', headers: this.headers(), body: JSON.stringify(body) },
+      body,
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as CredentialResponse;
   }
 
@@ -322,25 +332,20 @@ export class ApiClient {
   }
 
   async createMCPServer(body: MCPServerCreate): Promise<MCPServer> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/mcp-servers`, {
-      method: 'POST',
-      headers: this.headers({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw await this.parseError(resp);
+    const resp = await this.fetchJson(
+      'POST',
+      `${this.baseUrl}/api/v1/mcp-servers`,
+      body,
+    );
     return (await resp.json()) as MCPServer;
   }
 
   async updateMCPServer(id: string, body: MCPServerUpdate): Promise<MCPServer> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'PATCH',
       `${this.baseUrl}/api/v1/mcp-servers/${encodeURIComponent(id)}`,
-      {
-        method: 'PATCH',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify(body),
-      },
+      body,
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as MCPServer;
   }
 
@@ -382,15 +387,11 @@ export class ApiClient {
     coworkerId: string,
     body: CoworkerMCPBindingCreate,
   ): Promise<CoworkerMCPBindingResponse> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'POST',
       `${this.baseUrl}/api/v1/coworkers/${encodeURIComponent(coworkerId)}/mcp-servers`,
-      {
-        method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify(body),
-      },
+      body,
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as CoworkerMCPBindingResponse;
   }
 
@@ -425,27 +426,22 @@ export class ApiClient {
   }
 
   async createSkill(body: SkillCreate): Promise<Skill> {
-    const resp = await fetch(`${this.baseUrl}/api/v1/skills`, {
-      method: 'POST',
-      headers: this.headers({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    });
-    if (!resp.ok) throw await this.parseError(resp);
+    const resp = await this.fetchJson(
+      'POST',
+      `${this.baseUrl}/api/v1/skills`,
+      body,
+    );
     return (await resp.json()) as Skill;
   }
 
   /** PATCH. `name` is read-only server-side — omit it (edit sends the
    *  full `files` map for atomic replacement per the Lit contract). */
   async updateSkill(id: string, body: SkillUpdate): Promise<Skill> {
-    const resp = await fetch(
+    const resp = await this.fetchJson(
+      'PATCH',
       `${this.baseUrl}/api/v1/skills/${encodeURIComponent(id)}`,
-      {
-        method: 'PATCH',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify(body),
-      },
+      body,
     );
-    if (!resp.ok) throw await this.parseError(resp);
     return (await resp.json()) as Skill;
   }
 

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -68,6 +68,17 @@ export function useMCPServers(enabled: boolean) {
   });
 }
 
+// ---- Approval policies page (Part H) ----
+
+/** The tenant's approval policies. Surfaces load failures (page-owned
+ *  list, not a degrade-to-empty catalogue read). */
+export function useApprovalPolicies() {
+  return useQuery({
+    queryKey: ['approval-policies'],
+    queryFn: () => getApiClient().listApprovalPolicies(),
+  });
+}
+
 // ---- MCP server registry page (Part D) ----
 
 /** The registry list (its own key — the wizard's catalogue hook above

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -3,9 +3,11 @@
 // redirect map. Settings load via React.lazy — the structural
 // realization of lint-no-admin-chat's goal (a lean chat bundle).
 
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, type ReactNode } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { applyLegacyRedirect } from './legacy-redirects';
+import { entryForSlug } from './nav';
+import { hasCapability } from '../lib/capabilities';
 import { ChatPage } from '../features/chat/chat-page';
 
 const SettingsPage = lazy(() =>
@@ -13,6 +15,24 @@ const SettingsPage = lazy(() =>
     default: m.SettingsPage,
   })),
 );
+
+const AccessDeniedPage = lazy(() =>
+  import('../features/settings/access-denied-page').then((m) => ({
+    default: m.AccessDeniedPage,
+  })),
+);
+
+/** Capability gate for GROWN settings routes (spec §8: direct navigation
+ *  to a denied route renders the access-denied page). The generic
+ *  `/manage/:slug` stub route already checks inside SettingsPage; grown
+ *  pages have their own static routes, so the check lives here. */
+function Gated({ slug, children }: { slug: string; children: ReactNode }) {
+  const entry = entryForSlug(slug);
+  if (entry?.requires && !hasCapability(entry.requires)) {
+    return <AccessDeniedPage label={entry.label} />;
+  }
+  return <>{children}</>;
+}
 
 // Grown settings pages get their own lazy chunk keyed by slug (§1.1
 // settings growth rule) — the static route ranks above /manage/:slug.
@@ -46,6 +66,12 @@ const CredentialsPage = lazy(() =>
   })),
 );
 
+const ApprovalPoliciesPage = lazy(() =>
+  import('../features/settings/approval-policies/approval-policies-page').then(
+    (m) => ({ default: m.ApprovalPoliciesPage }),
+  ),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -71,7 +97,9 @@ export function AppRoutes() {
         path="/manage/mcp-servers/*"
         element={
           <Suspense fallback={null}>
-            <MCPServersPage />
+            <Gated slug="mcp-servers">
+              <MCPServersPage />
+            </Gated>
           </Suspense>
         }
       />
@@ -87,7 +115,19 @@ export function AppRoutes() {
         path="/manage/credentials/*"
         element={
           <Suspense fallback={null}>
-            <CredentialsPage />
+            <Gated slug="credentials">
+              <CredentialsPage />
+            </Gated>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/approval-policies/*"
+        element={
+          <Suspense fallback={null}>
+            <Gated slug="approval-policies">
+              <ApprovalPoliciesPage />
+            </Gated>
           </Suspense>
         }
       />

--- a/web-react/src/components/switch.tsx
+++ b/web-react/src/components/switch.tsx
@@ -1,0 +1,42 @@
+// Switch — the labelled toggle primitive (prototype `.switch` family).
+// New to components/ with Part H: its first two consumers are the
+// policy card's always-visible enable toggle and the policy dialog's
+// Status field (≥2-consumers admission rule). Styles live in ui.css.
+//
+// Renders `role="switch"` with the on/off word as its visible label —
+// the label IS part of the control (prototype anatomy), not a separate
+// element.
+
+export function Switch({
+  on,
+  disabled = false,
+  onToggle,
+  onLabel = 'Enabled',
+  offLabel = 'Disabled',
+  title,
+}: {
+  on: boolean;
+  disabled?: boolean;
+  onToggle: () => void;
+  onLabel?: string;
+  offLabel?: string;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      className={`switch${on ? ' on' : ''}`}
+      role="switch"
+      aria-checked={on}
+      title={title}
+      disabled={disabled}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+    >
+      <span className="track" />
+      {on ? onLabel : offLabel}
+    </button>
+  );
+}

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -568,3 +568,54 @@
 .model-row .m-fill {
   flex: 1;
 }
+
+/* Switch — labelled toggle primitive (components/switch.tsx). First
+ * consumers: the approval-policy card's enable toggle + the policy
+ * dialog's Status field. */
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--font-base);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--rm-text-muted);
+}
+.switch:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.switch .track {
+  width: 30px;
+  height: 16px;
+  border-radius: 999px;
+  background: var(--rm-border);
+  position: relative;
+  transition: background 0.12s;
+  flex-shrink: 0;
+}
+.switch .track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--rm-app-bg);
+  transition: left 0.12s;
+  box-shadow: 0 1px 2px var(--rm-scrim);
+}
+.switch.on {
+  color: var(--rm-text);
+}
+.switch.on .track {
+  background: var(--rm-action);
+}
+.switch.on .track::after {
+  left: 16px;
+}

--- a/web-react/src/features/settings/approval-policies/approval-policies-page.test.tsx
+++ b/web-react/src/features/settings/approval-policies/approval-policies-page.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ApprovalPolicy } from '../../../api/client';
+import { ApprovalPoliciesPage, sortPolicies } from './approval-policies-page';
+
+function policy(over: Partial<ApprovalPolicy>): ApprovalPolicy {
+  return {
+    id: 'pol-x',
+    tenant_id: 't1',
+    mcp_server_name: 'records-mcp',
+    tool_name: 'refund',
+    condition_expr: { always: true },
+    enabled: true,
+    priority: 0,
+    created_at: '2026-06-20T10:00:00Z',
+    updated_at: '2026-06-20T10:00:00Z',
+    ...over,
+  } as ApprovalPolicy;
+}
+
+function renderPage(seed: ApprovalPolicy[]) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  qc.setQueryData(['approval-policies'], seed);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ApprovalPoliciesPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe('sortPolicies', () => {
+  it('orders priority desc, created_at desc on ties (server evaluation order)', () => {
+    const rows = [
+      policy({ id: 'a', priority: 0, created_at: '2026-06-25T10:00:00Z' }),
+      policy({ id: 'b', priority: 20, created_at: '2026-06-20T10:00:00Z' }),
+      policy({ id: 'c', priority: 0, created_at: '2026-06-26T10:00:00Z' }),
+    ];
+    expect(sortPolicies(rows).map((r) => r.id)).toEqual(['b', 'c', 'a']);
+  });
+});
+
+describe('ApprovalPoliciesPage', () => {
+  it('renders cards in evaluation order with priority badges', () => {
+    renderPage([
+      policy({ id: 'lo', priority: 0, tool_name: 'a_tool' }),
+      policy({ id: 'hi', priority: 20, tool_name: 'z_tool' }),
+    ]);
+    const cards = document.querySelectorAll('.pol-card');
+    expect(cards.length).toBe(2);
+    expect(cards[0].getAttribute('data-policy-id')).toBe('hi');
+    expect(within(cards[0] as HTMLElement).getByText('priority 20')).toBeTruthy();
+  });
+
+  it('shows the evaluation-order hint (5-minute timeout copy) under a non-empty list', () => {
+    renderPage([policy({})]);
+    const hint = document.querySelector('.page-hint');
+    expect(hint?.textContent).toContain('highest priority wins');
+    expect(hint?.textContent).toContain('5 minutes');
+  });
+
+  it('empty list: hint hidden, empty state carries the true behavior + CTA', () => {
+    renderPage([]);
+    expect(document.querySelector('.page-hint')).toBeNull();
+    expect(screen.getByText('No approval policies yet.')).toBeTruthy();
+    expect(screen.getByText(/Every tool call runs without asking/)).toBeTruthy();
+    expect(screen.getByText('Create your first policy')).toBeTruthy();
+  });
+
+  it('delete confirm restates the rule via the sentence renderer + consequences', () => {
+    renderPage([
+      policy({
+        tool_name: '*',
+        condition_expr: { field: 'amount', op: '>', value: 5000 },
+      }),
+    ]);
+    fireEvent.click(screen.getByTitle('Delete policy'));
+    const dlg = screen.getByRole('alertdialog');
+    expect(within(dlg).getByText(/records-mcp · any tool/)).toBeTruthy();
+    expect(within(dlg).getByText('amount > 5000')).toBeTruthy();
+    expect(
+      within(dlg).getByText(/matching calls will run without asking/),
+    ).toBeTruthy();
+    expect(within(dlg).getByText(/stay live until decided or expired/)).toBeTruthy();
+    expect(within(dlg).getByText('Delete policy')).toBeTruthy();
+  });
+
+  it('optimistic toggle: flips immediately, reverts + toasts when the PATCH fails', async () => {
+    renderPage([policy({ id: 'p1', enabled: true })]);
+    const sw = screen.getByRole('switch');
+    expect(sw.getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(sw);
+    // Optimistic flip is synchronous.
+    expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('false');
+    // No backend in the test env → the PATCH rejects → revert + toast.
+    await screen.findByText('Couldn’t update — try again');
+    expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/web-react/src/features/settings/approval-policies/approval-policies-page.tsx
+++ b/web-react/src/features/settings/approval-policies/approval-policies-page.tsx
@@ -1,0 +1,306 @@
+// ApprovalPoliciesPage — HITL tool-approval policy CRUD (spec Part H;
+// behavioral reference web/src/components/approval-policies-page.ts).
+// The list ranks rules in the same order the server evaluates them
+// (priority desc, then created_at desc), shows a priority badge + an
+// always-visible enable switch per row, and reveals Edit / Duplicate /
+// Delete on hover. Create/edit/duplicate share one dialog; delete goes
+// through a confirmation that restates the rule via the SAME
+// conditionSentence renderer.
+//
+// The enable toggle is OPTIMISTIC (spec §5.3): flip the cache
+// immediately, PATCH behind, revert + toast on failure. No confirm —
+// fully reversible, and the high-frequency op stays out of hover.
+//
+// The timeout copy says 5 minutes — the Lit page documents the spec's
+// "20 minutes" as stale (APPROVAL_TIMEOUT = 300_000ms).
+
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Plus } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ApiError,
+  getApiClient,
+  type ApprovalPolicy,
+} from '../../../api/client';
+import { useApprovalPolicies } from '../../../api/queries';
+import { BrandMark } from '../../../components/brand-mark';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { conditionSentence } from './condition-form';
+import { PolicyCard } from './policy-card';
+import { PolicyDialog } from './policy-dialog';
+import './approval-policies.css';
+
+/** List order = server evaluation order (spec §5.5): priority desc, then
+ *  the newest rule first on ties. created_at is ISO-8601 from the API. */
+export function sortPolicies(rows: ApprovalPolicy[]): ApprovalPolicy[] {
+  return [...rows].sort(
+    (a, b) =>
+      b.priority - a.priority ||
+      Date.parse(b.created_at) - Date.parse(a.created_at),
+  );
+}
+
+function errText(err: unknown): string {
+  if (err instanceof ApiError) return err.body?.message ?? `HTTP ${err.status}`;
+  return (err as Error).message;
+}
+
+interface DialogState {
+  open: boolean;
+  editing: ApprovalPolicy | null;
+  duplicating: ApprovalPolicy | null;
+}
+
+export function ApprovalPoliciesPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const policiesQ = useApprovalPolicies();
+
+  const [dialog, setDialog] = useState<DialogState>({
+    open: false,
+    editing: null,
+    duplicating: null,
+  });
+  const [deleteTarget, setDeleteTarget] = useState<ApprovalPolicy | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  /** Ids mid-PATCH on their toggle — a double-click can't queue two
+   *  conflicting writes. */
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
+  /** Id to pulse after a create/duplicate/edit save (spec §5.7). */
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3200);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+    },
+    [],
+  );
+
+  const setRows = (fn: (rows: ApprovalPolicy[]) => ApprovalPolicy[]) =>
+    queryClient.setQueryData<ApprovalPolicy[]>(['approval-policies'], (cur) =>
+      fn(cur ?? []),
+    );
+
+  /** Optimistic enable/disable (spec §5.3): flip immediately, PATCH in
+   *  the background, revert + toast on failure. */
+  async function toggleEnabled(row: ApprovalPolicy) {
+    if (togglingIds.has(row.id)) return;
+    const next = !row.enabled;
+    setRows((rows) =>
+      rows.map((r) => (r.id === row.id ? { ...r, enabled: next } : r)),
+    );
+    setTogglingIds((ids) => new Set(ids).add(row.id));
+    try {
+      await getApiClient().updateApprovalPolicy(row.id, { enabled: next });
+    } catch {
+      // Revert to the value we flipped away from.
+      setRows((rows) =>
+        rows.map((r) => (r.id === row.id ? { ...r, enabled: row.enabled } : r)),
+      );
+      showToast('Couldn’t update — try again');
+    } finally {
+      setTogglingIds((ids) => {
+        const out = new Set(ids);
+        out.delete(row.id);
+        return out;
+      });
+    }
+  }
+
+  /** Splice the saved policy into the cache (no full re-fetch) so we can
+   *  pulse the exact card. Create/duplicate append; edit replaces. */
+  function onSaved(policy: ApprovalPolicy, toastMsg: string) {
+    setRows((rows) =>
+      rows.some((r) => r.id === policy.id)
+        ? rows.map((r) => (r.id === policy.id ? policy : r))
+        : [...rows, policy],
+    );
+    showToast(toastMsg);
+    setFlashId(policy.id);
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setFlashId(null), 1800);
+    // Scroll after the list re-renders (sorted position may be anywhere).
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-policy-id="${policy.id}"]`)
+        ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    });
+  }
+
+  async function performDelete() {
+    const row = deleteTarget;
+    if (!row || deleteBusy) return;
+    setDeleteBusy(true);
+    try {
+      await getApiClient().deleteApprovalPolicy(row.id);
+      setRows((rows) => rows.filter((r) => r.id !== row.id));
+      showToast('Policy deleted');
+    } catch (err) {
+      showToast(errText(err));
+    } finally {
+      setDeleteBusy(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  const openCreate = () =>
+    setDialog({ open: true, editing: null, duplicating: null });
+
+  const sorted = sortPolicies(policiesQ.data ?? []);
+  const deleteToolDisp =
+    deleteTarget?.tool_name === '*' ? 'any tool' : deleteTarget?.tool_name;
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Approval policies</h1>
+          <div className="page-sub" style={{ maxWidth: 640 }}>
+            Which actions your coworkers should pause and confirm with you before
+            running. Confirmations appear in the chat; for scheduled tasks they go
+            to whoever set up the task.
+          </div>
+        </div>
+        <button className="btn-primary" onClick={openCreate}>
+          <Plus />
+          New policy
+        </button>
+      </div>
+
+      <div className="grid-scroll" style={{ paddingTop: 12 }}>
+        {policiesQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : policiesQ.isError ? (
+          <div className="row-error">
+            Failed to load approval policies — retry from the sidebar.
+          </div>
+        ) : sorted.length === 0 ? (
+          <div className="grid-empty">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <BrandMark size={128} />
+              <div style={{ marginTop: '0.75rem', fontSize: '1rem' }}>
+                No approval policies yet.
+              </div>
+              <div
+                style={{
+                  marginTop: 4,
+                  fontSize: '0.875rem',
+                  color: 'var(--rm-text-muted)',
+                  maxWidth: 380,
+                }}
+              >
+                Every tool call runs without asking. Create your first policy to
+                gate consequential actions.
+              </div>
+              <button
+                className="btn-primary"
+                style={{ marginTop: '1rem' }}
+                onClick={openCreate}
+              >
+                <Plus />
+                Create your first policy
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {sorted.map((p) => (
+              <PolicyCard
+                key={p.id}
+                policy={p}
+                toggling={togglingIds.has(p.id)}
+                flash={flashId === p.id}
+                onToggle={() => void toggleEnabled(p)}
+                onEdit={() =>
+                  setDialog({ open: true, editing: p, duplicating: null })
+                }
+                onDuplicate={() =>
+                  setDialog({ open: true, editing: null, duplicating: p })
+                }
+                onDelete={() => setDeleteTarget(p)}
+              />
+            ))}
+            {/* Evaluation-order hint — meaningless with no rules, so it only
+                renders under a non-empty list. Timeout copy: 5 minutes (the
+                Lit page corrects the design's stale 20-minute text). */}
+            <div className="page-hint">
+              Anything not matching above runs without asking. When multiple rules
+              match the same call, the highest priority wins; ties go to the
+              newest. Approvals time out after 5 minutes and auto-reject — the
+              coworker can re-request next turn.
+            </div>
+          </>
+        )}
+      </div>
+
+      {dialog.open ? (
+        <PolicyDialog
+          editing={dialog.editing}
+          duplicating={dialog.duplicating}
+          onClose={() => setDialog({ open: false, editing: null, duplicating: null })}
+          onSaved={onSaved}
+        />
+      ) : null}
+
+      {deleteTarget ? (
+        <ConfirmDialog
+          title="Delete approval policy?"
+          confirmLabel="Delete policy"
+          busyLabel="Deleting…"
+          busy={deleteBusy}
+          onConfirm={() => void performDelete()}
+          onCancel={() => {
+            if (!deleteBusy) setDeleteTarget(null);
+          }}
+        >
+          <p style={{ margin: '0 0 10px' }}>
+            You’re about to delete the policy that pauses for{' '}
+            <b>
+              {deleteTarget.mcp_server_name} · {deleteToolDisp}
+            </b>{' '}
+            <span
+              dangerouslySetInnerHTML={{
+                __html: conditionSentence(deleteTarget.condition_expr),
+              }}
+            />
+            .
+          </p>
+          <p
+            style={{
+              margin: 0,
+              fontSize: '12.5px',
+              color: 'var(--rm-text-muted)',
+              lineHeight: 1.55,
+            }}
+          >
+            After deletion, matching calls will run without asking. Pending
+            approvals already raised under this policy stay live until decided or
+            expired; only future calls change.
+          </p>
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/approval-policies/approval-policies.css
+++ b/web-react/src/features/settings/approval-policies/approval-policies.css
@@ -1,0 +1,169 @@
+/* Approval policies page (spec Part H). Shared primitives (page chrome,
+ * buttons, dialog family, switch, toast) live in components/ui.css; this
+ * file owns the policy card, priority badge, evaluation-order hint,
+ * condition builder, and the dialog's live preview. */
+
+.pol-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  max-width: 760px;
+}
+.pol-card .body {
+  flex: 1;
+  min-width: 0;
+}
+.pol-card.off .body {
+  opacity: 0.55;
+}
+.pol-pri {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 2px;
+  white-space: nowrap;
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+}
+.pol-pri--hi {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.pol-pri--zero {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.pol-card .target {
+  font-weight: 700;
+  font-size: 0.9375rem;
+}
+.pol-card .target .all {
+  font-weight: 400;
+  color: var(--rm-text-muted);
+}
+.pol-card .sentence {
+  font-size: 0.875rem;
+  color: var(--rm-text);
+  margin-top: 2px;
+}
+.pol-card .sentence b {
+  font-weight: 700;
+}
+.pol-card .cardacts {
+  display: inline-flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.pol-card:hover .cardacts,
+.pol-card:focus-within .cardacts {
+  opacity: 1;
+}
+.page-hint {
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  border-top: 1px solid var(--rm-border);
+  padding: 10px 2px;
+  max-width: 760px;
+}
+@keyframes apprHighlight {
+  0% {
+    outline: 2px solid var(--rm-action);
+    outline-offset: -1px;
+  }
+  100% {
+    outline: 2px solid transparent;
+  }
+}
+.pol-card.flash {
+  animation: apprHighlight 1.8s ease-out;
+}
+
+/* condition builder */
+.seg {
+  display: inline-flex;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.seg button {
+  border: none;
+  background: var(--rm-app-bg);
+  cursor: pointer;
+  font-family: var(--font-base);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--rm-nav-text-2);
+  padding: 6px 12px;
+}
+.seg button.on {
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+}
+.cond-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.cond-row input,
+.cond-row select {
+  font-family: var(--font-base);
+  font-size: 0.875rem;
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  padding: 6px 8px;
+  background: var(--rm-app-bg);
+}
+.cond-row .cf {
+  flex: 2;
+  min-width: 0;
+}
+.cond-row .cv {
+  flex: 2;
+  min-width: 0;
+}
+.cond-row select {
+  flex: 0 0 auto;
+  /* ui.css's `.field select` sets width:100% for standalone fields —
+   * inside a condition row the op select must size to its content or
+   * it blows the row out and horizontally scrolls the dialog body. */
+  width: auto;
+  height: auto;
+}
+.cond-readonly {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+  overflow-x: auto;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  padding: 10px;
+  background: var(--rm-card-bg);
+  margin: 0;
+}
+
+/* live preview */
+.preview {
+  border: 1px solid var(--rm-border);
+  border-left: 3px solid var(--rm-action);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  padding: 10px 12px;
+  font-size: 0.875rem;
+  margin-top: 4px;
+}
+.preview .pv-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--rm-text-muted);
+  font-weight: 700;
+  margin-bottom: 4px;
+}

--- a/web-react/src/features/settings/approval-policies/condition-form.test.ts
+++ b/web-react/src/features/settings/approval-policies/condition-form.test.ts
@@ -1,0 +1,208 @@
+// Ported from web/src/components/condition-form.test.ts alongside the
+// module (H.5: copy WITH tests), plus sentence/round-trip additions for
+// the read-only fallback path.
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildConditionExpr,
+  conditionSentence,
+  exprToForm,
+  formatValue,
+  parseValue,
+  type LeafRow,
+} from './condition-form';
+
+const leaf = (field: string, op: LeafRow['op'], value: string): LeafRow => ({
+  field,
+  op,
+  value,
+});
+
+describe('parseValue', () => {
+  it('parses a numeric string to a number', () => {
+    expect(parseValue('100')).toBe(100);
+  });
+  it('parses a JSON array to an array', () => {
+    expect(parseValue('["USD","EUR"]')).toEqual(['USD', 'EUR']);
+  });
+  it('parses booleans', () => {
+    expect(parseValue('true')).toBe(true);
+  });
+  it('keeps a bare word as a string (JSON.parse would throw)', () => {
+    expect(parseValue('USD')).toBe('USD');
+  });
+  it('treats empty input as an empty string, not undefined', () => {
+    expect(parseValue('   ')).toBe('');
+  });
+});
+
+describe('buildConditionExpr', () => {
+  it('always-mode → {always:true}', () => {
+    expect(
+      buildConditionExpr({ mode: 'always', connective: 'and', rows: [] }),
+    ).toEqual({ always: true });
+  });
+
+  it('a single leaf is emitted bare (no connective wrapper)', () => {
+    expect(
+      buildConditionExpr({
+        mode: 'match',
+        connective: 'and',
+        rows: [leaf('amount', '>', '100')],
+      }),
+    ).toEqual({ field: 'amount', op: '>', value: 100 });
+  });
+
+  it('multiple leaves wrap in the chosen connective', () => {
+    expect(
+      buildConditionExpr({
+        mode: 'match',
+        connective: 'or',
+        rows: [leaf('a', '==', '1'), leaf('b', '==', '2')],
+      }),
+    ).toEqual({
+      or: [
+        { field: 'a', op: '==', value: 1 },
+        { field: 'b', op: '==', value: 2 },
+      ],
+    });
+  });
+
+  it('drops rows with a blank field', () => {
+    expect(
+      buildConditionExpr({
+        mode: 'match',
+        connective: 'and',
+        rows: [leaf('', '==', 'x'), leaf('amount', '>', '5')],
+      }),
+    ).toEqual({ field: 'amount', op: '>', value: 5 });
+  });
+
+  it('match-mode with no usable rows degrades to the conservative gate', () => {
+    // Never produce "approve nothing" — an empty match means require approval.
+    expect(
+      buildConditionExpr({
+        mode: 'match',
+        connective: 'and',
+        rows: [leaf('', '==', '')],
+      }),
+    ).toEqual({ always: true });
+  });
+
+  it('an `in` op carries a list value through', () => {
+    expect(
+      buildConditionExpr({
+        mode: 'match',
+        connective: 'and',
+        rows: [leaf('currency', 'in', '["USD","EUR"]')],
+      }),
+    ).toEqual({ field: 'currency', op: 'in', value: ['USD', 'EUR'] });
+  });
+});
+
+describe('exprToForm', () => {
+  it('round-trips a single leaf', () => {
+    const form = exprToForm({ field: 'amount', op: '>', value: 100 });
+    expect(form.editable).toBe(true);
+    expect(form.mode).toBe('match');
+    expect(form.rows).toEqual([{ field: 'amount', op: '>', value: '100' }]);
+    // ...and rebuilds to the same expr.
+    expect(buildConditionExpr(form)).toEqual({ field: 'amount', op: '>', value: 100 });
+  });
+
+  it('round-trips a flat or-of-leaves', () => {
+    const expr = {
+      or: [
+        { field: 'a', op: '==', value: 'x' },
+        { field: 'b', op: '!=', value: 2 },
+      ],
+    };
+    const form = exprToForm(expr);
+    expect(form.editable).toBe(true);
+    expect(form.connective).toBe('or');
+    expect(form.rows).toHaveLength(2);
+    expect(buildConditionExpr(form)).toEqual(expr);
+  });
+
+  it('round-trips a string-list `in` value back to its JSON text', () => {
+    const expr = { field: 'currency', op: 'in', value: ['USD', 'EUR'] };
+    const form = exprToForm(expr);
+    expect(form.rows[0].value).toBe('["USD","EUR"]');
+    expect(buildConditionExpr(form)).toEqual(expr);
+  });
+
+  it('marks a clean {always:true} editable in always-mode', () => {
+    const form = exprToForm({ always: true });
+    expect(form).toMatchObject({ mode: 'always', editable: true });
+  });
+
+  it('refuses a nested connective (not editable in the flat builder)', () => {
+    const form = exprToForm({
+      and: [{ or: [{ field: 'a', op: '==', value: 1 }] }],
+    });
+    expect(form.editable).toBe(false);
+  });
+
+  it('refuses an unknown op', () => {
+    expect(exprToForm({ field: 'a', op: 'regex', value: '.*' }).editable).toBe(
+      false,
+    );
+  });
+
+  it('refuses a mixed-form node (always + leaf keys)', () => {
+    expect(
+      exprToForm({ always: true, field: 'x', op: '==', value: 1 }).editable,
+    ).toBe(false);
+  });
+
+  it('refuses a non-object', () => {
+    expect(exprToForm('nope').editable).toBe(false);
+    expect(exprToForm(null).editable).toBe(false);
+  });
+});
+
+describe('formatValue', () => {
+  it('quotes strings so "5000" is distinguishable from 5000', () => {
+    expect(formatValue('5000')).toBe('"5000"');
+    expect(formatValue(5000)).toBe('5000');
+  });
+  it('renders null and booleans bare', () => {
+    expect(formatValue(null)).toBe('null');
+    expect(formatValue(false)).toBe('false');
+  });
+  it('renders arrays as JSON', () => {
+    expect(formatValue(['USD'])).toBe('["USD"]');
+  });
+});
+
+describe('conditionSentence', () => {
+  it('always:true → every time; always:false → never', () => {
+    expect(conditionSentence({ always: true })).toBe('every time');
+    expect(conditionSentence({ always: false })).toBe('never');
+  });
+  it('renders a leaf bolded with the display-form value', () => {
+    expect(conditionSentence({ field: 'amount', op: '>', value: 5000 })).toBe(
+      'when <b>amount &gt; 5000</b>',
+    );
+  });
+  it('joins a flat or with OR', () => {
+    expect(
+      conditionSentence({
+        or: [
+          { field: 'a', op: '==', value: 1 },
+          { field: 'b', op: '==', value: 2 },
+        ],
+      }),
+    ).toBe('when <b>a == 1 OR b == 2</b>');
+  });
+  it('escapes HTML in leaf text', () => {
+    expect(
+      conditionSentence({ field: '<img>', op: '==', value: 'x' }),
+    ).toContain('&lt;img&gt;');
+  });
+  it('collapses nested shapes to the advanced-condition note', () => {
+    expect(
+      conditionSentence({ and: [{ or: [{ field: 'a', op: '==', value: 1 }] }] }),
+    ).toBe('when <i>(advanced condition)</i>');
+  });
+});

--- a/web-react/src/features/settings/approval-policies/condition-form.ts
+++ b/web-react/src/features/settings/approval-policies/condition-form.ts
@@ -1,0 +1,239 @@
+// Copied from web/src/components/condition-form.ts @ feat/webui-react;
+// keep in sync manually until workspace extraction. Page-private pure
+// logic — colocated in the slug folder per the §1.1 settings growth
+// rule (the lib/ no-react rule is about lib/ itself, not pure files
+// elsewhere).
+//
+// Pure helpers for the approval-policy condition builder
+// (docs/12-hitl-approval-architecture.md §7 / §10 S5). Kept separate from the page
+// component so the (lossy, structured) form ⇄ condition_expr mapping is
+// unit-testable on its own.
+//
+// The §7 grammar this UI exposes is intentionally a *subset* of what the
+// matcher accepts: the builder produces either `{"always": true}` or a single
+// flat `and`/`or` of leaf comparisons. Arbitrary nesting is valid on the wire
+// (and round-trips through the REST API untouched), but the form only edits the
+// shallow shapes — `exprToForm` reports `editable: false` for anything deeper
+// so the page can fall back to read-only / raw display instead of silently
+// flattening a nested policy.
+
+import type { ConditionExpr } from '../../../api/client';
+
+export const CONDITION_OPS = [
+  '==',
+  '!=',
+  '>',
+  '>=',
+  '<',
+  '<=',
+  'in',
+  'not_in',
+  'contains',
+] as const;
+
+export type ConditionOp = (typeof CONDITION_OPS)[number];
+
+export interface LeafRow {
+  field: string;
+  op: ConditionOp;
+  /** Raw text from the input; parsed to a JSON value (or kept as a string)
+   *  by {@link parseValue} when the expression is built. */
+  value: string;
+}
+
+export type ConditionMode = 'always' | 'match';
+
+export interface ConditionForm {
+  mode: ConditionMode;
+  connective: 'and' | 'or';
+  rows: LeafRow[];
+  /** False when the loaded expression is too complex for the structured
+   *  builder (deep nesting, mixed forms) — the page shows it read-only. */
+  editable: boolean;
+}
+
+/** Parse a raw value string into the JSON value the comparison should use.
+ *
+ *  `"100"` → number 100, `"true"` → boolean, `'["USD","EUR"]'` → array,
+ *  `"USD"` → the string `"USD"` (JSON.parse throws → fall back to raw). This
+ *  is what lets `amount > 100` compare numerically while `currency in
+ *  ["USD","EUR"]` compares against a real list. */
+export function parseValue(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === '') return '';
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return raw;
+  }
+}
+
+/** Build a condition_expr from the structured form. */
+export function buildConditionExpr(form: {
+  mode: ConditionMode;
+  connective: 'and' | 'or';
+  rows: LeafRow[];
+}): ConditionExpr {
+  if (form.mode === 'always') {
+    return { always: true };
+  }
+  const leaves = form.rows
+    .filter((r) => r.field.trim() !== '')
+    .map((r) => ({
+      field: r.field.trim(),
+      op: r.op,
+      value: parseValue(r.value),
+    }));
+  if (leaves.length === 0) {
+    // A "match" mode with no usable rows degrades to always-require — the
+    // conservative gate, never accidentally "approve nothing".
+    return { always: true };
+  }
+  if (leaves.length === 1) {
+    return leaves[0] as unknown as ConditionExpr;
+  }
+  return { [form.connective]: leaves } as unknown as ConditionExpr;
+}
+
+/** Reverse of {@link parseValue} for display in a sentence (§5.12).
+ *
+ *  Numbers / booleans render bare, `null` as `null`, strings quoted (so the
+ *  reader can tell `"5000"` the string from `5000` the number), arrays/objects
+ *  as JSON. This is the *display* form — distinct from {@link leafToRow}'s
+ *  edit form, which strips the quotes off a string so the input is editable. */
+export function formatValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+  return JSON.stringify(value);
+}
+
+/** Escape a string for safe interpolation into the `conditionSentence` HTML. */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function leafSentence(leaf: Leaf): string {
+  return esc(`${leaf.field ?? '?'} ${leaf.op ?? '?'} ${formatValue(leaf.value)}`);
+}
+
+/** Human-readable, HTML-safe rendering of a `condition_expr` (Appendix C.3).
+ *
+ *  The single source of truth for both the list-card subtitle and the dialog's
+ *  live preview — the same sentence appears in both places so what the user
+ *  previews is exactly what the card will show. The condition body is wrapped
+ *  in `<b>…</b>`; callers must render the result with `dangerouslySetInnerHTML`
+ *  (the leaf text is escaped, so this is safe). Anything the flat builder
+ *  can't express (deep nesting, mixed forms) collapses to an
+ *  `(advanced condition)` note rather than lying about the shape.
+ *
+ *  Returns the *clause* only ("every time" / "when <b>…</b>"); callers add the
+ *  surrounding "→ pause to confirm" / full-sentence framing. */
+export function conditionSentence(expr: unknown): string {
+  if (typeof expr !== 'object' || expr === null) return 'every time';
+  const obj = expr as Record<string, unknown>;
+  if ('always' in obj) {
+    return obj.always === false ? 'never' : 'every time';
+  }
+  if (isLeaf(obj)) {
+    return `when <b>${leafSentence(obj)}</b>`;
+  }
+  for (const [connective, word] of [
+    ['and', 'AND'],
+    ['or', 'OR'],
+  ] as const) {
+    const subs = obj[connective];
+    if (Array.isArray(subs) && subs.length > 0 && subs.every(isLeaf)) {
+      return `when <b>${(subs as Leaf[]).map(leafSentence).join(` ${word} `)}</b>`;
+    }
+  }
+  return 'when <i>(advanced condition)</i>';
+}
+
+interface Leaf {
+  field: string;
+  op: string;
+  value: unknown;
+}
+
+function isLeaf(node: unknown): node is Leaf {
+  if (typeof node !== 'object' || node === null) return false;
+  const keys = Object.keys(node).sort();
+  return (
+    keys.length === 3 &&
+    keys[0] === 'field' &&
+    keys[1] === 'op' &&
+    keys[2] === 'value'
+  );
+}
+
+function leafToRow(leaf: Leaf): LeafRow | null {
+  if (!CONDITION_OPS.includes(leaf.op as ConditionOp)) return null;
+  // Reverse of parseValue: a string round-trips bare, everything else as JSON
+  // so the input shows `["USD","EUR"]` / `100`, not `[object Object]`.
+  const value =
+    typeof leaf.value === 'string' ? leaf.value : JSON.stringify(leaf.value);
+  return { field: String(leaf.field), op: leaf.op as ConditionOp, value };
+}
+
+function emptyRow(): LeafRow {
+  return { field: '', op: '==', value: '' };
+}
+
+/** Best-effort reverse of {@link buildConditionExpr}, for the edit flow.
+ *
+ *  Recognises `{always}`, a single leaf, and a flat `and`/`or` of leaves.
+ *  Anything else (nested connectives, unknown ops) → `editable: false` so the
+ *  caller renders it raw instead of corrupting it. */
+export function exprToForm(expr: unknown): ConditionForm {
+  const fallback: ConditionForm = {
+    mode: 'match',
+    connective: 'and',
+    rows: [emptyRow()],
+    editable: false,
+  };
+  if (typeof expr !== 'object' || expr === null) return fallback;
+  const obj = expr as Record<string, unknown>;
+
+  if ('always' in obj) {
+    // Only a clean `{always: bool}` is editable; a mixed node is not.
+    if (Object.keys(obj).length === 1 && typeof obj.always === 'boolean') {
+      return { mode: 'always', connective: 'and', rows: [emptyRow()], editable: true };
+    }
+    return fallback;
+  }
+
+  for (const connective of ['and', 'or'] as const) {
+    if (connective in obj) {
+      if (Object.keys(obj).length !== 1) return fallback;
+      const subs = obj[connective];
+      if (!Array.isArray(subs) || subs.length === 0) return fallback;
+      const rows: LeafRow[] = [];
+      for (const sub of subs) {
+        if (!isLeaf(sub)) return fallback;
+        const row = leafToRow(sub);
+        if (!row) return fallback;
+        rows.push(row);
+      }
+      return { mode: 'match', connective, rows, editable: true };
+    }
+  }
+
+  if (isLeaf(obj)) {
+    const row = leafToRow(obj);
+    if (!row) return fallback;
+    return { mode: 'match', connective: 'and', rows: [row], editable: true };
+  }
+
+  return fallback;
+}
+
+export { emptyRow };

--- a/web-react/src/features/settings/approval-policies/policy-card.test.tsx
+++ b/web-react/src/features/settings/approval-policies/policy-card.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ApprovalPolicy } from '../../../api/client';
+import { PolicyCard, priorityBadgeClass } from './policy-card';
+
+function policy(over: Partial<ApprovalPolicy> = {}): ApprovalPolicy {
+  return {
+    id: 'pol-1',
+    tenant_id: 't1',
+    mcp_server_name: 'records-mcp',
+    tool_name: 'refund',
+    condition_expr: { field: 'amount', op: '>', value: 5000 },
+    enabled: true,
+    priority: 20,
+    created_at: '2026-06-20T10:00:00Z',
+    updated_at: '2026-06-20T10:00:00Z',
+    ...over,
+  } as ApprovalPolicy;
+}
+
+function renderCard(p: ApprovalPolicy, toggling = false) {
+  const onToggle = vi.fn();
+  const onEdit = vi.fn();
+  const onDuplicate = vi.fn();
+  const onDelete = vi.fn();
+  render(
+    <PolicyCard
+      policy={p}
+      toggling={toggling}
+      flash={false}
+      onToggle={onToggle}
+      onEdit={onEdit}
+      onDuplicate={onDuplicate}
+      onDelete={onDelete}
+    />,
+  );
+  return { onToggle, onEdit, onDuplicate, onDelete };
+}
+
+afterEach(cleanup);
+
+describe('priorityBadgeClass', () => {
+  it('≥10 amber, 0 muted, else neutral', () => {
+    expect(priorityBadgeClass(10)).toContain('pol-pri--hi');
+    expect(priorityBadgeClass(20)).toContain('pol-pri--hi');
+    expect(priorityBadgeClass(0)).toContain('pol-pri--zero');
+    expect(priorityBadgeClass(5)).toBe('');
+  });
+});
+
+describe('PolicyCard', () => {
+  it('renders badge, target, and the condition sentence + framing', () => {
+    renderCard(policy());
+    expect(screen.getByText('priority 20')).toBeTruthy();
+    expect(screen.getByText(/records-mcp/)).toBeTruthy();
+    // conditionSentence bolds the leaf; formatValue renders 5000 bare.
+    expect(screen.getByText('amount > 5000')).toBeTruthy();
+    expect(screen.getByText(/pause to confirm/)).toBeTruthy();
+  });
+
+  it('wildcard tool renders * with the muted (all tools) suffix', () => {
+    renderCard(policy({ tool_name: '*' }));
+    expect(screen.getByText('(all tools)')).toBeTruthy();
+  });
+
+  it('disabled policy dims the body (off class) but the switch stays live', () => {
+    const { onToggle } = renderCard(policy({ enabled: false }));
+    expect(document.querySelector('.pol-card')?.className).toContain('off');
+    const sw = screen.getByRole('switch');
+    expect(sw.getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByText('Disabled')).toBeTruthy();
+    fireEvent.click(sw);
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('toggling disables the switch (double-click guard)', () => {
+    renderCard(policy(), true);
+    expect((screen.getByRole('switch') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('hover actions dispatch edit / duplicate / delete', () => {
+    const { onEdit, onDuplicate, onDelete } = renderCard(policy());
+    fireEvent.click(screen.getByTitle('Edit policy'));
+    fireEvent.click(screen.getByTitle('Duplicate policy'));
+    fireEvent.click(screen.getByTitle('Delete policy'));
+    expect(onEdit).toHaveBeenCalled();
+    expect(onDuplicate).toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/web-react/src/features/settings/approval-policies/policy-card.tsx
+++ b/web-react/src/features/settings/approval-policies/policy-card.tsx
@@ -1,0 +1,112 @@
+// PolicyCard — one approval policy in evaluation order (spec H.2;
+// behavioral reference web/src/components/approval-policies-page.ts
+// renderRow). Priority badge · target + condition sentence · the
+// ALWAYS-visible enable switch (a disabled card dims the body but the
+// switch stays bright — it's the way back) · hover-revealed
+// Edit / Duplicate / Delete.
+
+import { Copy, Pencil, Trash2 } from 'lucide-react';
+import type { ApprovalPolicy } from '../../../api/client';
+import { Switch } from '../../../components/switch';
+import { conditionSentence } from './condition-form';
+
+/** Badge tint class for a priority value (Appendix C.3): amber when ≥10,
+ *  muted when exactly 0, neutral otherwise. */
+export function priorityBadgeClass(priority: number): string {
+  if (priority >= 10) return ' pol-pri--hi';
+  if (priority === 0) return ' pol-pri--zero';
+  return '';
+}
+
+export function PolicyCard({
+  policy,
+  toggling,
+  flash,
+  onToggle,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: {
+  policy: ApprovalPolicy;
+  /** Mid-PATCH on the enable toggle — disables the switch so a
+   *  double-click can't queue two conflicting writes. */
+  toggling: boolean;
+  /** 1.8s highlight pulse after create/duplicate (spec §5.7). */
+  flash: boolean;
+  onToggle: () => void;
+  onEdit: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div
+      className={`pol-card${policy.enabled ? '' : ' off'}${flash ? ' flash' : ''}`}
+      data-policy-id={policy.id}
+    >
+      <span className={`pol-pri${priorityBadgeClass(policy.priority)}`}>
+        priority {policy.priority}
+      </span>
+      <span className="body">
+        <div className="target">
+          {policy.mcp_server_name} ·{' '}
+          {policy.tool_name === '*' ? (
+            <>
+              *<span className="all"> (all tools)</span>
+            </>
+          ) : (
+            policy.tool_name
+          )}
+        </div>
+        <div className="sentence">
+          {/* conditionSentence escapes leaf text; the only markup is its
+              own <b>/<i> wrapping — safe to inject (same contract as the
+              Lit unsafeHTML call). */}
+          <span
+            dangerouslySetInnerHTML={{
+              __html: conditionSentence(policy.condition_expr),
+            }}
+          />{' '}
+          → pause to confirm
+        </div>
+      </span>
+      <Switch
+        on={policy.enabled}
+        disabled={toggling}
+        onToggle={onToggle}
+        title={policy.enabled ? 'Click to disable' : 'Click to enable'}
+      />
+      <span className="cardacts">
+        <button
+          className="icon-btn"
+          title="Edit policy"
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
+        >
+          <Pencil />
+        </button>
+        <button
+          className="icon-btn"
+          title="Duplicate policy"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate();
+          }}
+        >
+          <Copy />
+        </button>
+        <button
+          className="icon-btn danger"
+          title="Delete policy"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 />
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/approval-policies/policy-dialog.test.tsx
+++ b/web-react/src/features/settings/approval-policies/policy-dialog.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ApprovalPolicy, MCPServer } from '../../../api/client';
+import { PolicyDialog } from './policy-dialog';
+
+const SERVERS: MCPServer[] = [
+  {
+    id: 'mcp-1',
+    tenant_id: 't1',
+    name: 'records-mcp',
+    type: 'http',
+    url: 'http://records/mcp',
+    auth_mode: 'service',
+    description: null,
+    tool_reversibility: { lookup_customer: true, refund: false },
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as unknown as MCPServer,
+];
+
+function renderDialog(opts: {
+  editing?: ApprovalPolicy | null;
+  duplicating?: ApprovalPolicy | null;
+}) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  qc.setQueryData(['mcp-servers'], SERVERS);
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  render(
+    <QueryClientProvider client={qc}>
+      <PolicyDialog
+        editing={opts.editing ?? null}
+        duplicating={opts.duplicating ?? null}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
+    </QueryClientProvider>,
+  );
+  return { onClose, onSaved };
+}
+
+function policy(over: Partial<ApprovalPolicy> = {}): ApprovalPolicy {
+  return {
+    id: 'pol-1',
+    tenant_id: 't1',
+    mcp_server_name: 'records-mcp',
+    tool_name: 'refund',
+    condition_expr: { field: 'amount', op: '>', value: 5000 },
+    enabled: true,
+    priority: 20,
+    created_at: '2026-06-20T10:00:00Z',
+    updated_at: '2026-06-20T10:00:00Z',
+    ...over,
+  } as ApprovalPolicy;
+}
+
+afterEach(cleanup);
+
+describe('PolicyDialog', () => {
+  it('create mode: defaults + Every time selected + Create label', () => {
+    renderDialog({});
+    expect(screen.getByText('New approval policy')).toBeTruthy();
+    expect(screen.getByText('Create policy')).toBeTruthy();
+    const always = screen.getByText('Every time');
+    expect(always.className).toContain('on');
+    // No condition rows in always-mode.
+    expect(document.querySelector('.cond-row')).toBeNull();
+    // Tool defaults to the wildcard.
+    expect((screen.getByLabelText('Tool') as HTMLInputElement).value).toBe('*');
+  });
+
+  it('Only when… reveals combiner + rows; typing updates the live preview', () => {
+    renderDialog({});
+    fireEvent.change(screen.getByLabelText('MCP server'), {
+      target: { value: 'records-mcp' },
+    });
+    fireEvent.click(screen.getByText('Only when…'));
+    expect(screen.getByText('All (AND)')).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText('field (e.g. amount)'), {
+      target: { value: 'amount' },
+    });
+    fireEvent.change(screen.getByLabelText('Operator'), { target: { value: '>' } });
+    fireEvent.change(screen.getByPlaceholderText('value (e.g. 5000)'), {
+      target: { value: '5000' },
+    });
+    const preview = screen.getByTestId('policy-preview');
+    expect(preview.textContent).toContain('records-mcp');
+    expect(preview.textContent).toContain('amount > 5000');
+    expect(preview.textContent).toContain('pause to confirm');
+  });
+
+  it('empty when-rows preview falls closed to "every time" (never approve-nothing)', () => {
+    renderDialog({});
+    fireEvent.click(screen.getByText('Only when…'));
+    expect(screen.getByTestId('policy-preview').textContent).toContain('every time');
+  });
+
+  it('save gate: server + tool required', () => {
+    renderDialog({});
+    fireEvent.change(screen.getByLabelText('MCP server'), { target: { value: '  ' } });
+    fireEvent.click(screen.getByText('Create policy'));
+    expect(screen.getByRole('alert').textContent).toBe(
+      'MCP server name and tool name are required.',
+    );
+  });
+
+  it('tool datalist offers * + the declared tool_reversibility keys', () => {
+    renderDialog({});
+    fireEvent.change(screen.getByLabelText('MCP server'), {
+      target: { value: 'records-mcp' },
+    });
+    const opts = [...document.querySelectorAll('#pf-tool-opts option')].map((o) =>
+      o.getAttribute('value'),
+    );
+    expect(opts).toEqual(['*', 'lookup_customer', 'refund']);
+  });
+
+  it('changing the server resets the tool to *', () => {
+    renderDialog({ duplicating: policy() }); // tool seeded to "refund"
+    expect((screen.getByLabelText('Tool') as HTMLInputElement).value).toBe('refund');
+    fireEvent.change(screen.getByLabelText('MCP server'), {
+      target: { value: 'other-mcp' },
+    });
+    expect((screen.getByLabelText('Tool') as HTMLInputElement).value).toBe('*');
+  });
+
+  it('duplicate seeds ALL fields from the source, enabled included (Lit parity)', () => {
+    renderDialog({ duplicating: policy({ enabled: false, priority: 7 }) });
+    expect(screen.getByText('Duplicate approval policy')).toBeTruthy();
+    expect(screen.getByText('Create policy')).toBeTruthy(); // create-flow label
+    expect((screen.getByLabelText('MCP server') as HTMLInputElement).value).toBe(
+      'records-mcp',
+    );
+    expect(
+      (screen.getByLabelText(/Priority/) as HTMLInputElement).value,
+    ).toBe('7');
+    // enabled copies the source — a disabled source duplicates disabled.
+    const status = screen.getAllByRole('switch')[0];
+    expect(status.getAttribute('aria-checked')).toBe('false');
+    // Condition seeded into the builder (leaf row, edit-form bare value).
+    expect(
+      (screen.getByPlaceholderText('field (e.g. amount)') as HTMLInputElement).value,
+    ).toBe('amount');
+  });
+
+  it('edit mode: title + Save changes label; leaf expr round-trips into rows', () => {
+    renderDialog({ editing: policy() });
+    expect(screen.getByText('Edit approval policy')).toBeTruthy();
+    expect(screen.getByText('Save changes')).toBeTruthy();
+    expect(
+      (screen.getByPlaceholderText('value (e.g. 5000)') as HTMLInputElement).value,
+    ).toBe('5000');
+  });
+
+  it('a nested stored expression opens READ-ONLY: notice + raw JSON, no rows', () => {
+    const nested = {
+      and: [{ or: [{ field: 'a', op: '==', value: 1 }] }],
+    } as unknown as ApprovalPolicy['condition_expr'];
+    renderDialog({ editing: policy({ condition_expr: nested }) });
+    expect(screen.getByTestId('condition-readonly')).toBeTruthy();
+    expect(
+      screen.getByText(/advanced condition that the form can't edit/),
+    ).toBeTruthy();
+    expect(document.querySelector('.cond-readonly')?.textContent).toContain('"or"');
+    expect(document.querySelector('.cond-row')).toBeNull();
+    // Lit parity: the mode seg is replaced too — switching to "Every
+    // time" on a pass-through expression would be a lying no-op.
+    expect(screen.queryByText('Every time')).toBeNull();
+    // Preview still renders — from the stored expression, collapsed note.
+    expect(screen.getByTestId('policy-preview').textContent).toContain(
+      '(advanced condition)',
+    );
+    // Other fields stay editable.
+    expect(
+      (screen.getByLabelText('MCP server') as HTMLInputElement).disabled,
+    ).toBe(false);
+  });
+
+  it('remove is disabled on the last row; add appends one', () => {
+    renderDialog({});
+    fireEvent.click(screen.getByText('Only when…'));
+    expect(
+      (screen.getByTitle('Remove condition') as HTMLButtonElement).disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByText('+ Add condition'));
+    expect(document.querySelectorAll('.cond-row').length).toBe(2);
+    const removes = screen.getAllByTitle('Remove condition') as HTMLButtonElement[];
+    expect(removes[0].disabled).toBe(false);
+    fireEvent.click(removes[0]);
+    expect(document.querySelectorAll('.cond-row').length).toBe(1);
+  });
+});

--- a/web-react/src/features/settings/approval-policies/policy-dialog.tsx
+++ b/web-react/src/features/settings/approval-policies/policy-dialog.tsx
@@ -1,0 +1,454 @@
+// PolicyDialog — create / edit / duplicate an HITL approval policy
+// (spec H.3; behavioral reference web/src/components/approval-policy-dialog.ts).
+// One dialog backs all three flows:
+//   - editing non-null     → edit  (PATCH; "Edit approval policy")
+//   - duplicating non-null → create, pre-filled (POST; "Duplicate …")
+//   - both null            → create, defaults (POST; "New approval policy")
+//
+// Every field is top-level — no disclosure. Server/tool are COMBOBOXES
+// (input + datalist): an unconfigured name may be typed, policies can
+// pre-date server registration. Tool options = `*` + the keys of the
+// typed server's tool_reversibility map (operator-declared names — no
+// live tool list exists). A live preview regenerates on every change
+// through the same conditionSentence renderer as the list cards.
+//
+// A stored expression too complex for the flat builder opens READ-ONLY
+// on the condition (other fields stay editable): edit-PATCH omits
+// condition_expr entirely; duplicate-POST carries the source expression
+// verbatim — never silently flatten a hand-crafted nested condition.
+//
+// Duplicate seeds ALL fields from the source, `enabled` included (Lit
+// seedForm parity — the spec's "duplicate starts disabled" note does
+// not match the shipped behavior).
+
+import { useEffect, useMemo, useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  ApiError,
+  getApiClient,
+  type ApprovalPolicy,
+  type ApprovalPolicyCreate,
+  type ApprovalPolicyUpdate,
+} from '../../../api/client';
+import { useMCPServers } from '../../../api/queries';
+import { BrandMark } from '../../../components/brand-mark';
+import { Switch } from '../../../components/switch';
+import {
+  CONDITION_OPS,
+  type ConditionMode,
+  type LeafRow,
+  buildConditionExpr,
+  conditionSentence,
+  emptyRow,
+  exprToForm,
+} from './condition-form';
+
+export function PolicyDialog({
+  editing,
+  duplicating,
+  onClose,
+  onSaved,
+}: {
+  editing: ApprovalPolicy | null;
+  duplicating: ApprovalPolicy | null;
+  onClose: () => void;
+  /** Fired with the saved policy + a toast line; the page splices it
+   *  into the list (create appends, edit replaces) and pulses the card. */
+  onSaved: (policy: ApprovalPolicy, toast: string) => void;
+}) {
+  const isEdit = editing !== null;
+  // The policy the form seeds from: the edit target, else the duplicate
+  // source, else nothing (defaults). Also the untouched-expression
+  // source for the read-only condition path.
+  const seedSource = editing ?? duplicating;
+
+  const [form, setForm] = useState(() => {
+    if (seedSource) {
+      const cond = exprToForm(seedSource.condition_expr);
+      return {
+        server: seedSource.mcp_server_name,
+        tool: seedSource.tool_name,
+        priority: seedSource.priority,
+        enabled: seedSource.enabled,
+        mode: cond.mode,
+        connective: cond.connective,
+        rows: cond.rows.length ? cond.rows : [emptyRow()],
+        editable: cond.editable,
+      };
+    }
+    return {
+      server: '',
+      tool: '*',
+      priority: 0,
+      enabled: true,
+      mode: 'always' as ConditionMode,
+      connective: 'and' as const,
+      rows: [emptyRow()],
+      editable: true,
+    };
+  });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Suggestion lists — the SAME ['mcp-servers'] query Part D owns;
+  // best-effort (catch-to-empty), the fields stay free-text regardless.
+  const serversQ = useMCPServers(true);
+  const servers = serversQ.data ?? [];
+  const toolOptions = useMemo(() => {
+    const match = servers.find((s) => s.name === form.server);
+    const declared = match ? Object.keys(match.tool_reversibility ?? {}) : [];
+    return ['*', ...declared.filter((t) => t && t !== '*')];
+  }, [servers, form.server]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onClose]);
+
+  /** condition_expr from the current form state (fail-closed §5.14);
+   *  a non-editable stored expression passes through verbatim. */
+  function currentExpr() {
+    if (!form.editable) return seedSource!.condition_expr;
+    return buildConditionExpr(form);
+  }
+
+  function updateRow(i: number, patch: Partial<LeafRow>) {
+    setForm((f) => ({
+      ...f,
+      rows: f.rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)),
+    }));
+  }
+
+  async function submit() {
+    if (busy) return;
+    if (form.server.trim() === '' || form.tool.trim() === '') {
+      setErr('MCP server name and tool name are required.');
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const api = getApiClient();
+      let saved: ApprovalPolicy;
+      if (isEdit) {
+        const body: ApprovalPolicyUpdate = {
+          mcp_server_name: form.server.trim(),
+          tool_name: form.tool.trim(),
+          priority: form.priority,
+          enabled: form.enabled,
+        };
+        // Only resend the condition if it's still editable here —
+        // otherwise leave the (complex) stored expression untouched.
+        if (form.editable) body.condition_expr = currentExpr();
+        saved = await api.updateApprovalPolicy(editing.id, body);
+        onSaved(saved, 'Policy updated');
+      } else {
+        // Create — covers both New and Duplicate (duplicate just seeds
+        // the form; the POST is identical, server assigns a new id).
+        const body: ApprovalPolicyCreate = {
+          mcp_server_name: form.server.trim(),
+          tool_name: form.tool.trim(),
+          priority: form.priority,
+          enabled: form.enabled,
+          condition_expr: currentExpr(),
+        };
+        saved = await api.createApprovalPolicy(body);
+        onSaved(saved, 'Policy created');
+      }
+      onClose();
+    } catch (e) {
+      setErr(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+      setBusy(false);
+    }
+  }
+
+  const title = isEdit
+    ? 'Edit approval policy'
+    : duplicating
+      ? 'Duplicate approval policy'
+      : 'New approval policy';
+  const previewTool = form.tool.trim() === '*' ? '* (all tools)' : form.tool.trim() || '—';
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        className="dlg"
+        style={{ width: 640 }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Approval policy"
+      >
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">{title}</h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body" style={{ minHeight: 0 }}>
+          <div style={{ display: 'flex', gap: 12 }}>
+            <div className="field" style={{ flex: 1 }}>
+              <label htmlFor="pf-server">MCP server</label>
+              <input
+                id="pf-server"
+                type="text"
+                list="pf-server-opts"
+                spellCheck={false}
+                value={form.server}
+                disabled={busy}
+                onChange={(e) =>
+                  // Server change resets the tool to `*` — the old
+                  // server's declared tool names don't carry over.
+                  setForm((f) => ({ ...f, server: e.target.value, tool: '*' }))
+                }
+              />
+              <datalist id="pf-server-opts">
+                {servers.map((s) => (
+                  <option key={s.id} value={s.name} />
+                ))}
+              </datalist>
+            </div>
+            <div className="field" style={{ flex: 1 }}>
+              <label htmlFor="pf-tool">Tool</label>
+              <input
+                id="pf-tool"
+                type="text"
+                list="pf-tool-opts"
+                spellCheck={false}
+                value={form.tool}
+                disabled={busy}
+                onChange={(e) => setForm((f) => ({ ...f, tool: e.target.value }))}
+              />
+              <datalist id="pf-tool-opts">
+                {toolOptions.map((t) => (
+                  <option key={t} value={t} />
+                ))}
+              </datalist>
+            </div>
+          </div>
+          <div className="hint" style={{ margin: '-6px 0 12px' }}>
+            Pick a configured server/tool, or type one that isn't connected yet.
+          </div>
+
+          {/* Lit parity: a non-editable condition replaces the WHOLE
+              condition area (mode seg included) with the read-only block —
+              the seg would be a lying no-op since the stored expression
+              passes through untouched regardless. */}
+          {!form.editable ? (
+            <div className="field" data-testid="condition-readonly">
+              <div className="hint">
+                This policy uses an advanced condition that the form can't edit. It
+                is kept as-is when you save.
+              </div>
+              <pre className="cond-readonly">
+                {JSON.stringify(seedSource?.condition_expr ?? {}, null, 2)}
+              </pre>
+            </div>
+          ) : (
+            <div className="field">
+              <label>Ask for approval</label>
+              <span className="seg" role="radiogroup" aria-label="When to require approval">
+                <button
+                  type="button"
+                  className={form.mode === 'always' ? 'on' : ''}
+                  aria-pressed={form.mode === 'always'}
+                  disabled={busy}
+                  onClick={() => setForm((f) => ({ ...f, mode: 'always' }))}
+                >
+                  Every time
+                </button>
+                <button
+                  type="button"
+                  className={form.mode === 'match' ? 'on' : ''}
+                  aria-pressed={form.mode === 'match'}
+                  disabled={busy}
+                  onClick={() =>
+                    setForm((f) => ({
+                      ...f,
+                      mode: 'match',
+                      rows: f.rows.length ? f.rows : [emptyRow()],
+                    }))
+                  }
+                >
+                  Only when…
+                </button>
+              </span>
+            </div>
+          )}
+
+          {form.editable && form.mode === 'match' ? (
+            <>
+                <div className="field">
+                  <label>Combine conditions with</label>
+                  <span className="seg">
+                    <button
+                      type="button"
+                      className={form.connective === 'and' ? 'on' : ''}
+                      disabled={busy}
+                      onClick={() => setForm((f) => ({ ...f, connective: 'and' }))}
+                    >
+                      All (AND)
+                    </button>
+                    <button
+                      type="button"
+                      className={form.connective === 'or' ? 'on' : ''}
+                      disabled={busy}
+                      onClick={() => setForm((f) => ({ ...f, connective: 'or' }))}
+                    >
+                      Any (OR)
+                    </button>
+                  </span>
+                </div>
+                <div className="field">
+                  <label>Conditions</label>
+                  {form.rows.map((r, i) => (
+                    <div className="cond-row" key={i}>
+                      <input
+                        className="cf"
+                        placeholder="field (e.g. amount)"
+                        value={r.field}
+                        disabled={busy}
+                        onChange={(e) => updateRow(i, { field: e.target.value })}
+                      />
+                      <select
+                        aria-label="Operator"
+                        value={r.op}
+                        disabled={busy}
+                        onChange={(e) =>
+                          updateRow(i, { op: e.target.value as LeafRow['op'] })
+                        }
+                      >
+                        {CONDITION_OPS.map((op) => (
+                          <option key={op} value={op}>
+                            {op}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        className="cv"
+                        placeholder="value (e.g. 5000)"
+                        value={r.value}
+                        disabled={busy}
+                        onChange={(e) => updateRow(i, { value: e.target.value })}
+                      />
+                      <button
+                        className="icon-btn danger"
+                        title="Remove condition"
+                        disabled={busy || form.rows.length === 1}
+                        onClick={() =>
+                          setForm((f) => ({
+                            ...f,
+                            rows: f.rows.filter((_, idx) => idx !== i),
+                          }))
+                        }
+                      >
+                        <X />
+                      </button>
+                    </div>
+                  ))}
+                  <button
+                    className="btn-ghost"
+                    style={{ paddingLeft: 0 }}
+                    disabled={busy}
+                    onClick={() =>
+                      setForm((f) => ({ ...f, rows: [...f.rows, emptyRow()] }))
+                    }
+                  >
+                    + Add condition
+                  </button>
+                </div>
+              </>
+          ) : null}
+
+          <div
+            style={{ display: 'flex', gap: 20, alignItems: 'flex-end', marginBottom: 14 }}
+          >
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label htmlFor="pf-priority" style={{ whiteSpace: 'nowrap' }}>
+                Priority{' '}
+                <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+                  higher wins on ties
+                </span>
+              </label>
+              <input
+                id="pf-priority"
+                type="text"
+                inputMode="numeric"
+                style={{ width: 96, display: 'block' }}
+                value={String(form.priority)}
+                disabled={busy}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    priority: parseInt(e.target.value, 10) || 0,
+                  }))
+                }
+              />
+            </div>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label>Status</label>
+              <Switch
+                on={form.enabled}
+                disabled={busy}
+                onToggle={() => setForm((f) => ({ ...f, enabled: !f.enabled }))}
+              />
+            </div>
+          </div>
+
+          <div className="preview" data-testid="policy-preview">
+            <div className="pv-label">This policy</div>
+            <span>
+              <b>
+                {form.server.trim() || '—'} · {previewTool}
+              </b>{' '}
+              —{' '}
+              <span
+                dangerouslySetInnerHTML={{ __html: conditionSentence(currentExpr()) }}
+              />{' '}
+              → pause to confirm
+            </span>
+          </div>
+        </div>
+        <div className="wiz-foot">
+          {err ? (
+            <span className="wiz-err" role="alert">
+              {err}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span style={{ display: 'inline-flex', gap: 8 }}>
+            <button className="btn-ghost" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+            <button className="btn-primary" disabled={busy} onClick={() => void submit()}>
+              {busy
+                ? isEdit
+                  ? 'Saving…'
+                  : 'Creating…'
+                : isEdit
+                  ? 'Save changes'
+                  : 'Create policy'}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Part H of the React SPA — HITL tool-approval policy CRUD, transcribed from the shipped Lit implementation (`approval-policies-page.ts` + `approval-policy-dialog.ts` + `condition-form.ts`) per the behavior-parity rule.

## List (`features/settings/approval-policies/`)
- Cards in **server evaluation order** (priority desc, `created_at` desc on ties) — reading top-to-bottom = reading the match-precedence chain.
- Priority badge (mono uppercase; ≥10 amber, 0 muted, else neutral), target line with the wildcard `(all tools)` suffix, condition sentence via `conditionSentence` + `→ pause to confirm` framing.
- **Always-visible enable switch**: optimistic flip, `PATCH {enabled}` behind, revert + toast on failure, per-id in-flight guard. A disabled card dims the body but the switch stays bright.
- Hover-revealed Edit / Duplicate / Delete.
- Evaluation-order hint hidden when the list is empty; empty state carries the true behavior + CTA. Timeout copy says **5 minutes** — the Lit page documents the spec/design "20 minutes" as stale (`APPROVAL_TIMEOUT = 300_000ms`).

## Dialog (create / edit / duplicate share one component)
- Server/tool are **comboboxes** (input + datalist): unconfigured names may be typed (policies can pre-date server registration). Tool options = `*` + the typed server's `tool_reversibility` keys, from the **same `['mcp-servers']` query Part D owns**; server change resets tool to `*`.
- Condition builder: `Every time | Only when…` seg, `All (AND) / Any (OR)` combiner, field/op/value rows; fail-closed to `{always:true}` when no usable rows. Live preview re-renders per change through the same `conditionSentence` renderer as the cards.
- **Read-only fallback**: a stored expression too complex for the flat builder replaces the whole condition area (mode seg included — Lit parity; the prototype still shows the seg, which would be a lying no-op) with a notice + pretty-printed JSON. Edit-PATCH **omits `condition_expr` entirely**; duplicate-POST carries the source expression **verbatim** — never silently flatten a nested condition.
- **Duplicate seeds ALL fields from the source, `enabled` included** (Lit `seedForm` parity; the spec's "duplicate starts disabled" note does not match the shipped behavior).
- Create/duplicate/edit splice into the cache, scroll to the card, and pulse it for 1.8s.

## Delete
Shared confirm with the three mandatory parts: restate the rule through the **same** sentence renderer, state the consequence, pre-empt the pending-approvals concern. Confirm label `Delete policy`.

## Pure module + shared primitives
- `condition-form.ts` copied **verbatim** from the Lit source with provenance header + its test suite (round-trips incl. the nested-refusal cases).
- `components/switch.tsx` — new labelled toggle primitive; first two consumers are the card toggle and the dialog's Status field (≥2-consumers rule). CSS in `ui.css`.
- **Cross-cutting fix**: grown settings routes now go through a `Gated` wrapper (spec §8: direct navigation to a denied route renders the access-denied page) — previously only the generic `/manage/:slug` stub route checked capabilities; `mcp-servers` and `credentials` gained the same gate.

## API client
`listApprovalPolicies` (page envelope, limit=200) / `createApprovalPolicy` / `updateApprovalPolicy` / `deleteApprovalPolicy` at `/api/v1/approvals/policies` (the contract path; spec H.1's "/approval-policies" wording is loose) + the `ApprovalPolicy` types.

## Verification
- **49 new tests, 207 total green** — condition-form port + sentence/formatValue additions; card badges/dim/switch/actions; dialog seg/rows/readonly/duplicate-enabled-parity/datalist/save-gate; page sort/hint/empty/delete-confirm/optimistic-revert.
- `tsc`, the three lint scripts, `openapi:check`, and `build` all clean.
- Mock-backend Playwright E2E (25 assertions): evaluation order, badges, dim, toggle round-trip, tool datalist from reversibility keys, live preview, create+flash, duplicate enabled parity, nested read-only pass-through (PATCH omits the expr), three-part delete confirm.

## Spec corrections recorded (source wins per the behavior-parity rule)
1. H.3 "duplicate → `enabled=false`" — Lit copies the source's `enabled`; implemented as Lit.
2. H.1 "malformed expr → 422" — the wire says 400; client surfaces whatever the server returns.
3. H.2 "20-minute timeout" copy — Lit corrects to 5 minutes (`APPROVAL_TIMEOUT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_