### PR TITLE
Safety log page (Part J)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -43,6 +43,25 @@ export type SafetyRuleAuditEntry = components['schemas']['SafetyRuleAuditEntry']
 export type SafetyCheck = components['schemas']['SafetyCheck'];
 export type SafetyStage = components['schemas']['SafetyStage'];
 export type SafetyVerdictAction = components['schemas']['SafetyVerdictAction'];
+export type SafetyDecision = components['schemas']['SafetyDecision'];
+export type SafetyDecisionPage = components['schemas']['SafetyDecisionPage'];
+export type SafetyFinding = components['schemas']['SafetyFinding'];
+export type SafetyFindingSeverity = components['schemas']['SafetyFindingSeverity'];
+
+/** Filter set for the safety-decisions list + CSV export (Part J).
+ *  Field names mirror the Lit client; keys serialize to the wire's
+ *  snake_case query params. */
+export interface SafetyDecisionFilters {
+  verdictAction?: SafetyVerdictAction | null;
+  coworkerId?: string | null;
+  stage?: SafetyStage | null;
+  fromTs?: string | null;
+  toTs?: string | null;
+  checkId?: string | null;
+  ruleId?: string | null;
+  limit?: number;
+  offset?: number;
+}
 export type MCPServer = components['schemas']['MCPServer'];
 export type MCPServerCreate = components['schemas']['MCPServerCreate'];
 export type MCPServerUpdate = components['schemas']['MCPServerUpdate'];
@@ -357,6 +376,49 @@ export class ApiClient {
     if (!resp.ok) throw await this.parseError(resp);
     return ((await resp.json()) as components['schemas']['SafetyRuleAuditPage'])
       .items;
+  }
+
+  private decisionsQuery(filters?: SafetyDecisionFilters): URLSearchParams {
+    const qs = new URLSearchParams();
+    if (filters?.verdictAction) qs.set('verdict_action', filters.verdictAction);
+    if (filters?.coworkerId) qs.set('coworker_id', filters.coworkerId);
+    if (filters?.stage) qs.set('stage', filters.stage);
+    if (filters?.fromTs) qs.set('from_ts', filters.fromTs);
+    if (filters?.toTs) qs.set('to_ts', filters.toTs);
+    if (filters?.checkId) qs.set('check_id', filters.checkId);
+    if (filters?.ruleId) qs.set('rule_id', filters.ruleId);
+    if (filters?.limit !== undefined) qs.set('limit', String(filters.limit));
+    if (filters?.offset !== undefined) qs.set('offset', String(filters.offset));
+    return qs;
+  }
+
+  /** Safety-decision log page (Part J). Paged envelope carries `total`
+   *  in-band — no second count call. */
+  async listSafetyDecisions(
+    filters?: SafetyDecisionFilters,
+  ): Promise<SafetyDecisionPage> {
+    const qs = this.decisionsQuery(filters);
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/safety/decisions${qs.size ? `?${qs}` : ''}`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as SafetyDecisionPage;
+  }
+
+  /** CSV export — an authenticated blob fetch (a plain <a href> cannot
+   *  carry the bearer token). Carries the SAME filters as the list
+   *  (Lit parity); pagination params are excluded — export is bulk. */
+  async downloadSafetyDecisionsCsv(
+    filters?: SafetyDecisionFilters,
+  ): Promise<Blob> {
+    const qs = this.decisionsQuery({ ...filters, limit: undefined, offset: undefined });
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/safety/decisions.csv${qs.size ? `?${qs}` : ''}`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return resp.blob();
   }
 
   /** Registered check catalog (rule-editor metadata; stable order). */

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -4,7 +4,7 @@
 // domains.
 
 import { useQuery } from '@tanstack/react-query';
-import { getApiClient } from './client';
+import { getApiClient, type SafetyDecisionFilters } from './client';
 
 export function useCoworkers() {
   return useQuery({
@@ -96,6 +96,19 @@ export function useSafetyChecks() {
     queryKey: ['safety-checks'],
     queryFn: () => getApiClient().listSafetyChecks(),
     staleTime: 5 * 60_000,
+  });
+}
+
+// ---- Safety log page (Part J) ----
+
+/** One page of the decision log. The filter object is part of the key —
+ *  every filter/page change is its own cache entry; `placeholderData`
+ *  keeps the previous page rendered while the next loads. */
+export function useSafetyDecisions(filters: SafetyDecisionFilters) {
+  return useQuery({
+    queryKey: ['safety-decisions', filters],
+    queryFn: () => getApiClient().listSafetyDecisions(filters),
+    placeholderData: (prev) => prev,
   });
 }
 

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -78,6 +78,12 @@ const SafetyRulesPage = lazy(() =>
   })),
 );
 
+const SafetyLogPage = lazy(() =>
+  import('../features/settings/safety-log/safety-log-page').then((m) => ({
+    default: m.SafetyLogPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -143,6 +149,16 @@ export function AppRoutes() {
           <Suspense fallback={null}>
             <Gated slug="safety">
               <SafetyRulesPage />
+            </Gated>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/safety-log/*"
+        element={
+          <Suspense fallback={null}>
+            <Gated slug="safety-log">
+              <SafetyLogPage />
             </Gated>
           </Suspense>
         }

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -729,3 +729,57 @@
   font-weight: 700;
   margin-bottom: 4px;
 }
+
+/* Verdict pill family (allow/warn/redact/require_approval/block) —
+ * shared by the safety-rules cards and the safety-log rows/detail. */
+/* five-color action pill (allow/warn/redact/require_approval/block) */
+.saf-act {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+.saf-act--allow {
+  background: var(--rm-success-bg);
+  color: var(--rm-success-text);
+}
+.saf-act--warn {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.saf-act--redact {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.saf-act--require_approval {
+  background: var(--rm-appr-bg);
+  color: var(--rm-appr-text);
+}
+.saf-act--block {
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+}
+
+/* Finding severity pill (safety-log detail modal). */
+.sev {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 1px 7px;
+  border-radius: 2px;
+}
+.sev--critical,
+.sev--high {
+  background: var(--rm-danger-bg);
+  color: var(--rm-danger);
+}
+.sev--medium {
+  background: var(--rm-warn-bg);
+  color: var(--rm-warn-text);
+}
+.sev--low,
+.sev--info {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}

--- a/web-react/src/features/settings/safety-log/decision-detail-dialog.tsx
+++ b/web-react/src/features/settings/safety-log/decision-detail-dialog.tsx
@@ -1,0 +1,160 @@
+// DecisionDetailDialog — read-only decision inspection (spec J.3;
+// behavioral reference web/src/components/safety-decision-detail-dialog.ts,
+// visuals per the v11 prototype). Metadata grid + platform-rule chip
+// (wire `source` surfaced) + triggered rules (ids referencing deleted
+// rules render "deleted rule" — the log outlives its rules) + findings
+// blocks + the data-minimization note anchored on the decision's own
+// timestamp. Renders entirely from the list row — the wire page items
+// already carry full findings; GET /decisions/{id} has no consumer.
+
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import type { SafetyDecision, SafetyRule } from '../../../api/client';
+import { BrandMark } from '../../../components/brand-mark';
+import { SAF_ACTION_LABEL, checkLabel } from '../../../lib/safety-catalog';
+
+export function DecisionDetailDialog({
+  decision,
+  rules,
+  coworkerName,
+  onClose,
+}: {
+  decision: SafetyDecision;
+  /** Part I's rules query — resolves triggered_rule_ids to check labels. */
+  rules: SafetyRule[];
+  coworkerName: string;
+  onClose: () => void;
+}) {
+  const d = decision;
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [onClose]);
+
+  const when = new Date(d.created_at);
+  const hhmmss = d.created_at.slice(11, 19);
+  const triggered = d.triggered_rule_ids ?? [];
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="dlg"
+        style={{ width: 600 }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Safety decision"
+      >
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">Decision {d.id}</h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body" style={{ minHeight: 0 }}>
+          <dl className="meta-grid">
+            <dt>When</dt>
+            <dd>
+              {when.toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}{' '}
+              {hhmmss}
+            </dd>
+            <dt>Verdict</dt>
+            <dd>
+              <span className={`saf-act saf-act--${d.verdict_action}`}>
+                {SAF_ACTION_LABEL[d.verdict_action] ?? d.verdict_action}
+              </span>
+              {d.source === 'platform' ? (
+                <span className="saf-chip" style={{ marginLeft: 6 }}>
+                  platform rule
+                </span>
+              ) : null}
+            </dd>
+            <dt>Stage</dt>
+            <dd className="mono" style={{ fontSize: '12.5px' }}>
+              {d.stage}
+            </dd>
+            <dt>Coworker</dt>
+            <dd>{coworkerName}</dd>
+            <dt>Triggered rule</dt>
+            <dd>
+              {triggered.length ? (
+                triggered.map((id, i) => {
+                  const rule = rules.find((r) => r.id === id);
+                  return (
+                    <span key={id}>
+                      {i > 0 ? ', ' : ''}
+                      {rule ? checkLabel(rule.check_id) : 'deleted rule'}{' '}
+                      <span style={{ color: 'var(--rm-text-muted)' }}>({id})</span>
+                    </span>
+                  );
+                })
+              ) : (
+                <span style={{ color: 'var(--rm-text-muted)' }}>—</span>
+              )}
+            </dd>
+            <dt>Context digest</dt>
+            <dd
+              className="mono"
+              style={{ fontSize: 12, color: 'var(--rm-text-muted)' }}
+            >
+              {d.context_digest}
+            </dd>
+            <dt>Summary</dt>
+            <dd>{d.context_summary}</dd>
+          </dl>
+
+          <div className="findings-title">Findings</div>
+          {(d.findings ?? []).length ? (
+            (d.findings ?? []).map((f, i) => (
+              <div className="finding" key={i}>
+                <div className="f-head">
+                  <span className="f-code">{f.code}</span>
+                  <span className={`sev sev--${f.severity}`}>{f.severity}</span>
+                </div>
+                <div style={{ fontSize: '0.875rem' }}>{f.message}</div>
+                {f.metadata ? (
+                  <div className="f-meta">{JSON.stringify(f.metadata)}</div>
+                ) : null}
+              </div>
+            ))
+          ) : (
+            <div className="hint" style={{ marginBottom: 12 }}>
+              No findings — check ran and verdict was <b>allow</b>.
+            </div>
+          )}
+
+          <div className="dm-note" style={{ marginTop: 14 }}>
+            <b>Data minimization</b> — the raw payload is not stored; only the
+            SHA-256 digest above and the short summary. To investigate root cause,
+            open the conversation around {hhmmss}.
+          </div>
+        </div>
+        <div className="wiz-foot">
+          <span />
+          <button className="btn-ghost" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-log/decision-row.tsx
+++ b/web-react/src/features/settings/safety-log/decision-row.tsx
@@ -1,0 +1,57 @@
+// DecisionRow — one log entry (spec J.2). 7-column grid, whole row
+// clickable: HH:MM:SS mono timestamp · verdict pill · mono stage ·
+// mono finding codes · truncating summary · coworker name · chevron.
+//
+// The 4th column: the wire SafetyDecision carries NO check_id — the
+// finding codes are the wire's signal of what the decision caught
+// (Lit renderRow documents this; the v11 prototype's mock check_id
+// column is a prototype liberty, corrected to source).
+
+import type { SafetyDecision } from '../../../api/client';
+import { SAF_ACTION_LABEL } from '../../../lib/safety-catalog';
+
+export function findingCodes(d: SafetyDecision): string {
+  return (d.findings ?? []).map((f) => f.code).join(', ') || '—';
+}
+
+export function DecisionRow({
+  decision,
+  coworkerName,
+  onOpen,
+}: {
+  decision: SafetyDecision;
+  /** Resolved name; `organization-wide` when the decision is unscoped. */
+  coworkerName: string;
+  onOpen: () => void;
+}) {
+  const d = decision;
+  return (
+    <div
+      className="log-row"
+      role="button"
+      tabIndex={0}
+      data-decision-id={d.id}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') onOpen();
+      }}
+    >
+      <span className="ts">{d.created_at.slice(11, 19)}</span>
+      <span
+        className={`saf-act saf-act--${d.verdict_action}`}
+        style={{ textAlign: 'center' }}
+      >
+        {SAF_ACTION_LABEL[d.verdict_action] ?? d.verdict_action}
+      </span>
+      <span className="tech">{d.stage}</span>
+      <span className="tech" title={findingCodes(d)}>
+        {findingCodes(d)}
+      </span>
+      <span className="sum" title={d.context_summary}>
+        {d.context_summary}
+      </span>
+      <span className="cw">{coworkerName}</span>
+      <span className="arrow">›</span>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-log/filter-bar.tsx
+++ b/web-react/src/features/settings/safety-log/filter-bar.tsx
@@ -1,0 +1,193 @@
+// FilterBar — four dropdowns + the programmatic rule_id chip + the
+// D-J1 time-range quick-select (spec J.2). The dropdowns are the source
+// of truth for their own state (no duplicate chips); rule_id is NEVER a
+// dropdown (rule lists unbounded) — deep-link only, rendered as a
+// removable chip whose × clears only rule_id. `Clear filters` resets
+// everything, chip included. Every change resets to page 0 (the page
+// owns that — every callback here funnels through onChange).
+//
+// D-J1 (user-approved): time range is a quick-select (24h/7d/30d) that
+// writes from_ts; `Custom` reveals the datetime-local pair (the shipped
+// Lit control) for arbitrary ranges. Same wire semantics either way.
+
+import type {
+  SafetyCheck,
+  SafetyStage,
+  SafetyVerdictAction,
+} from '../../../api/client';
+import {
+  SAF_ACTION_LABEL,
+  SAF_ACTION_ORDER,
+  SAF_STAGE_SHORT,
+  checkLabel,
+} from '../../../lib/safety-catalog';
+
+export type QuickRange = '' | '24h' | '7d' | '30d' | 'custom';
+
+export interface LogFilters {
+  verdict: SafetyVerdictAction | '';
+  stage: SafetyStage | '';
+  coworkerId: string;
+  checkId: string;
+  /** Deep-link-only chip filter. */
+  ruleId: string;
+  range: QuickRange;
+  /** ISO bounds — derived from `range` presets or the custom inputs. */
+  fromTs: string;
+  toTs: string;
+}
+
+export const EMPTY_FILTERS: LogFilters = {
+  verdict: '',
+  stage: '',
+  coworkerId: '',
+  checkId: '',
+  ruleId: '',
+  range: '',
+  fromTs: '',
+  toTs: '',
+};
+
+const RANGE_MS: Record<string, number> = {
+  '24h': 24 * 3600_000,
+  '7d': 7 * 24 * 3600_000,
+  '30d': 30 * 24 * 3600_000,
+};
+
+export function FilterBar({
+  filters,
+  checks,
+  coworkers,
+  ruleChipLabel,
+  onChange,
+}: {
+  filters: LogFilters;
+  checks: SafetyCheck[];
+  coworkers: { id: string; name: string }[];
+  /** Resolved check label for the rule chip (rule_id → its check). */
+  ruleChipLabel: string | null;
+  onChange: (next: LogFilters) => void;
+}) {
+  const set = (patch: Partial<LogFilters>) => onChange({ ...filters, ...patch });
+
+  function onRange(range: QuickRange) {
+    if (range === '' ) {
+      set({ range, fromTs: '', toTs: '' });
+    } else if (range === 'custom') {
+      // Keep any existing bounds; the inputs below take over.
+      set({ range });
+    } else {
+      // Preset computed ONCE when picked (not per render — a stable
+      // query key; Refresh refetches with the same window).
+      set({ range, fromTs: new Date(Date.now() - RANGE_MS[range]).toISOString(), toTs: '' });
+    }
+  }
+
+  const anyActive =
+    filters.verdict || filters.stage || filters.coworkerId || filters.checkId ||
+    filters.ruleId || filters.range;
+
+  return (
+    <div className="log-bar" data-testid="log-filter-bar">
+      {filters.ruleId ? (
+        <span className="rule-chip" data-testid="rule-chip">
+          🛡 Rule: {ruleChipLabel ?? filters.ruleId}
+          <button
+            title="Clear rule filter"
+            aria-label="Clear rule filter"
+            onClick={() => set({ ruleId: '' })}
+          >
+            ×
+          </button>
+        </span>
+      ) : null}
+      <select
+        aria-label="Verdict filter"
+        value={filters.verdict}
+        onChange={(e) => set({ verdict: e.target.value as LogFilters['verdict'] })}
+      >
+        <option value="">all verdicts</option>
+        {SAF_ACTION_ORDER.map((a) => (
+          <option key={a} value={a}>
+            {SAF_ACTION_LABEL[a]}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Stage filter"
+        value={filters.stage}
+        onChange={(e) => set({ stage: e.target.value as LogFilters['stage'] })}
+      >
+        <option value="">all stages</option>
+        {Object.keys(SAF_STAGE_SHORT).map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Coworker filter"
+        value={filters.coworkerId}
+        onChange={(e) => set({ coworkerId: e.target.value })}
+      >
+        <option value="">all coworkers</option>
+        {coworkers.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Check filter"
+        value={filters.checkId}
+        onChange={(e) => set({ checkId: e.target.value })}
+      >
+        <option value="">all checks</option>
+        {checks.map((c) => (
+          <option key={c.id} value={c.id}>
+            {checkLabel(c.id)}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Time range"
+        data-testid="log-range"
+        value={filters.range}
+        onChange={(e) => onRange(e.target.value as QuickRange)}
+      >
+        <option value="">all time</option>
+        <option value="24h">last 24h</option>
+        <option value="7d">last 7 days</option>
+        <option value="30d">last 30 days</option>
+        <option value="custom">custom…</option>
+      </select>
+      {filters.range === 'custom' ? (
+        <>
+          <input
+            type="datetime-local"
+            aria-label="From"
+            data-testid="log-from"
+            value={filters.fromTs ? filters.fromTs.slice(0, 16) : ''}
+            onChange={(e) =>
+              set({ fromTs: e.target.value ? new Date(e.target.value).toISOString() : '' })
+            }
+          />
+          <input
+            type="datetime-local"
+            aria-label="To"
+            data-testid="log-to"
+            value={filters.toTs ? filters.toTs.slice(0, 16) : ''}
+            onChange={(e) =>
+              set({ toTs: e.target.value ? new Date(e.target.value).toISOString() : '' })
+            }
+          />
+        </>
+      ) : null}
+      {anyActive ? (
+        <button className="btn-ghost" style={{ padding: '4px 8px' }} onClick={() => onChange({ ...EMPTY_FILTERS })}>
+          Clear filters
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-log/safety-log-page.test.tsx
+++ b/web-react/src/features/settings/safety-log/safety-log-page.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { SafetyCheck, SafetyDecision, SafetyRule } from '../../../api/client';
+import { SafetyLogPage } from './safety-log-page';
+
+function decision(over: Partial<SafetyDecision>): SafetyDecision {
+  return {
+    id: 'dec-x',
+    tenant_id: 't1',
+    coworker_id: null,
+    conversation_id: null,
+    job_id: null,
+    stage: 'pre_tool_call',
+    verdict_action: 'allow',
+    triggered_rule_ids: [],
+    findings: [],
+    context_digest: 'sha256:abc',
+    context_summary: 'tool ran clean',
+    source: 'tenant',
+    created_at: '2026-07-01T10:15:30Z',
+    ...over,
+  } as SafetyDecision;
+}
+
+const RULES: SafetyRule[] = [
+  {
+    id: 'sr-1',
+    tenant_id: 't1',
+    coworker_id: null,
+    stage: 'pre_tool_call',
+    check_id: 'pii.regex',
+    config: {},
+    priority: 100,
+    enabled: true,
+    description: '',
+    source: 'tenant',
+    tier: null,
+    created_at: '2026-06-01T00:00:00Z',
+    updated_at: '2026-06-01T00:00:00Z',
+  } as SafetyRule,
+];
+
+const CHECKS: SafetyCheck[] = [
+  {
+    id: 'pii.regex',
+    version: '1',
+    stages: ['pre_tool_call'],
+    cost_class: 'cheap',
+    action_model: 'fixed',
+    natural_actions: {},
+    supported_actions: {},
+    supported_codes: [],
+    config_schema: null,
+  } as unknown as SafetyCheck,
+];
+
+function renderPage(opts: {
+  items: SafetyDecision[];
+  total?: number;
+  initialEntry?: string;
+}) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  // Page-0 default query key (all filters empty).
+  qc.setQueryData(
+    [
+      'safety-decisions',
+      {
+        verdictAction: null,
+        stage: null,
+        coworkerId: null,
+        checkId: null,
+        ruleId: null,
+        fromTs: null,
+        toTs: null,
+        limit: 10,
+        offset: 0,
+      },
+    ],
+    { items: opts.items, total: opts.total ?? opts.items.length, limit: 10, offset: 0 },
+  );
+  qc.setQueryData(['safety-checks'], CHECKS);
+  qc.setQueryData(['safety-rules'], RULES);
+  qc.setQueryData(['coworkers'], [{ id: 'cw-1', name: 'Ops coworker' }]);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[opts.initialEntry ?? '/manage/safety-log']}>
+        <SafetyLogPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe('SafetyLogPage', () => {
+  it('renders rows: mono timestamp, verdict pill, finding codes (no check_id on the wire)', () => {
+    renderPage({
+      items: [
+        decision({
+          id: 'd1',
+          verdict_action: 'block',
+          findings: [
+            { code: 'PII.SSN', severity: 'high', message: 'SSN found', metadata: null },
+          ],
+        }),
+      ],
+    });
+    const row = document.querySelector('.log-row')!;
+    expect(within(row as HTMLElement).getByText('10:15:30')).toBeTruthy();
+    expect(within(row as HTMLElement).getByText('Block').className).toContain(
+      'saf-act--block',
+    );
+    expect(within(row as HTMLElement).getByText('PII.SSN')).toBeTruthy();
+    expect(within(row as HTMLElement).getByText('organization-wide')).toBeTruthy();
+  });
+
+  it('pager shows in-band total; edges disable', () => {
+    renderPage({ items: [decision({ id: 'd1' })], total: 23 });
+    const pager = screen.getByTestId('log-pager');
+    expect(pager.textContent).toContain('Showing 1–10 of 23');
+    expect(
+      (within(pager).getByText('← Previous') as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((within(pager).getByText('Next →') as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
+  it('deep link ?rule_id renders the chip with the rule check label; × clears it', () => {
+    renderPage({ items: [], initialEntry: '/manage/safety-log?rule_id=sr-1' });
+    const chip = screen.getByTestId('rule-chip');
+    expect(chip.textContent).toContain('Rule: Personal data (regex)');
+    fireEvent.click(within(chip).getByLabelText('Clear rule filter'));
+    expect(screen.queryByTestId('rule-chip')).toBeNull();
+  });
+
+  it('deep link ?check_id pre-selects the check dropdown', () => {
+    renderPage({ items: [], initialEntry: '/manage/safety-log?check_id=pii.regex' });
+    expect((screen.getByLabelText('Check filter') as HTMLSelectElement).value).toBe(
+      'pii.regex',
+    );
+  });
+
+  it('Clear filters resets everything, rule chip included', () => {
+    renderPage({ items: [], initialEntry: '/manage/safety-log?rule_id=sr-1&check_id=pii.regex' });
+    fireEvent.click(screen.getByText('Clear filters'));
+    expect(screen.queryByTestId('rule-chip')).toBeNull();
+    expect((screen.getByLabelText('Check filter') as HTMLSelectElement).value).toBe('');
+  });
+
+  it('D-J1: custom range reveals the datetime-local pair', () => {
+    renderPage({ items: [] });
+    fireEvent.change(screen.getByTestId('log-range'), { target: { value: 'custom' } });
+    expect(screen.getByTestId('log-from')).toBeTruthy();
+    expect(screen.getByTestId('log-to')).toBeTruthy();
+  });
+
+  it('empty state assumes over-narrow filters', () => {
+    renderPage({ items: [] });
+    expect(screen.getByText('No decisions match your filters.')).toBeTruthy();
+    expect(screen.getByText(/wait for new agent activity/)).toBeTruthy();
+  });
+
+  it('row click opens the detail modal: platform chip, deleted-rule fallback, findings, dm-note', () => {
+    renderPage({
+      items: [
+        decision({
+          id: 'd9',
+          verdict_action: 'redact',
+          source: 'platform',
+          triggered_rule_ids: ['sr-1', 'sr-gone'],
+          findings: [
+            {
+              code: 'PII.EMAIL',
+              severity: 'medium',
+              message: 'Email redacted',
+              metadata: { count: 2 },
+            },
+          ],
+        }),
+      ],
+    });
+    fireEvent.click(document.querySelector('.log-row')!);
+    const dlg = screen.getByRole('dialog');
+    const text = dlg.textContent ?? '';
+    expect(text).toContain('Decision d9');
+    expect(within(dlg).getByText('platform rule')).toBeTruthy();
+    expect(text).toContain('Personal data (regex)'); // resolved rule
+    expect(text).toContain('deleted rule'); // unknown id fallback
+    expect(within(dlg).getByText('PII.EMAIL')).toBeTruthy();
+    expect(within(dlg).getByText('medium').className).toContain('sev--medium');
+    expect(text).toContain('{"count":2}');
+    expect(text).toContain('Data minimization');
+    expect(text).toContain('10:15:30'); // dm-note anchored on the timestamp
+  });
+
+  it('zero findings renders the allow explainer', () => {
+    renderPage({ items: [decision({ id: 'd2', findings: [] })] });
+    fireEvent.click(document.querySelector('.log-row')!);
+    expect(screen.getByText(/No findings — check ran and verdict was/)).toBeTruthy();
+  });
+});

--- a/web-react/src/features/settings/safety-log/safety-log-page.tsx
+++ b/web-react/src/features/settings/safety-log/safety-log-page.tsx
@@ -1,0 +1,237 @@
+// SafetyLogPage — the read-only decision log (spec Part J; behavioral
+// reference web/src/components/safety-decisions-page.ts). Every check
+// decision lands here, allows included. No create/edit/delete — the
+// header actions are Refresh + Export CSV (ghost; a read-only page has
+// no primary action).
+//
+// Deep links (G6): ?check_id=X pre-selects the check dropdown;
+// ?rule_id=Y sets the programmatic chip (server-side triggered_rule_ids
+// containment); both AND-combine. The chat approval card sends
+// ?rule_id only — landing on the rule's full filtered list (newest
+// first) is deliberate: seeing the pattern beats auto-opening one
+// decision. This route is load-bearing for the HITL loop.
+//
+// Sort: created_at desc, always — no sort control. Pagination: 10/page
+// offset-based; the page envelope carries total in-band.
+
+import { useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft } from 'lucide-react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { getApiClient, type SafetyDecision } from '../../../api/client';
+import {
+  useCoworkers,
+  useSafetyChecks,
+  useSafetyDecisions,
+  useSafetyRules,
+} from '../../../api/queries';
+import { BrandMark } from '../../../components/brand-mark';
+import { checkLabel } from '../../../lib/safety-catalog';
+import { DecisionDetailDialog } from './decision-detail-dialog';
+import { DecisionRow } from './decision-row';
+import { EMPTY_FILTERS, FilterBar, type LogFilters } from './filter-bar';
+import './safety-log.css';
+
+const PAGE_SIZE = 10;
+
+export function SafetyLogPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+
+  // Deep-link params applied ONCE as initial state (Lit G6 semantics) —
+  // later filter edits own the state; the URL is not two-way bound.
+  const [filters, setFilters] = useState<LogFilters>(() => ({
+    ...EMPTY_FILTERS,
+    checkId: searchParams.get('check_id') ?? '',
+    ruleId: searchParams.get('rule_id') ?? '',
+  }));
+  const [page, setPage] = useState(0);
+  const [selected, setSelected] = useState<SafetyDecision | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3200);
+  }
+
+  const wireFilters = useMemo(
+    () => ({
+      verdictAction: filters.verdict || null,
+      stage: filters.stage || null,
+      coworkerId: filters.coworkerId || null,
+      checkId: filters.checkId || null,
+      ruleId: filters.ruleId || null,
+      fromTs: filters.fromTs || null,
+      toTs: filters.toTs || null,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    }),
+    [filters, page],
+  );
+  const decisionsQ = useSafetyDecisions(wireFilters);
+  const checksQ = useSafetyChecks();
+  const rulesQ = useSafetyRules();
+  const coworkersQ = useCoworkers();
+
+  const coworkers = coworkersQ.data ?? [];
+  const rules = rulesQ.data ?? [];
+  const coworkerName = (id: string | null | undefined): string => {
+    if (!id) return 'organization-wide';
+    const cw = coworkers.find((c) => c.id === id);
+    return cw ? cw.name : id.slice(0, 8);
+  };
+
+  // The chip label = the rule's check label (the log outlives its rules:
+  // an unknown id keeps the raw id as the label).
+  const chipRule = filters.ruleId
+    ? (rules.find((r) => r.id === filters.ruleId) ?? null)
+    : null;
+  const ruleChipLabel = chipRule ? checkLabel(chipRule.check_id) : null;
+
+  function onFiltersChange(next: LogFilters) {
+    setFilters(next);
+    setPage(0); // every filter change resets to page 0
+  }
+
+  function refresh() {
+    void queryClient.invalidateQueries({ queryKey: ['safety-decisions'] });
+  }
+
+  /** Authenticated blob download (a plain <a href> cannot carry the
+   *  bearer token) with the CURRENT filters — Lit parity. */
+  async function exportCsv() {
+    try {
+      const blob = await getApiClient().downloadSafetyDecisionsCsv(wireFilters);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `safety-log-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      showToast((err as Error).message ?? 'export failed');
+    }
+  }
+
+  const pageData = decisionsQ.data;
+  const items = pageData?.items ?? [];
+  const total = pageData?.total ?? 0;
+  const start = total === 0 ? 0 : page * PAGE_SIZE + 1;
+  const end = Math.min((page + 1) * PAGE_SIZE, total);
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Safety log</h1>
+          <div className="page-sub" style={{ maxWidth: 640 }}>
+            Every check decision lands here — both allows and blocks. Raw payloads
+            are never stored — only a SHA-256 digest and a short summary. To
+            root-cause, open the conversation around the timestamp.
+          </div>
+        </div>
+        <span style={{ display: 'inline-flex', gap: 8 }}>
+          <button className="btn-ghost" onClick={refresh}>
+            Refresh
+          </button>
+          <button className="btn-ghost" onClick={() => void exportCsv()}>
+            Export CSV
+          </button>
+        </span>
+      </div>
+
+      <FilterBar
+        filters={filters}
+        checks={checksQ.data ?? []}
+        coworkers={coworkers}
+        ruleChipLabel={ruleChipLabel}
+        onChange={onFiltersChange}
+      />
+
+      <div className="grid-scroll">
+        {decisionsQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : decisionsQ.isError ? (
+          <div className="row-error">
+            Failed to load the safety log — retry from the sidebar.
+          </div>
+        ) : items.length === 0 ? (
+          <div className="grid-empty">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <BrandMark size={128} />
+              <div style={{ marginTop: '0.75rem', fontSize: '1rem' }}>
+                No decisions match your filters.
+              </div>
+              <div
+                style={{
+                  marginTop: 4,
+                  fontSize: '0.875rem',
+                  color: 'var(--rm-text-muted)',
+                }}
+              >
+                Try clearing some filters, or wait for new agent activity.
+              </div>
+            </div>
+          </div>
+        ) : (
+          <>
+            {items.map((d) => (
+              <DecisionRow
+                key={d.id}
+                decision={d}
+                coworkerName={coworkerName(d.coworker_id)}
+                onOpen={() => setSelected(d)}
+              />
+            ))}
+            <div className="pager" data-testid="log-pager">
+              <span>
+                Showing {start}–{end} of {total}
+              </span>
+              <span className="sp" />
+              <button
+                className="btn-ghost"
+                disabled={page === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              >
+                ← Previous
+              </button>
+              <button
+                className="btn-ghost"
+                disabled={(page + 1) * PAGE_SIZE >= total}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next →
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {selected ? (
+        <DecisionDetailDialog
+          decision={selected}
+          rules={rules}
+          coworkerName={coworkerName(selected.coworker_id)}
+          onClose={() => setSelected(null)}
+        />
+      ) : null}
+
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-log/safety-log.css
+++ b/web-react/src/features/settings/safety-log/safety-log.css
@@ -1,0 +1,166 @@
+/* Safety log page (spec Part J). Verdict (.saf-act) and severity (.sev)
+ * pills live in components/ui.css (shared with safety-rules). This file
+ * owns the filter bar, rule chip, 7-column decision row, pager, and the
+ * detail modal's meta grid / finding blocks / data-minimization note.
+ * Log surfaces run 860px (prototype value) — the 7-column grid needs
+ * more room than the 760px name+controls rows. */
+
+.log-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 12px 0;
+  max-width: 860px;
+  flex-shrink: 0;
+}
+.log-bar select,
+.log-bar input[type='datetime-local'] {
+  font-family: var(--font-base);
+  font-size: 0.8125rem;
+  border: 1px solid var(--rm-text-muted);
+  border-radius: 4px;
+  padding: 5px 8px;
+  background: var(--rm-app-bg);
+  color: var(--rm-text);
+}
+.rule-chip {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+  font-size: 12px;
+  font-weight: 700;
+  border-radius: 2px;
+  padding: 4px 8px;
+}
+.rule-chip button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font-weight: 700;
+  padding: 0 2px;
+}
+
+.log-row {
+  display: grid;
+  grid-template-columns: 76px 70px 130px 150px 1fr 130px 16px;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 12px;
+  max-width: 860px;
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  margin-bottom: 6px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+.log-row:hover {
+  background: var(--rm-nav-hover);
+}
+.log-row .ts {
+  font-family: ui-monospace, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+.log-row .tech {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11.5px;
+  color: var(--rm-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.log-row .sum {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.log-row .cw {
+  font-size: 12px;
+  color: var(--rm-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.log-row .arrow {
+  color: var(--rm-text-muted);
+}
+
+.pager {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 2px;
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+  max-width: 860px;
+}
+.pager .sp {
+  flex: 1;
+}
+
+/* detail modal */
+.meta-grid {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 7px 12px;
+  font-size: 0.875rem;
+  margin-bottom: 16px;
+}
+.meta-grid dt {
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  color: var(--rm-text-muted);
+  align-self: baseline;
+}
+.meta-grid dd {
+  margin: 0;
+  min-width: 0;
+  word-break: break-word;
+}
+.finding {
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+}
+.finding .f-head {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.finding .f-code {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+.finding .f-meta {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11px;
+  color: var(--rm-text-muted);
+  margin-top: 4px;
+  word-break: break-all;
+}
+.dm-note {
+  border-left: 3px solid var(--rm-info-text);
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+  border-radius: 0 4px 4px 0;
+  padding: 10px 12px;
+  font-size: 0.8125rem;
+}
+.findings-title {
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  color: var(--rm-text-muted);
+  margin-bottom: 6px;
+}

--- a/web-react/src/features/settings/safety-rules/action-panel.tsx
+++ b/web-react/src/features/settings/safety-rules/action-panel.tsx
@@ -12,7 +12,7 @@ import {
   SAF_ACTION_SUB,
   actionButtonState,
   naturalAction,
-} from './safety-catalog';
+} from '../../../lib/safety-catalog';
 
 export function ActionPanel({
   check,

--- a/web-react/src/features/settings/safety-rules/audit-drawer.tsx
+++ b/web-react/src/features/settings/safety-rules/audit-drawer.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../../api/client';
 import { BrandMark } from '../../../components/brand-mark';
 import { auditSummary } from './audit-summary';
-import { checkLabel } from './safety-catalog';
+import { checkLabel } from '../../../lib/safety-catalog';
 
 export function AuditDrawer({
   rule,

--- a/web-react/src/features/settings/safety-rules/audit-summary.ts
+++ b/web-react/src/features/settings/safety-rules/audit-summary.ts
@@ -6,7 +6,7 @@
 // an operator cares about. Kept deliberately small + deterministic.
 
 import type { SafetyRuleAuditEntry } from '../../../api/client';
-import { checkLabel } from './safety-catalog';
+import { checkLabel } from '../../../lib/safety-catalog';
 
 export function auditSummary(entry: SafetyRuleAuditEntry): string {
   if (entry.action === 'created') {

--- a/web-react/src/features/settings/safety-rules/config-forms.tsx
+++ b/web-react/src/features/settings/safety-rules/config-forms.tsx
@@ -17,7 +17,7 @@ import {
   getSchemaEnum,
   normalizeDomainLine,
 } from './config-convert';
-import { SAF_ACTION_LABEL, supportedActions } from './safety-catalog';
+import { SAF_ACTION_LABEL, supportedActions } from '../../../lib/safety-catalog';
 
 export type Config = Record<string, unknown>;
 type OnChange = (next: Config) => void;

--- a/web-react/src/features/settings/safety-rules/rule-card.tsx
+++ b/web-react/src/features/settings/safety-rules/rule-card.tsx
@@ -16,7 +16,7 @@ import {
   checkLabel,
   effectiveAction,
   safSentence,
-} from './safety-catalog';
+} from '../../../lib/safety-catalog';
 
 export function RuleCard({
   rule,

--- a/web-react/src/features/settings/safety-rules/rule-dialog.tsx
+++ b/web-react/src/features/settings/safety-rules/rule-dialog.tsx
@@ -53,7 +53,7 @@ import {
   actionButtonState,
   naturalAction,
   safSentence,
-} from './safety-catalog';
+} from '../../../lib/safety-catalog';
 
 interface FormState {
   checkId: string;

--- a/web-react/src/features/settings/safety-rules/safety-rules-page.tsx
+++ b/web-react/src/features/settings/safety-rules/safety-rules-page.tsx
@@ -22,7 +22,7 @@ import { sortByEvaluationOrder } from '../../../lib/rule-ordering';
 import { AuditDrawer } from './audit-drawer';
 import { RuleCard } from './rule-card';
 import { RuleDialog } from './rule-dialog';
-import { checkLabel, safSentence } from './safety-catalog';
+import { checkLabel, safSentence } from '../../../lib/safety-catalog';
 import './safety-rules.css';
 
 interface DialogState {

--- a/web-react/src/features/settings/safety-rules/safety-rules.css
+++ b/web-react/src/features/settings/safety-rules/safety-rules.css
@@ -5,34 +5,8 @@
  * label, audit drawer rows, duplicate banners, action segmented
  * control, routing table, and config grid. */
 
-/* five-color action pill (allow/warn/redact/require_approval/block) */
-.saf-act {
-  font-size: 11px;
-  font-weight: 700;
-  padding: 2px 8px;
-  border-radius: 2px;
-  white-space: nowrap;
-}
-.saf-act--allow {
-  background: var(--rm-success-bg);
-  color: var(--rm-success-text);
-}
-.saf-act--warn {
-  background: var(--rm-border);
-  color: var(--rm-text-muted);
-}
-.saf-act--redact {
-  background: var(--rm-warn-bg);
-  color: var(--rm-warn-text);
-}
-.saf-act--require_approval {
-  background: var(--rm-appr-bg);
-  color: var(--rm-appr-text);
-}
-.saf-act--block {
-  background: var(--rm-danger-bg);
-  color: var(--rm-danger);
-}
+/* .saf-act verdict pill family hoisted to components/ui.css — the
+ * safety-log page is the second consumer. */
 
 /* slow-latency + scope chips (inline in the card's target row) */
 .saf-chip {

--- a/web-react/src/lib/safety-catalog.test.ts
+++ b/web-react/src/lib/safety-catalog.test.ts
@@ -2,7 +2,7 @@
 // module (I.5: port WHOLE, with tests).
 import { describe, expect, it } from 'vitest';
 
-import type { SafetyCheck, SafetyStage } from '../../../api/client';
+import type { SafetyCheck, SafetyStage } from '../api/client';
 import {
   SAFETY_CHECK_CATALOG,
   actionButtonState,

--- a/web-react/src/lib/safety-catalog.ts
+++ b/web-react/src/lib/safety-catalog.ts
@@ -1,6 +1,7 @@
 // Copied from web/src/components/safety-catalog.ts @ feat/webui-react;
-// keep in sync manually until workspace extraction. Page-private pure
-// module — colocated in the slug folder per the §1.1 growth rule.
+// keep in sync manually until workspace extraction. Graduated from
+// features/settings/safety-rules/ to lib/ when the safety-log page
+// became the second consumer (§1.1: pure + ≥2 consumers → lib/).
 // React note: sentence helpers return HTML strings rendered with
 // dangerouslySetInnerHTML (dynamic text escaped inside — same contract
 // as the Lit unsafeHTML call).
@@ -26,7 +27,7 @@ import type {
   SafetyCheck,
   SafetyStage,
   SafetyVerdictAction,
-} from '../../../api/client';
+} from '../api/client';
 
 // Which config form a check renders — a presentation hint derived from the
 // check's config_schema (spec §6.12). Not on the wire.


### PR DESCRIPTION
Part J of the React SPA — the read-only decision log: the audit-visible expression of the safety framework, and the **load-bearing landing surface** for the chat approval card's `view in safety log →` deep link (prerequisite for the deferred Phase-5 approval-card PR). Behavioral reference: `safety-decisions-page.ts` + `safety-decision-detail-dialog.ts`.

## List (`features/settings/safety-log/`)
- **7-column clickable rows**: mono `HH:MM:SS` · verdict pill · mono stage · mono **finding codes** · truncating summary · coworker name (`organization-wide` when unscoped) · chevron.
- Sort `created_at` desc always (no sort control). Offset pagination 10/page, `Showing a–b of {total}` from the in-band envelope total, edge-disabled Previous/Next. Empty state assumes over-narrow filters.
- Header: `Refresh` + `Export CSV` as ghost buttons — a read-only page has no primary action. Log surfaces run 860px (prototype value; the 7-column grid needs more than the 760px name+controls rows).

## Filter bar
- Four dropdowns (verdict/stage/coworker/check) defaulting `all {field}`; every change resets to page 0. The **`rule_id` filter is never a dropdown** — deep-link only, rendered as a removable chip labeled with the rule's check label; its × clears only `rule_id`; `Clear filters` resets everything, chip included.
- **Deep links** applied once on mount (Lit G6 semantics): `?check_id` pre-selects the dropdown, `?rule_id` sets the chip; both AND-combine. The approval card sends `?rule_id` only — landing on the rule's full filtered list is deliberate.
- **D-J1 (user-approved)**: time range as a quick-select (`24h/7d/30d`) writing `from_ts`, with `Custom` revealing the datetime-local pair (the shipped Lit control) for arbitrary ranges. Presets computed once when picked — stable query key.

## Detail modal
Renders from the list row (page items carry full `findings`; `GET /decisions/{id}` has no consumer). Metadata grid with `platform rule` chip when `source=platform` (wire delta surfaced) · **Triggered rule** = check label + muted rule id, unknown ids render `deleted rule` (the log outlives its rules) · findings blocks with severity pills (critical/high red · medium amber · low/info gray) + metadata JSON · zero-findings allow explainer · **data-minimization note** anchored on the decision's own timestamp.

## CSV export
Authenticated blob fetch of `GET /safety/decisions.csv` (a plain `<a href>` cannot carry the bearer token), downloaded as `safety-log-{ISO date}.csv`, **carrying the current filters** (Lit parity; pagination params excluded — export is bulk).

## Shared-artifact hoists (sibling-isolation rule, done before the page)
- **`lib/safety-catalog.ts`**: graduated from `features/settings/safety-rules/` when this page became the second consumer (check labels + action tables); all safety-rules imports rewired, tests moved alongside.
- `.saf-act` verdict pill family moved from `safety-rules.css` to `components/ui.css` + new shared `.sev` severity pills.
- API client: `SafetyDecision` types + `SafetyDecisionFilters`, `listSafetyDecisions`, `downloadSafetyDecisionsCsv`.

## Spec correction recorded (source wins per the behavior-parity rule)
**J.2's "mono check_id" row column**: the wire `SafetyDecision` carries **no `check_id`** — the finding codes are the wire's signal of what the decision caught (the Lit `renderRow` comment documents this; the v11 prototype's mock `check_id` column was a prototype liberty). The `check_id` **filter** is real and kept — only the row column differs.

## Verification
- **9 new tests, 292 total green** — rows/finding-codes column, pager totals + edge-disable, both deep links, chip-clear vs clear-all, D-J1 custom reveal, empty state, detail modal (platform chip / deleted-rule fallback / severity pills / dm-note), allow explainer.
- `tsc`, the three lint scripts, `openapi:check`, and `build` all clean.
- Mock-backend Playwright E2E (**28 assertions**): pagination edges, AND-combined filters + page-0 reset, 24h preset + custom range round-trip, rule-chip deep link with server-side filtering, `check_id` pre-select, detail modal content, CSV download with the filters applied to the file body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_