### PR TITLE
Appearance page — read-only theme surface (Part N)

### DIFF
--- a/web-react/src/app/routes.tsx
+++ b/web-react/src/app/routes.tsx
@@ -96,6 +96,12 @@ const MembersPage = lazy(() =>
   })),
 );
 
+const AppearancePage = lazy(() =>
+  import('../features/settings/appearance/appearance-page').then((m) => ({
+    default: m.AppearancePage,
+  })),
+);
+
 const ConnectedChannelsPage = lazy(() =>
   import('../features/settings/connected-channels/connected-channels-page').then(
     (m) => ({ default: m.ConnectedChannelsPage }),
@@ -188,6 +194,17 @@ export function AppRoutes() {
             <Gated slug="general">
               <GeneralPage />
             </Gated>
+          </Suspense>
+        }
+      />
+      {/* Personal page — no capability gate (nav requires: null).
+          With this route every named settings entry is grown (A–N);
+          the /manage/:slug stub is now unknown-slug fallback only. */}
+      <Route
+        path="/manage/appearance/*"
+        element={
+          <Suspense fallback={null}>
+            <AppearancePage />
           </Suspense>
         }
       />

--- a/web-react/src/features/settings/appearance/appearance-page.test.tsx
+++ b/web-react/src/features/settings/appearance/appearance-page.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppearancePage } from './appearance-page';
+
+type ChangeCb = (e: { matches: boolean }) => void;
+let listeners: ChangeCb[] = [];
+let systemDark = false;
+
+beforeEach(() => {
+  listeners = [];
+  systemDark = false;
+  vi.stubGlobal('matchMedia', (media: string) => ({
+    media,
+    get matches() {
+      return systemDark;
+    },
+    addEventListener: (_: string, cb: ChangeCb) => listeners.push(cb),
+    removeEventListener: (_: string, cb: ChangeCb) => {
+      listeners = listeners.filter((l) => l !== cb);
+    },
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AppearancePage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AppearancePage', () => {
+  it('renders the D-N1 copy and the detected light theme', () => {
+    renderPage();
+    expect(
+      screen.getByText(/ships the light palette today — there is no in-app toggle/),
+    ).toBeTruthy();
+    expect(screen.getByText('System: Light')).toBeTruthy();
+    expect(screen.getByText(/nothing is stored/)).toBeTruthy();
+  });
+
+  it('smoke: read-only means zero controls (no inputs/selects, no buttons beyond back-link)', () => {
+    const { container } = renderPage();
+    expect(container.querySelectorAll('input, select, textarea, [role="switch"]').length).toBe(0);
+    const buttons = [...container.querySelectorAll('button')];
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].className).toContain('back-link');
+  });
+
+  it('flips to Dark live when the media query fires mid-session', () => {
+    renderPage();
+    expect(screen.getByText('System: Light')).toBeTruthy();
+    act(() => {
+      systemDark = true;
+      listeners.forEach((cb) => cb({ matches: true }));
+    });
+    expect(screen.getByText('System: Dark')).toBeTruthy();
+    expect(screen.queryByText('System: Light')).toBeNull();
+  });
+
+  it('detects dark on mount and removes the listener on unmount', () => {
+    systemDark = true;
+    const { unmount } = renderPage();
+    expect(screen.getByText('System: Dark')).toBeTruthy();
+    expect(listeners.length).toBe(1);
+    unmount();
+    expect(listeners.length).toBe(0);
+  });
+});

--- a/web-react/src/features/settings/appearance/appearance-page.tsx
+++ b/web-react/src/features/settings/appearance/appearance-page.tsx
@@ -44,7 +44,8 @@ export function AppearancePage() {
             borderRadius: 4,
             background: 'var(--rm-card-bg)',
             padding: 16,
-            maxWidth: 560,
+            maxWidth: 760, // D-UI2 — one cap for every settings surface
+
           }}
         >
           <b>Theme</b>

--- a/web-react/src/features/settings/appearance/appearance-page.tsx
+++ b/web-react/src/features/settings/appearance/appearance-page.tsx
@@ -1,0 +1,69 @@
+// AppearancePage — read-only theme surface (spec Part N; behavioral
+// reference the shipped Lit appearance-page.ts).
+//
+// D-N1: the Lit page's premise (both palettes live under
+// prefers-color-scheme) doesn't transfer — this app's token set is
+// light-only — but its PURPOSE does: preempt "where's the dark-mode
+// toggle?" with the truth. The copy states today's reality; the live
+// detection row keeps the page forward-compatible (when dark tokens
+// land, only the copy changes — use-system-theme.ts already works).
+//
+// Locked decision carried over: no in-app toggle, no persistence.
+// Read-only means ZERO controls — the test suite smoke-asserts this.
+// The card styles are inline rather than borrowed from a sibling
+// chunk's CSS (.cc-panel) — the load-order trap ui.css exists to
+// prevent.
+
+import { ArrowLeft } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useSystemTheme } from './use-system-theme';
+
+export function AppearancePage() {
+  const navigate = useNavigate();
+  const theme = useSystemTheme();
+  const dark = theme === 'dark';
+
+  return (
+    <div className="page">
+      <div>
+        <button className="back-link" onClick={() => navigate('/')}>
+          <ArrowLeft />
+          Back to chat
+        </button>
+      </div>
+      <div className="page-head">
+        <div>
+          <h1 className="page-title">Appearance</h1>
+        </div>
+      </div>
+
+      <div className="grid-scroll" style={{ paddingTop: 12 }}>
+        <div
+          style={{
+            border: '1px solid var(--rm-border)',
+            borderRadius: 4,
+            background: 'var(--rm-card-bg)',
+            padding: 16,
+            maxWidth: 560,
+          }}
+        >
+          <b>Theme</b>
+          <div className="hint" style={{ margin: '4px 0 12px' }}>
+            This interface ships the light palette today — there is no in-app toggle. A
+            dark palette that follows your operating-system setting is planned; the
+            detected setting below will drive it automatically once it lands.
+          </div>
+          <div className="model-row" style={{ marginBottom: 0 }} data-testid="app-theme-row">
+            <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span>
+            <span>
+              <div className="m-name">System: {dark ? 'Dark' : 'Light'}</div>
+              <div className="m-sub" style={{ fontFamily: 'var(--font-base)' }}>
+                Detected from your OS · updates live · nothing is stored
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-react/src/features/settings/appearance/use-system-theme.ts
+++ b/web-react/src/features/settings/appearance/use-system-theme.ts
@@ -1,0 +1,31 @@
+// useSystemTheme — live `(prefers-color-scheme: dark)` subscription
+// (spec N.3; behavioral reference web/src/components/appearance-page.ts).
+// The listener is removed in the effect cleanup — the Lit
+// disconnectedCallback teardown. Nothing is persisted (locked
+// decision, plan §13 / v2-A: no in-app toggle).
+//
+// Single consumer today (the read-only Appearance page). The day the
+// dark token palette lands, this hook graduates to the app layer and
+// starts driving the actual theme — the mechanism is wired ahead of
+// the tokens on purpose (D-N1).
+
+import { useEffect, useState } from 'react';
+
+export function useSystemTheme(): 'light' | 'dark' {
+  const [dark, setDark] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      !!window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = (e: MediaQueryListEvent) => setDark(e.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return dark ? 'dark' : 'light';
+}

--- a/web-react/src/features/settings/connected-channels/connected-channels.css
+++ b/web-react/src/features/settings/connected-channels/connected-channels.css
@@ -1,12 +1,13 @@
 /* Connected channels (Part M) — page-owned chrome, single consumer.
- * Panels cap at 560px (the General form-column precedent); the
- * identity rows reuse the global .model-row at the D-UI1 760px cap. */
+ * Panels share the 760px cap with the .model-row identity rows
+ * (D-UI2 — forms and panels joined the D-UI1 row width; the v14
+ * prototype said 560). */
 .cc-panel {
   border: 1px solid var(--rm-border);
   border-radius: 4px;
   background: var(--rm-card-bg);
   padding: 16px;
-  max-width: 560px;
+  max-width: 760px;
   margin-bottom: 12px;
 }
 .cc-code {

--- a/web-react/src/features/settings/general/general-page.tsx
+++ b/web-react/src/features/settings/general/general-page.tsx
@@ -5,7 +5,9 @@
 // fields, no invented flows. Reconcile per the behavior-parity rule
 // when the Lit page lands.
 //
-// A form, not a collection: one 560px column, dirty-tracked Save
+// A form, not a collection: one 760px column (D-UI2 — the v12
+// prototype said 560; forms/panels joined the D-UI1 row cap so every
+// settings surface shares one width), dirty-tracked Save
 // (disabled when clean, invalid, or busy) + Revert (visible only when
 // dirty); one PATCH carries both writable fields; field errors replace
 // the hint line in danger color (the dialogs' pattern).
@@ -126,7 +128,7 @@ export function GeneralPage() {
             Failed to load workspace settings — retry from the sidebar.
           </div>
         ) : tenant && f ? (
-          <div style={{ maxWidth: 560 }}>
+          <div style={{ maxWidth: 760 }}>
             <div className="field">
               <label htmlFor="gen-name">Workspace name</label>
               <input


### PR DESCRIPTION
## Summary

Part N of the React SPA (v15 spec): the read-only Appearance page at `#/manage/appearance` — the smallest Part, whose entire job is one honest sentence.

**D-N1**: the Lit page's premise (both palettes live under `prefers-color-scheme`) doesn't transfer — this app's token set is light-only (verified: zero `prefers-color-scheme` in `web-react` tokens vs. present in the Lit tokens) — but its purpose does: preempt "where's the dark-mode toggle?" with the truth. The copy states today's reality; the live detection row keeps the page forward-compatible (when dark tokens land, only the copy changes — the mechanism already works).

## What's in here

- **`useSystemTheme()` hook** — live `(prefers-color-scheme: dark)` subscription, listener removed in the effect cleanup (the Lit `disconnectedCallback` teardown), nothing persisted. Single consumer today; graduates to the app layer the day dark tokens land.
- **Page** — one card: `Theme` heading, the D-N1 copy, a single read-only `.model-row` with sun/moon glyph, `System: Light|Dark`, and `Detected from your OS · updates live · nothing is stored`. **Zero controls** (read-only, smoke-asserted). Card styles are inline rather than borrowing the sibling chunk's `.cc-panel` — the CSS load-order trap avoided.
- **Locked decision carried over**: no in-app toggle, no persistence; a future toggle is a new decision to take together with the Lit side.
- With this route **every named settings entry is grown (A–N)**; `/manage/:slug` remains as unknown-slug fallback only.

## Rider: D-UI2 — form/panel columns unified at 760 px

Second commit (user-approved): the General form column, the Appearance card, and the connected-channels panels move 560 → 760, joining the D-UI1 row-list cap so **every settings surface shares one width**. The prototypes' 560 values (v12/v14/v15) are superseded. Verified 760 px computed width on all three pages via Playwright.

## Verification

- 4 new unit tests (315 total): D-N1 copy + detection row, zero-controls smoke, live flip on media-query change, dark-on-mount + listener removal on unmount
- tsc, three lint scripts, openapi:check, build all green (`appearance-page` chunk 1.89 kB)
- Playwright E2E: 8/8 assertions including a live mid-session flip via `page.emulateMedia({ colorScheme: 'dark' })` — end-to-end coverage the Lit tests don't have
- Screenshots reviewed against the v15 prototype

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXTcqiidT1nYAsSwCcQ2kh