### PR TITLE
Members page — tenant user management (Part L)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -45,6 +45,10 @@ export type SafetyStage = components['schemas']['SafetyStage'];
 export type SafetyVerdictAction = components['schemas']['SafetyVerdictAction'];
 export type TenantResponse = components['schemas']['TenantResponse'];
 export type TenantUpdate = components['schemas']['TenantUpdate'];
+export type UserResponse = components['schemas']['UserResponse'];
+export type UserCreate = components['schemas']['UserCreate'];
+export type UserUpdate = components['schemas']['UserUpdate'];
+export type UserPage = components['schemas']['UserPage'];
 export type SafetyDecision = components['schemas']['SafetyDecision'];
 export type SafetyDecisionPage = components['schemas']['SafetyDecisionPage'];
 export type SafetyFinding = components['schemas']['SafetyFinding'];
@@ -350,6 +354,52 @@ export class ApiClient {
       body,
     );
     return (await resp.json()) as TenantResponse;
+  }
+
+  // ------------------------------------------------------------------
+  // Users (Part L). Gated by `user.manage` (owner + admin). Two
+  // business rules live in the handler, not in capabilities: only an
+  // owner may create/assign the `owner` role (403), and you cannot
+  // delete yourself (400). The detail GET is omitted — the list rows
+  // already carry every field the page renders (trimmed-client rule).
+  // ------------------------------------------------------------------
+
+  async listUsers(limit = 20, offset = 0): Promise<UserPage> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/users?limit=${limit}&offset=${offset}`,
+      { method: 'GET', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as UserPage;
+  }
+
+  async createUser(body: UserCreate): Promise<UserResponse> {
+    const resp = await this.fetchJson(
+      'POST',
+      `${this.baseUrl}/api/v1/users`,
+      body,
+    );
+    return (await resp.json()) as UserResponse;
+  }
+
+  /** PATCH. `email: ""` clears the stored email; omit/null leaves it
+   *  unchanged. `channel_ids` has no write path here — channel identity
+   *  is owned by the channel-linking flows. */
+  async updateUser(id: string, body: UserUpdate): Promise<UserResponse> {
+    const resp = await this.fetchJson(
+      'PATCH',
+      `${this.baseUrl}/api/v1/users/${encodeURIComponent(id)}`,
+      body,
+    );
+    return (await resp.json()) as UserResponse;
+  }
+
+  async deleteUser(id: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/users/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
   }
 
   // ------------------------------------------------------------------

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -111,6 +111,20 @@ export function useTenant() {
   });
 }
 
+// ---- Members page (Part L) ----
+
+/** One page of the tenant's users. Gated by `user.manage` upstream
+ *  (route-level Gated) — a load failure here surfaces as an error row.
+ *  Offset is part of the key; invalidating the `['users']` prefix
+ *  refreshes every page. */
+export function useUsers(offset: number, limit: number) {
+  return useQuery({
+    queryKey: ['users', offset, limit],
+    queryFn: () => getApiClient().listUsers(limit, offset),
+    placeholderData: (prev) => prev,
+  });
+}
+
 // ---- Safety log page (Part J) ----
 
 /** One page of the decision log. The filter object is part of the key —

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -90,6 +90,12 @@ const GeneralPage = lazy(() =>
   })),
 );
 
+const MembersPage = lazy(() =>
+  import('../features/settings/members/members-page').then((m) => ({
+    default: m.MembersPage,
+  })),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -175,6 +181,16 @@ export function AppRoutes() {
           <Suspense fallback={null}>
             <Gated slug="general">
               <GeneralPage />
+            </Gated>
+          </Suspense>
+        }
+      />
+      <Route
+        path="/manage/members/*"
+        element={
+          <Suspense fallback={null}>
+            <Gated slug="members">
+              <MembersPage />
             </Gated>
           </Suspense>
         }

--- a/web-react/src/components/ui.css
+++ b/web-react/src/components/ui.css
@@ -571,6 +571,63 @@
   flex: 1;
 }
 
+/* Member-row chrome (Part L). Global (not members.css) because the
+ * spec anticipates the role pills back-propagating to the coworker
+ * ownership tags — and sibling-chunk CSS is the load-order trap this
+ * file exists to prevent. */
+.role-pill {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 2px;
+  text-transform: capitalize;
+}
+.role-pill--owner {
+  background: var(--rm-action);
+  color: #fff;
+}
+.role-pill--admin {
+  background: var(--rm-info-bg);
+  color: var(--rm-info-text);
+}
+.role-pill--member {
+  background: var(--rm-border);
+  color: var(--rm-text-muted);
+}
+.you-tag {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--rm-action);
+  border: 1px solid var(--rm-action);
+  border-radius: 2px;
+  padding: 0 5px;
+}
+.chan-tag {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 10.5px;
+  color: var(--rm-text-muted);
+  border: 1px solid var(--rm-border);
+  border-radius: 2px;
+  padding: 1px 5px;
+}
+
+/* Offset/limit pager — graduated from safety-log.css when the members
+ * page became its second consumer. Width is page-owned (safety-log
+ * caps it at its 860px surfaces, members at the 760px row column). */
+.pager {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 2px;
+  font-size: 0.8125rem;
+  color: var(--rm-text-muted);
+}
+.pager .sp {
+  flex: 1;
+}
+
 /* Switch — labelled toggle primitive (components/switch.tsx). First
  * consumers: the approval-policy card's enable toggle + the policy
  * dialog's Status field. */

--- a/web-react/src/features/settings/members/member-dialog.tsx
+++ b/web-react/src/features/settings/members/member-dialog.tsx
@@ -1,0 +1,198 @@
+// MemberDialog — add + edit share this one 480px dialog (spec L.3).
+//
+// Role rules — mirror, don't own: the page gate is the `user.manage`
+// capability, but "only owners grant the owner role" has NO capability
+// on the wire (it's a handler business rule keyed to the caller's
+// role). We read Me.role solely to MIRROR that server invariant for
+// display — owner option disabled + "(owners only)" + hint — never as
+// a client-side authorization decision; the POST/PATCH 403 stays
+// authoritative and surfaces in the footer if the mirror is ever
+// stale. Editing yourself to a lower role is server-allowed, so it
+// gets an advisory, not a block.
+//
+// Self-contained mutation (the credential-dialog pattern): owns the
+// POST/PATCH, invalidates ['users'], and hands the toast copy to the
+// page via onSaved.
+
+import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react';
+import {
+  ApiError,
+  getApiClient,
+  type UserResponse,
+} from '../../../api/client';
+import { currentMe } from '../../../lib/capabilities';
+import { BrandMark } from '../../../components/brand-mark';
+
+type Role = 'member' | 'admin' | 'owner';
+const ROLES: Role[] = ['member', 'admin', 'owner'];
+
+export function MemberDialog({
+  target,
+  onClose,
+  onSaved,
+}: {
+  /** Row being edited, or null for Add member. */
+  target: UserResponse | null;
+  onClose: () => void;
+  /** Toast hook — fires after the write lands and the list refreshes. */
+  onSaved: (message: string) => void;
+}) {
+  const queryClient = useQueryClient();
+  const me = currentMe();
+  const editing = !!target;
+  const isOwnerCaller = me?.role === 'owner';
+  const editingSelf = editing && target.id === me?.user_id;
+
+  const [name, setName] = useState(target?.name ?? '');
+  const [email, setEmail] = useState(target?.email ?? '');
+  const [role, setRole] = useState<Role>((target?.role as Role) ?? 'member');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      if (!busy) onClose();
+    }
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [busy, onClose]);
+
+  const roleHint = !isOwnerCaller
+    ? 'Only owners can grant the owner role — the server enforces this.'
+    : editingSelf && role !== 'owner'
+      ? '⚠ Lowering your own role may remove your access to this page.'
+      : 'Owners and admins can manage members and workspace resources.';
+
+  async function save() {
+    if (busy || !name.trim()) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const api = getApiClient();
+      if (editing) {
+        // PATCH sends email verbatim — "" is the wire's clear-it signal
+        // (omit/null would leave the stored value unchanged).
+        await api.updateUser(target.id, {
+          name: name.trim(),
+          email: email.trim(),
+          role,
+        });
+      } else {
+        await api.createUser({
+          name: name.trim(),
+          email: email.trim() || null,
+          role,
+        });
+      }
+      await queryClient.invalidateQueries({ queryKey: ['users'] });
+      onSaved(editing ? 'Member updated' : `Added ${name.trim()}`);
+      onClose();
+    } catch (e) {
+      setErr(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className="scrim"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        className="dlg"
+        style={{ width: 480 }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Member"
+      >
+        <div className="dlg-header">
+          <div className="hleft">
+            <div className="dlg-brand-icon">
+              <BrandMark size={16} />
+            </div>
+            <h2 className="dlg-title">{editing ? `Edit ${target.name}` : 'Add member'}</h2>
+          </div>
+          <button className="icon-btn" aria-label="Close" disabled={busy} onClick={onClose}>
+            <X />
+          </button>
+        </div>
+        <div className="wiz-body" style={{ minHeight: 0 }}>
+          <div className="field">
+            <label htmlFor="mem-name">Name</label>
+            <input
+              id="mem-name"
+              type="text"
+              maxLength={200}
+              value={name}
+              disabled={busy}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="field">
+            <label htmlFor="mem-email">
+              Email{' '}
+              <span style={{ fontWeight: 400, color: 'var(--rm-text-muted)' }}>optional</span>
+            </label>
+            <input
+              id="mem-email"
+              type="text"
+              placeholder="name@company.com"
+              value={email}
+              disabled={busy}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            {editing ? (
+              <div className="hint">Clearing this field removes the stored email.</div>
+            ) : null}
+          </div>
+          <div className="field">
+            <label htmlFor="mem-role">Role</label>
+            <select
+              id="mem-role"
+              value={role}
+              disabled={busy}
+              onChange={(e) => setRole(e.target.value as Role)}
+            >
+              {ROLES.map((r) => (
+                <option key={r} value={r} disabled={r === 'owner' && !isOwnerCaller}>
+                  {r === 'owner' && !isOwnerCaller ? 'owner (owners only)' : r}
+                </option>
+              ))}
+            </select>
+            <div className="hint">{roleHint}</div>
+          </div>
+        </div>
+        <div className="wiz-foot">
+          {err ? (
+            <span className="wiz-err" role="alert">
+              {err}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span style={{ display: 'inline-flex', gap: 8 }}>
+            <button className="btn-ghost" disabled={busy} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              className="btn-primary"
+              data-testid="mem-save"
+              disabled={busy || !name.trim()}
+              onClick={() => void save()}
+            >
+              {busy ? 'Saving…' : editing ? 'Save changes' : 'Add member'}
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/members/members-page.test.tsx
+++ b/web-react/src/features/settings/members/members-page.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { Me, UserPage, UserResponse } from '../../../api/client';
+import { setMe } from '../../../lib/capabilities';
+import { MembersPage } from './members-page';
+
+const OWNER_ME: Me = {
+  user_id: 'u-jerry',
+  tenant_id: 't-1',
+  name: 'Jerry',
+  role: 'owner',
+  plane: 'tenant',
+  capabilities: ['user.manage'],
+} as Me;
+
+const USERS: UserResponse[] = [
+  {
+    id: 'u-jerry',
+    tenant_id: 't-1',
+    name: 'Jerry Guan',
+    email: 'jerry@acme.example',
+    role: 'owner',
+    channel_ids: { telegram: '12345' },
+    created_at: '2026-04-02T09:00:00Z',
+  },
+  {
+    id: 'u-sam',
+    tenant_id: 't-1',
+    name: 'Sam Ortiz',
+    email: null,
+    role: 'member',
+    channel_ids: {},
+    created_at: '2026-05-03T09:00:00Z',
+  },
+] as UserResponse[];
+
+function renderPage(me: Me = OWNER_ME, users: UserResponse[] = USERS, total?: number) {
+  setMe(me);
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const pageData: UserPage = {
+    items: users,
+    total: total ?? users.length,
+    limit: 20,
+    offset: 0,
+  };
+  qc.setQueryData(['users', 0, 20], pageData);
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <MembersPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  setMe(null);
+});
+
+describe('MembersPage', () => {
+  it('renders rows: You tag on own row, channel chips, email fallback, role pills', () => {
+    renderPage();
+    expect(screen.getByText('You')).toBeTruthy();
+    expect(screen.getByText('telegram linked').className).toContain('chan-tag');
+    expect(screen.getByText('no email')).toBeTruthy();
+    expect(screen.getByText('owner').className).toContain('role-pill--owner');
+    expect(screen.getByText('member').className).toContain('role-pill--member');
+  });
+
+  it('Remove is absent on the caller\'s own row, present on others', () => {
+    renderPage();
+    const own = screen.getByTestId('mem-row-u-jerry');
+    const other = screen.getByTestId('mem-row-u-sam');
+    expect(own.querySelector('[title="Remove from workspace"]')).toBeNull();
+    expect(other.querySelector('[title="Remove from workspace"]')).toBeTruthy();
+    expect(own.querySelector('[title="Edit member"]')).toBeTruthy();
+  });
+
+  it('remove confirm states resources remain; owner target adds the last-owner caution', () => {
+    const owners = [
+      ...USERS,
+      { ...USERS[0], id: 'u-lena', name: 'Lena Fis', channel_ids: {} } as UserResponse,
+    ];
+    renderPage(OWNER_ME, owners);
+    // Non-owner target: no caution.
+    fireEvent.click(
+      screen
+        .getByTestId('mem-row-u-sam')
+        .querySelector('[title="Remove from workspace"]')!,
+    );
+    expect(screen.getByText(/resources they created remain/)).toBeTruthy();
+    expect(screen.queryByText(/is an owner/)).toBeNull();
+    fireEvent.click(screen.getByText('Cancel'));
+    // Owner target: caution appended.
+    fireEvent.click(
+      screen
+        .getByTestId('mem-row-u-lena')
+        .querySelector('[title="Remove from workspace"]')!,
+    );
+    expect(screen.getByText(/Lena Fis is an owner\./)).toBeTruthy();
+    expect(screen.getByText(/does not block removing the last one/)).toBeTruthy();
+  });
+
+  it('add dialog for an admin caller: owner option disabled with the server-enforces hint', () => {
+    renderPage({ ...OWNER_ME, user_id: 'u-ada', role: 'admin' } as Me);
+    fireEvent.click(screen.getByTestId('mem-add'));
+    const owner = screen.getByText('owner (owners only)') as HTMLOptionElement;
+    expect(owner.disabled).toBe(true);
+    expect(
+      screen.getByText('Only owners can grant the owner role — the server enforces this.'),
+    ).toBeTruthy();
+    // Save gated on name.
+    const save = screen.getByTestId('mem-save') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'New Person' } });
+    expect(save.disabled).toBe(false);
+  });
+
+  it('owner editing their own row to a lower role sees the advisory', () => {
+    renderPage();
+    fireEvent.click(
+      screen.getByTestId('mem-row-u-jerry').querySelector('[title="Edit member"]')!,
+    );
+    expect(screen.getByText('Edit Jerry Guan')).toBeTruthy();
+    // Email-clear hint is edit-mode only.
+    expect(screen.getByText('Clearing this field removes the stored email.')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Role'), { target: { value: 'member' } });
+    expect(
+      screen.getByText('⚠ Lowering your own role may remove your access to this page.'),
+    ).toBeTruthy();
+  });
+
+  it('pager appears only when total exceeds the page size', () => {
+    renderPage(OWNER_ME, USERS, 45);
+    const pager = screen.getByTestId('mem-pager');
+    expect(pager.textContent).toContain('Showing 1–2 of 45');
+    cleanup();
+    renderPage(OWNER_ME, USERS, 2);
+    expect(screen.queryByTestId('mem-pager')).toBeNull();
+  });
+});

--- a/web-react/src/features/settings/members/members-page.tsx
+++ b/web-react/src/features/settings/members/members-page.tsx
@@ -1,0 +1,230 @@
+// MembersPage — tenant user management (spec Part L). No Lit
+// behavioral reference exists (its Members entry is a coming-soon
+// stub); D-L1 (user-approved, same footing as D-K1) ships this ahead
+// of the Lit SPA, bound STRICTLY to the shipped wire (/api/v1/users).
+// Reconcile per the behavior-parity rule when the Lit page lands.
+//
+// Access is the `user.manage` capability (owner + admin), enforced by
+// the route-level <Gated>. Two handler business rules shape the rows:
+// you cannot delete yourself (400) — mirrored by HIDING Remove on the
+// caller's own row (a dead button loses to no button, the Part I §8.5
+// principle) — and only owners grant the owner role (the dialog
+// mirrors that one; see member-dialog.tsx).
+//
+// Row width joins the D-UI1 760px unification (the v13 prototype's
+// inline 680px cap is superseded — one cap for every row-list page).
+
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { ApiError, getApiClient, type UserResponse } from '../../../api/client';
+import { useUsers } from '../../../api/queries';
+import { currentMe } from '../../../lib/capabilities';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { MemberDialog } from './member-dialog';
+
+const PAGE_SIZE = 20;
+
+export function MembersPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const me = currentMe();
+
+  const [page, setPage] = useState(0);
+  const usersQ = useUsers(page * PAGE_SIZE, PAGE_SIZE);
+
+  /** null = closed; { target: null } = Add member. */
+  const [dialog, setDialog] = useState<{ target: UserResponse | null } | null>(null);
+  const [removing, setRemoving] = useState<UserResponse | null>(null);
+  const [removeBusy, setRemoveBusy] = useState(false);
+  const [removeErr, setRemoveErr] = useState<string | null>(null);
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  async function confirmRemove() {
+    if (!removing || removeBusy) return;
+    setRemoveBusy(true);
+    setRemoveErr(null);
+    try {
+      await getApiClient().deleteUser(removing.id);
+      // Removing the last row of a later page would land on an empty
+      // page — step back before the refetch.
+      if ((usersQ.data?.items.length ?? 0) === 1 && page > 0) setPage(page - 1);
+      await queryClient.invalidateQueries({ queryKey: ['users'] });
+      showToast(`Removed ${removing.name}`);
+      setRemoving(null);
+    } catch (e) {
+      setRemoveErr(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+    } finally {
+      setRemoveBusy(false);
+    }
+  }
+
+  const items = usersQ.data?.items ?? [];
+  const total = usersQ.data?.total ?? 0;
+  const start = total === 0 ? 0 : page * PAGE_SIZE + 1;
+  const end = Math.min(total, page * PAGE_SIZE + items.length);
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Members</h1>
+          <div className="page-sub" style={{ maxWidth: 640 }}>
+            People in this workspace and their roles. Owners and admins can manage
+            members; only owners can grant the owner role.
+          </div>
+        </div>
+        <button
+          className="btn-primary"
+          data-testid="mem-add"
+          onClick={() => setDialog({ target: null })}
+        >
+          <Plus />
+          Add member
+        </button>
+      </div>
+
+      <div className="grid-scroll" style={{ paddingTop: 12 }}>
+        {usersQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : usersQ.isError ? (
+          <div className="row-error">Failed to load members — retry from the sidebar.</div>
+        ) : (
+          <>
+            {items.map((u) => (
+              <div className="model-row" key={u.id} data-testid={`mem-row-${u.id}`}>
+                <span style={{ minWidth: 0 }}>
+                  <div
+                    className="m-name"
+                    style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+                  >
+                    {u.name}
+                    {u.id === me?.user_id ? <span className="you-tag">You</span> : null}
+                    {Object.keys(u.channel_ids ?? {}).map((ch) => (
+                      <span className="chan-tag" key={ch}>
+                        {ch} linked
+                      </span>
+                    ))}
+                  </div>
+                  <div className="m-sub" style={{ fontFamily: 'var(--font-base)' }}>
+                    {u.email || 'no email'}
+                  </div>
+                </span>
+                <span className="m-fill" />
+                <span className={`role-pill role-pill--${u.role}`}>{u.role}</span>
+                <span className="icon-acts">
+                  <button
+                    className="icon-btn"
+                    title="Edit member"
+                    onClick={() => setDialog({ target: u })}
+                  >
+                    <Pencil />
+                  </button>
+                  {u.id === me?.user_id ? null : (
+                    <button
+                      className="icon-btn danger"
+                      title="Remove from workspace"
+                      onClick={() => {
+                        setRemoveErr(null);
+                        setRemoving(u);
+                      }}
+                    >
+                      <Trash2 />
+                    </button>
+                  )}
+                </span>
+              </div>
+            ))}
+            {total > PAGE_SIZE ? (
+              <div className="pager" style={{ maxWidth: 760 }} data-testid="mem-pager">
+                <span>
+                  Showing {start}–{end} of {total}
+                </span>
+                <span className="sp" />
+                <button
+                  className="btn-ghost"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                >
+                  ← Previous
+                </button>
+                <button
+                  className="btn-ghost"
+                  disabled={(page + 1) * PAGE_SIZE >= total}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next →
+                </button>
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      {dialog ? (
+        <MemberDialog
+          target={dialog.target}
+          onClose={() => setDialog(null)}
+          onSaved={showToast}
+        />
+      ) : null}
+
+      {removing ? (
+        <ConfirmDialog
+          title={`Remove ${removing.name} from the workspace?`}
+          confirmLabel="Remove member"
+          busyLabel="Removing…"
+          busy={removeBusy}
+          onConfirm={() => void confirmRemove()}
+          onCancel={() => {
+            if (!removeBusy) setRemoving(null);
+          }}
+        >
+          <p>
+            {removing.name} loses access immediately. Coworkers, skills, and other
+            resources they created remain in the workspace.
+          </p>
+          {removing.role === 'owner' ? (
+            <p>
+              ⚠ <b>{removing.name} is an owner.</b> Make sure another owner remains —
+              the server does not block removing the last one.
+            </p>
+          ) : null}
+          {removeErr ? (
+            <p className="row-error" role="alert">
+              {removeErr}
+            </p>
+          ) : null}
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/safety-log/safety-log.css
+++ b/web-react/src/features/settings/safety-log/safety-log.css
@@ -90,17 +90,10 @@
   color: var(--rm-text-muted);
 }
 
+/* Base .pager graduated to ui.css (the members page is its second
+ * consumer); only this page's width cap stays here. */
 .pager {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 2px;
-  font-size: 0.8125rem;
-  color: var(--rm-text-muted);
   max-width: 860px;
-}
-.pager .sp {
-  flex: 1;
 }
 
 /* detail modal */


### PR DESCRIPTION
## Summary

Part L of the React SPA (v13 spec): the Members page at `#/manage/members`, against `/api/v1/users` (gated by `user.manage`, held by owner + admin).

**D-L1** (user-approved, same footing as D-K1): the Lit SPA's Members entry is a coming-soon stub, so this page ships ahead of it, bound strictly to the shipped wire — reconcile per the behavior-parity rule when a Lit page lands.

## What's in here

- **Client**: `UserResponse/UserCreate/UserUpdate/UserPage` types + `listUsers/createUser/updateUser/deleteUser` (writes via the `fetchJson` helper); `useUsers(offset, limit)` paged hook (key `['users', offset, limit]`, placeholder-data pagination).
- **Page**: read-only-row family at the D-UI1 760px cap (supersedes the prototype's inline 680px), name + `You` outline tag on the caller's row + mono `{channel} linked` chips from `channel_ids` (display-only), email line with `no email` fallback, role pills (owner accent / admin info / member gray), Edit + Remove hover acts. **Remove is absent on the caller's own row** — mirrors the server's self-delete 400 (hiding beats a dead button). Pager appears only when `total > 20`.
- **Dialog** (add + edit share one 480px dialog): Name gates save; Email with edit-mode `""`-clears hint; Role select. **Role rules are mirrored, not owned**: the frontend keeps no role→capability map — `Me.role` is read solely to display the server's owner-only-grants-owner invariant (owner option disabled + "(owners only)" + server-enforces hint); the POST/PATCH 403 stays authoritative. Owner lowering their own role gets an advisory (server allows it).
- **Remove confirm**: states that resources the member created remain in the workspace (`created_by_user_id` is not cascaded); an owner target appends the last-owner caution — surfacing the known wire gap (no last-owner protection) honestly instead of inventing a client block.
- **CSS**: `role-pill`/`you-tag`/`chan-tag` global in `ui.css` (spec anticipates back-propagation to coworker ownership tags); base `.pager` graduated from `safety-log.css` on its second consumer, page width caps stay page-owned.
- **Route**: `/manage/members/*` wrapped in `<Gated slug="members">` (nav entry already required `user.manage`).

## Wire verification

All L.1 claims checked against `src/webui/v1/users.py` + `contracts/openapi.yaml` — zero spec corrections needed this part. Business rules confirmed in-handler: owner-only owner grants (403 on POST + PATCH), self-delete 400, cross-tenant/unknown → 404, email `""`-clears, no last-owner protection.

## Verification

- 6 new unit tests (303 total): rows/tags/pills, own-row Remove hidden, remove copy + owner caution, admin-caller mirroring + save gate, self-demotion advisory, pager threshold
- tsc, three lint scripts, openapi:check, build all green (`members-page` chunk 7.42 kB)
- Playwright E2E against the mock backend (FastAPI-strict, full users CRUD + business rules): 33/33 assertions — row rendering, add/edit/remove round-trips persisted server-side, PATCH `""`-clears verified as stored null, direct wire probes (self-delete 400, unknown 404, admin owner-grant 403×2), and an admin-caller reload confirming the dialog mirror end-to-end
- Screenshots reviewed against the v13 prototype

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_