### PR TITLE
General page — tenant settings (Part K)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -43,6 +43,8 @@ export type SafetyRuleAuditEntry = components['schemas']['SafetyRuleAuditEntry']
 export type SafetyCheck = components['schemas']['SafetyCheck'];
 export type SafetyStage = components['schemas']['SafetyStage'];
 export type SafetyVerdictAction = components['schemas']['SafetyVerdictAction'];
+export type TenantResponse = components['schemas']['TenantResponse'];
+export type TenantUpdate = components['schemas']['TenantUpdate'];
 export type SafetyDecision = components['schemas']['SafetyDecision'];
 export type SafetyDecisionPage = components['schemas']['SafetyDecisionPage'];
 export type SafetyFinding = components['schemas']['SafetyFinding'];
@@ -322,6 +324,32 @@ export class ApiClient {
       { method: 'DELETE', headers: this.headers() },
     );
     if (!resp.ok) throw await this.parseError(resp);
+  }
+
+  // ------------------------------------------------------------------
+  // Tenant settings (Part K). Owner-only: both routes 403 without
+  // `tenant.manage` — the page turns the GET 403 into a friendly
+  // full-page notice.
+  // ------------------------------------------------------------------
+
+  async getTenant(): Promise<TenantResponse> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/tenant`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as TenantResponse;
+  }
+
+  /** PATCH — only `name` + `max_concurrent_containers` have a write
+   *  path (slug is fixed at creation; plan is a platform concern). */
+  async updateTenant(body: TenantUpdate): Promise<TenantResponse> {
+    const resp = await this.fetchJson(
+      'PATCH',
+      `${this.baseUrl}/api/v1/tenant`,
+      body,
+    );
+    return (await resp.json()) as TenantResponse;
   }
 
   // ------------------------------------------------------------------

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -99,6 +99,18 @@ export function useSafetyChecks() {
   });
 }
 
+// ---- General / tenant settings page (Part K) ----
+
+/** Owner-only tenant settings. Errors surface (the page maps a 403 to
+ *  the friendly owner-only notice). */
+export function useTenant() {
+  return useQuery({
+    queryKey: ['tenant'],
+    queryFn: () => getApiClient().getTenant(),
+    retry: false,
+  });
+}
+
 // ---- Safety log page (Part J) ----
 
 /** One page of the decision log. The filter object is part of the key —

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -84,6 +84,12 @@ const SafetyLogPage = lazy(() =>
   })),
 );
 
+const GeneralPage = lazy(() =>
+  import('../features/settings/general/general-page').then((m) => ({
+    default: m.GeneralPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -159,6 +165,16 @@ export function AppRoutes() {
           <Suspense fallback={null}>
             <Gated slug="safety-log">
               <SafetyLogPage />
+            </Gated>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/general/*"
+        element={
+          <Suspense fallback={null}>
+            <Gated slug="general">
+              <GeneralPage />
             </Gated>
           </Suspense>
         }

--- a/web-react/src/features/settings/general/general-page.test.tsx
+++ b/web-react/src/features/settings/general/general-page.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { ApiError, type TenantResponse } from '../../../api/client';
+import { GeneralPage } from './general-page';
+
+const TENANT: TenantResponse = {
+  id: 't-1',
+  name: 'Acme Capital',
+  slug: 'acme-capital',
+  plan: 'team',
+  max_concurrent_containers: 2,
+  created_at: '2026-04-02T09:00:00Z',
+} as TenantResponse;
+
+function renderPage(seed: TenantResponse | 'forbidden') {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  if (seed === 'forbidden') {
+    // Pre-populate the query cache with a settled 403 error state.
+    void qc.prefetchQuery({
+      queryKey: ['tenant'],
+      queryFn: () =>
+        Promise.reject(new ApiError(403, { code: 'FORBIDDEN', message: 'nope' }, 'nope')),
+      retry: false,
+    });
+  } else {
+    qc.setQueryData(['tenant'], seed);
+  }
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <GeneralPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(cleanup);
+
+describe('GeneralPage', () => {
+  it('renders the wire fields: editable name/mcc, disabled slug, plan pill, created date', () => {
+    renderPage(TENANT);
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe(
+      'Acme Capital',
+    );
+    const slug = screen.getByLabelText('Workspace slug') as HTMLInputElement;
+    expect(slug.disabled).toBe(true);
+    expect(slug.value).toBe('acme-capital');
+    expect(screen.getByText('team').className).toContain('pill-active');
+    expect(
+      (screen.getByLabelText('Concurrent coworker tasks') as HTMLInputElement).value,
+    ).toBe('2');
+  });
+
+  it('Save disabled when clean; dirty enables Save + reveals Revert; Revert restores', () => {
+    renderPage(TENANT);
+    const save = screen.getByTestId('gen-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    expect(screen.queryByTestId('gen-revert')).toBeNull();
+    fireEvent.change(screen.getByLabelText('Workspace name'), {
+      target: { value: 'Acme Capital LLC' },
+    });
+    expect(save.disabled).toBe(false);
+    fireEvent.click(screen.getByTestId('gen-revert'));
+    expect((screen.getByLabelText('Workspace name') as HTMLInputElement).value).toBe(
+      'Acme Capital',
+    );
+    expect((screen.getByTestId('gen-save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('validation replaces the hint line in danger color and blocks Save', () => {
+    renderPage(TENANT);
+    fireEvent.change(screen.getByLabelText('Workspace name'), { target: { value: '  ' } });
+    expect(screen.getByText('Workspace name is required.')).toBeTruthy();
+    expect((screen.getByTestId('gen-save') as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText('Workspace name'), {
+      target: { value: 'Acme' },
+    });
+    fireEvent.change(screen.getByLabelText('Concurrent coworker tasks'), {
+      target: { value: '0' },
+    });
+    expect(screen.getByText('Must be a whole number of at least 1.')).toBeTruthy();
+    expect((screen.getByTestId('gen-save') as HTMLButtonElement).disabled).toBe(true);
+    // Non-numeric input also blocks (NaN sentinel).
+    fireEvent.change(screen.getByLabelText('Concurrent coworker tasks'), {
+      target: { value: 'abc' },
+    });
+    expect((screen.getByTestId('gen-save') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('nullable slug/plan degrade gracefully', () => {
+    renderPage({ ...TENANT, slug: null, plan: null } as TenantResponse);
+    expect((screen.getByLabelText('Workspace slug') as HTMLInputElement).value).toBe('—');
+    expect(screen.queryByText('team')).toBeNull();
+  });
+
+  it('GET 403 renders the friendly owner-only notice, not a raw error', async () => {
+    renderPage('forbidden');
+    expect(
+      await screen.findByText('Only the workspace owner can view general settings.'),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText('Workspace name')).toBeNull();
+  });
+});

--- a/web-react/src/features/settings/general/general-page.tsx
+++ b/web-react/src/features/settings/general/general-page.tsx
@@ -1,0 +1,232 @@
+// GeneralPage — owner-only tenant settings (spec Part K). No Lit
+// behavioral reference exists (its General entry is a coming-soon
+// stub); D-K1 (user-approved) ships this ahead of the Lit SPA, bound
+// STRICTLY to the shipped wire (GET/PATCH /api/v1/tenant) — no invented
+// fields, no invented flows. Reconcile per the behavior-parity rule
+// when the Lit page lands.
+//
+// A form, not a collection: one 560px column, dirty-tracked Save
+// (disabled when clean, invalid, or busy) + Revert (visible only when
+// dirty); one PATCH carries both writable fields; field errors replace
+// the hint line in danger color (the dialogs' pattern).
+//
+// max_concurrent_containers closes a loop from Part C: the coworker
+// wizard's locked decision #10 kept it out of the wizard ("backend
+// default applies") — this tenant-level control is that decision's
+// intended home. Client-side gate is integer >= 1 only; the wire's
+// max (100) stays server-authoritative.
+
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { ApiError, getApiClient } from '../../../api/client';
+import { useTenant } from '../../../api/queries';
+import { BrandMark } from '../../../components/brand-mark';
+
+interface FormState {
+  name: string;
+  /** NaN while the input holds a non-integer — blocks Save. */
+  mcc: number;
+}
+
+export function GeneralPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const tenantQ = useTenant();
+  const tenant = tenantQ.data ?? null;
+
+  // Seeded from the loaded tenant; null until then (or after Revert).
+  const [form, setForm] = useState<FormState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [saveErr, setSaveErr] = useState<string | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  const f: FormState | null =
+    form ?? (tenant ? { name: tenant.name, mcc: tenant.max_concurrent_containers } : null);
+
+  const dirty =
+    !!tenant && !!f && (f.name !== tenant.name || f.mcc !== tenant.max_concurrent_containers);
+  const nameErr = f && !f.name.trim() ? 'Workspace name is required.' : '';
+  const mccErr =
+    f && !(Number.isInteger(f.mcc) && f.mcc >= 1)
+      ? 'Must be a whole number of at least 1.'
+      : '';
+
+  async function save() {
+    if (!f || !dirty || nameErr || mccErr || busy) return;
+    setBusy(true);
+    setSaveErr(null);
+    try {
+      const saved = await getApiClient().updateTenant({
+        name: f.name.trim(),
+        max_concurrent_containers: f.mcc,
+      });
+      queryClient.setQueryData(['tenant'], saved);
+      setForm(null); // re-render clean from the fresh server row
+      showToast('Workspace settings saved');
+    } catch (e) {
+      setSaveErr(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // The GET's 403 is the trigger for the friendly owner-only notice
+  // (deep links by non-owners must not dead-end on a raw error).
+  const forbidden =
+    tenantQ.isError && tenantQ.error instanceof ApiError && tenantQ.error.status === 403;
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">General</h1>
+          <div className="page-sub">
+            Workspace settings. Only the workspace owner can view or change these.
+          </div>
+        </div>
+      </div>
+
+      <div className="grid-scroll" style={{ paddingTop: 12 }}>
+        {tenantQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : forbidden ? (
+          <div className="grid-empty" data-testid="gen-forbidden">
+            <div style={{ margin: 'auto', textAlign: 'center' }}>
+              <BrandMark size={128} />
+              <div style={{ marginTop: '0.75rem', fontSize: '1rem' }}>
+                Only the workspace owner can view general settings.
+              </div>
+            </div>
+          </div>
+        ) : tenantQ.isError ? (
+          <div className="row-error">
+            Failed to load workspace settings — retry from the sidebar.
+          </div>
+        ) : tenant && f ? (
+          <div style={{ maxWidth: 560 }}>
+            <div className="field">
+              <label htmlFor="gen-name">Workspace name</label>
+              <input
+                id="gen-name"
+                type="text"
+                maxLength={120}
+                value={f.name}
+                disabled={busy}
+                onChange={(e) => setForm({ ...f, name: e.target.value })}
+              />
+              <div className="hint" style={nameErr ? { color: 'var(--rm-danger)' } : undefined}>
+                {nameErr || 'Shown across the app and in invitations.'}
+              </div>
+            </div>
+            <div className="field">
+              <label htmlFor="gen-slug">Workspace slug</label>
+              <input
+                id="gen-slug"
+                type="text"
+                disabled
+                value={tenant.slug ?? '—'}
+                style={{ fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 13 }}
+              />
+              <div className="hint">The workspace identifier — fixed at creation.</div>
+            </div>
+            <div style={{ display: 'flex', gap: 20 }}>
+              <div className="field" style={{ flex: 1 }}>
+                <label>Plan</label>
+                <div style={{ padding: '6px 0' }}>
+                  {tenant.plan ? (
+                    <span className="pill pill-active" style={{ textTransform: 'capitalize' }}>
+                      {tenant.plan}
+                    </span>
+                  ) : (
+                    <span className="hint">—</span>
+                  )}
+                </div>
+                <div className="hint">Plan changes are handled by the platform operator.</div>
+              </div>
+              <div className="field" style={{ flex: 1 }}>
+                <label>Created</label>
+                <div style={{ padding: '9px 0', fontSize: '0.875rem' }}>
+                  {new Date(tenant.created_at).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </div>
+              </div>
+            </div>
+            <div className="field">
+              <label htmlFor="gen-mcc" style={{ whiteSpace: 'nowrap' }}>
+                Concurrent coworker tasks
+              </label>
+              <input
+                id="gen-mcc"
+                type="text"
+                inputMode="numeric"
+                style={{ width: 96, display: 'block' }}
+                value={Number.isNaN(f.mcc) ? '' : String(f.mcc)}
+                disabled={busy}
+                onChange={(e) => {
+                  const t = e.target.value.trim();
+                  setForm({ ...f, mcc: /^\d+$/.test(t) ? parseInt(t, 10) : NaN });
+                }}
+              />
+              <div className="hint" style={mccErr ? { color: 'var(--rm-danger)' } : undefined}>
+                {mccErr ||
+                  'How many coworker containers may run at the same time. Higher values use more compute; queued tasks wait for a free slot.'}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center', paddingTop: 4 }}>
+              <button
+                className="btn-primary"
+                data-testid="gen-save"
+                disabled={!dirty || !!nameErr || !!mccErr || busy}
+                onClick={() => void save()}
+              >
+                {busy ? 'Saving…' : 'Save changes'}
+              </button>
+              {dirty && !busy ? (
+                <button className="btn-ghost" data-testid="gen-revert" onClick={() => setForm(null)}>
+                  Revert
+                </button>
+              ) : null}
+            </div>
+            {saveErr ? (
+              <div className="row-error" role="alert" style={{ marginTop: 8 }}>
+                {saveErr}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Part K of the React SPA — owner-only workspace settings. **No Lit behavioral reference exists** (its General entry is a coming-soon stub); **D-K1 (user-approved)** ships this ahead of the Lit SPA, bound **strictly to the shipped wire** (`GET/PATCH /api/v1/tenant`) — no invented fields, no invented flows. Reconcile per the behavior-parity rule when the Lit page lands.

## Form (`features/settings/general/`, single file)
A form, not a collection — no page-level primary action. One 560px column:

| Field | Wire | Treatment |
|---|---|---|
| Workspace name | `name` (PATCH) | text input, required |
| Workspace slug | `slug` | **disabled** mono input — fixed at creation |
| Plan | `plan` | read-only pill — platform-operator concern |
| Created | `created_at` | read-only date |
| Concurrent coworker tasks | `max_concurrent_containers` (PATCH) | narrow numeric; hint explains the compute/queueing tradeoff |

- **Dirty-tracked** `Save changes` (disabled when clean, invalid, or busy) + `Revert` (visible only when dirty). One PATCH carries both writable fields; success toast; re-renders clean from the fresh server row. Field errors replace the hint line in danger color (the dialogs' pattern). Nullable `slug`/`plan` degrade gracefully.
- Client-side gate is integer ≥ 1 only; the wire's max (100) stays **server-authoritative** (E2E probes the 422).
- `max_concurrent_containers` closes the Part C loop: the coworker wizard's locked decision #10 deliberately kept it out of the wizard — this tenant-level control is that decision's intended home.

## Access gating (two layers)
The nav entry's `tenant.manage` capability (existing `Gated` wrapper → access-denied page) **and** the GET's 403 mapped to a friendly full-page notice (`Only the workspace owner can view general settings.`) — deep links by non-owners never dead-end on a raw error.

## API client
`TenantResponse`/`TenantUpdate` types + `getTenant`/`updateTenant` (PATCH via `fetchJson`). Query key `['tenant']`.

## Verification
- **5 new tests, 297 total green** — wire-field rendering (disabled slug, plan pill), dirty/Save/Revert cycle, validation replacing hints + NaN sentinel, nullable degradation, 403 → friendly notice.
- `tsc`, the three lint scripts, `openapi:check`, and `build` all clean.
- Mock-backend Playwright E2E (**15 assertions**): clean/dirty gating, validation block, PATCH round-trip persisted server-side, server-authoritative 422 above 100, Revert restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_