### PR TITLE
fix(k8s): pin agent pods to the orchestrator's node in rwo-colocated mode

### DIFF
--- a/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
+++ b/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
@@ -54,17 +54,13 @@ spec:
       {{- end }}
       {{- if $rwo }}
       # rwo-colocated (docs/21 §7.2): the data PVC is ReadWriteOnce. The
-      # orchestrator mounts it directly, so the scheduler already pins this
-      # pod to the PVC's node — no extra affinity needed here. The agent
-      # pods the orchestrator spawns mount the SAME RWO PVC and are placed
-      # in this namespace; an RWO volume is only attachable on its current
-      # node, so they co-locate with the orchestrator automatically (a
-      # second node attempting to attach blocks with "Multi-Attach error").
-      # When that co-location must be SCHEDULED rather than merely enforced
-      # by the volume (e.g. to surface a clear pending reason instead of a
-      # Multi-Attach error), set agent.podAffinity in the orchestrator's
-      # agent-spawn config — that is runtime config, not a chart template,
-      # because this chart does not template agent pods.
+      # orchestrator mounts it directly, so the scheduler pins this pod to
+      # the PVC's node. Agent pods (spawned by the orchestrator, not
+      # templated here) mount the SAME RWO PVC — the runtime pins them to
+      # this pod's node via a nodeSelector built from the
+      # ROLEMESH_K8S_STORAGE_MODE + ROLEMESH_K8S_NODE_NAME env below;
+      # without that pin, an agent scheduled to another node hangs
+      # Pending forever on a Multi-Attach error.
       {{- end }}
       securityContext:
         runAsNonRoot: true
@@ -96,6 +92,16 @@ spec:
               value: {{ .Values.image.pullSecret | quote }}
             - name: ROLEMESH_K8S_RUNTIME_CLASS
               value: {{ .Values.orchestrator.runtimeClass | quote }}
+            # Storage mode + this pod's node: in rwo-colocated mode the
+            # runtime adds a nodeSelector pinning every spawned agent pod
+            # to this node — the only node the ReadWriteOnce data PVC can
+            # attach to (see the pod-template comment above).
+            - name: ROLEMESH_K8S_STORAGE_MODE
+              value: {{ .Values.storage.mode | quote }}
+            - name: ROLEMESH_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Single source of truth for the cluster DNS domain: the agent
             # pod search domains (here, via k8s_runtime), the gateway's
             # internal-name exemption suffix, and the connectivity-probe

--- a/src/rolemesh/container/k8s_runtime.py
+++ b/src/rolemesh/container/k8s_runtime.py
@@ -235,6 +235,8 @@ def spec_to_pod_manifest(
     image_pull_secret: str = "",
     image_pull_policy: str = "IfNotPresent",
     runtime_class: str = "",
+    storage_mode: str = "",
+    node_name: str = "",
 ) -> dict[str, Any]:
     """Map a ContainerSpec to a bare-Pod manifest (docs/21 §4.4).
 
@@ -364,6 +366,28 @@ def spec_to_pod_manifest(
 
     if image_pull_secret:
         pod_spec["imagePullSecrets"] = [{"name": image_pull_secret}]
+
+    # rwo-colocated (docs/21 §7.2): the data PVC is ReadWriteOnce, only
+    # attachable on one node — the orchestrator's own (it mounts the PVC
+    # directly). Without a scheduling constraint the scheduler places
+    # agent pods freely; any pod landing on another node hangs Pending
+    # forever on a Multi-Attach error ("starting container..." with no
+    # failure signal). Pin to the orchestrator's node by NAME (Downward
+    # API via ROLEMESH_K8S_NODE_NAME) rather than podAffinity on the
+    # orchestrator's labels: the node IS the constraint (it's where the
+    # volume lives), no label selector can be hijacked by an unrelated
+    # pod carrying the same labels, and a mismatch fails as a clear
+    # unschedulable event instead of a volume attach timeout.
+    if storage_mode == "rwo-colocated":
+        if node_name:
+            pod_spec["nodeSelector"] = {"kubernetes.io/hostname": node_name}
+        else:
+            logger.warning(
+                "storage_mode=rwo-colocated but no node name provided — "
+                "agent pods are unpinned and may hang on Multi-Attach; "
+                "check the ROLEMESH_K8S_NODE_NAME Downward API env",
+                pod=spec.name,
+            )
 
     return {
         "apiVersion": "v1",
@@ -686,7 +710,9 @@ class K8sRuntime:
             ROLEMESH_K8S_IMAGE_PULL_POLICY,
             ROLEMESH_K8S_IMAGE_PULL_SECRET,
             ROLEMESH_K8S_NAMESPACE,
+            ROLEMESH_K8S_NODE_NAME,
             ROLEMESH_K8S_RUNTIME_CLASS,
+            ROLEMESH_K8S_STORAGE_MODE,
         )
 
         manifest = spec_to_pod_manifest(
@@ -697,6 +723,8 @@ class K8sRuntime:
             image_pull_secret=ROLEMESH_K8S_IMAGE_PULL_SECRET,
             image_pull_policy=ROLEMESH_K8S_IMAGE_PULL_POLICY,
             runtime_class=ROLEMESH_K8S_RUNTIME_CLASS,
+            storage_mode=ROLEMESH_K8S_STORAGE_MODE,
+            node_name=ROLEMESH_K8S_NODE_NAME,
         )
 
         await self._delete_and_wait_gone(spec.name, ROLEMESH_K8S_NAMESPACE)

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -150,6 +150,15 @@ ROLEMESH_CONTAINER_RUNTIME: str = os.environ.get("ROLEMESH_CONTAINER_RUNTIME", "
 #   ROLEMESH_K8S_RUNTIME_CLASS    RuntimeClass used when a spec asks for the
 #                                 gVisor OCI runtime (spec.runtime="runsc");
 #                                 empty = the conventional name "gvisor"
+#   ROLEMESH_K8S_STORAGE_MODE     the chart's storage.mode ("rwx" |
+#                                 "rwo-colocated"). In rwo-colocated the
+#                                 data PVC is ReadWriteOnce and agent pods
+#                                 MUST land on the node it is attached to
+#                                 (this pod's own node) — otherwise they
+#                                 hang Pending on a Multi-Attach error.
+#   ROLEMESH_K8S_NODE_NAME        this pod's node (chart injects it via the
+#                                 Downward API, fieldRef spec.nodeName);
+#                                 the rwo-colocated nodeSelector target
 ROLEMESH_K8S_NAMESPACE: str = os.environ.get("ROLEMESH_K8S_NAMESPACE", "rolemesh")
 ROLEMESH_K8S_DATA_PVC: str = os.environ.get("ROLEMESH_K8S_DATA_PVC", "rolemesh-data")
 ROLEMESH_K8S_IMAGE_PULL_SECRET: str = os.environ.get("ROLEMESH_K8S_IMAGE_PULL_SECRET", "")
@@ -157,6 +166,8 @@ ROLEMESH_K8S_IMAGE_PULL_POLICY: str = os.environ.get(
     "ROLEMESH_K8S_IMAGE_PULL_POLICY", "IfNotPresent"
 )
 ROLEMESH_K8S_RUNTIME_CLASS: str = os.environ.get("ROLEMESH_K8S_RUNTIME_CLASS", "")
+ROLEMESH_K8S_STORAGE_MODE: str = os.environ.get("ROLEMESH_K8S_STORAGE_MODE", "")
+ROLEMESH_K8S_NODE_NAME: str = os.environ.get("ROLEMESH_K8S_NODE_NAME", "")
 
 # OCI runtime selection (R1). "runc" is the default; "runsc" enables gVisor
 # syscall-level sandboxing and requires runsc to be registered in

--- a/tests/container/test_k8s_runtime.py
+++ b/tests/container/test_k8s_runtime.py
@@ -1285,3 +1285,49 @@ async def test_run_without_ensure_available_raises() -> None:
     rt = K8sRuntime()
     with pytest.raises(RuntimeError, match="ensure_available"):
         await rt.run(ContainerSpec(name="a", image="img"))
+
+
+# ===========================================================================
+# rwo-colocated node pinning (docs/21 §7.2).
+# The data PVC is ReadWriteOnce in storage.mode=rwo-colocated: an agent pod
+# scheduled to any node but the orchestrator's hangs Pending forever on a
+# Multi-Attach error. The runtime therefore pins agent pods to the
+# orchestrator's own node (Downward-API-provided) via nodeSelector.
+# ===========================================================================
+
+
+def test_rwo_colocated_pins_agent_to_orchestrator_node() -> None:
+    manifest = _manifest(
+        ContainerSpec(name="a", image="img"),
+        storage_mode="rwo-colocated",
+        node_name="worker-1",
+    )
+    assert manifest["spec"]["nodeSelector"] == {"kubernetes.io/hostname": "worker-1"}
+
+
+def test_default_manifest_has_no_node_selector() -> None:
+    # Mutation caught: unconditionally emitting the selector would pin
+    # RWX-mode agents (and every existing deployment) to one node.
+    manifest = _manifest(ContainerSpec(name="a", image="img"))
+    assert "nodeSelector" not in manifest["spec"]
+
+
+def test_rwx_mode_has_no_node_selector() -> None:
+    manifest = _manifest(
+        ContainerSpec(name="a", image="img"),
+        storage_mode="rwx",
+        node_name="worker-1",
+    )
+    assert "nodeSelector" not in manifest["spec"]
+
+
+def test_rwo_colocated_without_node_name_stays_unpinned() -> None:
+    # Missing Downward API env must degrade to today's behavior (volume
+    # constraint only), never emit an empty/bogus selector that would make
+    # the pod unschedulable everywhere.
+    manifest = _manifest(
+        ContainerSpec(name="a", image="img"),
+        storage_mode="rwo-colocated",
+        node_name="",
+    )
+    assert "nodeSelector" not in manifest["spec"]


### PR DESCRIPTION
## Problem

In `storage.mode=rwo-colocated` the data PVC is ReadWriteOnce — attachable only on the orchestrator's node. Agent pods mount the same PVC but carried **no scheduling constraint**: on multi-node clusters the scheduler places them freely, and any pod landing on another node hangs **Pending forever on a Multi-Attach error** — user-visible as an agent start that never responds and never fails. The old chart comment deferred scheduled co-location to "the orchestrator's agent-spawn config", which did not exist.

## Fix

- Chart injects two envs into the orchestrator: `ROLEMESH_K8S_STORAGE_MODE` (from `.Values.storage.mode`) and `ROLEMESH_K8S_NODE_NAME` (Downward API, `fieldRef: spec.nodeName`).
- `spec_to_pod_manifest` adds `nodeSelector: kubernetes.io/hostname=<node>` to spawned agent pods when the mode is `rwo-colocated`.

**Why node name, not podAffinity on the orchestrator's labels**: the node is the actual constraint (it's where the volume attaches — the orchestrator mounts the PVC, so its node *is* the volume's node); no label selector can be matched by an unrelated pod that happens to carry the same labels; and a mismatch surfaces as a clear unschedulable scheduling event instead of a volume attach timeout.

Degradation: missing node name (Downward API absent) keeps today's volume-only enforcement and logs a loud warning. RWX mode, default mode, and the docker runtime are untouched.

Follow-up direction (out of scope, tracked): per-spawn ephemeral storage for agents would remove the co-location constraint entirely; this PR is the minimal correct fix for the existing mode.

## Verification

- Unit tests: `nodeSelector` present exactly when `mode=rwo-colocated` AND node name set; absent by default, in `rwx` mode, and when the node name is missing (4 new tests; `test_k8s_runtime.py` 57/57 green).
- Chart render diff vs main is exactly the two new envs (+ updated comment); helm lint clean; container suites 516 passed (pre-existing docker-daemon-dependent errors unchanged, same set as main).
- Live acceptance on a multi-node cluster: spawn an agent with the orchestrator pinned to one node and confirm the agent lands on the same node (`kubectl get pod -o wide`), where previously it had ~1/N chance of Multi-Attach Pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi

---
_Generated by [Claude Code](https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi)_