### PR TITLE
feat(chart): Cilium apiserver policy, webui loadBalancerClass, OIDC group-role mapping

### DIFF
--- a/deploy/charts/rolemesh/templates/cilium-networkpolicy.yaml
+++ b/deploy/charts/rolemesh/templates/cilium-networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.cilium.enabled }}
+{{- /*
+Cilium-specific companion to orchestrator-policy (networkpolicy.yaml).
+
+WHY: Cilium implements standard-NetworkPolicy ipBlock (toCIDR) as
+"traffic leaving the cluster" — it does NOT match pod -> Service
+ClusterIP / kube-apiserver traffic, which Cilium classifies as the
+special `kube-apiserver` entity. orchestrator-policy's
+`ipBlock 0.0.0.0/0 : 443/6443` rule therefore never admits the
+orchestrator's K8s API calls on Cilium: verify_infrastructure cannot
+reach the API server and the orchestrator fail-closes at startup
+(symptom: startup log stuck on API timeouts against the kubernetes
+Service ClusterIP).
+
+This policy adds ONLY that missing allowance, using Cilium's native
+entity concept. It is additive: Cilium merges allowances across
+CiliumNetworkPolicy and standard NetworkPolicy objects, so the four
+standard policies keep doing everything else and stay the contract
+verify_infrastructure checks. Non-Cilium clusters never render this
+(default off — the CRD does not exist there).
+*/ -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: orchestrator-apiserver-cilium
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rolemesh.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: orchestrator
+  egress:
+    - toEntities:
+        - kube-apiserver
+{{- end }}

--- a/deploy/charts/rolemesh/templates/webui.yaml
+++ b/deploy/charts/rolemesh/templates/webui.yaml
@@ -20,6 +20,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.webui.service.type }}
+  {{- with .Values.webui.service.loadBalancerClass }}
+  loadBalancerClass: {{ . | quote }}
+  {{- end }}
   selector:
     app.kubernetes.io/component: webui
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -121,6 +124,22 @@ spec:
               value: {{ .Values.auth.oidc.claimTenantId | quote }}
             - name: OIDC_CLAIM_ROLE
               value: {{ .Values.auth.oidc.claimRole | quote }}
+            {{- with .Values.auth.oidc.claimGroups }}
+            - name: OIDC_CLAIM_GROUPS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.auth.oidc.groupRoleMap }}
+            - name: OIDC_GROUP_ROLE_MAP
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.auth.oidc.scopeRoleMap }}
+            - name: OIDC_SCOPE_ROLE_MAP
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.auth.oidc.adapter }}
+            - name: OIDC_ADAPTER
+              value: {{ . | quote }}
+            {{- end }}
             - name: OIDC_COOKIE_SECURE
               value: {{ .Values.auth.oidc.cookieSecure | quote }}
             - name: OIDC_COOKIE_SAMESITE

--- a/deploy/charts/rolemesh/values-production.yaml
+++ b/deploy/charts/rolemesh/values-production.yaml
@@ -35,9 +35,11 @@ webui:
     repository: "registry.example.com/CHANGEME/rolemesh-webui"
     tag: "0.1.0"
   # Expose the UI through the platform load balancer (annotations are
-  # controller-specific; ask your platform team for the required set):
+  # controller-specific; ask your platform team for the required set;
+  # some controllers additionally require their loadBalancerClass):
   # service:
   #   type: LoadBalancer
+  #   loadBalancerClass: "lb.example.com"
   #   annotations:
   #     lb.example.com/hostname: "rolemesh.example.com"
 egressGateway:
@@ -67,15 +69,27 @@ secrets:
 
 # -- Auth: SSO via OIDC -----------------------------------------------------
 # Wires BOTH webui and orchestrator (see values.yaml `auth:` for every
-# field). redirectUri derives from webui.externalUrl when set.
+# field). redirectUri derives from webui.externalUrl when set. For IdPs
+# that deliver roles via a groups claim, add the group mapping fields —
+# JSON strings, set via this file (-f), never --set.
 # auth:
 #   mode: oidc
 #   oidc:
 #     discoveryUrl: "https://idp.example.com/realms/CHANGEME/.well-known/openid-configuration"
 #     clientId: "rolemesh-web"
 #     existingSecret: "CHANGEME-oidc-secret"   # key: OIDC_CLIENT_SECRET
+#     claimGroups: "groups"
+#     groupRoleMap: '{"idp-rolemesh-admins": "admin"}'
 # webui:
 #   externalUrl: "https://rolemesh.example.com"
+
+# -- NetworkPolicy: Cilium clusters ------------------------------------------
+# On Cilium, standard ipBlock rules do not cover pod -> kube-apiserver;
+# enable the companion CiliumNetworkPolicy or the orchestrator cannot
+# reach the K8s API and fail-closes at startup (see values.yaml).
+# networkPolicy:
+#   cilium:
+#     enabled: true
 
 # -- Database: external Postgres -----------------------------------------
 # Bundled Postgres is a dev/PoC convenience (single replica, chart-managed

--- a/deploy/charts/rolemesh/values.yaml
+++ b/deploy/charts/rolemesh/values.yaml
@@ -77,6 +77,12 @@ webui:
     # their parameters (set type: LoadBalancer alongside). Rendered
     # verbatim onto the webui Service; empty map renders nothing.
     annotations: {}
+    # spec.loadBalancerClass (K8s 1.24+): some platform LB controllers
+    # only reconcile Services carrying their class. Only meaningful with
+    # type: LoadBalancer; empty renders nothing. NOTE: the field is
+    # IMMUTABLE after Service creation — changing it later requires
+    # deleting and recreating the Service.
+    loadBalancerClass: ""
   # The UI's external URL once exposed (scheme://host[:port], no trailing
   # slash). Single source consumed by: WEBUI_BASE_URL (webui +
   # orchestrator env) and the auth.oidc.redirectUri default. Empty =
@@ -276,6 +282,15 @@ auth:
     # true, or the browser drops the refresh cookie.
     cookieSecure: true
     cookieSamesite: "lax"
+    # -- Group/scope-based role mapping (webui-only; IdPs that deliver
+    # roles via a groups claim rather than a flat role claim). All
+    # optional; empty renders nothing. The two *RoleMap values are JSON
+    # STRINGS — set them via a values FILE (-f), not --set, whose
+    # comma/brace escaping mangles JSON.
+    claimGroups: ""       # e.g. "groups"
+    groupRoleMap: ""      # e.g. '{"idp-admins": "admin", "idp-users": "member"}'
+    scopeRoleMap: ""      # e.g. '{"rolemesh.admin": "admin"}'
+    adapter: ""           # named claim-mapping adapter; empty = generic
 
 # -- Seed Job ----------------------------------------------------------------
 # Post-install/upgrade Job that runs schema creation + the initial admin
@@ -306,6 +321,15 @@ networkPolicy:
   # via another mechanism. Disabling removes agent isolation — never do this
   # in production.
   enabled: true
+  # Cilium CNI only: render a CiliumNetworkPolicy allowing the
+  # orchestrator to reach the kube-apiserver entity. Cilium implements
+  # standard-NetworkPolicy ipBlock as "external traffic only", so the
+  # orchestrator-policy 0.0.0.0/0:443/6443 rule does not cover pod ->
+  # K8s API on Cilium — the orchestrator then fail-closes at startup,
+  # its log stuck on API timeouts. Enable this on Cilium clusters; leave
+  # off elsewhere (the CRD does not exist on other CNIs).
+  cilium:
+    enabled: false
   # The cluster's DNS service IP+port for the gateway-policy/orchestrator
   # egress to kube-dns (the gateway forwards recursive queries upstream).
   kubeDns:

--- a/docs/23-rke2-production-deploy.md
+++ b/docs/23-rke2-production-deploy.md
@@ -21,7 +21,7 @@ refuses to run if they do not hold (fail-closed).
 
 | Requirement | Why | How on RKE2 |
 |---|---|---|
-| CNI enforces NetworkPolicy | agent isolation is policy-based | RKE2 ships Canal (Calico + Flannel) by default — it enforces. Cilium also fine. Do NOT run the `none` CNI. |
+| CNI enforces NetworkPolicy | agent isolation is policy-based | RKE2 ships Canal (Calico + Flannel) by default — it enforces. Cilium also fine, but set `networkPolicy.cilium.enabled=true` (Cilium's ipBlock semantics exclude pod→kube-apiserver; see values.yaml). Do NOT run the `none` CNI. |
 | PodSecurity `restricted` on the namespace | gateway/webui/orchestrator securityContexts target it | label the namespace (below) |
 | A free Service-CIDR address for the gateway | static ClusterIP == `EGRESS_GATEWAY_DNS_IP` | RKE2 default Service CIDR is `10.43.0.0/16`; pick a free address e.g. `10.43.0.53` |
 | Storage for the data PVC | shared agent/orchestrator data | RWX (Longhorn RWX / NFS) preferred; else `storage.mode=rwo-colocated` |


### PR DESCRIPTION
Three field-reported chart gaps, all default-off / render-nothing-by-default. **Default (values-kind) render verified byte-identical vs main** (helm 3.16).

## 1. Cilium: standard ipBlock does not cover pod → kube-apiserver (startup blocker)

Cilium implements standard-NetworkPolicy `ipBlock` as *external traffic only*, so `orchestrator-policy`'s `0.0.0.0/0 : 443/6443` rule never admits the orchestrator's K8s API calls there — `verify_infrastructure` cannot reach the API server and the orchestrator fail-closes (symptom: startup log stuck on API timeouts).

Fix: optional `CiliumNetworkPolicy` (`networkPolicy.cilium.enabled`, default **false**) allowing exactly one flow — orchestrator → Cilium's native `kube-apiserver` entity. Additive alongside the four standard policies, which remain the verify contract untouched. Non-Cilium clusters never render it (the CRD doesn't exist there). Docs/23 CNI row updated.

## 2. `webui.service.loadBalancerClass` (K8s 1.24+)

Some platform LB controllers only reconcile Services carrying their class; the chart exposed `type` + `annotations` but not this field. One values field + a `with` block; values comment flags that the field is **immutable after Service creation**.

## 3. OIDC group/scope → role mapping fields

IdPs that deliver roles via a groups claim need `OIDC_CLAIM_GROUPS` / `OIDC_GROUP_ROLE_MAP` (+ `OIDC_SCOPE_ROLE_MAP`, `OIDC_ADAPTER`), previously reachable only via the `extraEnv` backdoor. Now first-class as `auth.oidc.claimGroups/groupRoleMap/scopeRoleMap/adapter`.

Placement note: rendered in the **webui's oidc-only env section, NOT the shared `authEnv` helper** — these are consumed by the webui-side auth adapter only (verified: `src/webui/config.py`, `auth/oidc/adapter.py`); the orchestrator's OIDC needs stay discovery + client credentials. The `*RoleMap` values are JSON strings; comments direct operators to values files (`-f`), never `--set` (comma/brace escaping mangles JSON).

## Verification

- Default render byte-identical vs main; helm lint clean.
- CNP renders only when enabled, with `toEntities: [kube-apiserver]` scoped to the orchestrator endpointSelector.
- `loadBalancerClass` renders only when set; group envs land in the webui Deployment only; unset optionals render nothing.
- Cilium live acceptance (orchestrator reaches `Infrastructure verified` with the policy enabled) must run on a Cilium cluster — not possible in this sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi

---
_Generated by [Claude Code](https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi)_