### PR TITLE
fix(oidc): origin-derived redirect_uri + realm-seed offline_access roles

### DIFF
--- a/deploy/compose/compose.keycloak.yaml
+++ b/deploy/compose/compose.keycloak.yaml
@@ -88,7 +88,11 @@ services:
       # Audience left empty -> defaults to client_id. Keycloak id_token aud is
       # the client_id, so it validates with zero extra mappers.
       OIDC_AUDIENCE: ""
-      # redirect_uri is browser-facing -> the host-published webui address.
+      # Fallback only: both SPAs derive redirect_uri from their own origin
+      # (see oidc-auth.ts) and echo it through the code exchange, so login
+      # works from :8080 AND the Vite dev ports without flipping this env.
+      # Every SPA origin must be whitelisted in rolemesh-realm.json
+      # (redirectUris / webOrigins / post.logout.redirect.uris).
       OIDC_REDIRECT_URI: http://localhost:8080/oauth2/callback
       # offline_access is requested so the browser flow gets a refresh_token
       # (webui silent-refresh / session continuity). Not needed by promptfoo.

--- a/deploy/compose/keycloak/e2e-verify.sh
+++ b/deploy/compose/keycloak/e2e-verify.sh
@@ -31,10 +31,17 @@ pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
 
 # token <username> <id|access>  -> prints the requested token
+#
+# scope MUST stay aligned with the webui's OIDC_SCOPES (compose env):
+# requesting offline_access here is what catches realm-seed
+# regressions — Keycloak rejects the whole grant with
+# error=not_allowed when a user lacks the offline_access role, which
+# is exactly how the browser PKCE flow fails.
 token() {
   local user="$1" kind="$2"
   curl -sf "$TOKEN_URL" \
-    -d grant_type=password -d scope=openid \
+    -d grant_type=password \
+    --data-urlencode "scope=openid profile email offline_access" \
     -d client_id="$CLIENT_ID" -d client_secret="$CLIENT_SECRET" \
     -d username="$user" -d password="$PASSWORD" \
     | jq -r ".${kind}_token"

--- a/deploy/compose/keycloak/rolemesh-realm.json
+++ b/deploy/compose/keycloak/rolemesh-realm.json
@@ -38,14 +38,16 @@
       "implicitFlowEnabled": false,
       "serviceAccountsEnabled": false,
       "redirectUris": [
-        "http://localhost:8080/oauth2/callback"
+        "http://localhost:8080/oauth2/callback",
+        "http://localhost:5174/oauth2/callback"
       ],
       "webOrigins": [
-        "http://localhost:8080"
+        "http://localhost:8080",
+        "http://localhost:5174"
       ],
       "attributes": {
         "pkce.code.challenge.method": "S256",
-        "post.logout.redirect.uris": "http://localhost:8080/*"
+        "post.logout.redirect.uris": "http://localhost:8080/*##http://localhost:5174/*"
       },
       "protocolMappers": [
         {
@@ -95,7 +97,8 @@
       },
       "credentials": [
         { "type": "password", "value": "Passw0rd!", "temporary": false }
-      ]
+      ],
+      "realmRoles": ["default-roles-rolemesh", "offline_access"]
     },
     {
       "username": "member@t1",
@@ -110,7 +113,8 @@
       },
       "credentials": [
         { "type": "password", "value": "Passw0rd!", "temporary": false }
-      ]
+      ],
+      "realmRoles": ["default-roles-rolemesh", "offline_access"]
     },
     {
       "username": "owner@t2",
@@ -125,7 +129,8 @@
       },
       "credentials": [
         { "type": "password", "value": "Passw0rd!", "temporary": false }
-      ]
+      ],
+      "realmRoles": ["default-roles-rolemesh", "offline_access"]
     }
   ]
 }

--- a/web/src/services/oidc-auth.ts
+++ b/web/src/services/oidc-auth.ts
@@ -10,6 +10,7 @@
 const STORAGE_TOKEN = 'rm_id_token';
 const STORAGE_VERIFIER = 'rm_pkce_verifier';
 const STORAGE_STATE = 'rm_pkce_state';
+const STORAGE_REDIRECT = 'rm_oidc_redirect_uri';
 
 export interface AuthConfig {
   provider: string;
@@ -74,6 +75,7 @@ export function clearToken(): void {
   sessionStorage.removeItem(STORAGE_TOKEN);
   sessionStorage.removeItem(STORAGE_VERIFIER);
   sessionStorage.removeItem(STORAGE_STATE);
+  sessionStorage.removeItem(STORAGE_REDIRECT);
 }
 
 /** Decode JWT payload without signature verification (validation happens server-side). */
@@ -119,10 +121,22 @@ export async function startLogin(config: AuthConfig): Promise<void> {
   sessionStorage.setItem(STORAGE_VERIFIER, verifier);
   sessionStorage.setItem(STORAGE_STATE, state);
 
+  // redirect_uri is derived from THIS page's origin, not taken from the
+  // backend config: the /oauth2/callback bridge stores the auth code in
+  // sessionStorage, which is per-origin — if the IdP sent the browser
+  // back to a different origin (e.g. the backend's :8080 while the SPA
+  // runs on a Vite dev port), the SPA could never read the code. The
+  // exchange echoes the same value to the token endpoint (the backend's
+  // CodeExchangeRequest.redirect_uri override), so authorize and
+  // exchange always agree. The IdP must whitelist every SPA origin's
+  // /oauth2/callback; config.redirect_uri stays as the backend fallback.
+  const redirectUri = `${location.origin}/oauth2/callback`;
+  sessionStorage.setItem(STORAGE_REDIRECT, redirectUri);
+
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: config.client_id,
-    redirect_uri: config.redirect_uri,
+    redirect_uri: redirectUri,
     scope: config.scope,
     state,
     code_challenge: challenge,
@@ -140,14 +154,22 @@ export async function handleCallback(): Promise<ExchangeResponse | null> {
   const verifier = sessionStorage.getItem(STORAGE_VERIFIER);
   if (!code || !verifier) return null;
 
+  const redirectUri = sessionStorage.getItem(STORAGE_REDIRECT);
   sessionStorage.removeItem('oidc_code');
   sessionStorage.removeItem('oidc_state');
   sessionStorage.removeItem(STORAGE_VERIFIER);
+  sessionStorage.removeItem(STORAGE_REDIRECT);
 
   const res = await fetch('/api/auth/exchange', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code, code_verifier: verifier }),
+    body: JSON.stringify({
+      code,
+      code_verifier: verifier,
+      // Must match the redirect_uri used in the authorize request; when
+      // absent the backend falls back to its OIDC_REDIRECT_URI.
+      redirect_uri: redirectUri ?? undefined,
+    }),
     credentials: 'include', // accept the httpOnly refresh cookie set by backend
   });
   if (!res.ok) return null;


### PR DESCRIPTION
Backport of 404a508 (feat/webui-react-chat) minus the web-react/ paths, which do not exist on main. Two browser-SSO bugs, both present on main independent of the React SPA effort:

1. redirect_uri pinned to one origin. oidc-auth.ts now derives redirect_uri from location.origin at startLogin and echoes it through the code exchange (the backend's CodeExchangeRequest override already supports this); OIDC_REDIRECT_URI demotes to a fallback. Latent on main while the Lit SPA and the configured redirect happen to share :8080 — breaks silently (per-origin sessionStorage swallows the code) the day the SPA serves from any other origin. The realm whitelists :8080 and :5174 so a React SPA run from its branch can log into this same stack.

2. Seeded users had no realmRoles, so realm import gave them NO roles; requesting the offline_access scope (OIDC_SCOPES on main does) without the offline_access role makes Keycloak reject the whole code->token exchange with error=not_allowed - a bare 400. ANY browser SSO against a main-seeded stack fails this way, Lit included. Seed users now carry default-roles-rolemesh + offline_access; e2e-verify.sh requests the webui's scope set so a reseeded realm missing the role fails the script the way the browser fails.

Note: realm.json is an import seed - running Keycloak instances need a reseed (or manual role/whitelist edits) to pick this up.

Verified: web 660 tests green; realm.json parses.