### PR TITLE
Connected channels page — Telegram identity linking (Part M)

### DIFF
--- a/web-react/src/api/client.ts
+++ b/web-react/src/api/client.ts
@@ -45,6 +45,8 @@ export type SafetyStage = components['schemas']['SafetyStage'];
 export type SafetyVerdictAction = components['schemas']['SafetyVerdictAction'];
 export type TenantResponse = components['schemas']['TenantResponse'];
 export type TenantUpdate = components['schemas']['TenantUpdate'];
+export type ChannelLinkToken = components['schemas']['ChannelLinkToken'];
+export type ChannelLinkIdentity = components['schemas']['ChannelLinkIdentity'];
 export type UserResponse = components['schemas']['UserResponse'];
 export type UserCreate = components['schemas']['UserCreate'];
 export type UserUpdate = components['schemas']['UserUpdate'];
@@ -354,6 +356,41 @@ export class ApiClient {
       body,
     );
     return (await resp.json()) as TenantResponse;
+  }
+
+  // ------------------------------------------------------------------
+  // Personal channel links (Part M). Lifted from the Lit client —
+  // the caller's OWN Telegram identity links, not coworker↔channel
+  // bindings. The POST carries no body (fetchJson is body-carrying
+  // only); it mints a one-shot token and 409s RESOURCE_NOT_AVAILABLE
+  // when the tenant has no Telegram bot configured — the page renders
+  // that as a "configure a bot first" panel, not a transient error.
+  // ------------------------------------------------------------------
+
+  async issueTelegramLinkToken(): Promise<ChannelLinkToken> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/me/channel-links/telegram`, {
+      method: 'POST',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as ChannelLinkToken;
+  }
+
+  async listTelegramLinks(): Promise<ChannelLinkIdentity[]> {
+    const resp = await fetch(`${this.baseUrl}/api/v1/me/channel-links/telegram`, {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!resp.ok) throw await this.parseError(resp);
+    return (await resp.json()) as ChannelLinkIdentity[];
+  }
+
+  async unlinkChannelIdentity(identityId: string): Promise<void> {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/me/channel-links/${encodeURIComponent(identityId)}`,
+      { method: 'DELETE', headers: this.headers() },
+    );
+    if (!resp.ok) throw await this.parseError(resp);
   }
 
   // ------------------------------------------------------------------

--- a/web-react/src/api/queries.ts
+++ b/web-react/src/api/queries.ts
@@ -111,6 +111,21 @@ export function useTenant() {
   });
 }
 
+// ---- Connected channels page (Part M) ----
+
+/** The caller's own Telegram identity links. While a link attempt is
+ *  pending the page passes `polling: true` and TanStack re-fetches
+ *  every 3 s (the Lit poll loop; interval dies with the component).
+ *  Poll-round failures are swallowed by keeping the last good data —
+ *  a transient 5xx during the wait window must not break the flow. */
+export function useChannelLinks(polling: boolean) {
+  return useQuery({
+    queryKey: ['channel-links'],
+    queryFn: () => getApiClient().listTelegramLinks(),
+    refetchInterval: polling ? 3000 : false,
+  });
+}
+
 // ---- Members page (Part L) ----
 
 /** One page of the tenant's users. Gated by `user.manage` upstream

--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -96,6 +96,12 @@ const MembersPage = lazy(() =>
   })),
 );
 
+const ConnectedChannelsPage = lazy(() =>
+  import('../features/settings/connected-channels/connected-channels-page').then(
+    (m) => ({ default: m.ConnectedChannelsPage }),
+  ),
+);
+
 /** Catch-all: rewrite v1.1 flat bookmarks (query strings survive the
  *  redirect); anything else falls back to chat — same default the Lit
  *  topLevelShell() uses. */
@@ -182,6 +188,15 @@ export function AppRoutes() {
             <Gated slug="general">
               <GeneralPage />
             </Gated>
+          </Suspense>
+        }
+      />
+      {/* Personal page — no capability gate (nav requires: null). */}
+      <Route
+        path="/manage/connected-channels/*"
+        element={
+          <Suspense fallback={null}>
+            <ConnectedChannelsPage />
           </Suspense>
         }
       />

--- a/web-react/src/features/settings/connected-channels/connected-channels-page.test.tsx
+++ b/web-react/src/features/settings/connected-channels/connected-channels-page.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment happy-dom
+//
+// Test baseline = the Lit page's eight cases (connected-channels-
+// page.test.ts), re-expressed for React: empty state, identity rows,
+// no-bot 409 panel, deep-link present/omitted, baseline-set poll
+// detection, countdown expiry, disconnect (here through the D-M3
+// confirm dialog).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ChannelLinkIdentity } from '../../../api/client';
+import { ConnectedChannelsPage } from './connected-channels-page';
+
+const ID_A: ChannelLinkIdentity = {
+  id: 'cli-a',
+  platform: 'telegram',
+  channel_id: '784412903',
+  created_at: '2026-06-05T10:00:00Z',
+};
+
+let identities: ChannelLinkIdentity[] = [];
+let postBody: () => { status: number; body: unknown };
+let deleted: string[] = [];
+
+function jsonResp(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  identities = [];
+  deleted = [];
+  postBody = () => ({
+    status: 201,
+    body: {
+      token: 'rk_test_token_0123456789ab',
+      expires_at: new Date(Date.now() + 600_000).toISOString(),
+      deep_link: 'https://t.me/demo_bot?start=rk_test',
+    },
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? 'GET';
+      if (u.endsWith('/me/channel-links/telegram')) {
+        if (method === 'GET') return jsonResp(200, identities);
+        if (method === 'POST') {
+          const r = postBody();
+          return jsonResp(r.status, r.body);
+        }
+      }
+      if (method === 'DELETE') {
+        const id = u.split('/').pop()!;
+        deleted.push(id);
+        identities = identities.filter((i) => i.id !== id);
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected fetch ${method} ${u}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ConnectedChannelsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ConnectedChannelsPage', () => {
+  it('renders the reassuring empty state when no accounts are linked', async () => {
+    renderPage();
+    expect((await screen.findByTestId('cc-empty')).textContent).toContain(
+      'always remain available in the web app',
+    );
+  });
+
+  it('renders one row per identity with a Disconnect button', async () => {
+    identities = [ID_A];
+    renderPage();
+    const row = await screen.findByTestId('cc-row-cli-a');
+    expect(row.textContent).toContain('telegram');
+    expect(row.textContent).toContain('id 784412903');
+    expect(screen.getByTestId('cc-disconnect')).toBeTruthy();
+  });
+
+  it('POST 409 RESOURCE_NOT_AVAILABLE renders the configuration panel and hides Connect', async () => {
+    postBody = () => ({
+      status: 409,
+      body: { code: 'RESOURCE_NOT_AVAILABLE', message: 'no bot' },
+    });
+    renderPage();
+    fireEvent.click(await screen.findByTestId('cc-connect'));
+    expect((await screen.findByTestId('cc-no-bot')).textContent).toContain(
+      'Configure a Telegram bot first',
+    );
+    expect(screen.queryByTestId('cc-connect')).toBeNull();
+    expect(screen.queryByTestId('cc-pending')).toBeNull();
+  });
+
+  it('waiting panel shows deep-link anchor (when present) plus the raw token', async () => {
+    renderPage();
+    fireEvent.click(await screen.findByTestId('cc-connect'));
+    await screen.findByTestId('cc-pending');
+    expect((screen.getByTestId('cc-deep-link') as HTMLAnchorElement).href).toContain(
+      't.me/demo_bot',
+    );
+    expect(screen.getByTestId('cc-token').textContent).toBe('rk_test_token_0123456789ab');
+    expect(screen.queryByTestId('cc-connect')).toBeNull();
+  });
+
+  it('omits the deep-link anchor when POST returns null', async () => {
+    postBody = () => ({
+      status: 201,
+      body: {
+        token: 'rk_no_deeplink_0123456789',
+        expires_at: new Date(Date.now() + 600_000).toISOString(),
+        deep_link: null,
+      },
+    });
+    renderPage();
+    fireEvent.click(await screen.findByTestId('cc-connect'));
+    await screen.findByTestId('cc-pending');
+    expect(screen.queryByTestId('cc-deep-link')).toBeNull();
+    expect(screen.getByTestId('cc-token').textContent).toBe('rk_no_deeplink_0123456789');
+  });
+
+  it('poll flips to success only when an id OUTSIDE the baseline appears', async () => {
+    identities = [ID_A]; // pre-existing link — inside the baseline
+    renderPage();
+    // Initial load under real timers (Connect renders only after it —
+    // the baseline must be captured from loaded data); THEN freeze.
+    await screen.findByTestId('cc-row-cli-a');
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],
+    });
+    fireEvent.click(screen.getByTestId('cc-connect'));
+    await act(async () => {});
+    expect(screen.getByTestId('cc-pending')).toBeTruthy();
+
+    // Poll round returns only baseline ids → still waiting. (The extra
+    // 1 ms advance runs TanStack's setTimeout(0) notify batch, which
+    // fake timers would otherwise hold forever.)
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByTestId('cc-pending')).toBeTruthy();
+    expect(screen.queryByTestId('cc-ok')).toBeNull();
+
+    // A fresh id appears → confirmation panel, pending cleared.
+    identities = [
+      ID_A,
+      { id: 'cli-new', platform: 'telegram', channel_id: '551200784', created_at: null },
+    ];
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.queryByTestId('cc-pending')).toBeNull();
+    expect(screen.getByTestId('cc-ok').textContent).toContain('Telegram connected');
+    expect(screen.getByTestId('cc-row-cli-new')).toBeTruthy();
+  });
+
+  it('countdown ticks mm:ss and expiry clears the attempt with a toast', async () => {
+    postBody = () => ({
+      status: 201,
+      body: {
+        token: 'rk_short_lived_0123456789',
+        expires_at: new Date(Date.now() + 65_000).toISOString(),
+        deep_link: null,
+      },
+    });
+    renderPage();
+    await screen.findByTestId('cc-connect');
+    vi.useFakeTimers({
+      toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],
+    });
+    fireEvent.click(screen.getByTestId('cc-connect'));
+    await act(async () => {});
+    expect(screen.getByTestId('cc-countdown').textContent).toBe('1:05');
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByTestId('cc-countdown').textContent).toBe('1:04');
+    await act(async () => {
+      vi.advanceTimersByTime(64_000);
+    });
+    expect(screen.queryByTestId('cc-pending')).toBeNull();
+    expect(screen.getByText('Link code expired')).toBeTruthy();
+  });
+
+  it('disconnect goes through the D-M3 confirm with the what-stays copy, then DELETEs', async () => {
+    identities = [ID_A];
+    renderPage();
+    fireEvent.click(await screen.findByTestId('cc-disconnect'));
+    expect(screen.getByText('Disconnect this Telegram account?')).toBeTruthy();
+    expect(screen.getByText(/pending approvals remain in the web app/)).toBeTruthy();
+    expect(deleted).toEqual([]);
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Disconnect' }),
+    );
+    await screen.findByText('Telegram account disconnected');
+    expect(deleted).toEqual(['cli-a']);
+    expect(screen.queryByTestId('cc-row-cli-a')).toBeNull();
+    expect(await screen.findByTestId('cc-empty')).toBeTruthy();
+  });
+});

--- a/web-react/src/features/settings/connected-channels/connected-channels-page.tsx
+++ b/web-react/src/features/settings/connected-channels/connected-channels-page.tsx
@@ -1,0 +1,267 @@
+// ConnectedChannelsPage — personal Telegram identity linking (spec
+// Part M; behavioral reference the SHIPPED Lit connected-channels-page
+// — unlike General/Members this page has real parity to hold).
+//
+// Scope: the USER'S OWN IM identity links (/api/v1/me/channel-links),
+// so approvals and coworker messages push to them. Coworker↔channel
+// bot bindings are a different resource and not on this page. The
+// Part L member chips ({channel} linked) reflect THIS page's outcomes;
+// the write path is the gateway's token redemption, never a form.
+//
+// The attempt state machine (baseline set, 3 s poll, countdown,
+// 409-as-configuration) lives in use-link-attempt.ts. D-M3
+// (user-approved): disconnect gets the designed confirm dialog with
+// the "what stays" copy — the shipped Lit one-click is superseded;
+// losing HITL push is consequential and the reassurance is real.
+
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ApiError,
+  getApiClient,
+  type ChannelLinkIdentity,
+} from '../../../api/client';
+import { ConfirmDialog } from '../../../components/confirm-dialog';
+import { useLinkAttempt } from './use-link-attempt';
+import './connected-channels.css';
+
+function mmss(s: number): string {
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+}
+
+export function ConnectedChannelsPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function showToast(msg: string) {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }
+  useEffect(
+    () => () => {
+      if (toastTimer.current) clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  const attempt = useLinkAttempt(() => showToast('Link code expired'));
+  const { linksQ, pending } = attempt;
+  const identities = linksQ.data ?? [];
+
+  const [removing, setRemoving] = useState<ChannelLinkIdentity | null>(null);
+  const [removeBusy, setRemoveBusy] = useState(false);
+  const [removeErr, setRemoveErr] = useState<string | null>(null);
+
+  async function confirmDisconnect() {
+    if (!removing || removeBusy) return;
+    setRemoveBusy(true);
+    setRemoveErr(null);
+    try {
+      await getApiClient().unlinkChannelIdentity(removing.id);
+      await queryClient.invalidateQueries({ queryKey: ['channel-links'] });
+      showToast('Telegram account disconnected');
+      setRemoving(null);
+    } catch (e) {
+      setRemoveErr(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+    } finally {
+      setRemoveBusy(false);
+    }
+  }
+
+  async function copyToken() {
+    if (!pending) return;
+    try {
+      await navigator.clipboard.writeText(pending.token);
+      showToast('Code copied');
+    } catch {
+      // Clipboard may be denied — the code is on screen, selectable.
+    }
+  }
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Connected channels</h1>
+          <div className="page-sub" style={{ maxWidth: 640 }}>
+            Link your Telegram account to get coworker messages and approval requests
+            there. Approvals reach you on Telegram if connected, and always in the web
+            app&rsquo;s chat panel and inbox.
+          </div>
+        </div>
+        {/* Rendered only once the list has loaded — the baseline set
+            is captured from it on click, so connecting before the
+            first GET resolves would false-flip on pre-existing links
+            (Lit prevents this by not rendering the button until
+            refresh() completes). */}
+        {pending || attempt.noBot || !linksQ.data ? null : (
+          <button
+            className="btn-primary"
+            data-testid="cc-connect"
+            onClick={() => void attempt.connect()}
+          >
+            Connect Telegram
+          </button>
+        )}
+      </div>
+
+      <div className="grid-scroll" style={{ paddingTop: 12 }}>
+        {attempt.noBot ? (
+          <div className="cc-panel" data-testid="cc-no-bot">
+            <b>Configure a Telegram bot first</b>
+            <div className="hint" style={{ marginTop: 6 }}>
+              This workspace has no Telegram bot connected yet. An owner or admin needs
+              to bind one before members can link their accounts.
+            </div>
+          </div>
+        ) : null}
+
+        {attempt.justLinked ? (
+          <div className="cc-panel" data-testid="cc-ok">
+            <span className="cc-ok">✓ Telegram connected.</span>
+            <div className="hint" style={{ marginTop: 4 }}>
+              Approval requests and coworker messages will now reach this account.
+            </div>
+          </div>
+        ) : null}
+
+        {pending ? (
+          <div className="cc-panel" data-testid="cc-pending">
+            <b>Waiting for Telegram…</b>
+            <div className="hint" style={{ margin: '6px 0 12px' }}>
+              Open the link below (or send the code to the bot with{' '}
+              <span style={{ fontFamily: 'ui-monospace, Menlo, monospace' }}>/start</span>
+              ). This code works once and expires in{' '}
+              <span className="cc-count" data-testid="cc-countdown">
+                {mmss(attempt.secondsLeft)}
+              </span>
+              .
+            </div>
+            {pending.deep_link ? (
+              <div style={{ marginBottom: 10 }}>
+                <a
+                  className="btn-primary"
+                  style={{ textDecoration: 'none', display: 'inline-flex' }}
+                  href={pending.deep_link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid="cc-deep-link"
+                >
+                  Open in Telegram
+                </a>
+              </div>
+            ) : null}
+            <div>
+              <span className="cc-code" data-testid="cc-token">
+                {pending.token}
+              </span>
+              <button
+                className="btn-ghost"
+                style={{ marginLeft: 8 }}
+                data-testid="cc-copy"
+                onClick={() => void copyToken()}
+              >
+                Copy
+              </button>
+            </div>
+            <div style={{ marginTop: 12 }}>
+              <button className="btn-ghost" data-testid="cc-cancel" onClick={attempt.cancel}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {attempt.error ? (
+          <div className="row-error" role="alert" style={{ marginBottom: 12 }}>
+            {attempt.error}
+          </div>
+        ) : null}
+
+        {linksQ.isLoading ? (
+          <div className="page-sub">Loading…</div>
+        ) : linksQ.isError && !identities.length ? (
+          <div className="row-error">Failed to load links — retry from the sidebar.</div>
+        ) : identities.length ? (
+          identities.map((i) => (
+            <div className="model-row" key={i.id} data-testid={`cc-row-${i.id}`}>
+              <span>
+                <div className="m-name" style={{ textTransform: 'capitalize' }}>
+                  {i.platform}
+                </div>
+                <div className="m-sub">
+                  id {i.channel_id}
+                  {i.created_at
+                    ? ` · linked ${new Date(i.created_at).toLocaleDateString()}`
+                    : ''}
+                </div>
+              </span>
+              <span className="m-fill" />
+              <button
+                className="btn-ghost"
+                data-testid="cc-disconnect"
+                onClick={() => {
+                  setRemoveErr(null);
+                  setRemoving(i);
+                }}
+              >
+                Disconnect
+              </button>
+            </div>
+          ))
+        ) : (
+          <div className="hint" data-testid="cc-empty">
+            No Telegram account linked yet. Connect one to get approvals pushed to you —
+            they always remain available in the web app either way.
+          </div>
+        )}
+      </div>
+
+      {removing ? (
+        <ConfirmDialog
+          title="Disconnect this Telegram account?"
+          confirmLabel="Disconnect"
+          busyLabel="Disconnecting…"
+          busy={removeBusy}
+          onConfirm={() => void confirmDisconnect()}
+          onCancel={() => {
+            if (!removeBusy) setRemoving(null);
+          }}
+        >
+          <p>
+            Approval pushes and coworker messages to{' '}
+            <b>id {removing.channel_id}</b> stop immediately.
+          </p>
+          <p>
+            What stays: pending approvals remain in the web app&rsquo;s inbox, and you
+            can reconnect this account at any time.
+          </p>
+          {removeErr ? (
+            <p className="row-error" role="alert">
+              {removeErr}
+            </p>
+          ) : null}
+        </ConfirmDialog>
+      ) : null}
+
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web-react/src/features/settings/connected-channels/connected-channels.css
+++ b/web-react/src/features/settings/connected-channels/connected-channels.css
@@ -1,0 +1,34 @@
+/* Connected channels (Part M) — page-owned chrome, single consumer.
+ * Panels cap at 560px (the General form-column precedent); the
+ * identity rows reuse the global .model-row at the D-UI1 760px cap. */
+.cc-panel {
+  border: 1px solid var(--rm-border);
+  border-radius: 4px;
+  background: var(--rm-card-bg);
+  padding: 16px;
+  max-width: 560px;
+  margin-bottom: 12px;
+}
+.cc-code {
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 14px;
+  letter-spacing: 0.06em;
+  background: #fff;
+  border: 1px dashed var(--rm-text-muted);
+  border-radius: 4px;
+  padding: 8px 12px;
+  display: inline-block;
+  user-select: all;
+}
+.cc-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--rm-warn-text);
+}
+.cc-ok {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: var(--rm-success-text);
+  font-weight: 700;
+}

--- a/web-react/src/features/settings/connected-channels/use-link-attempt.ts
+++ b/web-react/src/features/settings/connected-channels/use-link-attempt.ts
@@ -1,0 +1,101 @@
+// useLinkAttempt — the Telegram link-attempt state machine (spec M.4;
+// behavioral reference web/src/components/connected-channels-page.ts).
+//
+// Lit decisions carried over verbatim:
+//   - BASELINE SET: the identity-id set is captured when the user
+//     clicks Connect; success fires only when an id OUTSIDE that set
+//     appears. A tenant peer linking their own account — or the
+//     user's pre-existing link (multi-bind is legal, decision #13) —
+//     never falsely flips this UI.
+//   - 409 RESOURCE_NOT_AVAILABLE from the POST is CONFIGURATION, not
+//     failure — surfaced as the `noBot` flag, not `error`.
+//   - Poll-round failures are swallowed (TanStack keeps the last good
+//     data); a transient 5xx during the wait window must not break
+//     the flow.
+//   - Timers die with the component: the countdown interval is an
+//     effect cleanup, the 3 s poll is the query's refetchInterval
+//     (both the Lit disconnectedCallback teardown).
+//
+// Deviations (spec-directed, visual layer): expiry reports through
+// `onExpired` (the page toasts — Lit used an inline error line), and
+// `justLinked` drives the "✓ Telegram connected." confirmation panel
+// Lit didn't render.
+
+import { useEffect, useRef, useState } from 'react';
+import { ApiError, getApiClient, type ChannelLinkToken } from '../../../api/client';
+import { useChannelLinks } from '../../../api/queries';
+
+function secondsUntil(iso: string): number {
+  return Math.max(0, Math.round((Date.parse(iso) - Date.now()) / 1000));
+}
+
+export function useLinkAttempt(onExpired: () => void) {
+  const [pending, setPending] = useState<ChannelLinkToken | null>(null);
+  const [secondsLeft, setSecondsLeft] = useState(0);
+  const [noBot, setNoBot] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [justLinked, setJustLinked] = useState(false);
+
+  const linksQ = useChannelLinks(pending !== null);
+
+  const baseline = useRef<Set<string>>(new Set());
+  const onExpiredRef = useRef(onExpired);
+  onExpiredRef.current = onExpired;
+
+  // Countdown tick (1 s, Lit TICK_INTERVAL_MS). Recomputed from
+  // expires_at each round so the display never drifts; hitting zero
+  // drops the attempt back to idle.
+  useEffect(() => {
+    if (!pending) return;
+    setSecondsLeft(secondsUntil(pending.expires_at));
+    const t = setInterval(() => {
+      const left = secondsUntil(pending.expires_at);
+      setSecondsLeft(left);
+      if (left === 0) {
+        setPending(null);
+        onExpiredRef.current();
+      }
+    }, 1000);
+    return () => clearInterval(t);
+  }, [pending]);
+
+  // Success detection: a fresh id outside the baseline.
+  useEffect(() => {
+    if (!pending || !linksQ.data) return;
+    if (linksQ.data.some((i) => !baseline.current.has(i.id))) {
+      setPending(null);
+      setJustLinked(true);
+    }
+  }, [pending, linksQ.data]);
+
+  async function connect() {
+    setNoBot(false);
+    setError(null);
+    setJustLinked(false);
+    baseline.current = new Set((linksQ.data ?? []).map((i) => i.id));
+    try {
+      setPending(await getApiClient().issueTelegramLinkToken());
+    } catch (e) {
+      if (
+        e instanceof ApiError &&
+        e.status === 409 &&
+        e.body?.code === 'RESOURCE_NOT_AVAILABLE'
+      ) {
+        setNoBot(true);
+        return;
+      }
+      setError(
+        e instanceof ApiError ? (e.body?.message ?? `HTTP ${e.status}`) : (e as Error).message,
+      );
+    }
+  }
+
+  /** Clears the attempt UI only — the one-shot token has no server
+   *  revocation path and dies on its own ~10 min TTL. */
+  function cancel() {
+    setPending(null);
+    setError(null);
+  }
+
+  return { linksQ, pending, secondsLeft, noBot, error, justLinked, connect, cancel };
+}


### PR DESCRIPTION
## Summary

Part M of the React SPA (v14 spec): the Connected channels page at `#/manage/connected-channels`, against `/api/v1/me/channel-links/telegram`. Unlike General/Members this page has a **real Lit behavioral reference** (`connected-channels-page.ts`) — its shipped decisions are carried over verbatim.

Scope: the user's **own** IM identity links (so approvals and coworker messages push to them). Coworker↔channel bot bindings are a different resource and not on this page; the Part L member chips reflect this page's outcomes.

## What's in here

- **Client**: `ChannelLinkToken/ChannelLinkIdentity` types + `issueTelegramLinkToken/listTelegramLinks/unlinkChannelIdentity` lifted from the Lit client (the bodiless POST stays off `fetchJson`); `useChannelLinks(polling)` with `refetchInterval`-driven 3 s polling that dies with the component.
- **`use-link-attempt` hook** — the Lit state machine: **baseline-set detection** (identity-id set captured on Connect; success fires only on an id *outside* it — a tenant peer linking their own account or a pre-existing link never false-flips), 1 s `mm:ss` countdown recomputed from `expires_at`, poll-round failures swallowed, `409 RESOURCE_NOT_AVAILABLE` surfaced as configuration (`noBot`) not error, Cancel clears UI only (the one-shot token has no revocation path).
- **Page**: waiting panel (deep-link button preferred + copyable one-shot code fallback + live countdown + Cancel), "✓ Telegram connected." confirmation panel, static "Configure a Telegram bot first" panel on 409, identity rows on the D-UI1 760 px `.model-row`, `.cc-panel`s at the 560 px General-form precedent. Connect renders **only after the first list load** — clicking earlier would capture an empty baseline and false-flip on pre-existing links (the Lit loading gate, caught by the poll unit test).
- **D-M3 (user-approved)**: disconnect goes through the shared confirm dialog with the what-stays copy (pending approvals remain in the web inbox; the account can relink anytime), superseding the shipped one-click.
- Spec-directed copy/visual deviations from Lit (per §8 corrections): expiry → toast, confirmation panel, `mm:ss` countdown, updated no-bot copy, corrected approval-reach subtitle.

## Wire note (source wins, recorded)

Spec M.1 conflated two states: the POST **409s only when no bot is configured at all**; a bot with no @username on file returns **201 with `deep_link: null`** (per openapi + the Lit test `omits the deep-link anchor when POST returns null`) — so the copy-code fallback is a real, reachable state.

## Verification

- 8 new unit tests (311 total) re-expressing the Lit page's eight-case baseline; countdown/poll under vitest fake timers (with a 1 ms advance to run TanStack's `setTimeout(0)` notify batch)
- tsc, three lint scripts, openapi:check, build all green (`connected-channels-page` chunk 6.39 kB + 0.55 kB css)
- Playwright E2E against the mock (bot-presence flip + gateway-redeem helper): 24/24 assertions — idle rows, waiting panel (deep-link/token/countdown), cancel, full connect→redeem→poll-flip→confirmation round-trip, D-M3 confirm → DELETE verified server-side, no-bot 409 panel
- Screenshots reviewed against the v14 prototype

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh)_