### PR TITLE
refactor(k8s): decision-typed agent node-pin contract

### DIFF
--- a/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
+++ b/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
@@ -57,10 +57,12 @@ spec:
       # orchestrator mounts it directly, so the scheduler pins this pod to
       # the PVC's node. Agent pods (spawned by the orchestrator, not
       # templated here) mount the SAME RWO PVC — the runtime pins them to
-      # this pod's node via a nodeSelector built from the
-      # ROLEMESH_K8S_STORAGE_MODE + ROLEMESH_K8S_NODE_NAME env below;
-      # without that pin, an agent scheduled to another node hangs
-      # Pending forever on a Multi-Attach error.
+      # this pod's node via a nodeSelector taken from the
+      # ROLEMESH_K8S_AGENT_PIN_NODE env below (rendered only in this
+      # mode — the mode decision lives HERE, at template time; the
+      # runtime just obeys "pin to this node"); without that pin, an
+      # agent scheduled to another node hangs Pending forever on a
+      # Multi-Attach error.
       {{- end }}
       securityContext:
         runAsNonRoot: true
@@ -92,16 +94,17 @@ spec:
               value: {{ .Values.image.pullSecret | quote }}
             - name: ROLEMESH_K8S_RUNTIME_CLASS
               value: {{ .Values.orchestrator.runtimeClass | quote }}
-            # Storage mode + this pod's node: in rwo-colocated mode the
-            # runtime adds a nodeSelector pinning every spawned agent pod
-            # to this node — the only node the ReadWriteOnce data PVC can
-            # attach to (see the pod-template comment above).
-            - name: ROLEMESH_K8S_STORAGE_MODE
-              value: {{ .Values.storage.mode | quote }}
-            - name: ROLEMESH_K8S_NODE_NAME
+            {{- if $rwo }}
+            # rwo-colocated only: pin every spawned agent pod to this
+            # pod's node — the only node the ReadWriteOnce data PVC can
+            # attach to (see the pod-template comment above). The env is
+            # a decision, not a description: the runtime pins whenever
+            # it is non-empty and knows nothing about storage modes.
+            - name: ROLEMESH_K8S_AGENT_PIN_NODE
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- end }}
             # Single source of truth for the cluster DNS domain: the agent
             # pod search domains (here, via k8s_runtime), the gateway's
             # internal-name exemption suffix, and the connectivity-probe

--- a/src/rolemesh/container/k8s_runtime.py
+++ b/src/rolemesh/container/k8s_runtime.py
@@ -235,8 +235,7 @@ def spec_to_pod_manifest(
     image_pull_secret: str = "",
     image_pull_policy: str = "IfNotPresent",
     runtime_class: str = "",
-    storage_mode: str = "",
-    node_name: str = "",
+    pin_node: str = "",
 ) -> dict[str, Any]:
     """Map a ContainerSpec to a bare-Pod manifest (docs/21 §4.4).
 
@@ -367,27 +366,20 @@ def spec_to_pod_manifest(
     if image_pull_secret:
         pod_spec["imagePullSecrets"] = [{"name": image_pull_secret}]
 
-    # rwo-colocated (docs/21 §7.2): the data PVC is ReadWriteOnce, only
-    # attachable on one node — the orchestrator's own (it mounts the PVC
-    # directly). Without a scheduling constraint the scheduler places
-    # agent pods freely; any pod landing on another node hangs Pending
-    # forever on a Multi-Attach error ("starting container..." with no
-    # failure signal). Pin to the orchestrator's node by NAME (Downward
-    # API via ROLEMESH_K8S_NODE_NAME) rather than podAffinity on the
-    # orchestrator's labels: the node IS the constraint (it's where the
-    # volume lives), no label selector can be hijacked by an unrelated
-    # pod carrying the same labels, and a mismatch fails as a clear
-    # unschedulable event instead of a volume attach timeout.
-    if storage_mode == "rwo-colocated":
-        if node_name:
-            pod_spec["nodeSelector"] = {"kubernetes.io/hostname": node_name}
-        else:
-            logger.warning(
-                "storage_mode=rwo-colocated but no node name provided — "
-                "agent pods are unpinned and may hang on Multi-Attach; "
-                "check the ROLEMESH_K8S_NODE_NAME Downward API env",
-                pod=spec.name,
-            )
+    # Node pinning (docs/21 §7.2). ``pin_node`` is a DECISION handed down
+    # by the deployment layer (ROLEMESH_K8S_AGENT_PIN_NODE — the chart
+    # renders it only in rwo-colocated storage mode, where the
+    # ReadWriteOnce data PVC attaches on exactly one node and an agent
+    # scheduled elsewhere hangs Pending forever on a Multi-Attach error).
+    # This function deliberately knows nothing about storage modes; it
+    # pins whenever told to. nodeSelector by node NAME rather than
+    # podAffinity on the orchestrator's labels: the node IS the
+    # constraint (it's where the volume lives), no label selector can be
+    # matched by an unrelated pod carrying the same labels, and a
+    # mismatch fails as a clear unschedulable event instead of a volume
+    # attach timeout.
+    if pin_node:
+        pod_spec["nodeSelector"] = {"kubernetes.io/hostname": pin_node}
 
     return {
         "apiVersion": "v1",
@@ -706,13 +698,12 @@ class K8sRuntime:
         core = self._ensure_core()
         from rolemesh.core.config import (
             DATA_DIR,
+            ROLEMESH_K8S_AGENT_PIN_NODE,
             ROLEMESH_K8S_DATA_PVC,
             ROLEMESH_K8S_IMAGE_PULL_POLICY,
             ROLEMESH_K8S_IMAGE_PULL_SECRET,
             ROLEMESH_K8S_NAMESPACE,
-            ROLEMESH_K8S_NODE_NAME,
             ROLEMESH_K8S_RUNTIME_CLASS,
-            ROLEMESH_K8S_STORAGE_MODE,
         )
 
         manifest = spec_to_pod_manifest(
@@ -723,8 +714,7 @@ class K8sRuntime:
             image_pull_secret=ROLEMESH_K8S_IMAGE_PULL_SECRET,
             image_pull_policy=ROLEMESH_K8S_IMAGE_PULL_POLICY,
             runtime_class=ROLEMESH_K8S_RUNTIME_CLASS,
-            storage_mode=ROLEMESH_K8S_STORAGE_MODE,
-            node_name=ROLEMESH_K8S_NODE_NAME,
+            pin_node=ROLEMESH_K8S_AGENT_PIN_NODE,
         )
 
         await self._delete_and_wait_gone(spec.name, ROLEMESH_K8S_NAMESPACE)

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -150,15 +150,16 @@ ROLEMESH_CONTAINER_RUNTIME: str = os.environ.get("ROLEMESH_CONTAINER_RUNTIME", "
 #   ROLEMESH_K8S_RUNTIME_CLASS    RuntimeClass used when a spec asks for the
 #                                 gVisor OCI runtime (spec.runtime="runsc");
 #                                 empty = the conventional name "gvisor"
-#   ROLEMESH_K8S_STORAGE_MODE     the chart's storage.mode ("rwx" |
-#                                 "rwo-colocated"). In rwo-colocated the
-#                                 data PVC is ReadWriteOnce and agent pods
-#                                 MUST land on the node it is attached to
-#                                 (this pod's own node) — otherwise they
-#                                 hang Pending on a Multi-Attach error.
-#   ROLEMESH_K8S_NODE_NAME        this pod's node (chart injects it via the
-#                                 Downward API, fieldRef spec.nodeName);
-#                                 the rwo-colocated nodeSelector target
+#   ROLEMESH_K8S_AGENT_PIN_NODE   non-empty = pin every spawned agent pod
+#                                 to this node (nodeSelector). The chart
+#                                 renders it ONLY in rwo-colocated storage
+#                                 mode (Downward API, fieldRef
+#                                 spec.nodeName): the ReadWriteOnce data
+#                                 PVC attaches on one node, and an agent
+#                                 scheduled elsewhere hangs Pending on a
+#                                 Multi-Attach error. A decision env, not
+#                                 a description — the runtime never
+#                                 learns the chart's storage vocabulary.
 ROLEMESH_K8S_NAMESPACE: str = os.environ.get("ROLEMESH_K8S_NAMESPACE", "rolemesh")
 ROLEMESH_K8S_DATA_PVC: str = os.environ.get("ROLEMESH_K8S_DATA_PVC", "rolemesh-data")
 ROLEMESH_K8S_IMAGE_PULL_SECRET: str = os.environ.get("ROLEMESH_K8S_IMAGE_PULL_SECRET", "")
@@ -166,8 +167,7 @@ ROLEMESH_K8S_IMAGE_PULL_POLICY: str = os.environ.get(
     "ROLEMESH_K8S_IMAGE_PULL_POLICY", "IfNotPresent"
 )
 ROLEMESH_K8S_RUNTIME_CLASS: str = os.environ.get("ROLEMESH_K8S_RUNTIME_CLASS", "")
-ROLEMESH_K8S_STORAGE_MODE: str = os.environ.get("ROLEMESH_K8S_STORAGE_MODE", "")
-ROLEMESH_K8S_NODE_NAME: str = os.environ.get("ROLEMESH_K8S_NODE_NAME", "")
+ROLEMESH_K8S_AGENT_PIN_NODE: str = os.environ.get("ROLEMESH_K8S_AGENT_PIN_NODE", "")
 
 # OCI runtime selection (R1). "runc" is the default; "runsc" enables gVisor
 # syscall-level sandboxing and requires runsc to be registered in

--- a/tests/container/test_k8s_runtime.py
+++ b/tests/container/test_k8s_runtime.py
@@ -1288,46 +1288,26 @@ async def test_run_without_ensure_available_raises() -> None:
 
 
 # ===========================================================================
-# rwo-colocated node pinning (docs/21 §7.2).
-# The data PVC is ReadWriteOnce in storage.mode=rwo-colocated: an agent pod
-# scheduled to any node but the orchestrator's hangs Pending forever on a
-# Multi-Attach error. The runtime therefore pins agent pods to the
-# orchestrator's own node (Downward-API-provided) via nodeSelector.
+# Node pinning (docs/21 §7.2). ``pin_node`` is a DECISION handed down by
+# the deployment layer: the chart renders ROLEMESH_K8S_AGENT_PIN_NODE only
+# in rwo-colocated storage mode, where the ReadWriteOnce data PVC attaches
+# on exactly one node and an agent scheduled elsewhere hangs Pending
+# forever on a Multi-Attach error. The manifest builder knows nothing
+# about storage modes — it pins iff told to.
 # ===========================================================================
 
 
-def test_rwo_colocated_pins_agent_to_orchestrator_node() -> None:
-    manifest = _manifest(
-        ContainerSpec(name="a", image="img"),
-        storage_mode="rwo-colocated",
-        node_name="worker-1",
-    )
+def test_pin_node_sets_node_selector() -> None:
+    manifest = _manifest(ContainerSpec(name="a", image="img"), pin_node="worker-1")
     assert manifest["spec"]["nodeSelector"] == {"kubernetes.io/hostname": "worker-1"}
 
 
-def test_default_manifest_has_no_node_selector() -> None:
+def test_no_pin_node_means_no_node_selector() -> None:
     # Mutation caught: unconditionally emitting the selector would pin
-    # RWX-mode agents (and every existing deployment) to one node.
-    manifest = _manifest(ContainerSpec(name="a", image="img"))
-    assert "nodeSelector" not in manifest["spec"]
-
-
-def test_rwx_mode_has_no_node_selector() -> None:
-    manifest = _manifest(
-        ContainerSpec(name="a", image="img"),
-        storage_mode="rwx",
-        node_name="worker-1",
+    # every deployment's agents to one node; an empty-string selector
+    # would make the pod unschedulable everywhere.
+    assert "nodeSelector" not in _manifest(ContainerSpec(name="a", image="img"))["spec"]
+    assert (
+        "nodeSelector"
+        not in _manifest(ContainerSpec(name="a", image="img"), pin_node="")["spec"]
     )
-    assert "nodeSelector" not in manifest["spec"]
-
-
-def test_rwo_colocated_without_node_name_stays_unpinned() -> None:
-    # Missing Downward API env must degrade to today's behavior (volume
-    # constraint only), never emit an empty/bogus selector that would make
-    # the pod unschedulable everywhere.
-    manifest = _manifest(
-        ContainerSpec(name="a", image="img"),
-        storage_mode="rwo-colocated",
-        node_name="",
-    )
-    assert "nodeSelector" not in manifest["spec"]


### PR DESCRIPTION
Forward-fix refining the contract shape of #121 (behavior unchanged). Doing it now, before anything depends on the env names #121 introduced — this is the cheapest moment for a contract change.

## What was wrong with the #121 contract

It passed the **reason** and let Python re-derive the decision:

- `ROLEMESH_K8S_STORAGE_MODE` leaked the chart's values vocabulary (`"rwo-colocated"`) across the process boundary — Python string-matched a Helm enum, so renaming/extending storage modes in the chart would require a Python change.
- Two envs made an invalid state representable (mode set, node name missing), which needed a warning branch to paper over.

## The fix: pass the decision

One env, `ROLEMESH_K8S_AGENT_PIN_NODE`. The chart makes the mode decision **at template time** (the env is rendered only under `storage.mode: rwo-colocated`, `valueFrom: spec.nodeName`); the runtime pins to the named node whenever the env is non-empty and knows nothing about storage modes. The warning branch is deleted because the inconsistent state is no longer representable.

```
before:  chart passes mode+node ──> Python: if mode == "rwo-colocated" and node: pin
after:   chart: {{ if $rwo }} pin-node env {{ end }} ──> Python: if pin_node: pin
```

Net **−27 lines** across chart, config, runtime, and tests.

## Verification

- rwo-colocated render carries the pin env; rwx render carries none of the three names; helm lint clean.
- No leftover references to the removed envs anywhere.
- `test_k8s_runtime.py` 55/55 (pinning tests rewritten to the two-state decision semantics); container suites 514 passed (pre-existing docker-daemon-dependent errors unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi

---
_Generated by [Claude Code](https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi)_