### PR TITLE
Safety rules page (Part I)

### DIFF
--- a/web-react/package-lock.json
+++ b/web-react/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
+        "ajv": "^8.20.0",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.560.0",
         "react": "^19.2.7",
@@ -909,6 +910,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -1535,7 +1552,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -1567,6 +1583,22 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -1954,7 +1986,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -3788,7 +3819,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/web-react/package.json
+++ b/web-react/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "engines": { "node": ">=22.12" },
+  "engines": {
+    "node": ">=22.12"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
@@ -18,6 +20,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
+    "ajv": "^8.20.0",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.560.0",
     "react": "^19.2.7",

--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -36,6 +36,13 @@ export type ConditionExpr = components['schemas']['ConditionExpr'];
 export type ApprovalPolicy = components['schemas']['ApprovalPolicy'];
 export type ApprovalPolicyCreate = components['schemas']['ApprovalPolicyCreate'];
 export type ApprovalPolicyUpdate = components['schemas']['ApprovalPolicyUpdate'];
+export type SafetyRule = components['schemas']['SafetyRule'];
+export type SafetyRuleCreate = components['schemas']['SafetyRuleCreate'];
+export type SafetyRuleUpdate = components['schemas']['SafetyRuleUpdate'];
+export type SafetyRuleAuditEntry = components['schemas']['SafetyRuleAuditEntry'];
+export type SafetyCheck = components['schemas']['SafetyCheck'];
+export type SafetyStage = components['schemas']['SafetyStage'];
+export type SafetyVerdictAction = components['schemas']['SafetyVerdictAction'];
 export type MCPServer = components['schemas']['MCPServer'];
 export type MCPServerCreate = components['schemas']['MCPServerCreate'];
 export type MCPServerUpdate = components['schemas']['MCPServerUpdate'];
@@ -296,6 +303,70 @@ export class ApiClient {
       { method: 'DELETE', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  // ------------------------------------------------------------------
+  // Safety rules (Part I). Method names identical to the Lit client.
+  // ------------------------------------------------------------------
+
+  /** Tenant rules + visible platform-owned rules (source=platform). */
+  async listSafetyRules(): Promise<SafetyRule[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/safety/rules?limit=200`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return ((await resp.json()) as components['schemas']['SafetyRulePage']).items;
+  }
+
+  async createSafetyRule(body: SafetyRuleCreate): Promise<SafetyRule> {
+    const resp = await this.fetchJson(
+      'POST',
+      `${this.baseUrl}/api/v1/safety/rules`,
+      body,
+    );
+    return (await resp.json()) as SafetyRule;
+  }
+
+  /** PATCH. Scope is immutable — SafetyRuleUpdate has no coworker_id
+   *  field; the sanctioned scope-change path is Duplicate. */
+  async updateSafetyRule(id: string, body: SafetyRuleUpdate): Promise<SafetyRule> {
+    const resp = await this.fetchJson(
+      'PATCH',
+      `${this.baseUrl}/api/v1/safety/rules/${encodeURIComponent(id)}`,
+      body,
+    );
+    return (await resp.json()) as SafetyRule;
+  }
+
+  async deleteSafetyRule(id: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/safety/rules/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  /** Newest-first change history for one rule (404 on unknown id —
+   *  RLS-safe existence semantics). */
+  async listSafetyRuleAudit(id: string): Promise<SafetyRuleAuditEntry[]> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/safety/rules/${encodeURIComponent(id)}/audit?limit=200`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return ((await resp.json()) as components['schemas']['SafetyRuleAuditPage'])
+      .items;
+  }
+
+  /** Registered check catalog (rule-editor metadata; stable order). */
+  async listSafetyChecks(): Promise<SafetyCheck[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/safety/checks`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as SafetyCheck[];
   }
 
   /** Upsert (create OR rotate) the credential for one provider.

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -79,6 +79,26 @@ export function useApprovalPolicies() {
   });
 }
 
+// ---- Safety rules page (Part I) ----
+
+/** Tenant + visible platform rules. Page-owned list — surfaces errors. */
+export function useSafetyRules() {
+  return useQuery({
+    queryKey: ['safety-rules'],
+    queryFn: () => getApiClient().listSafetyRules(),
+  });
+}
+
+/** Registered check catalog (behaviour metadata for the rule editor).
+ *  Near-static — cache aggressively. */
+export function useSafetyChecks() {
+  return useQuery({
+    queryKey: ['safety-checks'],
+    queryFn: () => getApiClient().listSafetyChecks(),
+    staleTime: 5 * 60_000,
+  });
+}
+
 // ---- MCP server registry page (Part D) ----
 
 /** The registry list (its own key — the wizard's catalogue hook above

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -72,6 +72,12 @@ const ApprovalPoliciesPage = lazy(() =>
   ),
 );
 
+const SafetyRulesPage = lazy(() =>
+  import('../features/settings/safety-rules/safety-rules-page').then((m) => ({
+    default: m.SafetyRulesPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -127,6 +133,16 @@ export function AppRoutes() {
           <Suspense fallback={null}>
             <Gated slug="approval-policies">
               <ApprovalPoliciesPage />
+            </Gated>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/safety/*"
+        element={
+          <Suspense fallback={null}>
+            <Gated slug="safety">
+              <SafetyRulesPage />
             </Gated>
           </Suspense>
         }

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -619,3 +619,111 @@
 .switch.on .track::after {
   left: 16px;
 }
+
+/* Priority badge — evaluation-order lists (approval policies + safety
+ * rules). Tint scale via lib/rule-ordering priorityBadgeClass. */
+.pol-pri {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 2px;
+  white-space: nowrap;
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+}
+.pol-pri--hi {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.pol-pri--zero {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+
+/* Evaluation-order rule card family + list hint + dialog live preview —
+ * shared by the approval-policies and safety-rules pages. */
+.pol-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  max-width: 760px;
+}
+.pol-card .body {
+  flex: 1;
+  min-width: 0;
+}
+.pol-card.off .body {
+  opacity: 0.55;
+}
+/* .pol-pri badge family hoisted to components/ui.css (shared with
+ * the safety-rules page). */
+.pol-card .target {
+  font-weight: 700;
+  font-size: 0.9375rem;
+}
+.pol-card .target .all {
+  font-weight: 400;
+  color: var(--rm-text-muted);
+}
+.pol-card .sentence {
+  font-size: 0.875rem;
+  color: var(--rm-text);
+  margin-top: 2px;
+}
+.pol-card .sentence b {
+  font-weight: 700;
+}
+.pol-card .cardacts {
+  display: inline-flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.pol-card:hover .cardacts,
+.pol-card:focus-within .cardacts {
+  opacity: 1;
+}
+@keyframes apprHighlight {
+  0% {
+    outline: 2px solid var(--rm-action);
+    outline-offset: -1px;
+  }
+  100% {
+    outline: 2px solid transparent;
+  }
+}
+.pol-card.flash {
+  animation: apprHighlight 1.8s ease-out;
+}
+.page-hint {
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  border-top: 1px solid var(--rm-border);
+  padding: 10px 2px;
+  max-width: 760px;
+}
+/* live preview */
+.preview {
+  border: 1px solid var(--rm-border);
+  border-left: 3px solid var(--rm-action);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  padding: 10px 12px;
+  font-size: 0.875rem;
+  margin-top: 4px;
+}
+.preview .pv-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--rm-text-muted);
+  font-weight: 700;
+  margin-bottom: 4px;
+}

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -541,7 +541,9 @@
 
 /* Read-only resource row — shared by the models catalog (provider
  * groups) and the credentials page (fixed provider rows). Page-specific
- * chrome (models .prov-group, cred status text) stays in each page CSS. */
+ * chrome (models .prov-group, cred status text) stays in each page CSS.
+ * Width unified at 760px with the .pol-card rule family (D-UI1 — the
+ * v7/v8 prototypes said 640; one cap for every row-list page). */
 .model-row {
   display: flex;
   align-items: center;
@@ -551,7 +553,7 @@
   background: var(--rm-card-bg);
   padding: 10px 14px;
   margin-bottom: 8px;
-  max-width: 640px;
+  max-width: 760px;
 }
 .model-row.dim {
   opacity: 0.45;

--- a/web-react/src/features/settings/approval-policies/approval-policies-page.tsx
+++ b/web-react/src/features/settings/approval-policies/approval-policies-page.tsx
@@ -24,6 +24,7 @@ import {
   type ApprovalPolicy,
 } from '../../../api/client';
 import { useApprovalPolicies } from '../../../api/queries';
+import { sortByEvaluationOrder } from '../../../lib/rule-ordering';
 import { BrandMark } from '../../../components/brand-mark';
 import { ConfirmDialog } from '../../../components/confirm-dialog';
 import { conditionSentence } from './condition-form';
@@ -31,15 +32,9 @@ import { PolicyCard } from './policy-card';
 import { PolicyDialog } from './policy-dialog';
 import './approval-policies.css';
 
-/** List order = server evaluation order (spec §5.5): priority desc, then
- *  the newest rule first on ties. created_at is ISO-8601 from the API. */
-export function sortPolicies(rows: ApprovalPolicy[]): ApprovalPolicy[] {
-  return [...rows].sort(
-    (a, b) =>
-      b.priority - a.priority ||
-      Date.parse(b.created_at) - Date.parse(a.created_at),
-  );
-}
+/** List order = server evaluation order (spec §5.5) — the shared
+ *  lib/rule-ordering sort, re-exported for this page's tests. */
+export const sortPolicies = sortByEvaluationOrder<ApprovalPolicy>;
 
 function errText(err: unknown): string {
   if (err instanceof ApiError) return err.body?.message ?? `HTTP ${err.status}`;

--- a/web-react/src/features/settings/approval-policies/approval-policies.css
+++ b/web-react/src/features/settings/approval-policies/approval-policies.css
@@ -1,90 +1,9 @@
-/* Approval policies page (spec Part H). Shared primitives (page chrome,
- * buttons, dialog family, switch, toast) live in components/ui.css; this
- * file owns the policy card, priority badge, evaluation-order hint,
- * condition builder, and the dialog's live preview. */
+/* Approval policies page (spec Part H). Shared primitives — page
+ * chrome, buttons, dialog family, switch, toast, the .pol-card rule
+ * family, priority badges, .page-hint, and the .preview box — live in
+ * components/ui.css (shared with the safety-rules page). This file owns
+ * only the condition builder. */
 
-.pol-card {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  border: 1px solid var(--rm-border);
-  border-radius: 4px;
-  background: var(--rm-card-bg);
-  padding: 12px 14px;
-  margin-bottom: 8px;
-  max-width: 760px;
-}
-.pol-card .body {
-  flex: 1;
-  min-width: 0;
-}
-.pol-card.off .body {
-  opacity: 0.55;
-}
-.pol-pri {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  padding: 3px 8px;
-  border-radius: 2px;
-  white-space: nowrap;
-  background: var(--rm-info-bg);
-  color: var(--rm-info-text);
-}
-.pol-pri--hi {
-  background: var(--rm-warn-bg);
-  color: var(--rm-warn-text);
-}
-.pol-pri--zero {
-  background: var(--rm-border);
-  color: var(--rm-text-muted);
-}
-.pol-card .target {
-  font-weight: 700;
-  font-size: 0.9375rem;
-}
-.pol-card .target .all {
-  font-weight: 400;
-  color: var(--rm-text-muted);
-}
-.pol-card .sentence {
-  font-size: 0.875rem;
-  color: var(--rm-text);
-  margin-top: 2px;
-}
-.pol-card .sentence b {
-  font-weight: 700;
-}
-.pol-card .cardacts {
-  display: inline-flex;
-  gap: 2px;
-  opacity: 0;
-  transition: opacity 0.12s;
-}
-.pol-card:hover .cardacts,
-.pol-card:focus-within .cardacts {
-  opacity: 1;
-}
-.page-hint {
-  font-size: 0.8125rem;
-  color: var(--rm-text-muted);
-  border-top: 1px solid var(--rm-border);
-  padding: 10px 2px;
-  max-width: 760px;
-}
-@keyframes apprHighlight {
-  0% {
-    outline: 2px solid var(--rm-action);
-    outline-offset: -1px;
-  }
-  100% {
-    outline: 2px solid transparent;
-  }
-}
-.pol-card.flash {
-  animation: apprHighlight 1.8s ease-out;
-}
 
 /* condition builder */
 .seg {
@@ -149,21 +68,3 @@
   margin: 0;
 }
 
-/* live preview */
-.preview {
-  border: 1px solid var(--rm-border);
-  border-left: 3px solid var(--rm-action);
-  border-radius: 4px;
-  background: var(--rm-card-bg);
-  padding: 10px 12px;
-  font-size: 0.875rem;
-  margin-top: 4px;
-}
-.preview .pv-label {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--rm-text-muted);
-  font-weight: 700;
-  margin-bottom: 4px;
-}

--- a/web-react/src/features/settings/approval-policies/policy-card.test.tsx
+++ b/web-react/src/features/settings/approval-policies/policy-card.test.tsx
@@ -2,7 +2,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ApprovalPolicy } from '../../../api/client';
-import { PolicyCard, priorityBadgeClass } from './policy-card';
+import { priorityBadgeClass } from '../../../lib/rule-ordering';
+import { PolicyCard } from './policy-card';
 
 function policy(over: Partial<ApprovalPolicy> = {}): ApprovalPolicy {
   return {

--- a/web-react/src/features/settings/approval-policies/policy-card.tsx
+++ b/web-react/src/features/settings/approval-policies/policy-card.tsx
@@ -8,15 +8,8 @@
 import { Copy, Pencil, Trash2 } from 'lucide-react';
 import type { ApprovalPolicy } from '../../../api/client';
 import { Switch } from '../../../components/switch';
+import { priorityBadgeClass } from '../../../lib/rule-ordering';
 import { conditionSentence } from './condition-form';
-
-/** Badge tint class for a priority value (Appendix C.3): amber when ≥10,
- *  muted when exactly 0, neutral otherwise. */
-export function priorityBadgeClass(priority: number): string {
-  if (priority >= 10) return ' pol-pri--hi';
-  if (priority === 0) return ' pol-pri--zero';
-  return '';
-}
 
 export function PolicyCard({
   policy,

--- a/web-react/src/features/settings/credentials/credentials.css
+++ b/web-react/src/features/settings/credentials/credentials.css
@@ -4,13 +4,13 @@
  * models catalog's model_id line). */
 
 .cred-row {
-  max-width: 640px;
+  max-width: 760px;
 }
 .cred-sub {
   /* status line is prose, not the monospace model_id of the models page */
   font-family: var(--font-base);
 }
 .cred-err {
-  max-width: 640px;
+  max-width: 760px;
   margin: -4px 0 8px;
 }

--- a/web-react/src/features/settings/safety-rules/action-panel.tsx
+++ b/web-react/src/features/settings/safety-rules/action-panel.tsx
@@ -1,0 +1,78 @@
+// ActionPanel — editor experience 1 (fixed checks, spec §6.11.1): a
+// plain-language default line + the five-action segmented control in
+// stable ladder order. The natural action is dot-marked; unsupported /
+// non-overridable actions are disabled + line-through with a reason
+// tooltip. Experiences 2/3 remove the field entirely — the dialog never
+// mounts this for them.
+
+import type { SafetyCheck, SafetyStage, SafetyVerdictAction } from '../../../api/client';
+import {
+  SAF_ACTION_LABEL,
+  SAF_ACTION_ORDER,
+  SAF_ACTION_SUB,
+  actionButtonState,
+  naturalAction,
+} from './safety-catalog';
+
+export function ActionPanel({
+  check,
+  stage,
+  pickedAction,
+  busy,
+  onPick,
+}: {
+  check: SafetyCheck | null;
+  stage: SafetyStage;
+  /** Override; null ⇒ the natural action is in effect. */
+  pickedAction: SafetyVerdictAction | null;
+  busy: boolean;
+  /** null when the user picked the natural action (no override written). */
+  onPick: (action: SafetyVerdictAction | null) => void;
+}) {
+  const natural = naturalAction(check, stage);
+  const current = pickedAction ?? natural;
+  const naturalLabel = natural ? SAF_ACTION_LABEL[natural].toLowerCase() : 'act on';
+  return (
+    <div className="field" data-testid="saf-action-field">
+      <label>When it triggers, do this</label>
+      <div className="hint" style={{ marginBottom: 6 }}>
+        By default, this check <b>{naturalLabel}s</b> anything it finds. You can
+        change the action below.
+      </div>
+      <div className="actseg" role="group">
+        {SAF_ACTION_ORDER.map((a) => {
+          const st = actionButtonState(check, stage, a, natural);
+          const on = a === current && st.enabled;
+          return (
+            <button
+              key={a}
+              type="button"
+              className={on ? 'on' : ''}
+              disabled={!st.enabled || busy}
+              title={st.enabled ? undefined : st.reason}
+              onClick={() => onPick(a === natural ? null : a)}
+            >
+              {SAF_ACTION_LABEL[a]}
+              {a === natural ? <span className="dot" title="Default for this check" /> : null}
+              <span className="sub">{SAF_ACTION_SUB[a]}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div className="hint" style={{ marginTop: 6 }}>
+        <span
+          className="dot"
+          style={{
+            display: 'inline-block',
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: 'var(--rm-text-muted)',
+            marginRight: 5,
+          }}
+        />
+        = the default. Pick something else to override.
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-rules/audit-drawer.tsx
+++ b/web-react/src/features/settings/safety-rules/audit-drawer.tsx
@@ -1,0 +1,123 @@
+// AuditDrawer — per-rule change history (spec I.4; behavioral reference
+// web/src/components/safety-rules-page.ts renderAuditDrawer). Available
+// on platform cards too — orgs can see when defaults changed. Entries
+// reverse-chronological: [VERB] by {actor} {date} + a client-diffed
+// summary (audit-summary.ts — the wire ships state snapshots, no server
+// summary string). Actor is the wire's actor_user_id (or "the system");
+// the prototype's friendly names are mock sugar we don't invent.
+
+import { useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  getApiClient,
+  type SafetyRule,
+  type SafetyRuleAuditEntry,
+} from '../../../api/client';
+import { BrandMark } from '../../../components/brand-mark';
+import { auditSummary } from './audit-summary';
+import { checkLabel } from './safety-catalog';
+
+export function AuditDrawer({
+  rule,
+  onClose,
+}: {
+  rule: SafetyRule;
+  onClose: () => void;
+}) {
+  const [entries, setEntries] = useState<SafetyRuleAuditEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setErr(null);
+    getApiClient()
+      .listSafetyRuleAudit(rule.id)
+      .then((rows) => {
+        if (!alive) return;
+        // Reverse-chronological (§6.9) — belt-and-braces re-sort.
+        setEntries(
+          [...rows].sort(
+            (a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),
+          ),
+        );
+      })
+      .catch((e) => {
+        if (alive) setErr((e as Error).message ?? 'failed to load history');
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [rule.id]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [onClose]);
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="dlg"
+        style={{ width: 520 }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Rule history"
+      >
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">Change history — {checkLabel(rule.check_id)}</h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body" style={{ minHeight: 0 }}>
+          {loading ? (
+            <div className="hint">Loading…</div>
+          ) : err ? (
+            <div className="row-error">{err}</div>
+          ) : entries.length === 0 ? (
+            <div className="hint">No change history yet.</div>
+          ) : (
+            entries.map((e) => (
+              <div className="audit-row" key={e.id}>
+                <span className={`audit-verb audit-verb--${e.action}`}>
+                  {e.action.toUpperCase()}
+                </span>
+                <span style={{ minWidth: 0 }}>
+                  <span className="who">by {e.actor_user_id ?? 'the system'}</span>
+                  <div className="diff">{auditSummary(e)}</div>
+                </span>
+                <span className="when">{new Date(e.created_at).toLocaleString()}</span>
+              </div>
+            ))
+          )}
+        </div>
+        <div className="wiz-foot">
+          <span />
+          <button className="btn-ghost" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-rules/audit-summary.ts
+++ b/web-react/src/features/settings/safety-rules/audit-summary.ts
@@ -1,0 +1,40 @@
+// Ported from web/src/components/safety-rules-page.ts auditSummary @
+// feat/webui-react. Human one-line summary of an audit entry (§6.9).
+// The wire ships before_state / after_state snapshots — there is NO
+// server-provided summary field (the v10 spec's I.4 claim is inverted;
+// the Lit source documents the actual contract) — so we diff the fields
+// an operator cares about. Kept deliberately small + deterministic.
+
+import type { SafetyRuleAuditEntry } from '../../../api/client';
+import { checkLabel } from './safety-catalog';
+
+export function auditSummary(entry: SafetyRuleAuditEntry): string {
+  if (entry.action === 'created') {
+    const a = entry.after_state ?? {};
+    const check = checkLabel(String(a['check_id'] ?? ''));
+    return `Created — ${check}${a['stage'] ? `, ${String(a['stage'])}` : ''}`;
+  }
+  if (entry.action === 'deleted') return 'Deleted';
+  const before = entry.before_state ?? {};
+  const after = entry.after_state ?? {};
+  const fields = ['priority', 'enabled', 'stage'];
+  const parts: string[] = [];
+  for (const f of fields) {
+    if (JSON.stringify(before[f]) !== JSON.stringify(after[f])) {
+      parts.push(`${f}: ${fmtVal(before[f])} → ${fmtVal(after[f])}`);
+    }
+  }
+  // action_override lives inside config; surface it specifically.
+  const bOv = (before['config'] as Record<string, unknown> | undefined)?.['action_override'];
+  const aOv = (after['config'] as Record<string, unknown> | undefined)?.['action_override'];
+  if (JSON.stringify(bOv) !== JSON.stringify(aOv)) {
+    parts.push(`action: ${fmtVal(bOv ?? 'default')} → ${fmtVal(aOv ?? 'default')}`);
+  }
+  return parts.length ? parts.join('; ') : 'Configuration updated';
+}
+
+function fmtVal(v: unknown): string {
+  if (v === true) return 'on';
+  if (v === false) return 'off';
+  return String(v);
+}

--- a/web-react/src/features/settings/safety-rules/config-convert.test.ts
+++ b/web-react/src/features/settings/safety-rules/config-convert.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import type { SafetyCheck } from '../../../api/client';
+import {
+  buildBackendConfig,
+  getSchemaEnum,
+  normalizeConfigFromBackend,
+  normalizeDomainLine,
+  parseBackend400,
+  sanityCheck,
+  validateBeforeSave,
+} from './config-convert';
+
+function check(over: Partial<SafetyCheck> & Pick<SafetyCheck, 'id'>): SafetyCheck {
+  return {
+    version: '1',
+    stages: [],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: {},
+    supported_actions: {},
+    supported_codes: [],
+    config_schema: null,
+    ...over,
+  } as SafetyCheck;
+}
+
+describe('config round-trip (wire ↔ internal)', () => {
+  it('pii.regex: patterns dict → _piiKeys and back', () => {
+    const cfg: Record<string, unknown> = {
+      patterns: { SSN: true, CREDIT_CARD: true, EMAIL: false },
+    };
+    normalizeConfigFromBackend('pii.regex', cfg);
+    expect(cfg['_piiKeys']).toEqual(['SSN', 'CREDIT_CARD']);
+    expect(cfg['patterns']).toBeUndefined();
+    const back = buildBackendConfig('pii.regex', cfg);
+    expect(back['patterns']).toEqual({ SSN: true, CREDIT_CARD: true });
+    expect(back['_piiKeys']).toBeUndefined();
+  });
+
+  it('presidio: block/redact codes → routing map + threshold and back', () => {
+    const cfg: Record<string, unknown> = {
+      block_codes: ['PII.SSN'],
+      redact_codes: ['PII.EMAIL'],
+      score_threshold: 0.55,
+      language: 'en',
+    };
+    normalizeConfigFromBackend('presidio.pii', cfg);
+    expect(cfg['routing']).toEqual({ 'PII.SSN': 'block', 'PII.EMAIL': 'redact' });
+    expect(cfg['threshold']).toBe(0.55);
+    expect(cfg['block_codes']).toBeUndefined();
+    const back = buildBackendConfig('presidio.pii', cfg);
+    expect(back['block_codes']).toEqual(['PII.SSN']);
+    expect(back['redact_codes']).toEqual(['PII.EMAIL']);
+    expect(back['score_threshold']).toBe(0.55);
+    expect(back['routing']).toBeUndefined();
+  });
+
+  it('moderation: block/warn categories → routing map and back', () => {
+    const cfg: Record<string, unknown> = {
+      block_categories: ['MODERATION.HATE'],
+      warn_categories: ['MODERATION.SEXUAL'],
+    };
+    normalizeConfigFromBackend('openai_moderation', cfg);
+    expect(cfg['routing']).toEqual({
+      'MODERATION.HATE': 'block',
+      'MODERATION.SEXUAL': 'warn',
+    });
+    const back = buildBackendConfig('openai_moderation', cfg);
+    expect(back['block_categories']).toEqual(['MODERATION.HATE']);
+    expect(back['warn_categories']).toEqual(['MODERATION.SEXUAL']);
+  });
+
+  it('leaves unknown checks untouched', () => {
+    const cfg: Record<string, unknown> = { phrases: ['x'] };
+    normalizeConfigFromBackend('llm_guard.jailbreak', cfg);
+    expect(cfg).toEqual({ phrases: ['x'] });
+    expect(buildBackendConfig('llm_guard.jailbreak', cfg)).toEqual({ phrases: ['x'] });
+  });
+});
+
+describe('normalizeDomainLine (Postel cleanup)', () => {
+  it('strips scheme + path, lowercases', () => {
+    expect(normalizeDomainLine('https://API.Stripe.com/v1/charges')).toBe(
+      'api.stripe.com',
+    );
+    expect(normalizeDomainLine('http://a.com/')).toBe('a.com');
+  });
+  it('keeps wildcards and bare hosts as-is', () => {
+    expect(normalizeDomainLine('*.acme.com')).toBe('*.acme.com');
+  });
+});
+
+describe('getSchemaEnum', () => {
+  it('reads array-item enums', () => {
+    const c = check({
+      id: 'presidio.pii',
+      config_schema: {
+        properties: {
+          block_codes: { items: { enum: ['PII.SSN', 'PII.EMAIL'] } },
+        },
+      },
+    });
+    expect(getSchemaEnum(c, 'block_codes', 'items')).toEqual(['PII.SSN', 'PII.EMAIL']);
+  });
+  it('reads propertyNames enums and falls back to [] when absent', () => {
+    const c = check({
+      id: 'pii.regex',
+      config_schema: {
+        properties: { patterns: { propertyNames: { enum: ['SSN'] } } },
+      },
+    });
+    expect(getSchemaEnum(c, 'patterns', 'propertyNames')).toEqual(['SSN']);
+    expect(getSchemaEnum(check({ id: 'x' }), 'patterns', 'propertyNames')).toEqual([]);
+    expect(getSchemaEnum(null, 'patterns', 'items')).toEqual([]);
+  });
+});
+
+describe('sanityCheck (schema-gated)', () => {
+  const schema = { type: 'object' };
+  it('flags empty pii.regex patterns / empty host lists', () => {
+    expect(
+      sanityCheck(check({ id: 'pii.regex', config_schema: schema }), { patterns: {} }),
+    ).toHaveLength(1);
+    expect(
+      sanityCheck(check({ id: 'domain_allowlist', config_schema: schema }), {
+        allowed_hosts: [],
+      }),
+    ).toHaveLength(1);
+    expect(
+      sanityCheck(check({ id: 'egress.domain_rule', config_schema: schema }), {}),
+    ).toHaveLength(1);
+  });
+  it('flags an inert presidio/moderation config', () => {
+    expect(
+      sanityCheck(check({ id: 'presidio.pii', config_schema: schema }), {
+        block_codes: [],
+        redact_codes: [],
+      }),
+    ).toHaveLength(1);
+  });
+  it('skips entirely when the check declares no config_schema', () => {
+    expect(sanityCheck(check({ id: 'pii.regex' }), { patterns: {} })).toEqual([]);
+  });
+});
+
+describe('validateBeforeSave — Ajv layer', () => {
+  it('surfaces a schema violation with the field path', () => {
+    const c = check({
+      id: 'llm_guard.toxicity',
+      config_schema: {
+        type: 'object',
+        properties: { threshold: { type: 'number', maximum: 1 } },
+      },
+    });
+    const errs = validateBeforeSave(c, { threshold: 2 });
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs[0].fieldId).toBe('threshold');
+  });
+  it('passes a valid config', () => {
+    const c = check({
+      id: 'llm_guard.toxicity',
+      config_schema: {
+        type: 'object',
+        properties: { threshold: { type: 'number', maximum: 1 } },
+      },
+    });
+    expect(validateBeforeSave(c, { threshold: 0.7 })).toEqual([]);
+  });
+});
+
+describe('parseBackend400', () => {
+  it('translates a FastAPI detail array to friendly messages', () => {
+    const errs = parseBackend400({
+      detail: [
+        { type: 'extra_forbidden', loc: ['body', 'config', 'bogus'], msg: 'extra' },
+        { type: 'missing', loc: ['body', 'check_id'], msg: 'required' },
+      ],
+    });
+    expect(errs).toHaveLength(2);
+    expect(errs[0].message).toMatch(/Unknown field 'config.bogus'/);
+    expect(errs[1].message).toMatch(/Required field 'check_id' is missing/);
+  });
+  it('returns [] for non-detail shapes', () => {
+    expect(parseBackend400({ message: 'nope' })).toEqual([]);
+    expect(parseBackend400(null)).toEqual([]);
+  });
+});

--- a/web-react/src/features/settings/safety-rules/config-convert.ts
+++ b/web-react/src/features/settings/safety-rules/config-convert.ts
@@ -1,0 +1,315 @@
+// Config format converters (backend ↔ internal display) + schema-enum
+// helpers + validation, ported from web/src/components/safety-rule-dialog.ts
+// @ feat/webui-react. Pure module so the wire round-trip is unit-testable.
+//
+// The wire stores per-check shapes (pii.regex `patterns` dict, presidio
+// `block_codes`/`redact_codes`/`score_threshold`, moderation
+// `block_categories`/`warn_categories`); the dialog edits a unified
+// internal shape (`_piiKeys` list, `routing` map, `threshold`). The v10
+// spec's I.6.3 "unified routing map" describes THIS internal form, not
+// the wire — safSentence deliberately handles both.
+
+import Ajv, { type ValidateFunction } from 'ajv';
+import type { SafetyCheck } from '../../../api/client';
+
+// ---- backend ↔ internal conversion ----
+
+/** Convert backend-stored config → internal UI format on load (in place). */
+export function normalizeConfigFromBackend(
+  checkId: string,
+  cfg: Record<string, unknown>,
+): void {
+  if (checkId === 'pii.regex') {
+    // Backend: { patterns: { SSN: true, CREDIT_CARD: true, ... } }
+    // Internal: selected backend keys as cfg['_piiKeys'] (string[])
+    const patterns = (cfg['patterns'] as Record<string, boolean> | undefined) ?? {};
+    cfg['_piiKeys'] = Object.keys(patterns).filter((k) => patterns[k]);
+    delete cfg['patterns'];
+  } else if (checkId === 'presidio.pii') {
+    // Backend: { block_codes: [...], redact_codes: [...], score_threshold: 0.4 }
+    // Internal: { routing: { CODE: 'block'|'redact' }, threshold: 0.4 }
+    const blockCodes = (cfg['block_codes'] as string[]) ?? [];
+    const redactCodes = (cfg['redact_codes'] as string[]) ?? [];
+    const routing: Record<string, string> = {};
+    for (const c of blockCodes) routing[c] = 'block';
+    for (const c of redactCodes) routing[c] = 'redact';
+    cfg['routing'] = routing;
+    cfg['threshold'] = cfg['score_threshold'] ?? 0.4;
+    delete cfg['block_codes'];
+    delete cfg['redact_codes'];
+    delete cfg['score_threshold'];
+    delete cfg['language'];
+  } else if (checkId === 'openai_moderation') {
+    // Backend: { block_categories: [...], warn_categories: [...] }
+    // Internal: { routing: { category: 'block'|'warn' } }
+    const blockCats = (cfg['block_categories'] as string[]) ?? [];
+    const warnCats = (cfg['warn_categories'] as string[]) ?? [];
+    const routing: Record<string, string> = {};
+    for (const c of blockCats) routing[c] = 'block';
+    for (const c of warnCats) routing[c] = 'warn';
+    cfg['routing'] = routing;
+    delete cfg['block_categories'];
+    delete cfg['warn_categories'];
+  }
+  // secret_scanner: backend only has action_override — no conversion.
+}
+
+/** Convert internal UI format → backend config on save. */
+export function buildBackendConfig(
+  checkId: string,
+  cfg: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...cfg };
+  if (checkId === 'pii.regex') {
+    const keys = (out['_piiKeys'] as string[]) ?? [];
+    delete out['_piiKeys'];
+    const patterns: Record<string, boolean> = {};
+    for (const k of keys) patterns[k] = true;
+    out['patterns'] = patterns;
+  } else if (checkId === 'presidio.pii') {
+    const routing = (out['routing'] as Record<string, string>) ?? {};
+    delete out['routing'];
+    const threshold = out['threshold'];
+    delete out['threshold'];
+    out['block_codes'] = Object.entries(routing)
+      .filter(([, a]) => a === 'block')
+      .map(([c]) => c);
+    out['redact_codes'] = Object.entries(routing)
+      .filter(([, a]) => a === 'redact')
+      .map(([c]) => c);
+    out['score_threshold'] = threshold ?? 0.4;
+  } else if (checkId === 'openai_moderation') {
+    const routing = (out['routing'] as Record<string, string>) ?? {};
+    delete out['routing'];
+    out['block_categories'] = Object.entries(routing)
+      .filter(([, a]) => a === 'block')
+      .map(([c]) => c);
+    out['warn_categories'] = Object.entries(routing)
+      .filter(([, a]) => a === 'warn')
+      .map(([c]) => c);
+  }
+  return out;
+}
+
+// ---- G7: schema-driven enum rendering (spec §6.12.5) ----
+
+// Human-readable labels for known enum values. Unknown values fall
+// through to raw-value display (reverse-drift property: backend adds a
+// new enum → frontend renders it immediately with the raw code).
+const ENUM_LABELS: Record<string, string> = {
+  // pii.regex pattern keys (uppercase, from _CONFIG_KEY_TO_CODE)
+  SSN: 'US Social Security numbers',
+  CREDIT_CARD: 'Credit card numbers',
+  EMAIL: 'Email addresses',
+  PHONE_US: 'Phone numbers (US)',
+  IP_ADDRESS: 'IP addresses',
+  // presidio.pii stable codes (PresidioPIICode enum)
+  'PII.SSN': 'US Social Security numbers',
+  'PII.CREDIT_CARD': 'Credit card numbers',
+  'PII.EMAIL': 'Email addresses',
+  'PII.PHONE': 'Phone numbers',
+  'PII.IP_ADDRESS': 'IP addresses',
+  'PII.PERSON_NAME': "People's names",
+  'PII.LOCATION': 'Locations',
+  'PII.DATE_TIME': 'Dates and times',
+  'PII.URL': 'URLs',
+  'PII.IBAN': 'IBAN bank account numbers',
+  'PII.US_BANK_NUMBER': 'US bank account numbers',
+  'PII.US_DRIVER_LICENSE': 'US driver license numbers',
+  'PII.US_PASSPORT': 'US passport numbers',
+  'PII.MEDICAL_LICENSE': 'Medical license numbers',
+  // openai_moderation stable codes (ModerationCode enum)
+  'MODERATION.HARASSMENT': 'Harassment',
+  'MODERATION.HATE': 'Hate speech',
+  'MODERATION.VIOLENCE': 'Violence',
+  'MODERATION.SEXUAL': 'Sexual content',
+  'MODERATION.SELF_HARM': 'Self-harm',
+  'MODERATION.ILLICIT': 'Illicit content',
+};
+
+export function enumLabel(v: string): string {
+  return ENUM_LABELS[v] ?? v;
+}
+
+/** Read enum values from a check's config_schema field. `kind` is
+ *  'items' for array-item enums or 'propertyNames' for dict-key enums.
+ *  [] when absent — caller falls back to the hardcoded lists. */
+export function getSchemaEnum(
+  check: SafetyCheck | null,
+  fieldPath: string,
+  kind: 'items' | 'propertyNames',
+): string[] {
+  const schema = check?.config_schema as Record<string, unknown> | null | undefined;
+  if (!schema || typeof schema !== 'object') return [];
+  const props = (schema['properties'] as Record<string, unknown> | undefined) ?? {};
+  const field = props[fieldPath] as Record<string, unknown> | undefined;
+  if (!field) return [];
+  const node = (field[kind] as Record<string, unknown> | undefined) ?? {};
+  return Array.isArray(node['enum']) ? (node['enum'] as string[]) : [];
+}
+
+// Fallback entity lists for when config_schema is absent. Backend stable
+// codes, NOT library entity names (verified against PresidioPIICode /
+// ModerationCode enums).
+export const PII_REGEX_FALLBACK: string[] = [
+  'SSN', 'CREDIT_CARD', 'EMAIL', 'PHONE_US', 'IP_ADDRESS',
+];
+export const PRESIDIO_FALLBACK: string[] = [
+  'PII.SSN', 'PII.CREDIT_CARD', 'PII.EMAIL', 'PII.PHONE', 'PII.IP_ADDRESS',
+  'PII.PERSON_NAME', 'PII.LOCATION', 'PII.DATE_TIME', 'PII.URL',
+  'PII.IBAN', 'PII.US_BANK_NUMBER', 'PII.US_DRIVER_LICENSE',
+  'PII.US_PASSPORT', 'PII.MEDICAL_LICENSE',
+];
+export const MODERATION_FALLBACK: string[] = [
+  'MODERATION.HARASSMENT', 'MODERATION.HATE', 'MODERATION.VIOLENCE',
+  'MODERATION.SEXUAL', 'MODERATION.SELF_HARM', 'MODERATION.ILLICIT',
+];
+
+// ---- G4: client-side validation (§6.12.3 / §6.18) ----
+
+export interface SaveError {
+  fieldId?: string;
+  message: string;
+}
+
+// Module-level Ajv + compiled-validator cache (compiled once per schema).
+const _ajv = new Ajv({ allErrors: true, strict: false });
+const _schemaValidators = new Map<string, ValidateFunction>();
+
+function getSchemaValidator(check: SafetyCheck): ValidateFunction | null {
+  const schema = check.config_schema as Record<string, unknown> | null | undefined;
+  if (!schema || typeof schema !== 'object') return null;
+  let v = _schemaValidators.get(check.id);
+  if (!v) {
+    v = _ajv.compile(schema);
+    _schemaValidators.set(check.id, v);
+  }
+  return v;
+}
+
+/** Layer 1a — Ajv validation against config_schema. */
+export function validateWithSchema(
+  check: SafetyCheck | null,
+  config: Record<string, unknown>,
+): SaveError[] {
+  if (!check) return [];
+  const validate = getSchemaValidator(check);
+  if (!validate) return [];
+  if (validate(config)) return [];
+  return (validate.errors ?? []).map((e) => {
+    const path = e.instancePath?.replace(/^\//, '') ?? '';
+    return { fieldId: path || undefined, message: e.message ?? 'Invalid value' };
+  });
+}
+
+/** Layer 1b — hand-coded sanity checks for constraints JSON Schema can't
+ *  express. Only runs when config_schema is present (without one the
+ *  backend hasn't declared a shape, so {} may be intentional). */
+export function sanityCheck(
+  check: SafetyCheck | null,
+  config: Record<string, unknown>,
+): SaveError[] {
+  if (!check?.config_schema) return [];
+  const errs: SaveError[] = [];
+  if (check.id === 'pii.regex') {
+    const patterns = config['patterns'] as Record<string, boolean> | undefined;
+    if (!patterns || Object.keys(patterns).length === 0) {
+      errs.push({
+        fieldId: 'saf-config',
+        message: 'Pick at least one type of personal data to look for.',
+      });
+    }
+  } else if (check.id === 'presidio.pii') {
+    const bc = (config['block_codes'] as string[]) ?? [];
+    const rc = (config['redact_codes'] as string[]) ?? [];
+    if (bc.length === 0 && rc.length === 0) {
+      errs.push({
+        fieldId: 'saf-config',
+        message: 'Set an action for at least one entity type.',
+      });
+    }
+  } else if (check.id === 'openai_moderation') {
+    const bl = (config['block_categories'] as string[]) ?? [];
+    const wl = (config['warn_categories'] as string[]) ?? [];
+    if (bl.length === 0 && wl.length === 0) {
+      errs.push({
+        fieldId: 'saf-config',
+        message: 'Set an action for at least one category.',
+      });
+    }
+  } else if (check.id === 'domain_allowlist') {
+    const hosts = (config['allowed_hosts'] as string[]) ?? [];
+    if (hosts.length === 0) {
+      errs.push({ fieldId: 'saf-hosts', message: 'Add at least one host.' });
+    }
+  } else if (check.id === 'egress.domain_rule') {
+    const patterns = (config['domain_patterns'] as string[]) ?? [];
+    if (patterns.length === 0) {
+      errs.push({ fieldId: 'saf-hosts', message: 'Add at least one domain pattern.' });
+    }
+  }
+  return errs;
+}
+
+/** Combined pre-save validation (Layer 1). */
+export function validateBeforeSave(
+  check: SafetyCheck | null,
+  config: Record<string, unknown>,
+): SaveError[] {
+  return [...validateWithSchema(check, config), ...sanityCheck(check, config)];
+}
+
+/** Layer 2 — translate a FastAPI 4xx `{ detail: [...] }` body into
+ *  friendly messages. Empty when the shape is unexpected. */
+export function parseBackend400(body: unknown): SaveError[] {
+  if (!body || typeof body !== 'object') return [];
+  const detail = (body as Record<string, unknown>)['detail'];
+  if (!Array.isArray(detail)) return [];
+  return detail
+    .filter((e): e is Record<string, unknown> => !!e && typeof e === 'object')
+    .map((e) => ({
+      fieldId: undefined,
+      message: translateFastApiError({
+        type: e['type'] as string | undefined,
+        loc: e['loc'] as unknown[] | undefined,
+        msg: e['msg'] as string | undefined,
+      }),
+    }));
+}
+
+function translateFastApiError(err: {
+  type?: string;
+  loc?: unknown[];
+  msg?: string;
+}): string {
+  const loc = Array.isArray(err.loc)
+    ? err.loc.filter((s) => s !== 'body').join('.')
+    : '';
+  const field = loc ? `(field: ${loc})` : '';
+  switch (err.type) {
+    case 'extra_forbidden':
+      return `Unknown field${loc ? ` '${loc}'` : ''} — this check doesn't accept that setting.`;
+    case 'missing':
+      return `Required field${loc ? ` '${loc}'` : ''} is missing.`;
+    case 'int_parsing':
+    case 'float_parsing':
+      return `Field${loc ? ` '${loc}'` : ''} must be a number.`;
+    case 'enum':
+      return `Field${loc ? ` '${loc}'` : ''} has an invalid value. ${err.msg ?? ''} ${field}`.trim();
+    default:
+      return err.msg
+        ? `${err.msg} ${field}`.trim()
+        : `The server rejected this field ${field}.`.trim();
+  }
+}
+
+/** Postel's-Law host normalizer: strip scheme + trailing path, lowercase.
+ *  Truly-invalid lines are left as-is so schema validation surfaces a
+ *  precise error rather than silently mangling them. */
+export function normalizeDomainLine(raw: string): string {
+  let s = raw.trim().toLowerCase();
+  s = s.replace(/^https?:\/\//, '');
+  const slash = s.indexOf('/');
+  if (slash !== -1) s = s.slice(0, slash);
+  return s;
+}

--- a/web-react/src/features/settings/safety-rules/config-forms.tsx
+++ b/web-react/src/features/settings/safety-rules/config-forms.tsx
@@ -1,0 +1,423 @@
+// Per-cfgKind config forms (spec §6.12 / I.3) — one module, one small
+// component per kind, all editing the dialog's INTERNAL config shape
+// (config-convert.ts translates wire ↔ internal on load/save):
+//   pii-entities      → checkbox grid over backend pattern keys
+//   secret-plugins    → info note (SecretScannerConfig has no options)
+//   threshold         → sensitivity slider
+//   host-list         → hosts textarea (+ optional Ports for egress)
+//   presidio-routing  → per-type routing table + confidence slider
+//   moderation-routing→ per-category routing table (block/warn only)
+
+import type { SafetyCheck, SafetyStage } from '../../../api/client';
+import {
+  MODERATION_FALLBACK,
+  PII_REGEX_FALLBACK,
+  PRESIDIO_FALLBACK,
+  enumLabel,
+  getSchemaEnum,
+  normalizeDomainLine,
+} from './config-convert';
+import { SAF_ACTION_LABEL, supportedActions } from './safety-catalog';
+
+export type Config = Record<string, unknown>;
+type OnChange = (next: Config) => void;
+
+export function ConfigForm({
+  check,
+  cfgKind,
+  stage,
+  config,
+  busy,
+  onChange,
+}: {
+  check: SafetyCheck;
+  cfgKind: string;
+  stage: SafetyStage;
+  config: Config;
+  busy: boolean;
+  onChange: OnChange;
+}) {
+  switch (cfgKind) {
+    case 'pii-entities':
+      return <PiiEntityGrid check={check} config={config} busy={busy} onChange={onChange} />;
+    case 'secret-plugins':
+      // Backend SecretScannerConfig has action_override only — an info
+      // note instead of a broken checkbox grid.
+      return (
+        <div className="hint">
+          This check runs all built-in secret detectors automatically. No
+          additional configuration is needed — use the action picker above to
+          choose what happens when a secret is found.
+        </div>
+      );
+    case 'threshold':
+      return (
+        <Threshold
+          label="How sensitive should the check be?"
+          fallback={0.7}
+          config={config}
+          busy={busy}
+          onChange={onChange}
+        />
+      );
+    case 'host-list':
+      return <HostList checkId={check.id} config={config} busy={busy} onChange={onChange} />;
+    case 'presidio-routing':
+      return (
+        <>
+          <RoutingTable
+            check={check}
+            stage={stage}
+            noun="type"
+            codes={
+              getSchemaEnum(check, 'block_codes', 'items').length
+                ? getSchemaEnum(check, 'block_codes', 'items')
+                : PRESIDIO_FALLBACK
+            }
+            excludeActions={['allow']}
+            config={config}
+            busy={busy}
+            onChange={onChange}
+          />
+          <Threshold
+            label="Confidence"
+            fallback={0.6}
+            config={config}
+            busy={busy}
+            onChange={onChange}
+          />
+        </>
+      );
+    case 'moderation-routing':
+      // Only block/warn are expressible per-category (the wire has no
+      // require_approval_categories field).
+      return (
+        <RoutingTable
+          check={check}
+          stage={stage}
+          noun="category"
+          codes={
+            getSchemaEnum(check, 'block_categories', 'items').length
+              ? getSchemaEnum(check, 'block_categories', 'items')
+              : MODERATION_FALLBACK
+          }
+          excludeActions={['allow', 'require_approval', 'redact']}
+          config={config}
+          busy={busy}
+          onChange={onChange}
+        />
+      );
+    case 'jailbreak-phrases':
+      return <JailbreakPhrases config={config} busy={busy} onChange={onChange} />;
+    default:
+      return null;
+  }
+}
+
+function PiiEntityGrid({
+  check,
+  config,
+  busy,
+  onChange,
+}: {
+  check: SafetyCheck;
+  config: Config;
+  busy: boolean;
+  onChange: OnChange;
+}) {
+  // G7: enum keys from config_schema; static fallback when absent.
+  const schemaKeys = getSchemaEnum(check, 'patterns', 'propertyNames');
+  const keys = schemaKeys.length ? schemaKeys : PII_REGEX_FALLBACK;
+  const selected = new Set((config['_piiKeys'] as string[]) ?? []);
+  return (
+    <div className="field" style={{ marginBottom: 0 }}>
+      <label>What to look for</label>
+      <div className="cfg-grid" data-testid="saf-pii-grid">
+        {keys.map((backendKey) => (
+          <label key={backendKey}>
+            <input
+              type="checkbox"
+              disabled={busy}
+              checked={selected.has(backendKey)}
+              onChange={(e) => {
+                const next = new Set(selected);
+                if (e.target.checked) next.add(backendKey);
+                else next.delete(backendKey);
+                onChange({ ...config, _piiKeys: [...next] });
+              }}
+            />
+            <span>
+              {enumLabel(backendKey)} <span className="code">{backendKey}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Threshold({
+  label,
+  fallback,
+  config,
+  busy,
+  onChange,
+}: {
+  label: string;
+  fallback: number;
+  config: Config;
+  busy: boolean;
+  onChange: OnChange;
+}) {
+  const value = (config['threshold'] as number) ?? fallback;
+  return (
+    <div className="field" style={{ marginBottom: 0, marginTop: 10 }}>
+      <label>{label}</label>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span className="hint" style={{ margin: 0, minWidth: 70 }}>
+          Sensitivity
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          data-testid="saf-threshold"
+          style={{ flex: 1 }}
+          disabled={busy}
+          value={value}
+          onChange={(e) =>
+            onChange({ ...config, threshold: parseFloat(e.target.value) })
+          }
+        />
+        <span style={{ fontSize: '0.8125rem', fontWeight: 700, minWidth: 34 }}>
+          {value}
+        </span>
+      </div>
+      <div
+        className="hint"
+        style={{ display: 'flex', justifyContent: 'space-between', marginTop: 2 }}
+      >
+        <span>stricter (catches more)</span>
+        <span>looser (catches less)</span>
+      </div>
+    </div>
+  );
+}
+
+function JailbreakPhrases({
+  config,
+  busy,
+  onChange,
+}: {
+  config: Config;
+  busy: boolean;
+  onChange: OnChange;
+}) {
+  const phrases = ((config['phrases'] as string[]) ?? []).join('\n');
+  const caseSensitive = (config['case_sensitive'] as boolean) ?? false;
+  return (
+    <div className="field" style={{ marginBottom: 0 }}>
+      <label>
+        Custom detection phrases{' '}
+        <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+          one per line · leave blank to use the built-in list
+        </span>
+      </label>
+      <textarea
+        className="mono"
+        style={{ minHeight: 72 }}
+        data-testid="saf-jailbreak-phrases"
+        placeholder={'ignore all previous instructions\npretend you have no restrictions'}
+        disabled={busy}
+        defaultValue={phrases}
+        onChange={(e) => {
+          const lines = e.target.value
+            .split('\n')
+            .map((s) => s.trim())
+            .filter(Boolean);
+          onChange({ ...config, phrases: lines });
+        }}
+      />
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginTop: 8,
+          fontWeight: 400,
+          fontSize: '0.8125rem',
+        }}
+      >
+        <input
+          type="checkbox"
+          disabled={busy}
+          checked={caseSensitive}
+          onChange={(e) => onChange({ ...config, case_sensitive: e.target.checked })}
+        />
+        Case-sensitive matching
+      </label>
+    </div>
+  );
+}
+
+function HostList({
+  checkId,
+  config,
+  busy,
+  onChange,
+}: {
+  checkId: string;
+  config: Config;
+  busy: boolean;
+  onChange: OnChange;
+}) {
+  const isEgress = checkId === 'egress.domain_rule';
+  // egress.domain_rule → domain_patterns (+ optional ports);
+  // domain_allowlist → allowed_hosts.
+  const configKey = isEgress ? 'domain_patterns' : 'allowed_hosts';
+  const hosts = ((config[configKey] as string[]) ?? []).join('\n');
+  const portsRaw = ((config['ports'] as number[]) ?? []).join(', ');
+
+  const readLines = (raw: string) =>
+    raw
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+  return (
+    <div className="field" style={{ marginBottom: 0 }}>
+      <label>
+        {isEgress ? 'Allowed domains' : 'Allowed hosts'}{' '}
+        <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+          one per line · wildcards like *.stripe.com
+          {isEgress ? " · we'll clean URLs on save" : ''}
+        </span>
+      </label>
+      <textarea
+        className="mono"
+        style={{ minHeight: 80 }}
+        data-testid="saf-hosts"
+        placeholder={'api.stripe.com\n*.internal.acme.com'}
+        disabled={busy}
+        defaultValue={hosts}
+        onChange={(e) => onChange({ ...config, [configKey]: readLines(e.target.value) })}
+        onBlur={(e) => {
+          // Postel's-Law cleanup: strip schemes/paths, lowercase.
+          const lines = readLines(e.target.value).map(normalizeDomainLine);
+          e.target.value = lines.join('\n');
+          onChange({ ...config, [configKey]: lines });
+        }}
+      />
+      {isEgress ? (
+        <>
+          <label style={{ marginTop: 8 }}>
+            Ports{' '}
+            <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+              optional · comma-separated · leave blank for any port
+            </span>
+          </label>
+          <input
+            type="text"
+            data-testid="saf-egress-ports"
+            placeholder="443, 8443"
+            disabled={busy}
+            defaultValue={portsRaw}
+            onChange={(e) => {
+              const parsed = e.target.value
+                .split(',')
+                .map((s) => parseInt(s.trim(), 10))
+                .filter((n) => !Number.isNaN(n) && n > 0 && n <= 65535);
+              const next = { ...config };
+              if (parsed.length) next['ports'] = parsed;
+              else delete next['ports'];
+              onChange(next);
+            }}
+          />
+        </>
+      ) : null}
+      <div className="hint">
+        The coworker can only reach these {isEgress ? 'domains' : 'hosts'}. Any
+        other outbound request is blocked.
+        {isEgress ? (
+          <>
+            {' '}
+            <code>*.acme.com</code> matches subdomains but not <code>acme.com</code>{' '}
+            itself.
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function RoutingTable({
+  check,
+  stage,
+  noun,
+  codes,
+  excludeActions,
+  config,
+  busy,
+  onChange,
+}: {
+  check: SafetyCheck;
+  stage: SafetyStage;
+  noun: 'type' | 'category';
+  codes: string[];
+  excludeActions: string[];
+  config: Config;
+  busy: boolean;
+  onChange: OnChange;
+}) {
+  const routing = (config['routing'] as Record<string, string>) ?? {};
+  const options = supportedActions(check, stage).filter(
+    (a) => !excludeActions.includes(a),
+  );
+  const anyRouted = Object.values(routing).some(Boolean);
+  return (
+    <div className="field" style={{ marginBottom: 0 }}>
+      <label>
+        Choose an action for each {noun}{' '}
+        <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+          leave any blank to let it through
+        </span>
+      </label>
+      <div className="route-table" data-testid="saf-routing">
+        {codes.map((code) => (
+          <div className="rt-row" key={code}>
+            <div className="rt-label">
+              {enumLabel(code)}
+              <span className="rt-code">{code}</span>
+            </div>
+            <select
+              aria-label={`Action for ${enumLabel(code)}`}
+              disabled={busy}
+              value={routing[code] ?? ''}
+              onChange={(e) => {
+                const v = e.target.value;
+                const next = { ...routing };
+                if (v) next[code] = v;
+                else delete next[code];
+                onChange({ ...config, routing: next });
+              }}
+            >
+              <option value="">— allow these —</option>
+              {options.map((a) => (
+                <option key={a} value={a}>
+                  {SAF_ACTION_LABEL[a]}
+                </option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </div>
+      {!anyRouted ? (
+        <div className="hint" data-testid="saf-routing-inert" style={{ marginTop: 6 }}>
+          <b>Nothing set yet.</b> The check runs but won't do anything. Pick an
+          action for at least one {noun} above to make it active.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-rules/duplicate-detection.test.ts
+++ b/web-react/src/features/settings/safety-rules/duplicate-detection.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { SafetyRule } from '../../../api/client';
+import { findDuplicate } from './duplicate-detection';
+import { auditSummary } from './audit-summary';
+import type { SafetyRuleAuditEntry } from '../../../api/client';
+
+function rule(over: Partial<SafetyRule>): SafetyRule {
+  return {
+    id: 'r1',
+    tenant_id: 't1',
+    coworker_id: null,
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: {},
+    priority: 100,
+    enabled: true,
+    description: '',
+    source: 'tenant',
+    tier: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...over,
+  } as SafetyRule;
+}
+
+describe('findDuplicate (G3 triple collision)', () => {
+  const triple = {
+    checkId: 'pii.regex',
+    stage: 'pre_tool_call' as const,
+    coworkerId: null,
+  };
+
+  it('finds an org rule with the same (check, stage, scope) triple', () => {
+    const hit = findDuplicate([rule({})], triple);
+    expect(hit.orgMatch?.id).toBe('r1');
+    expect(hit.platformMatch).toBeNull();
+  });
+
+  it('a DISABLED rule still collides (one toggle from running)', () => {
+    expect(findDuplicate([rule({ enabled: false })], triple).orgMatch).not.toBeNull();
+  });
+
+  it('different scope does not collide', () => {
+    expect(
+      findDuplicate([rule({ coworker_id: 'cw-1' })], triple).orgMatch,
+    ).toBeNull();
+    expect(
+      findDuplicate([rule({})], { ...triple, coworkerId: 'cw-1' }).orgMatch,
+    ).toBeNull();
+  });
+
+  it('different stage or check does not collide', () => {
+    expect(findDuplicate([rule({ stage: 'model_output' })], triple).orgMatch).toBeNull();
+    expect(
+      findDuplicate([rule({ check_id: 'secret_scanner' })], triple).orgMatch,
+    ).toBeNull();
+  });
+
+  it('excludes the duplicate source (a rule never collides with itself)', () => {
+    expect(findDuplicate([rule({ id: 'src' })], triple, 'src').orgMatch).toBeNull();
+  });
+
+  it('platform match reported only when no org collision (FYI, no flip)', () => {
+    const plat = rule({ id: 'p1', source: 'platform' });
+    const hit = findDuplicate([plat], triple);
+    expect(hit.orgMatch).toBeNull();
+    expect(hit.platformMatch?.id).toBe('p1');
+    // Org collision takes precedence.
+    const both = findDuplicate([plat, rule({ id: 'o1' })], triple);
+    expect(both.orgMatch?.id).toBe('o1');
+    expect(both.platformMatch).toBeNull();
+  });
+
+  it('empty triple → no detection', () => {
+    expect(
+      findDuplicate([rule({})], { checkId: '', stage: '', coworkerId: null }).orgMatch,
+    ).toBeNull();
+  });
+});
+
+describe('auditSummary (client diff — the wire has no summary field)', () => {
+  function entry(over: Partial<SafetyRuleAuditEntry>): SafetyRuleAuditEntry {
+    return {
+      id: 'a1',
+      rule_id: 'r1',
+      tenant_id: 't1',
+      action: 'updated',
+      actor_user_id: 'u1',
+      before_state: null,
+      after_state: null,
+      created_at: '2026-06-01T00:00:00Z',
+      ...over,
+    } as SafetyRuleAuditEntry;
+  }
+
+  it('created → labels the check + stage', () => {
+    const s = auditSummary(
+      entry({
+        action: 'created',
+        after_state: { check_id: 'pii.regex', stage: 'pre_tool_call' },
+      }),
+    );
+    expect(s).toBe('Created — Personal data (regex), pre_tool_call');
+  });
+
+  it('deleted → Deleted', () => {
+    expect(auditSummary(entry({ action: 'deleted' }))).toBe('Deleted');
+  });
+
+  it('diffs priority/enabled and formats booleans as on/off', () => {
+    const s = auditSummary(
+      entry({
+        before_state: { priority: 50, enabled: false },
+        after_state: { priority: 100, enabled: true },
+      }),
+    );
+    expect(s).toBe('priority: 50 → 100; enabled: off → on');
+  });
+
+  it('surfaces action_override changes from inside config', () => {
+    const s = auditSummary(
+      entry({
+        before_state: { config: {} },
+        after_state: { config: { action_override: 'warn' } },
+      }),
+    );
+    expect(s).toBe('action: default → warn');
+  });
+
+  it('falls back to "Configuration updated" when only config internals changed', () => {
+    const s = auditSummary(
+      entry({
+        before_state: { config: { patterns: { SSN: true } } },
+        after_state: { config: { patterns: { SSN: true, EMAIL: true } } },
+      }),
+    );
+    expect(s).toBe('Configuration updated');
+  });
+});

--- a/web-react/src/features/settings/safety-rules/duplicate-detection.ts
+++ b/web-react/src/features/settings/safety-rules/duplicate-detection.ts
@@ -1,0 +1,43 @@
+// G3 duplicate-rule detection (spec §6.10a / I.3) — the pure half of the
+// dialog's state machine, extracted so the collision predicate is
+// unit-testable. Triple = (check_id, coworker_id, stage); disabled rules
+// still collide (they are one toggle from running). The dialog owns the
+// stateful part (auto-flip / force-create / reset on triple change).
+
+import type { SafetyRule, SafetyStage } from '../../../api/client';
+
+export interface DuplicateHit {
+  /** Editable org-tier rule with the same triple → the dialog auto-flips
+   *  to editing it. */
+  orgMatch: SafetyRule | null;
+  /** Platform-tier rule covering the same triple → subtle FYI banner
+   *  only (the user cannot edit platform rules). */
+  platformMatch: SafetyRule | null;
+}
+
+export function findDuplicate(
+  rules: SafetyRule[],
+  triple: { checkId: string; stage: SafetyStage | ''; coworkerId: string | null },
+  /** The duplicate-source rule id — excluded so duplicating a rule does
+   *  not detect the rule against itself. */
+  excludeId?: string,
+): DuplicateHit {
+  if (!triple.checkId || !triple.stage) {
+    return { orgMatch: null, platformMatch: null };
+  }
+  const matches = (r: SafetyRule) =>
+    r.check_id === triple.checkId &&
+    r.stage === triple.stage &&
+    (r.coworker_id ?? null) === triple.coworkerId;
+
+  const orgMatch =
+    rules.find(
+      (r) => r.source !== 'platform' && matches(r) && r.id !== excludeId,
+    ) ?? null;
+  // Platform overlap only reported when there is no org collision — the
+  // org auto-flip takes precedence (Lit ordering).
+  const platformMatch = orgMatch
+    ? null
+    : (rules.find((r) => r.source === 'platform' && matches(r)) ?? null);
+  return { orgMatch, platformMatch };
+}

--- a/web-react/src/features/settings/safety-rules/rule-card.test.tsx
+++ b/web-react/src/features/settings/safety-rules/rule-card.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { SafetyCheck, SafetyRule } from '../../../api/client';
+import { RuleCard } from './rule-card';
+
+function rule(over: Partial<SafetyRule> = {}): SafetyRule {
+  return {
+    id: 'r1',
+    tenant_id: 't1',
+    coworker_id: null,
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: { patterns: { SSN: true } },
+    priority: 100,
+    enabled: true,
+    description: '',
+    source: 'tenant',
+    tier: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...over,
+  } as SafetyRule;
+}
+
+function check(over: Partial<SafetyCheck> & Pick<SafetyCheck, 'id'>): SafetyCheck {
+  return {
+    version: '1',
+    stages: ['pre_tool_call'],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: { pre_tool_call: 'block' },
+    supported_actions: {},
+    supported_codes: [],
+    config_schema: null,
+    ...over,
+  } as SafetyCheck;
+}
+
+function renderCard(r: SafetyRule, c: SafetyCheck | null, cwName: string | null = null) {
+  const fns = {
+    onToggle: vi.fn(),
+    onEdit: vi.fn(),
+    onDuplicate: vi.fn(),
+    onAudit: vi.fn(),
+    onDelete: vi.fn(),
+  };
+  render(
+    <RuleCard
+      rule={r}
+      check={c}
+      coworkerName={cwName}
+      toggling={false}
+      flash={false}
+      {...fns}
+    />,
+  );
+  return fns;
+}
+
+afterEach(cleanup);
+
+describe('RuleCard', () => {
+  it('org card: label (never the id), sentence, action pill, all four acts', () => {
+    const fns = renderCard(rule(), check({ id: 'pii.regex' }));
+    expect(screen.getByText('Personal data (regex)')).toBeTruthy();
+    expect(screen.queryByText('pii.regex')).toBeNull();
+    expect(screen.getByText(/detect SSNs/)).toBeTruthy();
+    // fixed check, natural block, no override → Block pill.
+    expect(screen.getByText('Block').className).toContain('saf-act--block');
+    fireEvent.click(screen.getByTitle('Edit rule'));
+    fireEvent.click(screen.getByTitle(/Duplicate/));
+    fireEvent.click(screen.getByTitle('Change history'));
+    fireEvent.click(screen.getByTitle('Delete rule'));
+    expect(fns.onEdit).toHaveBeenCalled();
+    expect(fns.onDuplicate).toHaveBeenCalled();
+    expect(fns.onAudit).toHaveBeenCalled();
+    expect(fns.onDelete).toHaveBeenCalled();
+  });
+
+  it('platform card: accent badge, fixed-on toggle, audit-only acts', () => {
+    renderCard(rule({ source: 'platform', tier: 'floor' }), check({ id: 'pii.regex' }));
+    expect(document.querySelector('.pol-pri--plat')).toBeTruthy();
+    const toggle = screen.getByTitle('Platform-tier rules are always enabled');
+    expect(toggle.textContent).toContain('Enabled');
+    expect(screen.queryByTitle('Edit rule')).toBeNull();
+    expect(screen.queryByTitle('Delete rule')).toBeNull();
+    expect(screen.getByTitle('Change history')).toBeTruthy();
+  });
+
+  it('slow chip when cost_class=slow; scope chip when coworker-bound', () => {
+    renderCard(
+      rule({ coworker_id: 'cw-1' }),
+      check({ id: 'pii.regex', cost_class: 'slow' }),
+      'Ops coworker',
+    );
+    expect(screen.getByText('slow').className).toContain('saf-chip--slow');
+    expect(screen.getByText('Ops coworker').className).toContain('saf-chip');
+  });
+
+  it('action pill OMITTED for config-routed and host-list rules', () => {
+    renderCard(
+      rule({
+        check_id: 'presidio.pii',
+        config: { block_codes: ['PII.SSN'], redact_codes: [] },
+      }),
+      check({ id: 'presidio.pii', action_model: 'config_routed' }),
+    );
+    expect(document.querySelector('.saf-act')).toBeNull();
+    cleanup();
+    renderCard(
+      rule({ check_id: 'domain_allowlist', config: { allowed_hosts: ['a.com'] } }),
+      check({ id: 'domain_allowlist' }),
+    );
+    expect(document.querySelector('.saf-act')).toBeNull();
+  });
+
+  it('disabled rule dims the body but keeps the switch live', () => {
+    const { onToggle } = renderCard(rule({ enabled: false }), check({ id: 'pii.regex' }));
+    expect(document.querySelector('.pol-card')?.className).toContain('off');
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onToggle).toHaveBeenCalled();
+  });
+});

--- a/web-react/src/features/settings/safety-rules/rule-card.tsx
+++ b/web-react/src/features/settings/safety-rules/rule-card.tsx
@@ -1,0 +1,178 @@
+// RuleCard — one safety rule in evaluation order (spec I.2; behavioral
+// reference web/src/components/safety-rules-page.ts renderCard, visual
+// layout per the v10 prototype). Priority badge (platform tier gets the
+// accent badge) · check LABEL (never the id) + slow/scope chips inline ·
+// safSentence line · action pill — omitted entirely for config-routed
+// and host-list rules (their sentence carries the semantics) · toggle
+// (platform: fixed-on no-op) · hover acts (platform: Audit only).
+
+import { Copy, History, Pencil, Trash2 } from 'lucide-react';
+import type { SafetyCheck, SafetyRule } from '../../../api/client';
+import { Switch } from '../../../components/switch';
+import { priorityBadgeClass } from '../../../lib/rule-ordering';
+import {
+  SAF_ACTION_LABEL,
+  SAFETY_CHECK_CATALOG,
+  checkLabel,
+  effectiveAction,
+  safSentence,
+} from './safety-catalog';
+
+export function RuleCard({
+  rule,
+  check,
+  coworkerName,
+  toggling,
+  flash,
+  onToggle,
+  onEdit,
+  onDuplicate,
+  onAudit,
+  onDelete,
+}: {
+  rule: SafetyRule;
+  /** Wire check behaviour (null when the catalog is still loading or the
+   *  check id is unknown — sentence helpers degrade gracefully). */
+  check: SafetyCheck | null;
+  /** Resolved coworker name when scoped; null for tenant-wide rules. */
+  coworkerName: string | null;
+  toggling: boolean;
+  flash: boolean;
+  onToggle: () => void;
+  onEdit: () => void;
+  onDuplicate: () => void;
+  onAudit: () => void;
+  onDelete: () => void;
+}) {
+  const platform = rule.source === 'platform';
+  const config = (rule.config ?? {}) as Record<string, unknown>;
+  const slow = check?.cost_class === 'slow';
+  // Pill suppressed when the sentence already carries the routing /
+  // allowlist semantics (spec I.2).
+  const routedNoAction =
+    check?.action_model === 'config_routed' ||
+    SAFETY_CHECK_CATALOG[rule.check_id]?.cfgKind === 'host-list';
+  const action = routedNoAction
+    ? null
+    : effectiveAction({ check_id: rule.check_id, stage: rule.stage, config }, check);
+
+  return (
+    <div
+      className={`pol-card${rule.enabled ? '' : ' off'}${flash ? ' flash' : ''}`}
+      data-rule-id={rule.id}
+    >
+      <span
+        className={`pol-pri${platform ? ' pol-pri--plat' : priorityBadgeClass(rule.priority)}`}
+      >
+        priority {rule.priority}
+      </span>
+      <span className="body">
+        <div className="target">
+          {checkLabel(rule.check_id)}{' '}
+          {slow ? (
+            <span className="saf-chip saf-chip--slow" title="This check adds latency">
+              slow
+            </span>
+          ) : null}{' '}
+          {coworkerName ? <span className="saf-chip">{coworkerName}</span> : null}
+        </div>
+        <div className="sentence">
+          {/* safSentence escapes dynamic text; its own <b>/<span> markup
+              is safe to inject (same contract as the Lit unsafeHTML). */}
+          <span
+            dangerouslySetInnerHTML={{
+              __html: safSentence(
+                { check_id: rule.check_id, stage: rule.stage, config },
+                check,
+                coworkerName,
+              ),
+            }}
+          />
+        </div>
+      </span>
+      {action ? (
+        <span className={`saf-act saf-act--${action}`}>
+          {SAF_ACTION_LABEL[action] ?? action}
+        </span>
+      ) : null}
+      {platform ? (
+        <button
+          type="button"
+          className="switch on"
+          style={{ cursor: 'default' }}
+          title="Platform-tier rules are always enabled"
+          aria-disabled="true"
+        >
+          <span className="track" />
+          Enabled
+        </button>
+      ) : (
+        <Switch
+          on={rule.enabled}
+          disabled={toggling}
+          onToggle={onToggle}
+          title={rule.enabled ? 'Click to disable' : 'Click to enable'}
+        />
+      )}
+      {platform ? (
+        // Platform rules: audit only (no edit / duplicate / delete) — §6.2.2;
+        // always visible (there is nothing else to reveal on hover).
+        <span className="cardacts" style={{ opacity: 1 }}>
+          <button
+            className="icon-btn"
+            title="Change history"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAudit();
+            }}
+          >
+            <History />
+          </button>
+        </span>
+      ) : (
+        <span className="cardacts">
+          <button
+            className="icon-btn"
+            title="Edit rule"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEdit();
+            }}
+          >
+            <Pencil />
+          </button>
+          <button
+            className="icon-btn"
+            title="Duplicate — useful for moving scope or branching config"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDuplicate();
+            }}
+          >
+            <Copy />
+          </button>
+          <button
+            className="icon-btn"
+            title="Change history"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAudit();
+            }}
+          >
+            <History />
+          </button>
+          <button
+            className="icon-btn danger"
+            title="Delete rule"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Trash2 />
+          </button>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-rules/rule-dialog.test.tsx
+++ b/web-react/src/features/settings/safety-rules/rule-dialog.test.tsx
@@ -1,0 +1,259 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Coworker, SafetyCheck, SafetyRule } from '../../../api/client';
+import { RuleDialog } from './rule-dialog';
+
+const piiRegex: SafetyCheck = {
+  id: 'pii.regex',
+  version: '1',
+  stages: ['input_prompt', 'pre_tool_call', 'model_output'],
+  cost_class: 'cheap',
+  action_model: 'fixed',
+  natural_actions: {
+    input_prompt: 'block',
+    pre_tool_call: 'block',
+    model_output: 'block',
+  },
+  supported_actions: {
+    input_prompt: ['allow', 'block', 'require_approval', 'warn'],
+    pre_tool_call: ['allow', 'block', 'require_approval', 'warn'],
+    model_output: ['allow', 'block', 'require_approval'],
+  },
+  supported_codes: [],
+  config_schema: null,
+} as unknown as SafetyCheck;
+
+const presidio: SafetyCheck = {
+  id: 'presidio.pii',
+  version: '1',
+  stages: ['post_tool_result'],
+  cost_class: 'slow',
+  action_model: 'config_routed',
+  natural_actions: { post_tool_result: 'allow' },
+  supported_actions: { post_tool_result: ['allow', 'block', 'redact', 'warn'] },
+  supported_codes: [],
+  config_schema: null,
+} as unknown as SafetyCheck;
+
+const domainAllowlist: SafetyCheck = {
+  id: 'domain_allowlist',
+  version: '1',
+  stages: ['pre_tool_call'],
+  cost_class: 'cheap',
+  action_model: 'fixed',
+  natural_actions: { pre_tool_call: 'block' },
+  supported_actions: { pre_tool_call: ['allow', 'block', 'warn'] },
+  supported_codes: [],
+  config_schema: null,
+} as unknown as SafetyCheck;
+
+const CHECKS = [piiRegex, presidio, domainAllowlist];
+const COWORKERS = [{ id: 'cw-1', name: 'Ops coworker' }] as unknown as Coworker[];
+
+function rule(over: Partial<SafetyRule> = {}): SafetyRule {
+  return {
+    id: 'r1',
+    tenant_id: 't1',
+    coworker_id: null,
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: { patterns: { SSN: true } },
+    priority: 100,
+    enabled: true,
+    description: '',
+    source: 'tenant',
+    tier: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...over,
+  } as SafetyRule;
+}
+
+function renderDialog(opts: {
+  editing?: SafetyRule | null;
+  duplicating?: SafetyRule | null;
+  rules?: SafetyRule[];
+}) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  const onDuplicateFromEdit = vi.fn();
+  render(
+    <RuleDialog
+      editing={opts.editing ?? null}
+      duplicating={opts.duplicating ?? null}
+      checks={CHECKS}
+      coworkers={COWORKERS}
+      rules={opts.rules ?? []}
+      onClose={onClose}
+      onSaved={onSaved}
+      onDuplicateFromEdit={onDuplicateFromEdit}
+    />,
+  );
+  return { onClose, onSaved, onDuplicateFromEdit };
+}
+
+afterEach(cleanup);
+
+describe('RuleDialog — experiences', () => {
+  it('fixed check: action panel with natural dot + disabled unsupported actions', () => {
+    renderDialog({});
+    expect(screen.getByTestId('saf-action-field')).toBeTruthy();
+    const seg = document.querySelector('.actseg')!;
+    const buttons = [...seg.querySelectorAll('button')] as HTMLButtonElement[];
+    const byLabel = (l: string) => buttons.find((b) => b.textContent?.includes(l))!;
+    // allow disabled with the disable-the-rule hint (block-natural check).
+    expect(byLabel('Allow').disabled).toBe(true);
+    expect(byLabel('Allow').title).toMatch(/disable the rule/i);
+    // redact never overridable outside presidio.
+    expect(byLabel('Redact').disabled).toBe(true);
+    // warn + approve pickable on pre_tool_call.
+    expect(byLabel('Warn').disabled).toBe(false);
+    expect(byLabel('Approve').disabled).toBe(false);
+    // natural (Block) carries the default dot.
+    expect(byLabel('Block').querySelector('.dot')).toBeTruthy();
+  });
+
+  it('config_routed: action field REMOVED, routing table renders instead', () => {
+    renderDialog({});
+    fireEvent.change(screen.getByLabelText('Check'), {
+      target: { value: 'presidio.pii' },
+    });
+    expect(screen.queryByTestId('saf-action-field')).toBeNull();
+    expect(screen.getByTestId('saf-routing')).toBeTruthy();
+    expect(screen.getByTestId('saf-routing-inert')).toBeTruthy(); // nothing routed yet
+  });
+
+  it('host-list: no action field, hosts textarea IS the rule', () => {
+    renderDialog({});
+    fireEvent.change(screen.getByLabelText('Check'), {
+      target: { value: 'domain_allowlist' },
+    });
+    expect(screen.queryByTestId('saf-action-field')).toBeNull();
+    expect(screen.getByTestId('saf-hosts')).toBeTruthy();
+  });
+
+  it('stage select constrained to the check stages + fail-mode note', () => {
+    renderDialog({});
+    const stageSel = screen.getByLabelText('Where it runs') as HTMLSelectElement;
+    expect(stageSel.querySelectorAll('option').length).toBe(3); // piiRegex stages
+    expect(screen.getByText(/the call is blocked by default/)).toBeTruthy();
+  });
+
+  it('live preview renders the safSentence + priority', () => {
+    renderDialog({});
+    const pv = screen.getByTestId('saf-preview');
+    expect(pv.textContent).toContain('On input'); // default stage = input_prompt
+    expect(pv.textContent).toContain('Priority 100');
+  });
+});
+
+describe('RuleDialog — G3 duplicate detection', () => {
+  it('collision auto-flips to editing the existing rule (blue banner + preload)', () => {
+    renderDialog({ rules: [rule({ stage: 'input_prompt', priority: 42 })] });
+    expect(screen.getByTestId('saf-dup-banner-info')).toBeTruthy();
+    expect(screen.getByText('Edit existing rule')).toBeTruthy();
+    expect(screen.getByText('Save changes')).toBeTruthy();
+    // Existing rule's priority pre-loaded.
+    expect((screen.getByLabelText(/Priority/) as HTMLInputElement).value).toBe('42');
+    // Scope locked in auto-flip mode.
+    expect((screen.getByLabelText('Applies to') as HTMLSelectElement).disabled).toBe(true);
+  });
+
+  it('force-create escape → amber banner + defaults reset + return path', () => {
+    renderDialog({ rules: [rule({ stage: 'input_prompt', priority: 42 })] });
+    fireEvent.click(screen.getByText('Create a separate rule anyway'));
+    expect(screen.getByTestId('saf-dup-banner-warn')).toBeTruthy();
+    // Title AND save button both read 'Create separate rule'.
+    expect(screen.getAllByText('Create separate rule').length).toBe(2);
+    expect((screen.getByLabelText(/Priority/) as HTMLInputElement).value).toBe('100');
+    expect((screen.getByLabelText('Applies to') as HTMLSelectElement).disabled).toBe(false);
+    // Return path re-runs detection → back to the blue banner.
+    fireEvent.click(screen.getByText('Switch back to editing the existing one'));
+    expect(screen.getByTestId('saf-dup-banner-info')).toBeTruthy();
+  });
+
+  it('platform overlap → subtle FYI, no flip', () => {
+    renderDialog({ rules: [rule({ stage: 'input_prompt', source: 'platform' })] });
+    expect(screen.getByTestId('saf-dup-banner-fyi')).toBeTruthy();
+    expect(screen.getByText('New safety rule')).toBeTruthy(); // no flip
+    expect(screen.getByText('Create rule')).toBeTruthy();
+  });
+
+  it('duplicating a rule does not detect it against itself', () => {
+    const src = rule({});
+    renderDialog({ duplicating: src, rules: [src] });
+    expect(screen.queryByTestId('saf-dup-banner-info')).toBeNull();
+    expect(screen.getByText('Duplicate safety rule')).toBeTruthy();
+  });
+
+  it('detection skipped entirely in real edit mode', () => {
+    const other = rule({ id: 'r2' });
+    renderDialog({ editing: rule({}), rules: [other] });
+    expect(screen.queryByTestId('saf-dup-banner-info')).toBeNull();
+    expect(screen.getByText('Edit safety rule')).toBeTruthy();
+  });
+});
+
+describe('RuleDialog — scope immutability', () => {
+  it('edit mode locks the scope select with the duplicate link-out', () => {
+    const { onDuplicateFromEdit } = renderDialog({ editing: rule({}) });
+    expect((screen.getByLabelText('Applies to') as HTMLSelectElement).disabled).toBe(true);
+    expect(screen.getByTestId('saf-scope-locked')).toBeTruthy();
+    fireEvent.click(screen.getByText('duplicate this rule'));
+    expect(onDuplicateFromEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'r1' }));
+  });
+
+  it('create + duplicate modes keep scope editable', () => {
+    renderDialog({ duplicating: rule({ coworker_id: 'cw-1' }) });
+    const sel = screen.getByLabelText('Applies to') as HTMLSelectElement;
+    expect(sel.disabled).toBe(false);
+    expect(sel.value).toBe('cw-1');
+  });
+});
+
+describe('RuleDialog — config seeding + advanced JSON', () => {
+  it('edit seeds the pii grid from the wire patterns dict', () => {
+    renderDialog({ editing: rule({ config: { patterns: { SSN: true, EMAIL: true } } }) });
+    const grid = screen.getByTestId('saf-pii-grid');
+    const checked = [...grid.querySelectorAll('input:checked')];
+    expect(checked.length).toBe(2);
+  });
+
+  it('advanced JSON hatch seeds from the current backend-shaped config', () => {
+    renderDialog({ editing: rule({ config: { patterns: { SSN: true } } }) });
+    fireEvent.click(screen.getByTestId('saf-adv-toggle'));
+    const ta = screen.getByTestId('saf-config-json') as HTMLTextAreaElement;
+    const parsed = JSON.parse(ta.value);
+    expect(parsed.patterns).toEqual({ SSN: true }); // backend shape, not _piiKeys
+    // Toggle back to the visual form.
+    fireEvent.click(screen.getByTestId('saf-adv-toggle'));
+    expect(screen.getByTestId('saf-pii-grid')).toBeTruthy();
+  });
+
+  it('G4: empty pii selection blocks the save with a friendly error', () => {
+    // config_schema present → sanity checks active.
+    const withSchema = {
+      ...piiRegex,
+      config_schema: { type: 'object' },
+    } as SafetyCheck;
+    const onSaved = vi.fn();
+    render(
+      <RuleDialog
+        editing={rule({ config: { patterns: {} } })}
+        duplicating={null}
+        checks={[withSchema, presidio, domainAllowlist]}
+        coworkers={COWORKERS}
+        rules={[]}
+        onClose={vi.fn()}
+        onSaved={onSaved}
+        onDuplicateFromEdit={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('saf-submit'));
+    expect(screen.getByTestId('saf-error-banner').textContent).toMatch(
+      /at least one type of personal data/,
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+});

--- a/web-react/src/features/settings/safety-rules/rule-dialog.tsx
+++ b/web-react/src/features/settings/safety-rules/rule-dialog.tsx
@@ -1,0 +1,682 @@
+// RuleDialog — create / edit / duplicate a safety rule (spec I.3;
+// behavioral reference web/src/components/safety-rule-dialog.ts). One
+// dialog backs all three flows:
+//   - editing non-null     → edit  (PATCH; scope LOCKED — §6.11.3)
+//   - duplicating non-null → create, pre-filled (POST; scope editable)
+//   - both null            → create, defaults (POST)
+//
+// THREE EDITOR EXPERIENCES for the action, keyed on the wire check's
+// action_model + cfgKind (the taxonomy is never shown): fixed →
+// segmented control; config_routed → the routing table IS the editor
+// (action field REMOVED); host-list → no action field (the list is the
+// whole rule). A fully-inert field is removed, not greyed.
+//
+// G3 duplicate detection: (check_id, coworker_id, stage) collision in
+// create/duplicate mode auto-flips the form to editing the existing
+// rule (config pre-loaded, blue banner) with a "Create a separate rule
+// anyway" escape (amber banner + return path). Platform overlaps get a
+// subtle FYI only. Save dispatch: editing → PATCH; dupTarget && !force
+// → PATCH the target; else POST.
+//
+// Scope is immutable after creation (SafetyRuleUpdate has no
+// coworker_id) — edit mode locks the select; the hint's "duplicate this
+// rule" link is the sanctioned scope-change path.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  ApiError,
+  getApiClient,
+  type Coworker,
+  type SafetyCheck,
+  type SafetyRule,
+  type SafetyStage,
+  type SafetyVerdictAction,
+} from '../../../api/client';
+import { BrandMark } from '../../../components/brand-mark';
+import { Switch } from '../../../components/switch';
+import { ActionPanel } from './action-panel';
+import { ConfigForm } from './config-forms';
+import {
+  buildBackendConfig,
+  normalizeConfigFromBackend,
+  parseBackend400,
+  validateBeforeSave,
+  type SaveError,
+} from './config-convert';
+import { findDuplicate } from './duplicate-detection';
+import {
+  SAF_CONTROL_STAGES,
+  SAF_STAGE_LABEL,
+  SAFETY_CATEGORY_ORDER,
+  SAFETY_CHECK_CATALOG,
+  actionButtonState,
+  naturalAction,
+  safSentence,
+} from './safety-catalog';
+
+interface FormState {
+  checkId: string;
+  stage: SafetyStage | '';
+  /** Override for fixed checks; null ⇒ natural action. */
+  pickedAction: SafetyVerdictAction | null;
+  coworkerId: string | null;
+  priority: number;
+  enabled: boolean;
+  /** cfgKind-specific INTERNAL config (see config-convert). */
+  config: Record<string, unknown>;
+  /** Raw-JSON escape hatch; null ⇒ the visual form is authoritative. */
+  advancedJson: string | null;
+}
+
+function seedFromRule(src: SafetyRule): FormState {
+  const cfg = { ...(src.config ?? {}) } as Record<string, unknown>;
+  const override = cfg['action_override'];
+  delete cfg['action_override'];
+  normalizeConfigFromBackend(src.check_id, cfg);
+  return {
+    checkId: src.check_id,
+    stage: src.stage,
+    pickedAction: typeof override === 'string' ? (override as SafetyVerdictAction) : null,
+    coworkerId: src.coworker_id ?? null,
+    priority: src.priority,
+    enabled: src.enabled,
+    config: cfg,
+    advancedJson: null,
+  };
+}
+
+export function RuleDialog({
+  editing,
+  duplicating,
+  checks,
+  coworkers,
+  rules,
+  onClose,
+  onSaved,
+  onDuplicateFromEdit,
+}: {
+  editing: SafetyRule | null;
+  duplicating: SafetyRule | null;
+  checks: SafetyCheck[];
+  coworkers: Coworker[];
+  /** All existing rules — G3 duplicate detection input. */
+  rules: SafetyRule[];
+  onClose: () => void;
+  onSaved: (rule: SafetyRule, toast: string) => void;
+  /** The scope-change path: close this edit, reopen as duplicate. */
+  onDuplicateFromEdit: (source: SafetyRule) => void;
+}) {
+  const isEdit = editing !== null;
+  const seedSource = editing ?? duplicating;
+
+  const [form, setForm] = useState<FormState>(() => {
+    if (seedSource) return seedFromRule(seedSource);
+    const first = checks[0];
+    return {
+      checkId: first?.id ?? '',
+      stage: (first?.stages?.[0] as SafetyStage) ?? '',
+      pickedAction: null,
+      coworkerId: null,
+      priority: 100,
+      enabled: true,
+      config: {},
+      advancedJson: null,
+    };
+  });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [saveErrors, setSaveErrors] = useState<SaveError[]>([]);
+  // G3 state.
+  const [dupTarget, setDupTarget] = useState<SafetyRule | null>(null);
+  const [forceCreate, setForceCreate] = useState(false);
+  const [platformOverlap, setPlatformOverlap] = useState<SafetyRule | null>(null);
+  /** Last auto-loaded dup id — guards the preload against re-running. */
+  const loadedDupId = useRef<string | null>(null);
+
+  const check = useMemo(
+    () => checks.find((c) => c.id === form.checkId) ?? null,
+    [checks, form.checkId],
+  );
+  const pres = check ? SAFETY_CHECK_CATALOG[check.id] : undefined;
+  const cfgKind = pres?.cfgKind;
+  const showActionPanel =
+    !!check && cfgKind !== 'host-list' && check.action_model === 'fixed';
+
+  // G3: re-detect whenever the triple changes (skipped in real edit mode
+  // and after the force-create opt-out).
+  useEffect(() => {
+    if (isEdit || forceCreate) {
+      setDupTarget(null);
+      setPlatformOverlap(null);
+      return;
+    }
+    const hit = findDuplicate(
+      rules,
+      { checkId: form.checkId, stage: form.stage, coworkerId: form.coworkerId },
+      duplicating?.id,
+    );
+    setDupTarget(hit.orgMatch);
+    setPlatformOverlap(hit.platformMatch);
+    if (hit.orgMatch && loadedDupId.current !== hit.orgMatch.id) {
+      // Pre-load the existing rule — the user is editing it now.
+      loadedDupId.current = hit.orgMatch.id;
+      setForm(seedFromRule(hit.orgMatch));
+    }
+    if (!hit.orgMatch) loadedDupId.current = null;
+  }, [
+    isEdit,
+    forceCreate,
+    rules,
+    form.checkId,
+    form.stage,
+    form.coworkerId,
+    duplicating?.id,
+  ]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onClose]);
+
+  function onCheckChange(id: string) {
+    const next = checks.find((c) => c.id === id);
+    setForm((f) => ({
+      ...f,
+      checkId: id,
+      stage: (next?.stages?.[0] as SafetyStage) ?? '',
+      pickedAction: null,
+      config: {},
+      advancedJson: null,
+    }));
+  }
+
+  function onStageChange(stage: SafetyStage) {
+    setForm((f) => {
+      // An override valid on the old stage may be unsupported on the new
+      // one; drop it so we never submit an unsupported action.
+      let picked = f.pickedAction;
+      if (picked) {
+        const nat = naturalAction(check, stage);
+        if (!actionButtonState(check, stage, picked, nat).enabled) picked = null;
+      }
+      return { ...f, stage, pickedAction: picked };
+    });
+  }
+
+  function onForceCreate() {
+    setForceCreate(true);
+    loadedDupId.current = null;
+    // Reset to defaults; keep the check/stage the user selected.
+    setForm((f) => ({
+      ...f,
+      pickedAction: null,
+      config: {},
+      priority: 100,
+      enabled: true,
+      coworkerId: null,
+      advancedJson: null,
+    }));
+  }
+
+  /** Backend-shaped config from the current form state. Advanced JSON
+   *  wins when visible + parseable (§6.12); otherwise the visual form,
+   *  with action_override written only for a non-natural fixed pick. */
+  function buildConfig(): Record<string, unknown> {
+    if (form.advancedJson !== null) {
+      const trimmed = form.advancedJson.trim();
+      if (trimmed) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+          }
+        } catch {
+          /* fall through to the form */
+        }
+      }
+    }
+    const cfg: Record<string, unknown> = { ...form.config };
+    if (showActionPanel && form.pickedAction) {
+      const nat = naturalAction(check, form.stage as SafetyStage);
+      if (form.pickedAction !== nat) cfg['action_override'] = form.pickedAction;
+    }
+    return buildBackendConfig(form.checkId, cfg);
+  }
+
+  async function submit() {
+    if (busy) return;
+    if (!form.checkId || !form.stage) {
+      setErr('Pick a check and a stage.');
+      return;
+    }
+    // G4 Layer 1 — client-side validation before any network call.
+    const config = buildConfig();
+    const errs = validateBeforeSave(check, config);
+    if (errs.length > 0) {
+      setSaveErrors(errs);
+      return;
+    }
+    setSaveErrors([]);
+    setBusy(true);
+    setErr(null);
+    try {
+      const api = getApiClient();
+      let saved: SafetyRule;
+      let toast: string;
+      if (isEdit) {
+        // Scope (coworker_id) intentionally omitted — immutable on edit.
+        saved = await api.updateSafetyRule(editing.id, {
+          check_id: form.checkId,
+          stage: form.stage,
+          config,
+          priority: form.priority,
+          enabled: form.enabled,
+        });
+        toast = 'Rule updated';
+      } else if (dupTarget && !forceCreate) {
+        // G3 auto-flip: PATCH the existing rule, not POST.
+        saved = await api.updateSafetyRule(dupTarget.id, {
+          check_id: form.checkId,
+          stage: form.stage,
+          config,
+          priority: form.priority,
+          enabled: form.enabled,
+        });
+        toast = 'Rule updated';
+      } else {
+        saved = await api.createSafetyRule({
+          check_id: form.checkId,
+          stage: form.stage,
+          coworker_id: form.coworkerId,
+          config,
+          priority: form.priority,
+          enabled: form.enabled,
+          // Wire default; the card renderer doesn't consume description
+          // (I.6.4) and the dialog exposes no field for it.
+          description: '',
+        });
+        toast = 'Rule created';
+      }
+      onSaved(saved, toast);
+      onClose();
+    } catch (e) {
+      // G4 Layer 2 — translate a FastAPI 4xx detail array when present.
+      if (e instanceof ApiError && e.body) {
+        const backend400 = parseBackend400(e.body);
+        if (backend400.length > 0) {
+          setSaveErrors(backend400);
+          setBusy(false);
+          return;
+        }
+      }
+      setErr(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+      setBusy(false);
+    }
+  }
+
+  const title = isEdit
+    ? 'Edit safety rule'
+    : dupTarget && !forceCreate
+      ? 'Edit existing rule'
+      : forceCreate
+        ? 'Create separate rule'
+        : duplicating
+          ? 'Duplicate safety rule'
+          : 'New safety rule';
+  const saveLabel =
+    isEdit || (dupTarget && !forceCreate)
+      ? 'Save changes'
+      : forceCreate
+        ? 'Create separate rule'
+        : 'Create rule';
+  const scopeLocked = isEdit || (dupTarget !== null && !forceCreate);
+
+  // Check select grouped by category, catalog order first.
+  const byCategory = useMemo(() => {
+    const map = new Map<string, SafetyCheck[]>();
+    for (const c of checks) {
+      const cat = SAFETY_CHECK_CATALOG[c.id]?.category ?? 'Other';
+      map.set(cat, [...(map.get(cat) ?? []), c]);
+    }
+    return [...map.entries()].sort(
+      (a, b) =>
+        (SAFETY_CATEGORY_ORDER.indexOf(a[0]) + 99) -
+        (SAFETY_CATEGORY_ORDER.indexOf(b[0]) + 99),
+    );
+  }, [checks]);
+
+  const stages = (check?.stages ?? []) as SafetyStage[];
+  const controlStage = form.stage && SAF_CONTROL_STAGES.has(form.stage);
+  const scopeName = form.coworkerId
+    ? (coworkers.find((c) => c.id === form.coworkerId)?.name ?? null)
+    : null;
+  const previewSentence = form.checkId && form.stage
+    ? safSentence(
+        { check_id: form.checkId, stage: form.stage as SafetyStage, config: buildConfig() },
+        check,
+        scopeName,
+      )
+    : '';
+
+  const dupScopeName = dupTarget?.coworker_id
+    ? (coworkers.find((c) => c.id === dupTarget.coworker_id)?.name ?? dupTarget.coworker_id)
+    : 'all coworkers';
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        className="dlg"
+        style={{ width: 640 }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Safety rule"
+      >
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">{title}</h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body" style={{ minHeight: 0 }}>
+          <div className="hint" style={{ marginBottom: 12 }}>
+            Safety rules run automatically — no one in the loop — except when you
+            set the action to <b>Approve</b>, which routes to the same approval
+            surface as business policies. Changes apply to new agent tasks;
+            already-running tasks finish with the current rules.
+          </div>
+
+          {/* G3 banners */}
+          {dupTarget && !forceCreate ? (
+            <div className="dup-banner info" data-testid="saf-dup-banner-info">
+              <span>ℹ</span>
+              <span>
+                You already have a <b>{SAFETY_CHECK_CATALOG[dupTarget.check_id]?.label ?? dupTarget.check_id}</b>{' '}
+                rule for <b>{SAF_STAGE_LABEL[dupTarget.stage] ?? dupTarget.stage}</b> on{' '}
+                <b>{dupScopeName}</b>. You're editing that rule now (not creating a
+                new one).{' '}
+                <button type="button" onClick={onForceCreate}>
+                  Create a separate rule anyway
+                </button>
+              </span>
+            </div>
+          ) : forceCreate ? (
+            <div className="dup-banner warn" data-testid="saf-dup-banner-warn">
+              <span>⚠</span>
+              <span>
+                Creating a second rule for the same surface — they may conflict.{' '}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setForceCreate(false);
+                    loadedDupId.current = null;
+                  }}
+                >
+                  Switch back to editing the existing one
+                </button>
+              </span>
+            </div>
+          ) : platformOverlap ? (
+            <div className="dup-banner subtle" data-testid="saf-dup-banner-fyi">
+              <span>🛡</span>
+              <span>
+                A platform default{' '}
+                <b>{SAFETY_CHECK_CATALOG[platformOverlap.check_id]?.label ?? platformOverlap.check_id}</b>{' '}
+                already covers this surface — your org rule will run alongside it.
+              </span>
+            </div>
+          ) : null}
+
+          {/* Check */}
+          <div className="field">
+            <label htmlFor="saf-check">Check</label>
+            <select
+              id="saf-check"
+              disabled={busy}
+              value={form.checkId}
+              onChange={(e) => onCheckChange(e.target.value)}
+            >
+              {byCategory.map(([cat, list]) => (
+                <optgroup key={cat} label={cat}>
+                  {list.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {SAFETY_CHECK_CATALOG[c.id]?.label ?? c.id} ({c.cost_class})
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            {pres ? <div className="hint">{pres.desc}</div> : null}
+            {check?.cost_class === 'slow' ? (
+              <div className="hint" style={{ color: 'var(--rm-warn-text)' }} data-testid="saf-slow-warn">
+                This check adds noticeable latency — avoid putting it on a fast-path
+                stage like "before tool calls".
+              </div>
+            ) : null}
+          </div>
+
+          {/* Stage */}
+          <div className="field">
+            <label htmlFor="saf-stage">Where it runs</label>
+            <select
+              id="saf-stage"
+              disabled={busy}
+              value={form.stage}
+              onChange={(e) => onStageChange(e.target.value as SafetyStage)}
+            >
+              {stages.map((s) => (
+                <option key={s} value={s}>
+                  {SAF_STAGE_LABEL[s] ?? s}
+                </option>
+              ))}
+            </select>
+            {form.stage ? (
+              <div className="hint">
+                {controlStage
+                  ? 'If this check errors here, the call is blocked by default.'
+                  : 'If this check errors here, the call is let through.'}
+              </div>
+            ) : null}
+          </div>
+
+          {/* Action panel — experience 1 only */}
+          {showActionPanel ? (
+            <ActionPanel
+              check={check}
+              stage={form.stage as SafetyStage}
+              pickedAction={form.pickedAction}
+              busy={busy}
+              onPick={(a) => setForm((f) => ({ ...f, pickedAction: a }))}
+            />
+          ) : null}
+
+          {/* Config form + advanced JSON hatch */}
+          {check && cfgKind ? (
+            <div className="field" data-testid="saf-config">
+              {form.advancedJson !== null ? (
+                <>
+                  <label htmlFor="saf-config-json">Configuration (JSON)</label>
+                  <textarea
+                    id="saf-config-json"
+                    className="mono"
+                    style={{ minHeight: 120 }}
+                    data-testid="saf-config-json"
+                    disabled={busy}
+                    value={form.advancedJson}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, advancedJson: e.target.value }))
+                    }
+                  />
+                </>
+              ) : (
+                <ConfigForm
+                  check={check}
+                  cfgKind={cfgKind}
+                  stage={form.stage as SafetyStage}
+                  config={form.config}
+                  busy={busy}
+                  onChange={(next) => setForm((f) => ({ ...f, config: next }))}
+                />
+              )}
+              <button
+                type="button"
+                className="btn-ghost"
+                style={{ padding: 0, fontSize: '11.5px', marginTop: 8 }}
+                data-testid="saf-adv-toggle"
+                disabled={busy}
+                onClick={() =>
+                  setForm((f) =>
+                    f.advancedJson === null
+                      ? { ...f, advancedJson: JSON.stringify(buildConfig(), null, 2) }
+                      : { ...f, advancedJson: null },
+                  )
+                }
+              >
+                {form.advancedJson !== null ? 'Use the visual form' : 'Advanced: edit as JSON'}
+              </button>
+            </div>
+          ) : null}
+
+          {/* Scope */}
+          <div className="field">
+            <label htmlFor="saf-scope">Applies to</label>
+            <select
+              id="saf-scope"
+              disabled={scopeLocked || busy}
+              style={scopeLocked ? { opacity: 0.55, cursor: 'not-allowed' } : undefined}
+              value={form.coworkerId ?? ''}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, coworkerId: e.target.value || null }))
+              }
+            >
+              <option value="">All coworkers</option>
+              {coworkers.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            {scopeLocked ? (
+              <div className="hint" data-testid="saf-scope-locked">
+                🔒 Scope is fixed after creation (for audit consistency). To move
+                scope,{' '}
+                <button
+                  type="button"
+                  className="btn-ghost"
+                  style={{ padding: 0, fontSize: 'inherit', textDecoration: 'underline' }}
+                  onClick={() => {
+                    const src = editing ?? dupTarget;
+                    if (src) onDuplicateFromEdit(src);
+                  }}
+                >
+                  duplicate this rule
+                </button>{' '}
+                with the new scope, then delete this one.
+              </div>
+            ) : null}
+          </div>
+
+          {/* Priority + Status */}
+          <div
+            style={{ display: 'flex', gap: 20, alignItems: 'flex-end', marginBottom: 14 }}
+          >
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label htmlFor="saf-priority" style={{ whiteSpace: 'nowrap' }}>
+                Priority{' '}
+                <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>
+                  higher wins on ties
+                </span>
+              </label>
+              <input
+                id="saf-priority"
+                type="text"
+                inputMode="numeric"
+                style={{ width: 96, display: 'block' }}
+                disabled={busy}
+                value={String(form.priority)}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    priority: parseInt(e.target.value, 10) || 0,
+                  }))
+                }
+              />
+            </div>
+            <div className="field" style={{ marginBottom: 0 }}>
+              <label>Status</label>
+              <Switch
+                on={form.enabled}
+                disabled={busy}
+                onToggle={() => setForm((f) => ({ ...f, enabled: !f.enabled }))}
+              />
+            </div>
+          </div>
+
+          {/* Live preview — the SAME safSentence the cards render */}
+          {previewSentence ? (
+            <div className="preview" data-testid="saf-preview">
+              <div className="pv-label">This rule</div>
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: `${previewSentence} Priority <b>${form.priority}</b>.${
+                    form.enabled ? '' : " <i>(disabled — won't run until re-enabled)</i>"
+                  }`,
+                }}
+              />
+            </div>
+          ) : null}
+
+          {saveErrors.length > 0 ? (
+            <div className="row-error" style={{ marginTop: 10 }} data-testid="saf-error-banner">
+              <b>{saveErrors.length === 1 ? 'Fix this before saving' : 'Fix these before saving'}</b>
+              <ul style={{ margin: '4px 0 0 18px' }}>
+                {saveErrors.map((e, i) => (
+                  <li key={i}>{e.message}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+        <div className="wiz-foot">
+          {err ? (
+            <span className="wiz-err" role="alert">
+              {err}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span style={{ display: 'inline-flex', gap: 8 }}>
+            <button className="btn-ghost" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              className="btn-primary"
+              data-testid="saf-submit"
+              disabled={busy}
+              onClick={() => void submit()}
+            >
+              {busy ? 'Saving…' : saveLabel}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-rules/safety-catalog.test.ts
+++ b/web-react/src/features/settings/safety-rules/safety-catalog.test.ts
@@ -1,0 +1,300 @@
+// Ported from web/src/components/safety-catalog.test.ts alongside the
+// module (I.5: port WHOLE, with tests).
+import { describe, expect, it } from 'vitest';
+
+import type { SafetyCheck, SafetyStage } from '../../../api/client';
+import {
+  SAFETY_CHECK_CATALOG,
+  actionButtonState,
+  checkLabel,
+  effectiveAction,
+  naturalAction,
+  safSentence,
+  safWhatPhrase,
+} from './safety-catalog';
+
+// Minimal wire SafetyCheck factory — only the behaviour fields the helpers
+// read. Mirrors the real registry shape (verified against the live dump).
+function check(over: Partial<SafetyCheck> & Pick<SafetyCheck, 'id'>): SafetyCheck {
+  return {
+    version: '1',
+    stages: [],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: {},
+    supported_actions: {},
+    supported_codes: [],
+    config_schema: null,
+    ...over,
+  } as SafetyCheck;
+}
+
+const piiRegex = check({
+  id: 'pii.regex',
+  action_model: 'fixed',
+  stages: ['input_prompt', 'pre_tool_call', 'post_tool_result', 'model_output'],
+  natural_actions: {
+    input_prompt: 'block',
+    pre_tool_call: 'block',
+    post_tool_result: 'block',
+    model_output: 'block',
+  },
+  supported_actions: {
+    input_prompt: ['allow', 'block', 'require_approval', 'warn'],
+    pre_tool_call: ['allow', 'block', 'require_approval', 'warn'],
+    post_tool_result: ['allow', 'block', 'warn'],
+    model_output: ['allow', 'block', 'require_approval'],
+  },
+});
+
+const presidio = check({
+  id: 'presidio.pii',
+  action_model: 'config_routed',
+  stages: ['input_prompt', 'post_tool_result', 'model_output'],
+  natural_actions: { input_prompt: 'allow', post_tool_result: 'allow', model_output: 'allow' },
+  supported_actions: {
+    post_tool_result: ['allow', 'block', 'redact', 'warn'],
+  },
+});
+
+const domainAllowlist = check({
+  id: 'domain_allowlist',
+  action_model: 'fixed',
+  stages: ['pre_tool_call'],
+  natural_actions: { pre_tool_call: 'block' },
+  supported_actions: { pre_tool_call: ['allow', 'block', 'require_approval', 'warn'] },
+});
+
+describe('safety catalog coverage', () => {
+  it('labels every catalog check and never echoes the raw id', () => {
+    for (const id of Object.keys(SAFETY_CHECK_CATALOG)) {
+      expect(checkLabel(id)).toBe(SAFETY_CHECK_CATALOG[id].label);
+      expect(checkLabel(id)).not.toBe(id);
+    }
+  });
+
+  it('falls back to the id for an unknown check', () => {
+    expect(checkLabel('not.a.real.check')).toBe('not.a.real.check');
+  });
+});
+
+describe('actionButtonState — backend override whitelist {block,warn,require_approval}', () => {
+  // The natural action is the default and is always pickable.
+  it('enables the natural action even though it is not "overridable"', () => {
+    const presidioNatural = naturalAction(presidio, 'post_tool_result' as SafetyStage);
+    expect(presidioNatural).toBe('allow');
+    expect(
+      actionButtonState(presidio, 'post_tool_result' as SafetyStage, 'allow', 'allow').enabled,
+    ).toBe(true);
+  });
+
+  // allow is server-"supported" everywhere but cannot be written as an
+  // override — picking it on a block-natural check would 400. Must be
+  // disabled with a "disable the rule instead" hint, NOT the generic reason.
+  it('disables allow on a block-natural check with the disable-rule hint', () => {
+    const st = actionButtonState(
+      piiRegex,
+      'pre_tool_call' as SafetyStage,
+      'allow',
+      'block',
+    );
+    expect(st.enabled).toBe(false);
+    expect(st.reason).toMatch(/disable the rule/i);
+  });
+
+  // redact is only synthesizable by Presidio routing, never an override.
+  it('disables redact on pii.regex (cannot rewrite payload)', () => {
+    const st = actionButtonState(
+      piiRegex,
+      'pre_tool_call' as SafetyStage,
+      'redact',
+      'block',
+    );
+    expect(st.enabled).toBe(false);
+    expect(st.reason).toMatch(/redact|rewrite|presidio/i);
+  });
+
+  it('enables warn + require_approval where the stage supports them', () => {
+    expect(
+      actionButtonState(piiRegex, 'pre_tool_call' as SafetyStage, 'warn', 'block').enabled,
+    ).toBe(true);
+    expect(
+      actionButtonState(piiRegex, 'pre_tool_call' as SafetyStage, 'require_approval', 'block')
+        .enabled,
+    ).toBe(true);
+  });
+
+  // warn is excluded on model_output by the wire matrix — server-driven.
+  it('disables an action the stage does not support, with a reason', () => {
+    const st = actionButtonState(
+      piiRegex,
+      'model_output' as SafetyStage,
+      'warn',
+      'block',
+    );
+    expect(st.enabled).toBe(false);
+    expect(st.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe('effectiveAction', () => {
+  it('uses the config override when present', () => {
+    const a = effectiveAction(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: { action_override: 'warn' } },
+      piiRegex,
+    );
+    expect(a).toBe('warn');
+  });
+
+  it('falls back to the natural action with no override', () => {
+    const a = effectiveAction(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: {} },
+      piiRegex,
+    );
+    expect(a).toBe('block');
+  });
+
+  it('returns block for host-list checks regardless of action_model', () => {
+    const a = effectiveAction(
+      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { allowed_hosts: ['a.com'] } },
+      domainAllowlist,
+    );
+    expect(a).toBe('block');
+  });
+
+  it('returns null for presidio.pii with empty block/redact lists (inert)', () => {
+    // Backend stores block_codes + redact_codes (not a routing dict).
+    const a = effectiveAction(
+      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { block_codes: [], redact_codes: [] } },
+      presidio,
+    );
+    expect(a).toBeNull();
+  });
+
+  it('picks redact over block for the presidio pill (most-severe wins)', () => {
+    const a = effectiveAction(
+      {
+        check_id: 'presidio.pii',
+        stage: 'post_tool_result' as SafetyStage,
+        config: { block_codes: ['US_SSN'], redact_codes: ['EMAIL_ADDRESS'] },
+      },
+      presidio,
+    );
+    expect(a).toBe('redact');
+  });
+});
+
+describe('safWhatPhrase', () => {
+  it('names the entities for pii.regex (backend patterns dict, uppercase keys)', () => {
+    // Backend stores { patterns: { SSN: true, CREDIT_CARD: true } }
+    expect(safWhatPhrase('pii.regex', { patterns: { SSN: true, CREDIT_CARD: true } })).toBe(
+      'detect SSNs, credit cards',
+    );
+  });
+
+  it('shows nothing-configured for pii.regex with empty patterns', () => {
+    expect(safWhatPhrase('pii.regex', { patterns: {} })).toBe(
+      'detect configured personal data',
+    );
+  });
+
+  it('avoids the word "inert" for an unconfigured presidio check', () => {
+    // Backend stores { block_codes: [], redact_codes: [] }
+    const phrase = safWhatPhrase('presidio.pii', { block_codes: [], redact_codes: [] });
+    expect(phrase).not.toMatch(/inert/i);
+    expect(phrase).toMatch(/running but doing nothing/i);
+  });
+
+  it('summarizes presidio block/redact codes with a +N overflow', () => {
+    // Backend stores block_codes + redact_codes
+    const phrase = safWhatPhrase('presidio.pii', {
+      block_codes: ['US_SSN', 'PERSON'],
+      redact_codes: ['EMAIL_ADDRESS', 'PHONE_NUMBER'],
+    });
+    expect(phrase).toContain('SSNs→block');
+    expect(phrase).toContain('+1 more');
+  });
+
+  it('counts hosts for an allowlist', () => {
+    expect(safWhatPhrase('domain_allowlist', { allowed_hosts: ['a.com', 'b.com'] })).toBe(
+      'allow only 2 hosts',
+    );
+    expect(safWhatPhrase('domain_allowlist', { allowed_hosts: ['a.com'] })).toBe('allow only 1 host');
+  });
+
+  // G1/G2 fix: egress.domain_rule now uses domain_patterns (list), not the
+  // pre-PR-#55 singular domain_pattern (string).
+  it('counts domain_patterns for egress.domain_rule (post-PR-#55 shape)', () => {
+    expect(
+      safWhatPhrase('egress.domain_rule', { domain_patterns: ['api.stripe.com', '*.acme.com'] }),
+    ).toBe('allow 2 domains');
+    expect(
+      safWhatPhrase('egress.domain_rule', { domain_patterns: ['api.stripe.com'] }),
+    ).toBe('allow 1 domain');
+  });
+
+  it('falls back gracefully for egress.domain_rule with empty or missing domain_patterns', () => {
+    expect(safWhatPhrase('egress.domain_rule', {})).toBe('allow listed domains');
+    expect(safWhatPhrase('egress.domain_rule', { domain_patterns: [] })).toBe('allow listed domains');
+  });
+
+  it('ignores the old singular domain_pattern key for egress.domain_rule', () => {
+    // Pre-PR-#55 shape — must NOT be read anymore.
+    const phrase = safWhatPhrase('egress.domain_rule', { domain_pattern: 'api.stripe.com' });
+    expect(phrase).toBe('allow listed domains'); // treated as empty/unknown
+  });
+});
+
+describe('safSentence', () => {
+  it('renders a fixed-check sentence with the effective verb and scope', () => {
+    const s = safSentence(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: { patterns: { SSN: true } } },
+      piiRegex,
+      null,
+    );
+    expect(s).toContain('Before tool calls');
+    expect(s).toContain('detect SSNs');
+    expect(s).toContain('<b>block the call</b>');
+    expect(s).toContain('All coworkers.');
+  });
+
+  it('shows the coworker name when scoped', () => {
+    const s = safSentence(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: {} },
+      piiRegex,
+      'Ops coworker',
+    );
+    expect(s).toContain('Ops coworker only.');
+  });
+
+  it('omits the verb for an inert routed check (no contradiction)', () => {
+    const s = safSentence(
+      { check_id: 'presidio.pii', stage: 'post_tool_result' as SafetyStage, config: { block_codes: [], redact_codes: [] } },
+      presidio,
+      null,
+    );
+    expect(s).not.toContain('<b>');
+    expect(s).toContain('running but doing nothing');
+  });
+
+  it('uses the allowlist phrasing for host-list checks', () => {
+    const s = safSentence(
+      { check_id: 'domain_allowlist', stage: 'pre_tool_call' as SafetyStage, config: { allowed_hosts: ['a.com', 'b.com', 'c.com'] } },
+      domainAllowlist,
+      'Ops coworker',
+    );
+    expect(s).toContain('allow only 3 hosts');
+    expect(s).toContain('<b>block the call</b>');
+    expect(s).toContain('(for anything else)');
+  });
+
+  it('escapes a coworker name with HTML metacharacters', () => {
+    const s = safSentence(
+      { check_id: 'pii.regex', stage: 'pre_tool_call' as SafetyStage, config: {} },
+      piiRegex,
+      '<script>x</script>',
+    );
+    expect(s).not.toContain('<script>');
+    expect(s).toContain('&lt;script&gt;');
+  });
+});

--- a/web-react/src/features/settings/safety-rules/safety-catalog.ts
+++ b/web-react/src/features/settings/safety-rules/safety-catalog.ts
@@ -1,0 +1,476 @@
+// Copied from web/src/components/safety-catalog.ts @ feat/webui-react;
+// keep in sync manually until workspace extraction. Page-private pure
+// module — colocated in the slug folder per the §1.1 growth rule.
+// React note: sentence helpers return HTML strings rendered with
+// dangerouslySetInnerHTML (dynamic text escaped inside — same contract
+// as the Lit unsafeHTML call).
+//
+// Safety-check presentation catalog + sentence / action helpers (spec §6).
+//
+// WHY THIS FILE EXISTS — the wire/presentation split.
+// `GET /api/v1/safety/checks` returns `SafetyCheck[]` carrying only the
+// *behaviour* of each check: which `stages` it runs at, its `action_model`,
+// the `natural_actions` a hit produces, the `supported_actions` a rule may
+// pick, and `cost_class`. It does NOT carry the human label, description,
+// category grouping, or which config form to render — those are pure
+// presentation and live here, keyed by `check_id`. Components merge the two:
+// behaviour from the wire (never hardcoded), presentation from this catalog.
+//
+// USER-FACING LANGUAGE (spec §8.5). Nothing here leaks engineering taxonomy.
+// `action_model` ("fixed" / "config_routed" / "aggregated") drives which
+// editor experience renders but is never shown; "inert" becomes "running but
+// doing nothing"; stages get friendly phrases ("before tool calls"), with the
+// mono enum kept only for deep-inspection surfaces (the decision detail modal).
+
+import type {
+  SafetyCheck,
+  SafetyStage,
+  SafetyVerdictAction,
+} from '../../../api/client';
+
+// Which config form a check renders — a presentation hint derived from the
+// check's config_schema (spec §6.12). Not on the wire.
+export type CfgKind =
+  | 'pii-entities'
+  | 'presidio-routing'
+  | 'moderation-routing'
+  | 'threshold'
+  | 'host-list'
+  | 'secret-plugins'
+  | 'jailbreak-phrases';
+
+export interface CheckPresentation {
+  /** Human label — shown everywhere a check is named. Never the raw id. */
+  label: string;
+  /** One-line "what this check does", shown under the dialog's check select. */
+  desc: string;
+  /** Group heading in the check `<optgroup>` (Sensitive data / … / Network). */
+  category: string;
+  /** Which config form to render; absent ⇒ the check takes no config. */
+  cfgKind?: CfgKind;
+}
+
+// Presentation metadata, keyed by registered check id. Keys MUST match the
+// ids the backend registry exposes (verified by the catalog-coverage test).
+// Behaviour fields (stages/action_model/…) are intentionally absent — they
+// come from the wire SafetyCheck so the two never drift.
+export const SAFETY_CHECK_CATALOG: Record<string, CheckPresentation> = {
+  'pii.regex': {
+    label: 'Personal data (regex)',
+    desc: 'Fast pattern matchers for SSN, credit cards, email, phone, and IP addresses. Cheap enough to run before every tool call; for broader coverage use the Presidio check.',
+    category: 'Sensitive data',
+    cfgKind: 'pii-entities',
+  },
+  'presidio.pii': {
+    label: 'Personal data (Presidio)',
+    desc: 'Broader entity coverage (names, locations, emails, and more) with an adjustable confidence threshold. The only check that can rewrite a payload — required for redaction.',
+    category: 'Sensitive data',
+    cfgKind: 'presidio-routing',
+  },
+  secret_scanner: {
+    label: 'Secrets & credentials',
+    desc: 'Scans for API keys, tokens, passwords, and cloud credentials. Run it on outputs to stop a coworker from leaking a secret. Runs all built-in detectors automatically — no configuration needed.',
+    category: 'Sensitive data',
+    // No cfgKind: backend SecretScannerConfig only has action_override.
+    // The dialog shows a plain info note instead of a config form.
+    cfgKind: 'secret-plugins' as const,
+  },
+  domain_allowlist: {
+    label: 'Allowed domains only',
+    desc: 'Blocks any tool call whose URL reaches a host that is not on the allowlist. Complements network egress control.',
+    category: 'Network',
+    cfgKind: 'host-list',
+  },
+  'egress.domain_rule': {
+    label: 'Egress domain rule',
+    desc: 'Restricts the hosts a coworker can reach over the network. Enforced on every outbound request the coworker makes.',
+    category: 'Network',
+    cfgKind: 'host-list',
+  },
+  'llm_guard.prompt_injection': {
+    label: 'Prompt injection',
+    desc: 'Catches attempts to hijack the coworker through instructions hidden in user input or tool output.',
+    category: 'Adversarial input',
+    cfgKind: 'threshold',
+  },
+  'llm_guard.jailbreak': {
+    label: 'Jailbreak attempts',
+    desc: 'Detects attempts to talk the coworker out of its guardrails (role-play exploits and similar tricks). Uses a built-in phrase list by default; add custom phrases for tenant-specific patterns.',
+    category: 'Adversarial input',
+    cfgKind: 'jailbreak-phrases',
+  },
+  'llm_guard.toxicity': {
+    label: 'Toxic content',
+    desc: 'Flags hateful, harassing, or abusive language on either side of the conversation.',
+    category: 'Content',
+    cfgKind: 'threshold',
+  },
+  openai_moderation: {
+    label: 'Content moderation',
+    desc: 'Runs text through moderation categories (sexual / hate / harassment / self-harm / violence) and lets you choose what to do for each.',
+    category: 'Content',
+    cfgKind: 'moderation-routing',
+  },
+};
+
+// Category render order for the check `<optgroup>` list — most-reached for
+// the common case first.
+export const SAFETY_CATEGORY_ORDER = [
+  'Sensitive data',
+  'Adversarial input',
+  'Content',
+  'Network',
+];
+
+// Action ladder, severity-ascending — the stable order the segmented control
+// renders regardless of which subset a (check, stage) supports.
+export const SAF_ACTION_ORDER: SafetyVerdictAction[] = [
+  'allow',
+  'warn',
+  'redact',
+  'require_approval',
+  'block',
+];
+
+// The only actions a rule may set via `config.action_override` (backend
+// whitelist — see src/webui/admin.py `_validate_safety_rule_body`). `allow`
+// is the absence of an override (a rule that "allows" everything is just the
+// natural pass-through), and `redact` cannot be synthesized by an override
+// (it needs a check that emits a modified payload — that path is the Presidio
+// routing form, not an override). The action panel uses this to decide which
+// non-natural actions are pickable, so the UI never produces a 400.
+export const OVERRIDABLE_ACTIONS: ReadonlySet<SafetyVerdictAction> = new Set([
+  'block',
+  'warn',
+  'require_approval',
+]);
+
+// Stages where a check failure fails CLOSED (the call is blocked). The other
+// two (post_tool_result, pre_compaction) fail SAFE (the call is let through).
+// Surfaced as a one-line helper in the dialog, never as "control/observational".
+export const SAF_CONTROL_STAGES: ReadonlySet<string> = new Set([
+  'input_prompt',
+  'pre_tool_call',
+  'model_output',
+  'egress_request',
+]);
+
+// Long form for the stage `<select>` — teaches the concept in plain language.
+export const SAF_STAGE_LABEL: Record<string, string> = {
+  input_prompt: 'On user input — before the coworker processes it',
+  pre_tool_call: 'Before a tool runs — check the tool arguments first',
+  post_tool_result: 'After a tool returns — before the coworker sees the result',
+  model_output: 'On the reply — before the user sees it',
+  pre_compaction: 'Before conversation compaction',
+  egress_request: 'On outbound network requests',
+};
+
+// Short friendly phrase for sentences/cards (NOT the mono enum — §8.5).
+export const SAF_STAGE_SHORT: Record<string, string> = {
+  input_prompt: 'on input',
+  pre_tool_call: 'before tool calls',
+  post_tool_result: 'on tool results',
+  model_output: 'on the reply',
+  pre_compaction: 'before compaction',
+  egress_request: 'on network requests',
+};
+
+export const SAF_ACTION_LABEL: Record<SafetyVerdictAction, string> = {
+  allow: 'Allow',
+  warn: 'Warn',
+  redact: 'Redact',
+  require_approval: 'Approve',
+  block: 'Block',
+};
+
+// Tiny sub-caption under each segmented-control button.
+export const SAF_ACTION_SUB: Record<SafetyVerdictAction, string> = {
+  allow: 'log only',
+  warn: 'flag the coworker',
+  redact: 'strip + continue',
+  require_approval: 'ask the user',
+  block: 'stop the call',
+};
+
+// Sentence verb for each action (spec §6.13).
+export const SAF_ACTION_VERB: Record<SafetyVerdictAction, string> = {
+  allow: 'let it through (audit only)',
+  warn: 'let it through but flag it for the coworker',
+  redact: 'strip the matched content and continue',
+  require_approval: 'pause and ask the person in the chat',
+  block: 'block the call',
+};
+
+// Map an action to the pill modifier class (defined in settings-pages.css).
+// allow=green, warn=gray, redact=amber, require_approval=purple, block=red.
+const SAF_ACTION_PILL: Record<SafetyVerdictAction, string> = {
+  allow: 'rm-pill-on',
+  warn: 'rm-pill-off',
+  redact: 'rm-pill-warn',
+  require_approval: 'rm-pill-appr',
+  block: 'rm-pill-bad',
+};
+
+export function safActionPillClass(action: SafetyVerdictAction): string {
+  return SAF_ACTION_PILL[action] ?? 'rm-pill-off';
+}
+
+// Why an action is unavailable for a (check, stage). The server is the source
+// of truth for WHICH (via supported_actions); these strings only explain the
+// common reasons in plain language. A reason not listed falls back to generic.
+const SAF_UNSUPPORTED_REASON: Partial<Record<SafetyVerdictAction, string>> = {
+  redact: 'Only the Presidio check can rewrite a payload, so redaction is not available here.',
+  warn: 'Nothing reads a warning at this stage.',
+  require_approval: 'There is no one to ask at this stage — the tool has already run, or there is no chat.',
+};
+
+export function unsupportedReason(action: SafetyVerdictAction): string {
+  return (
+    SAF_UNSUPPORTED_REASON[action] ??
+    'Not available for this check at this stage.'
+  );
+}
+
+// ---- behaviour lookups against the wire SafetyCheck ----
+
+export function naturalAction(
+  check: SafetyCheck | null,
+  stage: SafetyStage,
+): SafetyVerdictAction | null {
+  const na = check?.natural_actions as
+    | Partial<Record<string, SafetyVerdictAction>>
+    | undefined;
+  return na?.[stage] ?? null;
+}
+
+export function supportedActions(
+  check: SafetyCheck | null,
+  stage: SafetyStage,
+): SafetyVerdictAction[] {
+  const sa = check?.supported_actions as
+    | Partial<Record<string, SafetyVerdictAction[]>>
+    | undefined;
+  return sa?.[stage] ?? [];
+}
+
+export interface ActionButtonState {
+  enabled: boolean;
+  /** Tooltip shown when disabled; empty when enabled. */
+  reason: string;
+}
+
+// Whether a segmented-control button for `action` is pickable, and why not.
+// A button is enabled when it is the natural action (the default — selecting
+// it writes no override) OR it is both server-supported AND writable as an
+// override. `allow`/`redact` therefore stay disabled on a block-natural check
+// (you cannot downgrade to allow; redaction is configured on Presidio, not
+// overridden) — which is exactly what the backend accepts.
+export function actionButtonState(
+  check: SafetyCheck | null,
+  stage: SafetyStage,
+  action: SafetyVerdictAction,
+  natural: SafetyVerdictAction | null,
+): ActionButtonState {
+  if (action === natural) return { enabled: true, reason: '' };
+  const supported = supportedActions(check, stage).includes(action);
+  if (!supported) return { enabled: false, reason: unsupportedReason(action) };
+  if (!OVERRIDABLE_ACTIONS.has(action)) {
+    // Supported as a verdict, but not reachable as a rule override.
+    const reason =
+      action === 'allow'
+        ? 'This check always acts on a hit. To stop it, disable the rule instead.'
+        : unsupportedReason(action);
+    return { enabled: false, reason };
+  }
+  return { enabled: true, reason: '' };
+}
+
+// ---- effective action (no top-level `action` field in production) ----
+
+// The host-list checks express their whole intent as "allow these, block the
+// rest", regardless of action_model — so their effective verdict for display
+// is always block (for anything off the list).
+function isHostList(checkId: string): boolean {
+  return SAFETY_CHECK_CATALOG[checkId]?.cfgKind === 'host-list';
+}
+
+// Port note: the Lit source carries a dead `representativeRoutedAction`
+// helper (+ ROUTED_VERB_PRIORITY) left over from the routing-map era —
+// effectiveAction reads the wire's block_codes/redact_codes directly.
+// Dropped here; strict noUnusedLocals would reject the dead code.
+
+/** A rule (saved or in-progress draft) reduced to what the sentence needs. */
+export interface SentenceRule {
+  check_id: string;
+  stage: SafetyStage;
+  config: Record<string, unknown>;
+}
+
+// The single action a rule effectively takes, for the card pill and preview.
+// Returns null when a routed check has no routing yet (inert — no pill verb).
+export function effectiveAction(
+  rule: SentenceRule,
+  check: SafetyCheck | null,
+): SafetyVerdictAction | null {
+  if (isHostList(rule.check_id)) return 'block';
+  if (check?.action_model === 'config_routed') {
+    if (rule.check_id === 'presidio.pii') {
+      // Backend stores block_codes + redact_codes (not a routing dict).
+      const blockCodes = (rule.config?.['block_codes'] as string[]) ?? [];
+      const redactCodes = (rule.config?.['redact_codes'] as string[]) ?? [];
+      if (redactCodes.length > 0) return 'redact';
+      if (blockCodes.length > 0) return 'block';
+      return null; // inert
+    }
+    if (rule.check_id === 'openai_moderation') {
+      // Backend stores block_categories + warn_categories (not a routing dict).
+      const blockCats = (rule.config?.['block_categories'] as string[]) ?? [];
+      const warnCats = (rule.config?.['warn_categories'] as string[]) ?? [];
+      if (blockCats.length > 0) return 'block';
+      if (warnCats.length > 0) return 'warn';
+      return null; // inert
+    }
+    return null;
+  }
+  const override = rule.config?.['action_override'];
+  if (typeof override === 'string') return override as SafetyVerdictAction;
+  return naturalAction(check, rule.stage) ?? 'block';
+}
+
+// ---- sentence rendering (HTML string; the single source of truth) ----
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Keys match the backend pattern keys (uppercase, per _CONFIG_KEY_TO_CODE).
+const PII_REGEX_LABELS: Record<string, string> = {
+  SSN: 'SSNs',
+  CREDIT_CARD: 'credit cards',
+  EMAIL: 'emails',
+  PHONE_US: 'phones',
+  IP_ADDRESS: 'IPs',
+};
+const PRESIDIO_ENTITY_LABELS: Record<string, string> = {
+  EMAIL_ADDRESS: 'emails',
+  PHONE_NUMBER: 'phones',
+  US_SSN: 'SSNs',
+  CREDIT_CARD: 'credit cards',
+  PERSON: 'names',
+  LOCATION: 'locations',
+  IP_ADDRESS: 'IPs',
+  DATE_TIME: 'dates',
+};
+
+// Subject+verb phrase describing what the check looks for, varying by check
+// (spec §6.13). Returns plain text; the caller wraps it in the sentence.
+export function safWhatPhrase(
+  checkId: string,
+  config: Record<string, unknown>,
+): string {
+  const pres = SAFETY_CHECK_CATALOG[checkId];
+  if (checkId === 'pii.regex') {
+    // Backend: { patterns: { SSN: true, CREDIT_CARD: true, ... } }
+    const patterns = (config?.['patterns'] as Record<string, boolean> | undefined) ?? {};
+    const keys = Object.keys(patterns).filter((k) => patterns[k]);
+    const named = keys.map((k) => PII_REGEX_LABELS[k] ?? k);
+    return `detect ${named.length ? named.join(', ') : 'configured personal data'}`;
+  }
+  if (checkId === 'presidio.pii') {
+    // Backend: { block_codes: [...], redact_codes: [...] }
+    const blockCodes = (config?.['block_codes'] as string[]) ?? [];
+    const redactCodes = (config?.['redact_codes'] as string[]) ?? [];
+    const total = blockCodes.length + redactCodes.length;
+    if (total === 0)
+      return 'scan for personal data (not configured yet — running but doing nothing)';
+    const entries: [string, string][] = [
+      ...blockCodes.map((c): [string, string] => [c, 'block']),
+      ...redactCodes.map((c): [string, string] => [c, 'redact']),
+    ];
+    const summary = entries
+      .slice(0, 3)
+      .map(([k, a]) => `${PRESIDIO_ENTITY_LABELS[k] ?? k}→${a}`)
+      .join(', ');
+    const more = entries.length > 3 ? ` +${entries.length - 3} more` : '';
+    return summary + more;
+  }
+  if (checkId === 'secret_scanner') {
+    // SecretScannerConfig has no plugin selection — runs all detectors.
+    return 'scan for secrets';
+  }
+  if (checkId === 'domain_allowlist') {
+    // domain_allowlist backend key is `allowed_hosts` (DomainAllowlistConfig).
+    const n = ((config?.['allowed_hosts'] as string[]) ?? []).length;
+    return `allow only ${n || 'listed'} host${n === 1 ? '' : 's'}`;
+  }
+  if (checkId === 'egress.domain_rule') {
+    // Post PR #55: domain_patterns is list[str] (was singular domain_pattern: str).
+    const patterns = (config?.['domain_patterns'] as string[]) ?? [];
+    const n = patterns.length;
+    return n > 0 ? `allow ${n} domain${n === 1 ? '' : 's'}` : 'allow listed domains';
+  }
+  if (checkId === 'openai_moderation') {
+    // Backend: { block_categories: [...], warn_categories: [...] }
+    const blockCats = (config?.['block_categories'] as string[]) ?? [];
+    const warnCats = (config?.['warn_categories'] as string[]) ?? [];
+    const n = blockCats.length + warnCats.length;
+    if (n === 0) return 'check content moderation (not configured yet)';
+    return `flag ${n} categor${n === 1 ? 'y' : 'ies'}`;
+  }
+  if (pres?.cfgKind === 'threshold') {
+    const t = config?.['threshold'];
+    const label = (pres.label || checkId).toLowerCase();
+    return `detect ${label}${t != null ? ` (sensitivity ${t})` : ''}`;
+  }
+  if (checkId === 'llm_guard.jailbreak') {
+    // Backend: { phrases: [...], case_sensitive: bool }
+    const phrases = (config?.['phrases'] as string[]) ?? [];
+    const custom = phrases.length;
+    return `detect jailbreak attempts${custom ? ` (${custom} custom phrase${custom === 1 ? '' : 's'})` : ''}`;
+  }
+  return (pres?.label ?? checkId).toLowerCase();
+}
+
+// Human-readable rule sentence — used on list cards, the dialog live preview,
+// and the delete-confirmation modal. Returns an HTML string (with <b>/<span>)
+// for `unsafeHTML`; all dynamic text is escaped.
+export function safSentence(
+  rule: SentenceRule,
+  check: SafetyCheck | null,
+  coworkerName: string | null,
+): string {
+  const scope = coworkerName ? `${coworkerName} only.` : 'All coworkers.';
+  const what = safWhatPhrase(rule.check_id, rule.config);
+  const stageShort = SAF_STAGE_SHORT[rule.stage] ?? rule.stage;
+  const stageCap = stageShort.charAt(0).toUpperCase() + stageShort.slice(1);
+  const scopeSpan = `<span class="rm-saf-scope-mute">${esc(scope)}</span>`;
+
+  // Inert routed checks: the "running but doing nothing" phrase already
+  // carries the meaning — appending a verb would contradict it.
+  if (check?.action_model === 'config_routed') {
+    const routing = (rule.config?.['routing'] as Record<string, unknown>) ?? {};
+    if (Object.keys(routing).length === 0) {
+      return `${esc(stageCap)}, ${esc(what)}. ${scopeSpan}`;
+    }
+  }
+
+  if (isHostList(rule.check_id)) {
+    return `${esc(stageCap)}, ${esc(what)} — <b>block the call</b> <span class="rm-saf-scope-mute">(for anything else)</span>. ${scopeSpan}`;
+  }
+
+  const action = effectiveAction(rule, check);
+  const verb = action ? SAF_ACTION_VERB[action] : null;
+  if (!verb) return `${esc(stageCap)}, ${esc(what)}. ${scopeSpan}`;
+  return `${esc(stageCap)}, ${esc(what)} — <b>${esc(verb)}</b>. ${scopeSpan}`;
+}
+
+export function checkLabel(checkId: string): string {
+  return SAFETY_CHECK_CATALOG[checkId]?.label ?? checkId;
+}
+
+export function safStageShort(stage: SafetyStage): string {
+  return SAF_STAGE_SHORT[stage] ?? stage;
+}

--- a/web-react/src/features/settings/safety-rules/safety-rules-page.test.tsx
+++ b/web-react/src/features/settings/safety-rules/safety-rules-page.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { SafetyCheck, SafetyRule } from '../../../api/client';
+import { SafetyRulesPage } from './safety-rules-page';
+
+function rule(over: Partial<SafetyRule>): SafetyRule {
+  return {
+    id: 'r-x',
+    tenant_id: 't1',
+    coworker_id: null,
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: { patterns: { SSN: true } },
+    priority: 100,
+    enabled: true,
+    description: '',
+    source: 'tenant',
+    tier: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+    ...over,
+  } as SafetyRule;
+}
+
+const CHECKS: SafetyCheck[] = [
+  {
+    id: 'pii.regex',
+    version: '1',
+    stages: ['pre_tool_call'],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: { pre_tool_call: 'block' },
+    supported_actions: {},
+    supported_codes: [],
+    config_schema: null,
+  } as unknown as SafetyCheck,
+];
+
+function renderPage(rules: SafetyRule[]) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  qc.setQueryData(['safety-rules'], rules);
+  qc.setQueryData(['safety-checks'], CHECKS);
+  qc.setQueryData(['coworkers'], [{ id: 'cw-1', name: 'Ops coworker' }]);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <SafetyRulesPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe('SafetyRulesPage', () => {
+  it('two tiers never interleave: platform (banner) first, then org section', () => {
+    renderPage([
+      rule({ id: 'org-hi', priority: 999 }),
+      rule({ id: 'plat-lo', priority: 1, source: 'platform', tier: 'floor' }),
+    ]);
+    expect(screen.getByText(/Platform defaults/)).toBeTruthy();
+    expect(screen.getByText("Your organization's rules")).toBeTruthy();
+    const cards = [...document.querySelectorAll('[data-rule-id]')];
+    // Platform card first despite lower priority — tiers don't interleave.
+    expect(cards[0].getAttribute('data-rule-id')).toBe('plat-lo');
+    expect(cards[1].getAttribute('data-rule-id')).toBe('org-hi');
+  });
+
+  it('no platform rules → no banner, no section label', () => {
+    renderPage([rule({ id: 'o1' })]);
+    expect(screen.queryByText(/Platform defaults/)).toBeNull();
+    expect(screen.queryByText("Your organization's rules")).toBeNull();
+  });
+
+  it('hint carries snapshot semantics in plain words; hidden when empty', () => {
+    renderPage([rule({ id: 'o1' })]);
+    expect(
+      screen.getByText(/tasks already in progress keep the rules they started with/),
+    ).toBeTruthy();
+    cleanup();
+    renderPage([]);
+    expect(document.querySelector('.page-hint')).toBeNull();
+    expect(screen.getByText('No safety rules yet.')).toBeTruthy();
+    expect(screen.getByText(/no automatic guardrails/)).toBeTruthy();
+  });
+
+  it('delete confirm: four parts in everyday language', () => {
+    renderPage([rule({ id: 'o1' })]);
+    fireEvent.click(screen.getByTitle('Delete rule'));
+    const dlg = screen.getByRole('alertdialog');
+    const text = dlg.textContent ?? '';
+    // 1. which rule (label + sentence)
+    expect(within(dlg).getByText('Personal data (regex)')).toBeTruthy();
+    expect(text).toContain('detect SSNs');
+    // 2. new tasks stop running the check
+    expect(text).toMatch(/stops running on new agent tasks/);
+    // 3. already-running tasks keep it (expected, not a bug)
+    expect(text).toMatch(/keep using this rule until they finish/);
+    // 4. what survives (log entries + change history)
+    expect(text).toMatch(/safety log entries are kept/i);
+    expect(text).toMatch(/change history .* is also kept/i);
+    expect(within(dlg).getByText('Delete rule')).toBeTruthy();
+  });
+});

--- a/web-react/src/features/settings/safety-rules/safety-rules-page.tsx
+++ b/web-react/src/features/settings/safety-rules/safety-rules-page.tsx
@@ -1,0 +1,335 @@
+// SafetyRulesPage — detector-driven guardrail CRUD (spec Part I;
+// behavioral reference web/src/components/safety-rules-page.ts). Two
+// tiers, never interleaved: platform defaults first (banner + read-only
+// cards, audit-only), then YOUR ORGANIZATION'S RULES. Each tier sorts
+// in server evaluation order (priority desc, created_at desc — the
+// shared lib/rule-ordering sort). Optimistic enable toggle (§H
+// semantics); create/edit/duplicate share one dialog; delete restates
+// the rule and explains snapshot semantics in plain words.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Plus, ShieldCheck } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { getApiClient, type SafetyRule } from '../../../api/client';
+import {
+  useCoworkers,
+  useSafetyChecks,
+  useSafetyRules,
+} from '../../../api/queries';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { sortByEvaluationOrder } from '../../../lib/rule-ordering';
+import { AuditDrawer } from './audit-drawer';
+import { RuleCard } from './rule-card';
+import { RuleDialog } from './rule-dialog';
+import { checkLabel, safSentence } from './safety-catalog';
+import './safety-rules.css';
+
+interface DialogState {
+  open: boolean;
+  editing: SafetyRule | null;
+  duplicating: SafetyRule | null;
+}
+
+export function SafetyRulesPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const rulesQ = useSafetyRules();
+  const checksQ = useSafetyChecks();
+  const coworkersQ = useCoworkers();
+
+  const [dialog, setDialog] = useState<DialogState>({
+    open: false,
+    editing: null,
+    duplicating: null,
+  });
+  const [deleteTarget, setDeleteTarget] = useState<SafetyRule | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [auditTarget, setAuditTarget] = useState<SafetyRule | null>(null);
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3200);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+      if (flashTimer.current) clearTimeout(flashTimer.current);
+    },
+    [],
+  );
+
+  const rules = useMemo(() => rulesQ.data ?? [], [rulesQ.data]);
+  const checks = checksQ.data ?? [];
+  const coworkers = coworkersQ.data ?? [];
+
+  const checkMeta = (id: string) => checks.find((c) => c.id === id) ?? null;
+  const coworkerName = (id: string | null | undefined): string | null => {
+    if (!id) return null;
+    const cw = coworkers.find((c) => c.id === id);
+    return cw ? cw.name : id.slice(0, 8);
+  };
+
+  const { platform, org } = useMemo(() => {
+    const sorted = sortByEvaluationOrder(rules);
+    return {
+      platform: sorted.filter((r) => r.source === 'platform'),
+      org: sorted.filter((r) => r.source !== 'platform'),
+    };
+  }, [rules]);
+
+  const setRows = (fn: (rows: SafetyRule[]) => SafetyRule[]) =>
+    queryClient.setQueryData<SafetyRule[]>(['safety-rules'], (cur) =>
+      fn(cur ?? []),
+    );
+
+  /** Optimistic enable/disable (§H semantics): flip immediately, PATCH
+   *  behind, revert + toast on failure. Platform rules never reach here
+   *  (the card renders a fixed-on no-op). */
+  async function toggleEnabled(rule: SafetyRule) {
+    if (rule.source === 'platform' || togglingIds.has(rule.id)) return;
+    const next = !rule.enabled;
+    setRows((rows) =>
+      rows.map((r) => (r.id === rule.id ? { ...r, enabled: next } : r)),
+    );
+    setTogglingIds((ids) => new Set(ids).add(rule.id));
+    try {
+      await getApiClient().updateSafetyRule(rule.id, { enabled: next });
+    } catch {
+      setRows((rows) =>
+        rows.map((r) => (r.id === rule.id ? { ...r, enabled: rule.enabled } : r)),
+      );
+      showToast('Couldn’t update — try again');
+    } finally {
+      setTogglingIds((ids) => {
+        const out = new Set(ids);
+        out.delete(rule.id);
+        return out;
+      });
+    }
+  }
+
+  /** Splice the saved rule into the cache + pulse the card. */
+  function onSaved(rule: SafetyRule, toastMsg: string) {
+    setRows((rows) =>
+      rows.some((r) => r.id === rule.id)
+        ? rows.map((r) => (r.id === rule.id ? rule : r))
+        : [...rows, rule],
+    );
+    showToast(toastMsg);
+    setFlashId(rule.id);
+    if (flashTimer.current) clearTimeout(flashTimer.current);
+    flashTimer.current = setTimeout(() => setFlashId(null), 1800);
+    requestAnimationFrame(() => {
+      document
+        .querySelector(`[data-rule-id="${rule.id}"]`)
+        ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    });
+  }
+
+  /** Edit-dialog "duplicate this rule" link (§6.11.3 — the sanctioned
+   *  scope-change path): close the edit, reopen as duplicate. */
+  function onDuplicateFromEdit(source: SafetyRule) {
+    setDialog({ open: false, editing: null, duplicating: null });
+    requestAnimationFrame(() =>
+      setDialog({ open: true, editing: null, duplicating: source }),
+    );
+  }
+
+  async function performDelete() {
+    const r = deleteTarget;
+    if (!r || deleteBusy) return;
+    setDeleteBusy(true);
+    try {
+      await getApiClient().deleteSafetyRule(r.id);
+      setRows((rows) => rows.filter((x) => x.id !== r.id));
+      showToast('Rule deleted');
+    } catch (err) {
+      showToast((err as Error).message ?? 'delete failed');
+    } finally {
+      setDeleteBusy(false);
+      setDeleteTarget(null);
+    }
+  }
+
+  const openCreate = () =>
+    setDialog({ open: true, editing: null, duplicating: null });
+
+  const renderCard = (r: SafetyRule) => (
+    <RuleCard
+      key={r.id}
+      rule={r}
+      check={checkMeta(r.check_id)}
+      coworkerName={coworkerName(r.coworker_id)}
+      toggling={togglingIds.has(r.id)}
+      flash={flashId === r.id}
+      onToggle={() => void toggleEnabled(r)}
+      onEdit={() => setDialog({ open: true, editing: r, duplicating: null })}
+      onDuplicate={() => setDialog({ open: true, editing: null, duplicating: r })}
+      onAudit={() => setAuditTarget(r)}
+      onDelete={() => setDeleteTarget(r)}
+    />
+  );
+
+  const deleteMeta = deleteTarget ? checkMeta(deleteTarget.check_id) : null;
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Safety rules</h1>
+          <div className="page-sub" style={{ maxWidth: 640 }}>
+            Automatic guardrails that scan for personal data, prompt injection,
+            secrets, or untrusted domains. Unlike approval policies these run with
+            no human in the loop — except when a rule's action is set to Approve,
+            which routes to the same approval surface.
+          </div>
+        </div>
+        <button className="btn-primary" onClick={openCreate}>
+          <Plus />
+          New rule
+        </button>
+      </div>
+
+      <div className="grid-scroll" style={{ paddingTop: 12 }}>
+        {rulesQ.isLoading || checksQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : rulesQ.isError ? (
+          <div className="row-error">
+            Failed to load safety rules — retry from the sidebar.
+          </div>
+        ) : rules.length === 0 ? (
+          <div className="grid-empty">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <span style={{ color: 'var(--rm-action)' }}>
+                <ShieldCheck size={64} strokeWidth={1.2} />
+              </span>
+              <div style={{ marginTop: '0.75rem', fontSize: '1rem' }}>
+                No safety rules yet.
+              </div>
+              <div
+                style={{
+                  marginTop: 4,
+                  fontSize: '0.875rem',
+                  color: 'var(--rm-text-muted)',
+                  maxWidth: 400,
+                }}
+              >
+                Coworkers run with no automatic guardrails. Create your first rule
+                to scan for personal data, prompt injection, or untrusted domains.
+              </div>
+              <button
+                className="btn-primary"
+                style={{ marginTop: '1rem' }}
+                onClick={openCreate}
+              >
+                <Plus />
+                Create your first rule
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {platform.length ? (
+              <div className="plat-banner">
+                <ShieldCheck size={16} style={{ flexShrink: 0, marginTop: 1 }} />
+                <span>
+                  <b>Platform defaults</b> — these rules apply to every
+                  organization and can't be edited or disabled at this level.
+                  Contact the platform admin to change.
+                </span>
+              </div>
+            ) : null}
+            {platform.map(renderCard)}
+            {platform.length && org.length ? (
+              <div className="saf-section">Your organization's rules</div>
+            ) : null}
+            {org.map(renderCard)}
+            {/* Evaluation-order + snapshot semantics in plain words —
+                hidden when the list is empty. */}
+            <div className="page-hint">
+              Higher-priority rules run first; ties go to the newest. Changes apply
+              to new agent tasks — tasks already in progress keep the rules they
+              started with until they finish.
+            </div>
+          </>
+        )}
+      </div>
+
+      {dialog.open ? (
+        <RuleDialog
+          editing={dialog.editing}
+          duplicating={dialog.duplicating}
+          checks={checks}
+          coworkers={coworkers}
+          rules={rules}
+          onClose={() => setDialog({ open: false, editing: null, duplicating: null })}
+          onSaved={onSaved}
+          onDuplicateFromEdit={onDuplicateFromEdit}
+        />
+      ) : null}
+
+      {auditTarget ? (
+        <AuditDrawer rule={auditTarget} onClose={() => setAuditTarget(null)} />
+      ) : null}
+
+      {deleteTarget ? (
+        <ConfirmDialog
+          title="Delete safety rule?"
+          confirmLabel="Delete rule"
+          busyLabel="Deleting…"
+          busy={deleteBusy}
+          onConfirm={() => void performDelete()}
+          onCancel={() => {
+            if (!deleteBusy) setDeleteTarget(null);
+          }}
+        >
+          <p style={{ margin: '0 0 10px' }}>
+            You're about to delete the rule <b>{checkLabel(deleteTarget.check_id)}</b>{' '}
+            —{' '}
+            <span
+              dangerouslySetInnerHTML={{
+                __html: safSentence(
+                  {
+                    check_id: deleteTarget.check_id,
+                    stage: deleteTarget.stage,
+                    config: (deleteTarget.config ?? {}) as Record<string, unknown>,
+                  },
+                  deleteMeta,
+                  coworkerName(deleteTarget.coworker_id),
+                ),
+              }}
+            />
+          </p>
+          <p style={{ margin: '0 0 10px' }}>
+            After deletion, this check stops running on new agent tasks. Tasks
+            already in progress keep using this rule until they finish, then move
+            on.
+          </p>
+          <p style={{ margin: 0, fontSize: '12.5px', color: 'var(--rm-text-muted)' }}>
+            Past safety log entries are kept. The change history for this rule is
+            also kept — you can review it later if there's ever an audit.
+          </p>
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-rules/safety-rules.css
+++ b/web-react/src/features/settings/safety-rules/safety-rules.css
@@ -1,0 +1,259 @@
+/* Safety rules page (spec Part I). Shared primitives (page chrome,
+ * pol-card family, priority badge, switch, dialog family, toast) live
+ * in components/ui.css + the approval-policies hoists; this file owns
+ * the safety-specific chips, action pill, platform banner, section
+ * label, audit drawer rows, duplicate banners, action segmented
+ * control, routing table, and config grid. */
+
+/* five-color action pill (allow/warn/redact/require_approval/block) */
+.saf-act {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+.saf-act--allow {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.saf-act--warn {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.saf-act--redact {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.saf-act--require_approval {
+  background: var(--rm-appr-bg);
+  color: var(--rm-appr-text);
+}
+.saf-act--block {
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+}
+
+/* slow-latency + scope chips (inline in the card's target row) */
+.saf-chip {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 2px;
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+  white-space: nowrap;
+}
+.saf-chip--slow {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+
+/* platform tier: accent badge + info banner + section label */
+.pol-pri--plat {
+  background: var(--rm-action);
+  color: var(--rm-app-bg);
+}
+.plat-banner {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  max-width: 760px;
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+  border-radius: 4px;
+  padding: 10px 14px;
+  font-size: 0.8125rem;
+  margin-bottom: 12px;
+}
+.saf-section {
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  color: var(--rm-text-muted);
+  border-bottom: 1px solid var(--rm-border);
+  padding-bottom: 6px;
+  margin: 18px 0 10px;
+  max-width: 760px;
+}
+
+/* audit drawer rows */
+.audit-row {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--rm-border);
+  font-size: 0.875rem;
+}
+.audit-row:last-child {
+  border-bottom: none;
+}
+.audit-verb {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+.audit-verb--created {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.audit-verb--updated {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.audit-verb--deleted {
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+}
+.audit-row .who {
+  font-weight: 700;
+}
+.audit-row .when {
+  color: var(--rm-text-muted);
+  font-size: 12px;
+  margin-left: auto;
+  white-space: nowrap;
+}
+.audit-row .diff {
+  width: 100%;
+  color: var(--rm-text);
+  font-size: 0.8125rem;
+}
+
+/* G3 duplicate-detection banners (info = auto-flipped to edit,
+ * warn = forced-create, subtle = platform-overlap FYI) */
+.dup-banner {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  border-radius: 4px;
+  padding: 10px 12px;
+  font-size: 0.8125rem;
+  margin-bottom: 12px;
+}
+.dup-banner.info {
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+}
+.dup-banner.warn {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.dup-banner.subtle {
+  background: var(--rm-card-bg);
+  border: 1px solid var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.dup-banner button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  color: inherit;
+}
+
+/* action segmented control (experience 1) */
+.actseg {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.actseg button {
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-app-bg);
+  cursor: pointer;
+  font-family: var(--font-base);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 6px 12px;
+  color: var(--rm-nav-text-2);
+}
+.actseg button.on {
+  border-color: var(--rm-action);
+  color: var(--rm-action);
+  box-shadow: inset 0 0 0 1px var(--rm-action);
+}
+.actseg button:disabled {
+  opacity: 0.45;
+  text-decoration: line-through;
+  cursor: not-allowed;
+}
+.actseg .sub {
+  display: block;
+  font-size: 10.5px;
+  font-weight: 400;
+  color: var(--rm-text-muted);
+}
+.actseg .dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  margin-left: 5px;
+  vertical-align: 2px;
+}
+
+/* per-finding routing table (experience 2) */
+.route-table {
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+}
+.route-table .rt-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--rm-border);
+}
+.route-table .rt-row:last-child {
+  border-bottom: none;
+}
+.route-table .rt-label {
+  flex: 1;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+.route-table .rt-code {
+  display: block;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--rm-text-muted);
+}
+.route-table select {
+  font-family: var(--font-base);
+  font-size: 0.8125rem;
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  padding: 4px 8px;
+  background: var(--rm-app-bg);
+  cursor: pointer;
+}
+
+/* pii-entities checkbox grid */
+.cfg-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 14px;
+}
+.cfg-grid label {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.cfg-grid .code {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11px;
+  color: var(--rm-text-muted);
+}

--- a/web-react/src/lib/rule-ordering.ts
+++ b/web-react/src/lib/rule-ordering.ts
@@ -1,0 +1,24 @@
+// Rule-list ordering + priority badge tint — graduated from
+// features/settings/approval-policies/ when the safety-rules page became
+// the second consumer (§1.1: pure + ≥2 consumers → lib/). Both pages
+// list rules in SERVER EVALUATION ORDER and share the badge scale.
+
+/** List order = server evaluation order: priority desc, then the newest
+ *  first on ties. `created_at` is an ISO-8601 string from the API. */
+export function sortByEvaluationOrder<
+  T extends { priority: number; created_at: string },
+>(rows: T[]): T[] {
+  return [...rows].sort(
+    (a, b) =>
+      b.priority - a.priority ||
+      Date.parse(b.created_at) - Date.parse(a.created_at),
+  );
+}
+
+/** Badge tint class for a priority value (Appendix C.3): amber when ≥10,
+ *  muted when exactly 0, neutral otherwise. Classes live in ui.css. */
+export function priorityBadgeClass(priority: number): string {
+  if (priority >= 10) return ' pol-pri--hi';
+  if (priority === 0) return ' pol-pri--zero';
+  return '';
+}

--- a/web-react/src/styles/tokens.css
+++ b/web-react/src/styles/tokens.css
@@ -51,6 +51,11 @@
   /* typography */
   --font-base: "Nunito Sans", Helvetica, Arial, sans-serif;
 
+  /* require_approval pill (safety rules Part I) — the only non-derived
+   * purple in the palette */
+  --rm-appr-bg: #efe5f6;
+  --rm-appr-text: #6b2fa0;
+
   /* chat layout */
   --chat-max-width: 72rem;
   --chat-row-gap: 1rem;


### PR DESCRIPTION
Part I of the React SPA — detector-driven guardrail CRUD, transcribed from the shipped Lit implementation (`safety-rules-page.ts` + `safety-rule-dialog.ts` + `safety-catalog.ts`) per the behavior-parity rule. The largest settings branch.

## Ported pure modules (`features/settings/safety-rules/`)
- **`safety-catalog.ts`** copied verbatim with its full test suite: presentation catalog (labels/descriptions/categories/cfgKind — behaviour always comes from the wire `SafetyCheck`), stage/action language tables, `actionButtonState` (backend override whitelist `{block,warn,require_approval}`; allow/redact disabled with plain-language reasons), `effectiveAction`, `safWhatPhrase`, `safSentence`. One deviation: the Lit source's dead `representativeRoutedAction` helper is dropped (strict `noUnusedLocals`).
- **`config-convert.ts`**: wire ↔ internal converters (pii `patterns` dict ↔ `_piiKeys`; presidio `block_codes`/`redact_codes`/`score_threshold` ↔ `routing` map + threshold; moderation categories ↔ `routing` map), G7 schema-enum readers with stable-code fallbacks, G4 validation (Ajv layer + sanity checks, FastAPI-400 translator), Postel host normalizer.
- **`duplicate-detection.ts`**: the pure G3 triple predicate (disabled rules still collide; duplicate source excluded; org match precedes the platform FYI).
- **`audit-summary.ts`**: client-side diff of before/after snapshots.

## List (two tiers, never interleaved)
Platform defaults first (info banner, accent priority badge, fixed-on no-op toggle, **audit-only** actions), then `YOUR ORGANIZATION'S RULES`. Each tier in server evaluation order via the shared `lib/rule-ordering` sort. Cards: check **label** (never the id) + slow/scope chips inline + `safSentence` + five-color action pill — **omitted entirely for config-routed and host-list rules**. Optimistic toggle (Part H semantics). Hint carries snapshot semantics in plain words; hidden when empty.

## Dialog — three action experiences (taxonomy never shown)
1. **fixed** → segmented control: natural action dot-marked, unsupported/non-overridable actions disabled + line-through with `UNSUPPORTED_REASON` tooltips.
2. **config_routed** → the per-finding routing table IS the editor (action field **removed**, not greyed); inert note when nothing is routed.
3. **host-list** → the allowlist is the whole rule (keyed on `cfgKind`, not check ids).

Check select grouped by category with `(cost)` suffix + slow-latency warning; stage select constrained to `check.stages` + fail-mode note; per-cfgKind config forms; **advanced-JSON escape hatch** (form wins when JSON absent/invalid); live preview through the same `safSentence`.

**G3 state machine**: a `(check_id, coworker_id, stage)` collision in create/duplicate mode auto-flips to "Edit existing rule" (config preloaded + blue banner) with a `Create a separate rule anyway` escape (amber banner + return path); platform overlaps get a subtle FYI only. Save dispatch: editing → PATCH; dupTarget && !force → PATCH the target; else POST.

**Scope immutability**: `SafetyRuleUpdate` has no `coworker_id` — edit + auto-flip lock the select; the hint's `duplicate this rule` link closes-and-reopens as Duplicate (the sanctioned scope-change path). PATCH bodies never carry `coworker_id`.

## Audit drawer + delete
Audit (platform cards too): reverse-chronological `[VERB] by {actor} {date}` + client-diffed summary, verbs colored by action. Delete: four-part confirm in everyday language — which rule (same sentence renderer) / new tasks stop / in-flight tasks keep it until they finish / log entries AND change history survive.

## Shared-artifact hoists (sibling-isolation rule)
- `sortPolicies` + `priorityBadgeClass` graduate to **`lib/rule-ordering.ts`**.
- The `.pol-card` family, `.pol-pri` badges, `.page-hint`, and `.preview` box move from `approval-policies.css` to **`components/ui.css`** — a sibling chunk's CSS must never be a hidden load-order dependency.
- New tokens `--rm-appr-bg`/`--rm-appr-text` (the require_approval purple).
- API client: 6 safety methods + types; `ajv` dependency added (spec §1.2 always listed it; first consumer).

## Spec corrections recorded (source wins per the behavior-parity rule)
1. **I.4 audit summary is inverted**: the wire's `SafetyRuleAuditEntry` has NO server summary field (only `before_state`/`after_state`); the Lit source diffs client-side (`auditSummary`) and its comment says so explicitly. Ported the client diff.
2. **I.6.3 "unified routing map"** describes the dialog's INTERNAL form state, not the wire — the wire keeps `block_codes`/`redact_codes` / `block_categories`/`warn_categories`; the dialog converts both ways on load/save.
3. Audit actor is the wire's `actor_user_id` (or "the system") — the prototype's friendly names are mock sugar; no members lookup invented.

## Verification
- **76 new tests, 283 total green** — catalog port + coverage additions, config round-trips, schema-enum/sanity/400-translation, G3 predicate, audit summary, card platform/org/pill-suppression, dialog experiences + G3 flip/force/return + scope lock + advanced JSON + G4 gate, page tiers/hint/delete copy.
- `tsc`, the three lint scripts, `openapi:check`, and `build` all clean.
- Mock-backend Playwright E2E (**45 assertions**): tiers, platform card behaviors, optimistic toggle, audit drawer with live entries, G3 auto-flip/preload/force-create, three dialog experiences, schema-driven routing codes, Postel host cleanup, create+flash, scope lock + duplicate-from-edit reopen, four-part delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_