### PR TITLE
fix(orchestrator): refresh coworker MCP projections on mcp_servers changes

### DIFF
--- a/src/rolemesh/db/coworker_mcp.py
+++ b/src/rolemesh/db/coworker_mcp.py
@@ -27,7 +27,7 @@ import json
 from typing import TYPE_CHECKING
 
 from rolemesh.core.types import McpServerConfig
-from rolemesh.db._pool import tenant_conn
+from rolemesh.db._pool import admin_conn, tenant_conn
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
+    "list_coworker_ids_bound_to_mcp_server",
     "list_coworker_mcp_configs",
     "replace_coworker_mcp_configs",
 ]
@@ -125,6 +126,46 @@ async def list_coworker_mcp_configs(
             coworker_id, tenant_id,
         )
     return [_row_to_mcp_config(r) for r in rows]
+
+
+async def list_coworker_ids_bound_to_mcp_server(
+    name: str,
+) -> list[tuple[str, str]]:
+    """Return ``(coworker_id, tenant_id)`` pairs bound to server ``name``.
+
+    Affected-coworker discovery for the ``egress.mcp.changed``
+    projection-refresh path (see
+    ``coworker_hot_reload.refresh_coworkers_for_mcp_server``). The
+    junction binds by ``mcp_server_id``, so this JOIN still finds every
+    bound coworker after a PATCH renames the server — the in-memory
+    projections hold the OLD name at that point and a name-based scan
+    of ``state.coworkers`` would miss them all.
+
+    Deliberately cross-tenant: the ``egress.mcp.changed`` payload
+    carries no ``tenant_id`` (see ``mcp_events._build_entry``), and
+    ``mcp_servers.name`` is only unique per tenant — so we match every
+    tenant's server of this name. That is safe by construction: the
+    caller only uses the pairs to make each coworker re-read its OWN
+    projection from DB, so refreshing a same-named neighbour tenant's
+    coworkers is a harmless no-op refresh, not a data leak. Do NOT
+    "fix" this by adding a tenant filter — there is no tenant to
+    filter by.
+    """
+    # inv-1-ok: cross-tenant by design (classification B list_*) — the
+    # change event has no tenant_id and names collide across tenants;
+    # see the docstring. Rows are only used as refresh targets.
+    async with admin_conn() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT cms.coworker_id, c.tenant_id
+            FROM coworker_mcp_servers cms
+            JOIN mcp_servers m ON m.id = cms.mcp_server_id
+            JOIN coworkers c ON c.id = cms.coworker_id
+            WHERE m.name = $1
+            """,
+            name,
+        )
+    return [(str(r["coworker_id"]), str(r["tenant_id"])) for r in rows]
 
 
 async def replace_coworker_mcp_configs(

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -2051,6 +2051,7 @@ async def main() -> None:
     from rolemesh.db import get_coworker as _db_get_coworker
     from rolemesh.db import list_skills_for_coworker as _db_list_skills
     from rolemesh.orchestration.coworker_hot_reload import (
+        apply_mcp_changed_event_to_projections,
         subscribe_coworker_mcp_changed,
         subscribe_coworker_restart,
         subscribe_coworker_skills_changed,
@@ -2103,6 +2104,52 @@ async def main() -> None:
         fetch_mcp_configs=_fetch_mcp_configs,
     )
     egress_responder_subs.append(coworker_mcp_sub)
+
+    # egress.mcp.changed → coworker projections. A /mcp-servers PATCH
+    # or DELETE changes the JOINed view every bound coworker spawns
+    # with, but that surface only publishes ``egress.mcp.changed`` —
+    # the ``web.coworker.mcp_changed`` chain above never fires for it,
+    # so projections stayed stale until an unrelated unlink/relink.
+    # Second core-NATS subscription on the same subject as the
+    # registry-mirror one wired earlier (multiple subscribers per
+    # subject is normal NATS); ``mcp_cache.subscribe_mcp_changes`` is
+    # shared with the gateway and stays untouched. Fire-and-forget is
+    # acceptable here for the same reason it is for the registry
+    # mirror: a missed event degrades to staleness until the next
+    # orchestrator restart re-seeds projections from DB.
+    from rolemesh.db import list_coworker_ids_bound_to_mcp_server
+    from rolemesh.egress.mcp_cache import MCP_CHANGED_SUBJECT
+
+    async def _on_mcp_changed_refresh_projections(msg: object) -> None:
+        try:
+            event = json.loads(msg.data)  # type: ignore[attr-defined]
+        except (ValueError, AttributeError):
+            return  # registry-mirror subscriber already logs these
+        try:
+            n = await apply_mcp_changed_event_to_projections(
+                event,
+                state=_state,
+                fetch_mcp_configs=_fetch_mcp_configs,
+                list_bound_coworker_ids=list_coworker_ids_bound_to_mcp_server,
+            )
+        except Exception:
+            logger.exception(
+                "egress.mcp.changed projection refresh failed",
+                payload=event,
+            )
+            return
+        if n:
+            logger.info(
+                "Coworker MCP projections refreshed after server change",
+                mcp_server=event.get("name") if isinstance(event, dict) else None,
+                action=event.get("action") if isinstance(event, dict) else None,
+                refreshed=n,
+            )
+
+    mcp_projection_sub = await _transport.nc.subscribe(
+        MCP_CHANGED_SUBJECT, cb=_on_mcp_changed_refresh_projections,
+    )
+    egress_responder_subs.append(mcp_projection_sub)
 
     # web.coworker.skills_changed — sibling of mcp_changed for the
     # per-tenant skills catalog (v1.1 03b). Catalog edits and

--- a/src/rolemesh/orchestration/coworker_hot_reload.py
+++ b/src/rolemesh/orchestration/coworker_hot_reload.py
@@ -170,6 +170,137 @@ async def reload_coworker_mcp_into_state(
     return True
 
 
+async def refresh_coworkers_for_mcp_server(
+    *,
+    name: str,
+    state: OrchestratorState,
+    fetch_mcp_configs: Callable[
+        [str, str], Awaitable[list[McpServerConfig]]
+    ],
+    list_bound_coworker_ids: (
+        Callable[[str], Awaitable[list[tuple[str, str]]]] | None
+    ) = None,
+) -> int:
+    """Refresh ``mcp_configs`` for every coworker affected by a change
+    to the ``mcp_servers`` row named ``name``. Returns the refresh count.
+
+    Closes the third leg of the ``egress.mcp.changed`` fan-out: the
+    gateway registry and the orchestrator's registry mirror already
+    follow ``/mcp-servers`` CRUD via ``mcp_cache.subscribe_mcp_changes``,
+    but the per-coworker projection (``CoworkerState.mcp_configs`` — the
+    JOIN snapshot handed to agents at spawn) was only refreshed by
+    link/unlink events, so a URL/headers/auth_mode edit left every bound
+    coworker spawning with a stale config until someone happened to
+    unlink/relink.
+
+    Affected-coworker discovery is the union of two sources, applied
+    unconditionally (no per-action branching needed):
+
+    * In-memory scan — coworkers whose cached projection already
+      contains ``name``. Covers ``deleted`` (the row is gone, so a DB
+      lookup finds nothing, but the stale projection still matches)
+      and ordinary ``updated``.
+    * DB reverse lookup (``list_bound_coworker_ids``) — the junction
+      binds by ``mcp_server_id``, so this also finds coworkers after a
+      PATCH *renames* the server: the event carries only the NEW name
+      while cached projections hold the OLD one, and the scan alone
+      would miss every one of them, leaving projections stale forever.
+      For ``created``/``deleted`` the lookup naturally returns nothing.
+
+    Refreshes re-read the DB (source of truth) via ``fetch_mcp_configs``
+    rather than trusting event fields — the payload's ``url`` is
+    origin-only (path stripped) and carries no tenant, so it could not
+    be copied into projections even if we wanted to. Best-effort per
+    coworker: one failing refresh logs and moves on.
+
+    Rejected alternative (do not reinvent): having the orchestrator
+    republish per-coworker ``web.coworker.mcp_changed`` events onto
+    JetStream would reuse the durable subscriber, but makes the
+    orchestrator both subscriber and publisher of the same semantic
+    chain — a loop-shaped topology for what is just a local cache
+    refresh. A direct function call is simpler and has no redelivery
+    ambiguity.
+    """
+    targets: dict[str, str] = {}
+    for cw_id, cw_state in state.coworkers.items():
+        if any(cfg.name == name for cfg in cw_state.mcp_configs):
+            targets[cw_id] = cw_state.config.tenant_id
+
+    if list_bound_coworker_ids is not None:
+        try:
+            for cw_id, tenant_id in await list_bound_coworker_ids(name):
+                targets.setdefault(cw_id, tenant_id)
+        except Exception:
+            # Degrade to scan-only discovery — still correct for every
+            # case except rename, and a failed lookup shouldn't stop
+            # the refreshes we can do.
+            logger.exception(
+                "MCP-server bound-coworker lookup failed; "
+                "refreshing in-memory matches only",
+                mcp_server=name,
+            )
+
+    refreshed = 0
+    for cw_id, tenant_id in targets.items():
+        try:
+            ok = await reload_coworker_mcp_into_state(
+                coworker_id=cw_id,
+                tenant_id=tenant_id,
+                state=state,
+                fetch_mcp_configs=fetch_mcp_configs,
+            )
+        except Exception:
+            logger.exception(
+                "Coworker MCP projection refresh failed; continuing",
+                coworker_id=cw_id,
+                mcp_server=name,
+            )
+            continue
+        if ok:
+            refreshed += 1
+    return refreshed
+
+
+async def apply_mcp_changed_event_to_projections(
+    event: object,
+    *,
+    state: OrchestratorState,
+    fetch_mcp_configs: Callable[
+        [str, str], Awaitable[list[McpServerConfig]]
+    ],
+    list_bound_coworker_ids: (
+        Callable[[str], Awaitable[list[tuple[str, str]]]] | None
+    ) = None,
+) -> int:
+    """Validate one decoded ``egress.mcp.changed`` payload and refresh.
+
+    Robustness contract mirrors ``mcp_cache.apply_change_event``: a
+    non-dict payload or a missing/empty ``name`` is dropped without
+    raising (returns 0). ``action`` is deliberately not branched on —
+    see :func:`refresh_coworkers_for_mcp_server` for why the same
+    union discovery is correct for created/updated/deleted alike.
+    """
+    if not isinstance(event, dict):
+        logger.warning(
+            "egress.mcp.changed projection event not a dict",
+            got=type(event).__name__,
+        )
+        return 0
+    name = event.get("name")
+    if not isinstance(name, str) or not name:
+        logger.warning(
+            "egress.mcp.changed projection event missing 'name'",
+            payload=event,
+        )
+        return 0
+    return await refresh_coworkers_for_mcp_server(
+        name=name,
+        state=state,
+        fetch_mcp_configs=fetch_mcp_configs,
+        list_bound_coworker_ids=list_bound_coworker_ids,
+    )
+
+
 async def subscribe_coworker_restart(
     js: JetStreamContext,
     *,

--- a/tests/egress/test_mcp_view_convergence.py
+++ b/tests/egress/test_mcp_view_convergence.py
@@ -1,0 +1,120 @@
+"""Convergence contract for every materialized view of ``mcp_servers``.
+
+A row in ``mcp_servers`` (name / url / headers / auth_mode) has, at the
+time of writing, exactly THREE runtime materializations:
+
+  1. gateway-registry        — ``reverse_proxy._mcp_registry`` in the
+                               gateway process; fed by
+                               ``mcp_cache.subscribe_mcp_changes``.
+  2. orch-registry-mirror    — the same module-level dict in the
+                               orchestrator process (source for the
+                               gateway's boot snapshot RPC); fed by a
+                               second subscription to the same subject.
+  3. coworker-projection     — ``CoworkerState.mcp_configs`` (the JOIN
+                               snapshot handed to agents at spawn); fed
+                               by ``refresh_coworkers_for_mcp_server``
+                               via the ``egress.mcp.changed``
+                               subscription wired in ``rolemesh.main``.
+
+REGISTRATION REQUIREMENT: if you add a NEW materialized view of
+``mcp_servers`` anywhere in the codebase, you MUST add a case to this
+file proving it converges after a change event. This file is the CI
+form of the view inventory — before it existed the inventory lived in
+scattered comments, and the coworker-projection leg was silently missed
+by the ``/mcp-servers`` update path (agents kept spawning with stale
+URLs until an unrelated unlink/relink; observed in production).
+
+Views 1 and 2 share ``apply_change_event`` — both cases run the same
+code path on purpose: the parametrization documents the inventory, not
+code-path diversity.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from rolemesh.core.orchestrator_state import CoworkerState, OrchestratorState
+from rolemesh.core.types import Coworker, McpServerConfig
+from rolemesh.egress import reverse_proxy
+from rolemesh.egress.mcp_cache import apply_change_event
+from rolemesh.egress.reverse_proxy import get_mcp_registry, register_mcp_server
+from rolemesh.orchestration.coworker_hot_reload import (
+    refresh_coworkers_for_mcp_server,
+)
+
+OLD_URL = "http://mcp-x:8000"
+NEW_URL = "http://mcp-x-moved:9000"
+
+CHANGE_EVENT = {
+    "action": "updated",
+    "name": "X",
+    "url": NEW_URL,
+    "headers": {"X-Key": "v2"},
+    "auth_mode": "service",
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> None:
+    # Same convention as test_mcp_cache.py: the registry is a
+    # module-global dict; wipe it between cases.
+    reverse_proxy._mcp_registry.clear()
+
+
+def _apply_to_registry() -> None:
+    register_mcp_server("X", OLD_URL, {"X-Key": "v1"}, "user")
+    apply_change_event(CHANGE_EVENT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "view",
+    ["gateway-registry", "orch-registry-mirror", "coworker-projection"],
+)
+async def test_view_converges_after_mcp_server_update(view: str) -> None:
+    if view in ("gateway-registry", "orch-registry-mirror"):
+        _apply_to_registry()
+        url, headers, auth_mode = get_mcp_registry()["X"]
+        assert url == NEW_URL
+        assert headers == {"X-Key": "v2"}
+        assert auth_mode == "service"
+        return
+
+    # coworker-projection: the refresh re-reads DB truth (faked here)
+    # instead of trusting event fields — the event's url is origin-only.
+    cw = Coworker(
+        id=str(uuid.uuid4()),
+        tenant_id=str(uuid.uuid4()),
+        name="cw",
+        folder="cw-folder",
+        agent_backend="claude",
+        system_prompt="hi",
+    )
+    state = OrchestratorState()
+    state.coworkers[cw.id] = CoworkerState(
+        config=cw,
+        mcp_configs=[McpServerConfig(name="X", type="http", url=OLD_URL)],
+    )
+
+    async def _fetch(coworker_id: str, tenant_id: str) -> list[McpServerConfig]:
+        assert (coworker_id, tenant_id) == (cw.id, cw.tenant_id)
+        return [
+            McpServerConfig(
+                name="X", type="http", url=NEW_URL,
+                headers={"X-Key": "v2"}, auth_mode="service",
+            )
+        ]
+
+    n = await refresh_coworkers_for_mcp_server(
+        name=CHANGE_EVENT["name"],  # type: ignore[arg-type]
+        state=state,
+        fetch_mcp_configs=_fetch,
+    )
+
+    assert n == 1
+    (cfg,) = state.coworkers[cw.id].mcp_configs
+    assert cfg.url == NEW_URL
+    assert cfg.headers == {"X-Key": "v2"}
+    assert cfg.auth_mode == "service"

--- a/tests/orchestration/test_mcp_server_projection_refresh.py
+++ b/tests/orchestration/test_mcp_server_projection_refresh.py
@@ -1,0 +1,235 @@
+"""Unit tests for ``refresh_coworkers_for_mcp_server`` and its event seam.
+
+Covers the third leg of the ``egress.mcp.changed`` fan-out: a
+``/mcp-servers`` PATCH/DELETE must refresh the ``CoworkerState.
+mcp_configs`` projection of every bound coworker, without relying on a
+later unlink/relink. The NATS wiring lives in ``rolemesh.main``; these
+tests exercise the pure logic with injected fakes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from rolemesh.core.orchestrator_state import CoworkerState, OrchestratorState
+from rolemesh.core.types import Coworker, McpServerConfig
+from rolemesh.orchestration.coworker_hot_reload import (
+    apply_mcp_changed_event_to_projections,
+    refresh_coworkers_for_mcp_server,
+)
+
+
+def _make_coworker(*, tenant_id: str | None = None) -> Coworker:
+    return Coworker(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id or str(uuid.uuid4()),
+        name="cw",
+        folder="cw-folder",
+        agent_backend="claude",
+        system_prompt="hi",
+    )
+
+
+def _mcp(name: str, url: str = "http://old:1") -> McpServerConfig:
+    return McpServerConfig(name=name, type="http", url=url)
+
+
+def _state_with(*coworkers: tuple[Coworker, list[McpServerConfig]]) -> OrchestratorState:
+    state = OrchestratorState()
+    for cw, configs in coworkers:
+        state.coworkers[cw.id] = CoworkerState(config=cw, mcp_configs=list(configs))
+    return state
+
+
+class _FetchRecorder:
+    """Fake ``list_coworker_mcp_configs`` that records call args."""
+
+    def __init__(self, result: list[McpServerConfig]) -> None:
+        self.result = result
+        self.calls: list[tuple[str, str]] = []
+
+    async def __call__(self, coworker_id: str, tenant_id: str) -> list[McpServerConfig]:
+        self.calls.append((coworker_id, tenant_id))
+        return list(self.result)
+
+
+@pytest.mark.asyncio
+async def test_updated_refreshes_bound_coworkers_across_tenants() -> None:
+    """Two coworkers in different tenants bound to X refresh (fetch is
+    called with each coworker's own id + tenant); an unrelated third
+    coworker is left untouched."""
+    cw_a = _make_coworker()
+    cw_b = _make_coworker()  # different tenant (random uuid)
+    cw_other = _make_coworker()
+    state = _state_with(
+        (cw_a, [_mcp("X")]),
+        (cw_b, [_mcp("X"), _mcp("other")]),
+        (cw_other, [_mcp("unrelated")]),
+    )
+    fetch = _FetchRecorder([_mcp("X", url="http://new:9")])
+
+    n = await refresh_coworkers_for_mcp_server(
+        name="X", state=state, fetch_mcp_configs=fetch,
+    )
+
+    assert n == 2
+    assert sorted(fetch.calls) == sorted(
+        [(cw_a.id, cw_a.tenant_id), (cw_b.id, cw_b.tenant_id)]
+    )
+    assert state.coworkers[cw_a.id].mcp_configs[0].url == "http://new:9"
+    assert state.coworkers[cw_b.id].mcp_configs[0].url == "http://new:9"
+    # The unrelated coworker's projection was not re-fetched or altered.
+    assert state.coworkers[cw_other.id].mcp_configs[0].name == "unrelated"
+
+
+@pytest.mark.asyncio
+async def test_deleted_row_matches_via_stale_projection_scan() -> None:
+    """After a DELETE the row is gone, so a DB reverse lookup finds
+    nothing — the in-memory scan must still match the stale projection
+    and refresh it (the re-read then drops the vanished server).
+
+    Note the API refuses DELETE while coworkers are still bound (409
+    RESOURCE_IN_USE), so this path is defensive: it covers the race
+    between the reference check and the DELETE, and non-API deletes.
+    """
+    cw = _make_coworker()
+    state = _state_with((cw, [_mcp("X")]))
+    fetch = _FetchRecorder([])  # server gone from the JOIN
+
+    async def _lookup_finds_nothing(name: str) -> list[tuple[str, str]]:
+        return []
+
+    n = await refresh_coworkers_for_mcp_server(
+        name="X",
+        state=state,
+        fetch_mcp_configs=fetch,
+        list_bound_coworker_ids=_lookup_finds_nothing,
+    )
+
+    assert n == 1
+    assert state.coworkers[cw.id].mcp_configs == []
+
+
+@pytest.mark.asyncio
+async def test_rename_found_via_db_reverse_lookup() -> None:
+    """THE reason the DB reverse lookup exists: a PATCH rename means
+    the event carries the NEW name while cached projections hold the
+    OLD one, so the in-memory scan alone finds nobody. The junction
+    binds by server id, so the lookup (by new name) still returns the
+    bound coworkers. Do not "simplify" discovery back to scan-only —
+    this test is the guard against exactly that."""
+    cw = _make_coworker()
+    state = _state_with((cw, [_mcp("old-name")]))
+    fetch = _FetchRecorder([_mcp("new-name", url="http://new:9")])
+
+    async def _lookup(name: str) -> list[tuple[str, str]]:
+        assert name == "new-name"
+        return [(cw.id, cw.tenant_id)]
+
+    n = await refresh_coworkers_for_mcp_server(
+        name="new-name",
+        state=state,
+        fetch_mcp_configs=fetch,
+        list_bound_coworker_ids=_lookup,
+    )
+
+    assert n == 1
+    assert state.coworkers[cw.id].mcp_configs[0].name == "new-name"
+
+
+@pytest.mark.asyncio
+async def test_one_failing_coworker_does_not_starve_the_rest() -> None:
+    cw_ok = _make_coworker()
+    cw_bad = _make_coworker()
+    state = _state_with((cw_ok, [_mcp("X")]), (cw_bad, [_mcp("X")]))
+
+    calls: list[str] = []
+
+    async def _fetch(coworker_id: str, tenant_id: str) -> list[McpServerConfig]:
+        calls.append(coworker_id)
+        if coworker_id == cw_bad.id:
+            raise RuntimeError("db blip")
+        return [_mcp("X", url="http://new:9")]
+
+    n = await refresh_coworkers_for_mcp_server(
+        name="X", state=state, fetch_mcp_configs=_fetch,
+    )
+
+    assert n == 1  # only the healthy coworker counts
+    assert set(calls) == {cw_ok.id, cw_bad.id}  # both were attempted
+    assert state.coworkers[cw_ok.id].mcp_configs[0].url == "http://new:9"
+
+
+@pytest.mark.asyncio
+async def test_failed_db_lookup_degrades_to_scan_only() -> None:
+    """A broken reverse lookup must not stop the refreshes the
+    in-memory scan can still deliver."""
+    cw = _make_coworker()
+    state = _state_with((cw, [_mcp("X")]))
+    fetch = _FetchRecorder([_mcp("X", url="http://new:9")])
+
+    async def _lookup_raises(name: str) -> list[tuple[str, str]]:
+        raise RuntimeError("db down")
+
+    n = await refresh_coworkers_for_mcp_server(
+        name="X",
+        state=state,
+        fetch_mcp_configs=fetch,
+        list_bound_coworker_ids=_lookup_raises,
+    )
+
+    assert n == 1
+    assert state.coworkers[cw.id].mcp_configs[0].url == "http://new:9"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event",
+    [
+        "not-a-dict",
+        ["also", "not", "a", "dict"],
+        {},
+        {"action": "updated"},  # missing name
+        {"action": "updated", "name": ""},  # empty name
+        {"action": "updated", "name": 42},  # non-str name
+    ],
+)
+async def test_malformed_event_is_dropped_without_refreshing(event: object) -> None:
+    """Robustness contract mirrors ``mcp_cache.apply_change_event``."""
+    cw = _make_coworker()
+    state = _state_with((cw, [_mcp("X")]))
+    fetch = _FetchRecorder([_mcp("X", url="http://new:9")])
+
+    n = await apply_mcp_changed_event_to_projections(
+        event, state=state, fetch_mcp_configs=fetch,
+    )
+
+    assert n == 0
+    assert fetch.calls == []
+    assert state.coworkers[cw.id].mcp_configs[0].url == "http://old:1"
+
+
+@pytest.mark.asyncio
+async def test_created_event_refreshes_nothing() -> None:
+    """A just-created server cannot be bound to anyone yet: the scan
+    matches nobody and the reverse lookup returns no junction rows, so
+    no per-action branch is needed."""
+    cw = _make_coworker()
+    state = _state_with((cw, [_mcp("existing")]))
+    fetch = _FetchRecorder([])
+
+    async def _lookup(name: str) -> list[tuple[str, str]]:
+        return []
+
+    n = await apply_mcp_changed_event_to_projections(
+        {"action": "created", "name": "brand-new", "url": "http://n:1",
+         "headers": {}, "auth_mode": "user"},
+        state=state,
+        fetch_mcp_configs=fetch,
+        list_bound_coworker_ids=_lookup,
+    )
+
+    assert n == 0
+    assert fetch.calls == []


### PR DESCRIPTION
## Problem

A row in `mcp_servers` has three runtime materializations: the gateway's MCP routing registry, the orchestrator's registry mirror (both fed by `egress.mcp.changed`), and the per-coworker `CoworkerState.mcp_configs` projection — the JOIN snapshot handed to agents at spawn — fed only by `web.coworker.mcp_changed` from link/unlink.

A `/mcp-servers` PATCH or DELETE affects the projection of every bound coworker, but that surface only publishes `egress.mcp.changed`. Result: after an admin edits a server's URL/headers/auth_mode, newly spawned agents keep using the stale config until an unrelated unlink/relink happens to fire. Observed in production.

## Fix

- **`refresh_coworkers_for_mcp_server`** (`coworker_hot_reload.py`, the projection-refresh owner module): discovers affected coworkers as the **union of an in-memory projection scan and a DB reverse lookup**, then re-reads each one's projection from DB via the existing `reload_coworker_mcp_into_state` primitive. Best-effort per coworker: one failing refresh logs and continues; a failing DB lookup degrades to scan-only discovery. No per-action branching is needed — the union is correct for `created` (both sources empty), `updated` (lookup + scan), and `deleted` (row gone, stale projection still matches the scan) alike. A thin `apply_mcp_changed_event_to_projections` seam validates decoded payloads with the same robustness contract as `mcp_cache.apply_change_event`.
- **`list_coworker_ids_bound_to_mcp_server`** (`db/coworker_mcp.py`): junction JOIN by server name, `admin_conn` (classification B `list_*`), with an `inv-1-ok` annotation.
- **Wiring** (`main.py`): a **second core-NATS subscription** on `egress.mcp.changed`, placed next to the existing coworker hot-reload subscribers. Chosen over the alternative (an optional `post_apply` callback on `mcp_cache.subscribe_mcp_changes`) because the shared module — also used by the gateway — stays byte-identical, and multiple subscribers per subject is normal NATS. The rejected republish-to-JetStream alternative is documented in the function docstring so it doesn't get reinvented.

## Rename investigation (handoff doc §3c)

**`name` IS mutable**: the PATCH handler's updatable-field list includes `name`. This rules out scan-only discovery: the event carries only the NEW name (payload has no `id`/`old_name`) while cached projections hold the OLD one, so a name-based scan would miss every bound coworker and leave projections stale forever. The junction binds by `mcp_server_id`, so a DB join on the new name still finds them — hence the reverse-lookup helper, and a dedicated rename regression test guarding against simplifying discovery back to scan-only.

The lookup is **deliberately cross-tenant**: the event payload carries no `tenant_id` and `mcp_servers.name` is only unique per tenant. Safe by construction — targets only re-read their own DB truth, so refreshing a same-named neighbour tenant's coworkers is a harmless no-op refresh, not a data leak. Documented in the helper's docstring to prevent a well-meaning tenant filter being added later.

## Reported, not fixed (pre-existing, out of scope)

1. **Rename leaks the old-name entry in the registry views**: `apply_change_event(updated)` registers the new name but nothing ever unregisters the old one (the event has no `old_name`). The gateway keeps routing the stale name, and the orchestrator mirror serves it in snapshots. A clean fix needs an event-schema change (`old_name` or `id`), which the handoff doc explicitly scopes out. (Post-#116, the periodic snapshot reconcile re-seeds the gateway from the orchestrator mirror — but the mirror carries the same stale entry, so only an orchestrator restart clears it.)
2. **The `deleted` path is defensive**: the API refuses DELETE while coworkers are bound (409 `RESOURCE_IN_USE`), so a successful delete affects zero linked coworkers via the API. The uniform scan still covers the reference-check/delete race and non-API deletes at zero cost.

## Tests

- **`tests/egress/test_mcp_view_convergence.py`** — parametrized convergence contract over all three materialized views against one fixed change event, with a file-header requirement that any new view of `mcp_servers` must register a case there (the view inventory as CI contract). Views 1–2 intentionally share a code path; the parametrization documents the inventory.
- **`tests/orchestration/test_mcp_server_projection_refresh.py`** — unit tests: cross-tenant refresh with an unrelated coworker untouched; delete via stale-projection scan; **rename via DB lookup** (the guard for the discovery strategy); per-coworker fault isolation; degraded-lookup fallback; six malformed-payload shapes dropped without refreshing; created no-op.
- Acceptance scope green: `tests/agent tests/container tests/egress tests/orchestration` — 996 passed, 0 failed (NATS-dependent `test_run_cancel_subscriber.py` excluded in the Docker-less sandbox; it self-skips in CI). Rebased onto latest `main` including #116 (orthogonal: gateway seed retry/reconcile; `mcp_cache.py` changes there are docstring-only) and re-verified including its new `test_gateway_mcp_sync.py`.

## Scope guarantees

- `mcp_cache.py` diff is empty (gateway path byte-identical).
- No changes to the webui publishers, the event wire format, the JetStream `web.coworker.mcp_changed` chain, or running-agent config (spawn-snapshot semantics unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqG8e3i9x49S3TRHwv9QoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqG8e3i9x49S3TRHwv9QoD)_