### PR TITLE
fix(egress): harden MCP registry sync — seed retry, periodic reconcile, healthz visibility

### DIFF
--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -20,14 +20,20 @@ the Internal=true flag on agent-net — see docs/egress/deployment.md.
 Startup is *degraded-but-serving* (docs/21-container-runtime-decoupling
 §5): once NATS is connected, every listener (reverse proxy with
 /healthz, forward proxy, DNS) binds immediately without waiting for the
-rule snapshot. The snapshot responder lives in the orchestrator, and in
-the compose deployment the gateway starts first — blocking on the
-snapshot would deadlock the whole stack. Until the snapshot arrives the
-policy plane is deny-all (an unseeded PolicyCache makes the safety
-caller block every request) and a background task retries the snapshot
-RPC with exponential backoff; /healthz reports
-``{"status": "degraded", "rules_seeded": false}`` in the meantime but
-always returns 200 — health means "NATS connected + listeners bound".
+rule or MCP snapshots. The snapshot responders live in the
+orchestrator, and in the compose deployment the gateway starts first —
+blocking on a snapshot would deadlock the whole stack. Until the rule
+snapshot arrives the policy plane is deny-all (an unseeded PolicyCache
+makes the safety caller block every request); until the MCP snapshot
+arrives ``/mcp-proxy`` answers 404. Each plane has a background task
+that retries its snapshot RPC with exponential backoff; the MCP task
+then keeps re-fetching the snapshot every _RECONCILE_INTERVAL_S — core
+NATS deltas are at-most-once, so the periodic full reconcile, not the
+delta stream, is what guarantees the registry converges (see
+``_seed_and_reconcile_mcp``). /healthz stays 200 throughout (health
+means "NATS connected + listeners bound"); its body reports
+``rules_seeded`` / ``mcp_seeded`` / ``mcp_entries``, and ``status`` is
+"ok" only when both planes are seeded.
 
 Hard prerequisites stay fail-closed: a NATS that won't connect or a
 missing EGRESS_TOKEN_SECRET raises out of ``main``, exits non-zero,
@@ -112,6 +118,12 @@ _SNAPSHOT_TIMEOUT_S = 5.0
 # window after the orchestrator comes up, and tests patch them directly.
 _SNAPSHOT_RETRY_INITIAL_S = 1.0
 _SNAPSHOT_RETRY_MAX_S = 30.0
+
+# Steady-state interval for the MCP registry reconcile loop (same
+# module-level-constant rationale as the retry schedule above). Bounds
+# how long a lost ``egress.mcp.changed`` delta can keep the registry
+# stale.
+_RECONCILE_INTERVAL_S = 300.0
 
 
 def _derive_internal_exemption(
@@ -231,6 +243,113 @@ async def _cancel_task(task: asyncio.Task[Any]) -> None:
         await task
 
 
+class _McpSyncState:
+    """Seed marker for the MCP registry sync, polled by /healthz.
+
+    ``seeded`` means "the snapshot RPC has succeeded at least once",
+    NOT "the registry is non-empty" — an empty registry is a legal
+    state (no MCP servers configured yet) and must not read as
+    degraded.
+    """
+
+    def __init__(self) -> None:
+        self.seeded = False
+
+
+async def _seed_and_reconcile_mcp(
+    nats_client: nats.aio.client.Client,
+    state: _McpSyncState,
+) -> None:
+    """Seed the MCP registry, then reconcile it against the
+    orchestrator forever. One task, two phases:
+
+    Seed — retry the snapshot RPC with the same exponential backoff as
+    ``_seed_rules_with_retry`` until the first success, then set
+    ``state.seeded``. Covers the cold-start race where the gateway is
+    up before the orchestrator's responder.
+
+    Reconcile — every ``_RECONCILE_INTERVAL_S``, re-fetch the snapshot
+    and apply it as a full replacement (``apply_snapshot_to_registry``
+    is replace-not-merge and idempotent). This loop is the registry's
+    ONLY correctness mechanism: core NATS pub/sub is at-most-once, so
+    ``egress.mcp.changed`` deltas dropped across a NATS reconnect
+    would otherwise leave the registry stale until a restart. The
+    delta subscription on top is purely a propagation-latency
+    optimisation — losing every delta delays convergence by at most
+    one interval. That bound also covers deletions: a removed MCP
+    server may stay routable here for up to one interval, which is
+    acceptable because this table is routing, not access control —
+    egress rules gate what agents may actually reach.
+
+    A reconcile failure (orchestrator temporarily away) logs a warning
+    and waits for the next interval; fast backoff is seed-phase-only
+    behaviour. Cancellation (gateway shutdown) propagates.
+    """
+    delay = _SNAPSHOT_RETRY_INITIAL_S
+    attempt = 0
+    while not state.seeded:
+        attempt += 1
+        try:
+            entries = await fetch_mcp_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
+        except Exception as exc:  # noqa: BLE001 — any RPC failure means "retry"
+            logger.warning(
+                "gateway: MCP snapshot fetch failed — /mcp-proxy serves 404s until seeded, retrying",
+                attempt=attempt,
+                retry_in_s=delay,
+                error=str(exc),
+            )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, _SNAPSHOT_RETRY_MAX_S)
+            continue
+        apply_snapshot_to_registry(entries)
+        state.seeded = True
+        logger.info(
+            "gateway: MCP registry seeded — leaving degraded mode",
+            attempt=attempt,
+            count=len(entries),
+        )
+
+    while True:
+        await asyncio.sleep(_RECONCILE_INTERVAL_S)
+        try:
+            entries = await fetch_mcp_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "gateway: MCP reconcile fetch failed — registry may be stale until next interval",
+                error=str(exc),
+            )
+            continue
+        apply_snapshot_to_registry(entries)
+        logger.debug("gateway: MCP registry reconciled", count=len(entries))
+
+
+async def _start_mcp_sync(
+    nats_client: nats.aio.client.Client,
+    stack: AsyncExitStack,
+) -> _McpSyncState:
+    """Wire the MCP registry sync: subscribe to change deltas FIRST,
+    then start the background seed+reconcile task.
+
+    Subscription-before-snapshot mirrors the rule-side ordering above
+    so no delta can fall between snapshot generation and subscription.
+    Unlike PolicyCache the registry dict has no unseeded deny-all gate,
+    so a delta that lands while a snapshot reply is in flight can be
+    overwritten by the slightly older snapshot — at seed time and on
+    every reconcile fetch alike. Accepted (the rule side carries the
+    same theoretical race): the periodic reconcile bounds any such
+    loss to one interval.
+    """
+    mcp_sub = await subscribe_mcp_changes(nats_client)
+    stack.push_async_callback(mcp_sub.unsubscribe)  # type: ignore[attr-defined]
+    state = _McpSyncState()
+    task = asyncio.create_task(
+        _seed_and_reconcile_mcp(nats_client, state),
+        name="egress-mcp-snapshot-seed",
+    )
+    stack.push_async_callback(_cancel_task, task)
+    return state
+
+
 async def main() -> None:
     upstream_dns = _parse_upstream_dns(os.environ.get("EGRESS_UPSTREAM_DNS", _UPSTREAM_DNS_DEFAULT))
 
@@ -317,27 +436,13 @@ async def main() -> None:
             bedrock="bedrock-runtime.<region>.amazonaws.com:443",
         )
 
-        # --- MCP server registry: snapshot + hot reload --------------
-        # The MCP registry has to be seeded BEFORE start_credential_proxy
-        # binds — otherwise a client request that lands during the boot
-        # window between bind and snapshot-arrival sees the registry as
-        # empty and gets a 404 it shouldn't have. Snapshot failure is
-        # fail-soft (log + continue with empty registry); subsequent
-        # ``egress.mcp.changed`` events still fill it in as the
-        # orchestrator publishes them, and the operator sees the warning
-        # instead of crash-looping the gateway over a transient NATS
-        # blip on the orchestrator side.
-        try:
-            mcp_entries = await fetch_mcp_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
-            apply_snapshot_to_registry(mcp_entries)
-            logger.info("gateway: MCP registry seeded", count=len(mcp_entries))
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "gateway: MCP snapshot fetch failed — continuing with empty registry; live change events will refill",
-                error=str(exc),
-            )
-        mcp_sub = await subscribe_mcp_changes(nats_client)
-        stack.push_async_callback(mcp_sub.unsubscribe)  # type: ignore[attr-defined]
+        # --- MCP server registry: subscribe + seed + reconcile --------
+        # Same degraded-start shape as the policy cache above: listeners
+        # bind now, /mcp-proxy answers 404 until the first snapshot
+        # lands, and /healthz reports mcp_seeded=false in the meantime.
+        # Ordering and correctness rationale live on _start_mcp_sync /
+        # _seed_and_reconcile_mcp.
+        mcp_state = await _start_mcp_sync(nats_client, stack)
 
         # --- Token vault: forward per-user MCP token requests --------
         # The orchestrator owns the DB-backed TokenVault (refresh
@@ -375,10 +480,11 @@ async def main() -> None:
             credential_resolver=credential_resolver,
             safety_caller=safety,
             token_authority=token_authority,
-            # /healthz stays 200 while degraded; the body flips from
-            # {"status": "degraded"} to {"status": "ok"} once the
-            # background snapshot retry seeds the cache.
+            # /healthz stays 200 while degraded; the body's "status"
+            # flips to "ok" once BOTH background snapshot tasks have
+            # seeded their plane (rules_seeded and mcp_seeded).
             rules_seeded=lambda: cache.seeded,
+            mcp_seeded=lambda: mcp_state.seeded,
         )
         stack.push_async_callback(reverse_runner.cleanup)
 

--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -243,6 +243,27 @@ async def _cancel_task(task: asyncio.Task[Any]) -> None:
         await task
 
 
+def _log_task_death(task: asyncio.Task[Any]) -> None:
+    """Done-callback for the background sync tasks.
+
+    A task that dies on an unexpected exception (not cancellation)
+    would otherwise vanish silently — asyncio only surfaces the
+    exception at GC time, and /healthz keeps reporting the last seeded
+    state while seeding/reconciling has actually stopped. There is no
+    in-task recovery for a bug-grade failure; this ERROR log is the
+    operator's signal to restart the gateway.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "gateway: background sync task died — its state stays frozen until restart",
+            task=task.get_name(),
+            error=repr(exc),
+        )
+
+
 class _McpSyncState:
     """Seed marker for the MCP registry sync, polled by /healthz.
 
@@ -281,9 +302,12 @@ async def _seed_and_reconcile_mcp(
     acceptable because this table is routing, not access control —
     egress rules gate what agents may actually reach.
 
-    A reconcile failure (orchestrator temporarily away) logs a warning
-    and waits for the next interval; fast backoff is seed-phase-only
-    behaviour. Cancellation (gateway shutdown) propagates.
+    A failed cycle — fetch or apply — logs a warning and waits for the
+    next attempt/interval; fast backoff is seed-phase-only behaviour.
+    Apply sits inside the try deliberately: an exception escaping the
+    loop would kill this task while /healthz keeps reporting the last
+    seeded state — exactly the invisible degradation this task exists
+    to prevent. Cancellation (gateway shutdown) propagates.
     """
     delay = _SNAPSHOT_RETRY_INITIAL_S
     attempt = 0
@@ -291,9 +315,10 @@ async def _seed_and_reconcile_mcp(
         attempt += 1
         try:
             entries = await fetch_mcp_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
-        except Exception as exc:  # noqa: BLE001 — any RPC failure means "retry"
+            apply_snapshot_to_registry(entries)
+        except Exception as exc:  # noqa: BLE001 — any failure means "retry"
             logger.warning(
-                "gateway: MCP snapshot fetch failed — /mcp-proxy serves 404s until seeded, retrying",
+                "gateway: MCP snapshot seed failed — /mcp-proxy serves 404s until seeded, retrying",
                 attempt=attempt,
                 retry_in_s=delay,
                 error=str(exc),
@@ -301,7 +326,6 @@ async def _seed_and_reconcile_mcp(
             await asyncio.sleep(delay)
             delay = min(delay * 2, _SNAPSHOT_RETRY_MAX_S)
             continue
-        apply_snapshot_to_registry(entries)
         state.seeded = True
         logger.info(
             "gateway: MCP registry seeded — leaving degraded mode",
@@ -313,13 +337,13 @@ async def _seed_and_reconcile_mcp(
         await asyncio.sleep(_RECONCILE_INTERVAL_S)
         try:
             entries = await fetch_mcp_snapshot_via_nats(nats_client, timeout_s=_SNAPSHOT_TIMEOUT_S)
+            apply_snapshot_to_registry(entries)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "gateway: MCP reconcile fetch failed — registry may be stale until next interval",
+                "gateway: MCP reconcile failed — registry may be stale until next interval",
                 error=str(exc),
             )
             continue
-        apply_snapshot_to_registry(entries)
         logger.debug("gateway: MCP registry reconciled", count=len(entries))
 
 
@@ -346,6 +370,7 @@ async def _start_mcp_sync(
         _seed_and_reconcile_mcp(nats_client, state),
         name="egress-mcp-snapshot-seed",
     )
+    task.add_done_callback(_log_task_death)
     stack.push_async_callback(_cancel_task, task)
     return state
 
@@ -397,6 +422,7 @@ async def main() -> None:
             _seed_rules_with_retry(nats_client, cache),
             name="egress-rule-snapshot-seed",
         )
+        seed_task.add_done_callback(_log_task_death)
         stack.push_async_callback(_cancel_task, seed_task)
 
         # --- Safety caller (audit publish via NATS) ------------------

--- a/src/rolemesh/egress/mcp_cache.py
+++ b/src/rolemesh/egress/mcp_cache.py
@@ -16,10 +16,15 @@ IPC fed it, so every ``/mcp-proxy/<name>/<path>`` request returned
 This module fills that gap with the same NATS pattern safety rules
 use:
 
-  - ``egress.mcp.snapshot.request`` (request-reply): gateway boots,
-    fetches the orchestrator's current registry, seeds itself.
+  - ``egress.mcp.snapshot.request`` (request-reply): the gateway
+    seeds itself from this at boot — retrying until the
+    orchestrator's responder answers — and then re-fetches it
+    periodically to reconcile drift (``gateway._seed_and_reconcile_mcp``).
   - ``egress.mcp.changed`` (broadcast): orchestrator pushes deltas
-    so the gateway can hot-reload without a restart.
+    so the gateway can hot-reload without a restart. Core NATS is
+    at-most-once, so deltas are a propagation-latency optimisation
+    only; the periodic snapshot reconcile is what guarantees the
+    registry converges.
 
 The gateway end is intentionally thin: it just translates each
 event into a ``register_mcp_server`` / ``unregister_mcp_server``

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -11,8 +11,11 @@ Routes:
     /healthz                  Liveness probe. Always 200 once the listener
                               is bound ("healthy" = NATS connected +
                               listeners up); the JSON body carries the
-                              degraded-startup indicator:
-                              {"status": "ok"|"degraded", "rules_seeded": bool}.
+                              degraded-startup indicators:
+                              {"status": "ok"|"degraded",
+                               "rules_seeded": bool, "mcp_seeded": bool,
+                               "mcp_entries": int} — status is "ok" only
+                              when both planes are seeded.
 
 Credential resolution is fail-closed by design:
 
@@ -374,13 +377,16 @@ async def start_credential_proxy(
     safety_caller: EgressSafetyCaller | None = None,
     token_authority: TokenAuthority | None = None,
     rules_seeded: Callable[[], bool] | None = None,
+    mcp_seeded: Callable[[], bool] | None = None,
 ) -> web.AppRunner:
     """Start the reverse-proxy HTTP server on ``(host, port)``.
 
-    ``rules_seeded`` feeds the /healthz degraded indicator: it is polled
-    per probe and reflects whether the gateway's policy cache has been
-    seeded with the authoritative rule snapshot. ``None`` (host-side
-    deployments without the degraded-startup machinery) reports "ok".
+    ``rules_seeded`` / ``mcp_seeded`` feed the /healthz degraded
+    indicators: both are polled per probe and reflect whether the
+    gateway's policy cache / MCP registry have been seeded with their
+    authoritative snapshots. ``None`` (host-side deployments without
+    the degraded-startup machinery) counts as seeded; ``status`` is
+    "ok" only when both count as seeded.
     The HTTP status is 200 either way — health means "NATS connected and
     listeners bound", and orchestration must not restart-loop a gateway
     that is merely waiting for the orchestrator to answer the snapshot
@@ -651,9 +657,17 @@ async def start_credential_proxy(
             return web.Response(status=502, text="MCP proxy: Bad Gateway")
 
     async def handle_healthz(_request: web.Request) -> web.Response:
-        seeded = rules_seeded() if rules_seeded is not None else True
+        rules_ok = rules_seeded() if rules_seeded is not None else True
+        mcp_ok = mcp_seeded() if mcp_seeded is not None else True
         return web.json_response(
-            {"status": "ok" if seeded else "degraded", "rules_seeded": seeded},
+            {
+                "status": "ok" if rules_ok and mcp_ok else "degraded",
+                "rules_seeded": rules_ok,
+                "mcp_seeded": mcp_ok,
+                # Entry count is observability, not the seed signal —
+                # an empty registry is legal (no MCP servers configured).
+                "mcp_entries": len(_mcp_registry),
+            },
             status=200,
         )
 

--- a/tests/egress/test_gateway_degraded_startup.py
+++ b/tests/egress/test_gateway_degraded_startup.py
@@ -38,6 +38,16 @@ from rolemesh.safety.checks.egress_domain_rule import make_egress_domain_check
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def _isolate_mcp_registry() -> None:
+    # /healthz now reports mcp_entries from the module-global MCP
+    # registry — wipe it so another module's leftovers can't skew the
+    # exact-body assertions below.
+    from rolemesh.egress import reverse_proxy
+
+    reverse_proxy._mcp_registry.clear()
+
+
 # ---------------------------------------------------------------------------
 # NATS-boundary fake (the only mock in this module)
 # ---------------------------------------------------------------------------
@@ -166,7 +176,12 @@ async def test_healthz_is_200_and_degraded_while_snapshot_missing() -> None:
         resp = await client.get("/healthz")
         assert resp.status == 200
         body = await resp.json()
-        assert body == {"status": "degraded", "rules_seeded": False}
+        assert body == {
+            "status": "degraded",
+            "rules_seeded": False,
+            "mcp_seeded": True,  # no mcp_seeded callable wired -> counts as seeded
+            "mcp_entries": 0,
+        }
 
 
 async def test_healthz_reports_ok_once_snapshot_seeded() -> None:
@@ -177,7 +192,12 @@ async def test_healthz_reports_ok_once_snapshot_seeded() -> None:
         resp = await client.get("/healthz")
         assert resp.status == 200
         body = await resp.json()
-        assert body == {"status": "ok", "rules_seeded": True}
+        assert body == {
+            "status": "ok",
+            "rules_seeded": True,
+            "mcp_seeded": True,
+            "mcp_entries": 0,
+        }
 
 
 async def test_healthz_without_seeded_callable_reports_ok() -> None:

--- a/tests/egress/test_gateway_mcp_sync.py
+++ b/tests/egress/test_gateway_mcp_sync.py
@@ -1,0 +1,305 @@
+"""Gateway MCP registry sync: cold-start convergence + reconcile.
+
+The contract under test (mirrors test_gateway_degraded_startup for the
+rule side): the gateway serves immediately; a background task retries
+the MCP snapshot until the orchestrator's responder appears — the
+regression test for the incident where a lost cold-start snapshot left
+the registry empty for 22 days — then reconciles the registry against
+the orchestrator every _RECONCILE_INTERVAL_S; the change-delta
+subscription opens before the first snapshot fetch; and /healthz
+exposes the MCP seed state without ever leaving 200.
+
+Only the NATS boundary is faked (_ScriptedMcpNats). The registry,
+apply_snapshot_to_registry, the subscription wiring, and the aiohttp
+/healthz endpoint are all real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import AsyncExitStack
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+import rolemesh.egress.gateway as gateway
+from rolemesh.egress import reverse_proxy
+from rolemesh.egress.mcp_cache import (
+    MCP_CHANGED_SUBJECT,
+    MCP_SNAPSHOT_REQUEST_SUBJECT,
+)
+from rolemesh.egress.reverse_proxy import start_credential_proxy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> None:
+    # The registry is module-global — wipe it between cases so tests
+    # don't observe each other's writes.
+    reverse_proxy._mcp_registry.clear()
+
+
+# ---------------------------------------------------------------------------
+# NATS-boundary fake (the only mock in this module)
+# ---------------------------------------------------------------------------
+
+
+class _Msg:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+
+class _Sub:
+    async def unsubscribe(self) -> None:
+        return None
+
+
+def _entry(name: str, url: str) -> dict[str, Any]:
+    return {"name": name, "url": url, "headers": {}, "auth_mode": "user"}
+
+
+class _ScriptedMcpNats:
+    """NATS client fake: ``request`` fails *failures* times, then
+    answers with *snapshot_entries* (mutable — tests may change it
+    between reconcile cycles, and ``fail_next`` injects transient
+    failures after the seed); ``events`` records every subscribe and
+    request in arrival order for the ordering assertion."""
+
+    def __init__(
+        self,
+        *,
+        snapshot_entries: list[dict[str, Any]] | None = None,
+        failures: int = 0,
+    ) -> None:
+        self.snapshot_entries = snapshot_entries or []
+        self.failures = failures
+        self.fail_next = 0
+        self.request_count = 0
+        self.events: list[tuple[str, str]] = []
+        self.handlers: dict[str, Any] = {}
+
+    async def request(self, subject: str, payload: bytes, timeout: float) -> _Msg:
+        self.events.append(("request", subject))
+        self.request_count += 1
+        if self.request_count <= self.failures or self.fail_next > 0:
+            if self.fail_next > 0:
+                self.fail_next -= 1
+            raise TimeoutError("no snapshot responder")
+        return _Msg(json.dumps({"entries": self.snapshot_entries}).encode())
+
+    async def subscribe(self, subject: str, cb: Any) -> _Sub:
+        self.events.append(("subscribe", subject))
+        self.handlers[subject] = cb
+        return _Sub()
+
+
+async def _wait_for(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
+    async def _poll() -> None:
+        while not predicate():
+            await asyncio.sleep(0.005)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# cold-start race: retry until the responder appears (22-day incident)
+# ---------------------------------------------------------------------------
+
+
+async def test_cold_start_race_converges_when_responder_appears(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gateway up before the orchestrator, snapshot RPC timing out. The
+    old one-shot fetch left the registry empty until a manual restart —
+    pre-existing MCP servers never emit deltas, so nothing refilled it.
+    The seed task must keep retrying and converge once the responder
+    answers."""
+    monkeypatch.setattr(gateway, "_SNAPSHOT_RETRY_INITIAL_S", 0.01)
+    monkeypatch.setattr(gateway, "_SNAPSHOT_RETRY_MAX_S", 0.04)
+
+    nc = _ScriptedMcpNats(
+        snapshot_entries=[_entry("github", "https://api.github.com")],
+        failures=3,
+    )
+    async with AsyncExitStack() as stack:
+        state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
+
+        # Degraded window: attempts are happening, nothing is seeded.
+        await _wait_for(lambda: nc.request_count >= 1)
+        assert not state.seeded
+        assert reverse_proxy.get_mcp_registry() == {}
+
+        # Responder "appears" after the scripted failures; the retry
+        # loop must land the snapshot on the next attempt.
+        await _wait_for(lambda: state.seeded)
+        assert nc.request_count == 4, "3 failures + 1 success"
+        assert set(reverse_proxy.get_mcp_registry()) == {"github"}
+
+
+async def test_seed_success_with_empty_snapshot_still_counts_as_seeded() -> None:
+    """An orchestrator with zero MCP servers is a legal steady state:
+    seeded must mean "the RPC succeeded", never "the registry is
+    non-empty"."""
+    nc = _ScriptedMcpNats(snapshot_entries=[])
+    async with AsyncExitStack() as stack:
+        state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
+        await _wait_for(lambda: state.seeded)
+        assert reverse_proxy.get_mcp_registry() == {}
+
+
+# ---------------------------------------------------------------------------
+# periodic reconcile: drift self-heals within one interval
+# ---------------------------------------------------------------------------
+
+
+async def test_reconcile_heals_registry_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delta lost to at-most-once NATS shows up as registry drift.
+    Simulate it by mutating the registry behind the sync's back and
+    assert the next reconcile cycle restores snapshot state — both a
+    dropped entry and a diverged URL."""
+    monkeypatch.setattr(gateway, "_RECONCILE_INTERVAL_S", 0.02)
+
+    nc = _ScriptedMcpNats(
+        snapshot_entries=[
+            _entry("github", "https://api.github.com"),
+            _entry("jira", "https://jira.internal"),
+        ]
+    )
+    async with AsyncExitStack() as stack:
+        state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
+        await _wait_for(lambda: state.seeded)
+
+        # Drift: one entry vanished, one points at the wrong origin.
+        reverse_proxy.unregister_mcp_server("github")
+        reverse_proxy.register_mcp_server("jira", "https://wrong", {}, "user")
+
+        def _healed() -> bool:
+            reg = reverse_proxy.get_mcp_registry()
+            return set(reg) == {"github", "jira"} and reg["jira"][0] == "https://jira.internal"
+
+        await _wait_for(_healed)
+
+
+async def test_reconcile_failure_keeps_task_alive_until_next_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reconcile fetch failure (orchestrator restarting) must not kill
+    the task, un-seed the state, or fall back to fast backoff; the next
+    cycle picks the snapshot up again."""
+    monkeypatch.setattr(gateway, "_RECONCILE_INTERVAL_S", 0.02)
+
+    nc = _ScriptedMcpNats(snapshot_entries=[_entry("github", "https://api.github.com")])
+    async with AsyncExitStack() as stack:
+        state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
+        await _wait_for(lambda: state.seeded)
+
+        nc.fail_next = 1  # one orchestrator hiccup
+        reverse_proxy.unregister_mcp_server("github")  # drift during the hiccup
+
+        await _wait_for(lambda: "github" in reverse_proxy.get_mcp_registry())
+        assert state.seeded
+
+
+# ---------------------------------------------------------------------------
+# ordering: subscription opens before the first snapshot fetch
+# ---------------------------------------------------------------------------
+
+
+async def test_subscription_opens_before_first_snapshot_fetch() -> None:
+    """No delta may fall between snapshot generation and subscription:
+    _start_mcp_sync must subscribe to the change subject before the
+    seed task's first fetch hits the wire."""
+    nc = _ScriptedMcpNats(snapshot_entries=[])
+    async with AsyncExitStack() as stack:
+        state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
+        await _wait_for(lambda: state.seeded)
+
+    sub_idx = nc.events.index(("subscribe", MCP_CHANGED_SUBJECT))
+    req_idx = nc.events.index(("request", MCP_SNAPSHOT_REQUEST_SUBJECT))
+    assert sub_idx < req_idx
+
+
+# ---------------------------------------------------------------------------
+# healthz: both seed flags, entry count, always 200
+# ---------------------------------------------------------------------------
+
+
+class _UnusedCredResolver:
+    """healthz never touches credentials; resolving here is a test bug."""
+
+    async def resolve(self, tenant_id: str, provider: str) -> dict[str, Any]:
+        raise AssertionError("credential resolver must not be hit by /healthz")
+
+
+async def test_healthz_combines_both_seed_flags_and_stays_200() -> None:
+    """status must be "ok" iff BOTH planes are seeded; each flag is
+    reported independently; mcp_entries tracks the registry; and the
+    HTTP status never leaves 200 (a probe restarting a gateway that is
+    merely waiting for the orchestrator recreates the startup
+    deadlock)."""
+    flags = {"rules": False, "mcp": False}
+    async with AsyncExitStack() as stack:
+        runner = await start_credential_proxy(
+            0,
+            credential_resolver=_UnusedCredResolver(),  # type: ignore[arg-type]
+            rules_seeded=lambda: flags["rules"],
+            mcp_seeded=lambda: flags["mcp"],
+        )
+        stack.push_async_callback(runner.cleanup)
+        client = TestClient(TestServer(runner.app))
+        await client.start_server()
+        stack.push_async_callback(client.close)
+
+        async def _body() -> dict[str, Any]:
+            resp = await client.get("/healthz")
+            assert resp.status == 200
+            return await resp.json()
+
+        assert await _body() == {
+            "status": "degraded",
+            "rules_seeded": False,
+            "mcp_seeded": False,
+            "mcp_entries": 0,
+        }
+
+        flags["rules"] = True
+        assert await _body() == {
+            "status": "degraded",
+            "rules_seeded": True,
+            "mcp_seeded": False,
+            "mcp_entries": 0,
+        }
+
+        flags["rules"], flags["mcp"] = False, True
+        assert await _body() == {
+            "status": "degraded",
+            "rules_seeded": False,
+            "mcp_seeded": True,
+            "mcp_entries": 0,
+        }
+
+        # Both seeded with an EMPTY registry is "ok" — no MCP servers
+        # configured is a legal state, not a degradation.
+        flags["rules"] = True
+        assert await _body() == {
+            "status": "ok",
+            "rules_seeded": True,
+            "mcp_seeded": True,
+            "mcp_entries": 0,
+        }
+
+        reverse_proxy.register_mcp_server("github", "https://api.github.com", {}, "user")
+        assert await _body() == {
+            "status": "ok",
+            "rules_seeded": True,
+            "mcp_seeded": True,
+            "mcp_entries": 1,
+        }

--- a/tests/egress/test_gateway_mcp_sync.py
+++ b/tests/egress/test_gateway_mcp_sync.py
@@ -17,6 +17,7 @@ apply_snapshot_to_registry, the subscription wiring, and the aiohttp
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
@@ -303,3 +304,79 @@ async def test_healthz_combines_both_seed_flags_and_stays_200() -> None:
             "mcp_seeded": True,
             "mcp_entries": 1,
         }
+
+
+# ---------------------------------------------------------------------------
+# apply failures and task death stay visible
+# ---------------------------------------------------------------------------
+
+
+async def test_apply_failure_is_retried_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A snapshot that fetches fine but fails to APPLY must count as a
+    failed attempt (warning + retry), not escape the loop — an escaped
+    exception kills the sync task while /healthz keeps reporting the
+    last seeded state, recreating the invisible degradation this
+    module exists to prevent."""
+    monkeypatch.setattr(gateway, "_SNAPSHOT_RETRY_INITIAL_S", 0.01)
+    monkeypatch.setattr(gateway, "_SNAPSHOT_RETRY_MAX_S", 0.04)
+
+    real_apply = gateway.apply_snapshot_to_registry
+    calls = {"n": 0}
+
+    def _flaky_apply(entries: list[Any]) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("injected apply failure")
+        real_apply(entries)
+
+    monkeypatch.setattr(gateway, "apply_snapshot_to_registry", _flaky_apply)
+
+    nc = _ScriptedMcpNats(snapshot_entries=[_entry("github", "https://api.github.com")])
+    async with AsyncExitStack() as stack:
+        state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
+        await _wait_for(lambda: state.seeded)
+        assert calls["n"] == 2, "failed apply + successful retry"
+        assert set(reverse_proxy.get_mcp_registry()) == {"github"}
+
+
+async def test_sync_task_death_emits_error_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defence in depth behind the try: if a bug-grade exception ever
+    does kill a background sync task, the done-callback must emit an
+    ERROR — the only remaining operator signal, since /healthz keeps
+    reporting the last seeded state."""
+    errors: list[tuple[str, dict[str, Any]]] = []
+
+    class _RecordingLogger:
+        def error(self, msg: str, **kw: Any) -> None:
+            errors.append((msg, kw))
+
+        def __getattr__(self, name: str) -> Any:  # swallow other levels
+            return lambda *a, **k: None
+
+    monkeypatch.setattr(gateway, "logger", _RecordingLogger())
+
+    async def _boom() -> None:
+        raise RuntimeError("bug-grade failure")
+
+    task = asyncio.create_task(_boom(), name="egress-mcp-snapshot-seed")
+    task.add_done_callback(gateway._log_task_death)
+    with contextlib.suppress(RuntimeError):
+        await task
+    await asyncio.sleep(0)  # done-callbacks run via call_soon
+
+    assert len(errors) == 1
+    msg, kw = errors[0]
+    assert "died" in msg
+    assert kw["task"] == "egress-mcp-snapshot-seed"
+
+    # Cancellation is normal shutdown, never an ERROR.
+    errors.clear()
+    hung = asyncio.create_task(asyncio.Event().wait(), name="egress-mcp-snapshot-seed")
+    hung.add_done_callback(gateway._log_task_death)
+    await gateway._cancel_task(hung)
+    await asyncio.sleep(0)
+    assert errors == []


### PR DESCRIPTION
## Problem

The gateway's MCP registry sync had a one-shot snapshot fetch with no retry: if the orchestrator's snapshot responder wasn't up within 5s of gateway boot — the normal cold-start order in compose — the registry stayed empty until a manual restart. The old comment claimed "live change events will refill" — wrong, since pre-existing MCP servers never emit deltas. Observed in production as **22 days of `/mcp-proxy` 404s with no signal**: healthz only exposed `rules_seeded`, so the degradation was invisible.

Systemic weakness fixed alongside: core NATS pub/sub is at-most-once, so `egress.mcp.changed` deltas lost during a NATS reconnect window drifted the registry until restart.

## Changes

- **Subscribe before snapshot** (`gateway._start_mcp_sync`): the `egress.mcp.changed` subscription now opens before the first fetch, mirroring the rule-side ordering, so no delta falls between snapshot generation and subscription. The registry dict has no unseeded deny-all gate, so an in-flight-snapshot-overwrites-delta race remains — accepted and documented in code; the reconcile bounds it to one interval.
- **Seed retry + periodic reconcile** (`gateway._seed_and_reconcile_mcp`): one background task, two phases — fast exponential backoff (1s→30s, same constants as the rule side) until the first successful seed, then a full snapshot re-fetch every `_RECONCILE_INTERVAL_S` (300s). `apply_snapshot_to_registry` was already replace-not-merge and idempotent; reconcile reuses it unchanged. **The reconcile loop — not the delta stream — is the registry's correctness mechanism**; deltas are a propagation-latency optimisation only, and losing every delta delays convergence by at most one interval.
- **healthz visibility** (`reverse_proxy`): body now carries `mcp_seeded` and `mcp_entries` alongside `rules_seeded`; `status` is `"ok"` iff both planes are seeded. HTTP stays 200 throughout — the degraded-but-serving startup contract is unchanged (a probe restarting a gateway that is merely waiting for the orchestrator recreates the startup deadlock).
- **Failure visibility hardening** (second commit): `apply_snapshot_to_registry` moved inside the try in both loops — a failed apply is a failed attempt (warning + retry / next interval), not a silent task death. Both background sync tasks (rule + MCP) get a done-callback that logs ERROR on non-cancellation death, since healthz alone cannot distinguish "in sync" from "sync stopped".

No orchestrator-side, NATS-subject, or wire-format changes. Constants stay module-level per the existing decision (tests patch them directly; not config.py knobs).

## Decisions (per handover doc)

**Single task for seed + reconcile, not two.** Seed is just the fast-backoff first reconcile; one task means one lifecycle, one cancellation path on the exit stack, and no coordination between a seed task and a reconcile task over the seeded flag.

**Rule-side reconcile is NOT included.** The rule side already retries its snapshot at cold start, so the incident class this PR fixes (permanent empty state after a boot race) does not exist there. Runtime delta loss on the rule side is real but has the opposite failure direction: a lost rule-revocation event fails *open* (a stale allow rule keeps admitting traffic) rather than degrading routing. That makes the reconcile interval a security parameter, not just a convergence knob — it deserves its own design pass and tests rather than riding along here. `cache.seed()` is already an authoritative full overwrite, so the mechanism from this PR transfers directly when that follow-up lands. The shared-loop-helper abstraction was also deferred until it has two real call sites.

**`status` flips to `degraded` when MCP is unseeded** (ok iff rules AND mcp seeded). Test sweep confirmed the only exact-body assertions on the healthz JSON live in the gateway's own unit tests (updated here); integration tests and `verify_infrastructure` consume HTTP 200 only, which is unchanged. `mcp_seeded` means "the snapshot RPC succeeded at least once", deliberately not "registry non-empty" — zero configured MCP servers is a legal state. Known semantic bound (documented, not mechanised): it does not mean "currently in sync"; prolonged reconcile failure surfaces as warnings, and task death as the new ERROR log.

## Tests

`tests/egress/` 205 passed. New in `test_gateway_mcp_sync.py` (only the NATS boundary is faked, per the existing `test_gateway_degraded_startup` pattern):

1. Cold-start race converges once the responder appears — direct regression test for the 22-day incident
2. Empty snapshot still counts as seeded
3. Reconcile heals manual registry drift (dropped entry + diverged URL) within one interval
4. Reconcile fetch failure keeps the task alive; next cycle recovers
5. Subscription opens before the first snapshot fetch (event-order assertion)
6. healthz: all four seed-flag combinations, `mcp_entries` tracking, HTTP 200 throughout
7. Apply failure is retried, not fatal
8. Task death emits exactly one ERROR; cancellation emits none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEwW6RFCVnxQmp9JymjdGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEwW6RFCVnxQmp9JymjdGW)_