### PR TITLE
chore: neutralize project-specific references in docs and test fixtures

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -96,10 +96,10 @@ separation, because the call site cost (frontend branching on mode
 just to log out) is real and the implementation cost (a small
 internal dispatch) is trivial.
 
-**Compared to Tropos**: Tropos's contract unifies all 5 auth
-operations under `/auth/*`. Their design works because they appear
-to have one auth mode; we have at least three (bootstrap / OIDC /
-future builtin), and the cost-benefit tilts the other way.
+**Compared to a fully unified design**: a contract that puts all 5
+auth operations under `/auth/*` works when there is a single auth
+mode; we have at least three (bootstrap / OIDC / future builtin),
+and the cost-benefit tilts the other way.
 
 A signpost comment lives at the top of the `paths:` block in
 `openapi.yaml` next to the `/api/v1/auth/*` endpoints — devs

--- a/docs/22-container-runtime-decoupling.md
+++ b/docs/22-container-runtime-decoupling.md
@@ -224,7 +224,7 @@ different routes per runtime:
   answers container names locally and forwards only external names to the
   gateway. Internal names never reach the gateway resolver — no exemption
   needed. (This is why the empty-allowlist default works on Docker but
-  broke on K8s when tropos first ran a full agent round-trip there.)
+  broke on K8s the first time a full agent round-trip ran there.)
 - K8s: `dnsPolicy: None` pins the agent's resolver straight at the gateway,
   so the gateway itself EXEMPTS internal names from the allowlist and
   forwards them to kube-dns. It reads both the internal-name set and the

--- a/tests/egress/test_mcp_glue.py
+++ b/tests/egress/test_mcp_glue.py
@@ -253,11 +253,11 @@ class TestSnapshotUrlPassthrough:
     @pytest.mark.asyncio
     async def test_fetch_all_passes_service_name_url_verbatim(self) -> None:
         reverse_proxy.register_mcp_server(
-            "tropos-mcp", "https://tropos-mcp:8509", {}, "user"
+            "example-mcp", "https://example-mcp:8509", {}, "user"
         )
         entries = await fetch_all_mcp_servers()
         assert len(entries) == 1
-        assert entries[0].url == "https://tropos-mcp:8509"
+        assert entries[0].url == "https://example-mcp:8509"
 
     @pytest.mark.asyncio
     async def test_fetch_all_does_not_rewrite_loopback(self) -> None:


### PR DESCRIPTION
Repo-wide hygiene sweep found three places referencing a named external project; this neutralizes them with zero behavior change:

- **docs/22** (DNS-exemption history note): the lesson stays, the actor is anonymized — "broke on K8s the first time a full agent round-trip ran there".
- **contracts/README** (auth-namespace design comparison): rewritten as "Compared to a fully unified design" — the argument (one auth mode vs our three) stands on its own without naming the comparison target.
- **tests/egress/test_mcp_glue.py**: fixture rename `tropos-mcp` → `example-mcp`.

Verification: repo-wide case-insensitive scan clean (all trees, including contracts/ and web/); `test_mcp_glue.py` 13/13 green; diff is 7+/7− across 3 files.

Note: the term remains in historical commit diffs from May–June (immutable git history; project codename only, no environment details). Current file content, PR metadata, and commit messages are all clean going forward — including this PR's own commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi

---
_Generated by [Claude Code](https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi)_