### PR TITLE
feat(webui): enforce per-user conversation ownership

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -102,6 +102,11 @@ paths:
         bound to one `conversation_id`; the handshake compares it
         against the path so it cannot be reused across conversations
         (design §4 / 01a Open Question 1).
+
+        Ownership is enforced at mint time: the conversation must
+        belong to the caller (or the caller holds `coworker.manage`).
+        A conversation that exists but is another member's returns the
+        same 404 as a non-existent one.
       security: [ { bearerAuth: [] } ]
       requestBody:
         required: true
@@ -399,6 +404,13 @@ paths:
     get:
       tags: [Conversations]
       operationId: listCoworkerConversations
+      summary: List the caller's own conversations with a coworker
+      description: |
+        Chat privacy is per-user: the page contains only conversations
+        the caller owns (`user_id` = caller), oldest first. Two members
+        chatting with the same coworker never see each other's history;
+        this applies to admins' lists too. Delegation child
+        conversations are excluded.
       security: [ { bearerAuth: [] } ]
       parameters:
         - { $ref: '#/components/parameters/LimitParam' }
@@ -441,6 +453,12 @@ paths:
     get:
       tags: [Conversations]
       operationId: getConversation
+      description: |
+        Ownership-scoped: 404 unless the conversation belongs to the
+        caller or the caller holds `coworker.manage`. Another member's
+        conversation is indistinguishable from a non-existent one. The
+        same rule guards the messages / approval-requests sub-resources,
+        DELETE, and WS-ticket minting.
       security: [ { bearerAuth: [] } ]
       responses:
         '200':

--- a/src/rolemesh/db/chat.py
+++ b/src/rolemesh/db/chat.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     import asyncpg
 
 __all__ = [
-    "count_conversations_for_coworker",
+    "count_conversations_for_coworker_and_user",
     "create_channel_binding",
     "create_conversation",
     "delete_channel_binding",
@@ -38,6 +38,7 @@ __all__ = [
     "get_conversation_by_binding_and_chat",
     "get_conversation_for_notification",
     "get_conversations_for_coworker",
+    "get_conversations_for_coworker_and_user",
     "get_messages_since",
     "get_new_messages_for_conversations",
     "get_session",
@@ -437,15 +438,58 @@ async def get_conversations_for_coworker(
     return [_record_to_conversation(row) for row in rows]
 
 
-async def count_conversations_for_coworker(
-    coworker_id: str, *, tenant_id: str,
+async def get_conversations_for_coworker_and_user(
+    coworker_id: str, user_id: str, *, tenant_id: str,
+    limit: int | None = None, offset: int = 0,
+) -> list[Conversation]:
+    """One user's conversations under one coworker (oldest first, paged).
+
+    The per-user variant of :func:`get_conversations_for_coworker`,
+    backing ``GET /api/v1/coworkers/{id}/conversations``: chat privacy
+    is per-user, so the web list shows the caller ONLY their own
+    conversations with the coworker. The unfiltered variant above
+    remains for orchestrator-internal state loading, which must see
+    every conversation regardless of owner.
+
+    Delegation children (``parent_conversation_id IS NOT NULL``) are
+    excluded unconditionally — this feeds a user-facing list, never
+    ``_state``. Ownerless rows (``user_id IS NULL``) can never match.
+    """
+    sql = (
+        "SELECT * FROM conversations "
+        "WHERE coworker_id = $1::uuid AND user_id = $2::uuid "
+        "AND tenant_id = $3::uuid "
+        "AND parent_conversation_id IS NULL "
+        "ORDER BY created_at"
+    )
+    params: list[object] = [coworker_id, user_id, tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
+    async with tenant_conn(tenant_id) as conn:
+        rows = await conn.fetch(sql, *params)
+    return [_record_to_conversation(row) for row in rows]
+
+
+async def count_conversations_for_coworker_and_user(
+    coworker_id: str, user_id: str, *, tenant_id: str,
 ) -> int:
-    """Total conversation count for a coworker (for the pagination envelope)."""
+    """Pagination-envelope total for the per-user coworker list.
+
+    Must apply the exact predicate of
+    :func:`get_conversations_for_coworker_and_user` — the old
+    coworker-wide count skipped the child-exclusion its list applied,
+    so ``total`` overcounted by the delegation children and clients
+    paged into empty pages.
+    """
     async with tenant_conn(tenant_id) as conn:
         row = await conn.fetchrow(
             "SELECT COUNT(*) AS n FROM conversations "
-            "WHERE coworker_id = $1::uuid AND tenant_id = $2::uuid",
+            "WHERE coworker_id = $1::uuid AND user_id = $2::uuid "
+            "AND tenant_id = $3::uuid "
+            "AND parent_conversation_id IS NULL",
             coworker_id,
+            user_id,
             tenant_id,
         )
     return int(row["n"]) if row else 0

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -687,7 +687,7 @@ async def _auto_create_telegram_1on1_conversation(
 async def _auto_create_web_conversation(
     binding_id: str, chat_id: str
 ) -> tuple[CoworkerState, ConversationState] | None:
-    """Auto-create a conversation for web channel (each browser tab gets a new chat_id)."""
+    """Resolve a web inbound's conversation, hot-loading caches as needed."""
     # First: check coworkers whose ``channel_bindings`` cache already
     # contains the binding (the startup-loaded path).
     for cw in _state.coworkers.values():
@@ -725,31 +725,30 @@ async def _auto_create_web_conversation(
 
 async def _land_web_conversation(
     cw: CoworkerState, binding_id: str, chat_id: str
-) -> tuple[CoworkerState, ConversationState]:
-    """Get-or-create + cache the conversation row for a web binding."""
-    # ws.py may have already created the conversation before the
-    # NATS message reaches the orchestrator. Check DB first to
-    # avoid a UniqueViolationError on (binding_id, chat_id).
+) -> tuple[CoworkerState, ConversationState] | None:
+    """Hot-load the conversation row for a web binding into state.
+
+    Lookup-only, never create: web conversations are minted exclusively
+    by ``POST /api/v1/coworkers/{id}/conversations``, which stamps
+    ``user_id`` from the authenticated caller. Creating here would land
+    an ownerless (``user_id IS NULL``) row that the per-user chat
+    privacy rules hide from every member, so an inbound whose
+    (binding, chat_id) has no row — deleted mid-flight, or a stale
+    client-side chat_id — is dropped instead.
+    """
     conv = await get_conversation_by_binding_and_chat(
         binding_id, chat_id, tenant_id=cw.config.tenant_id
     )
     if conv is None:
-        conv = await create_conversation(
-            tenant_id=cw.config.tenant_id,
-            coworker_id=cw.config.id,
-            channel_binding_id=binding_id,
-            channel_chat_id=chat_id,
-            name=f"Web Chat {chat_id[:8]}",
-            user_id=None,
+        logger.warning(
+            "web inbound for unknown conversation; dropping",
+            coworker=cw.config.name,
+            binding_id=binding_id,
+            chat_id=chat_id,
         )
+        return None
     conv_state = ConversationState(conversation=conv)
     cw.conversations[conv.id] = conv_state
-    logger.info(
-        "Auto-created web conversation",
-        coworker=cw.config.name,
-        chat_id=chat_id,
-        conversation_id=conv.id,
-    )
     return cw, conv_state
 
 

--- a/src/webui/dependencies.py
+++ b/src/webui/dependencies.py
@@ -150,3 +150,35 @@ def user_can_see_resource(
     if created_by is not None and created_by == user.user_id:
         return True
     return user_can(user.role, manage_action)  # type: ignore[arg-type]
+
+
+def user_can_access_conversation(
+    *, conversation: object, user: AuthenticatedUser
+) -> bool:
+    """May this user read/delete/attach-to this conversation?
+
+    Chat privacy is per-user: a conversation belongs to the user who
+    opened it (``conversations.user_id``), not to everyone who can see
+    the coworker it is bound to. Accessible when EITHER holds:
+
+    * the caller owns it (``user_id == user.user_id``), OR
+    * the caller holds ``coworker.manage`` — owner / admin /
+      platform_admin reach every conversation in the tenant (cleanup,
+      moderation).
+
+    Same three-valued logic as ``require_manage_or_owner``: a row with
+    ``user_id IS NULL`` (Telegram sender not yet linked, legacy rows)
+    is nobody's — NULL never equals the caller, so it falls through to
+    requiring the manage capability rather than becoming tenant-public.
+
+    Every conversation fetch path — REST detail / messages / approvals
+    / delete AND the WS-ticket mint — routes through this predicate;
+    the list paths mirror the ownership half in SQL
+    (``rolemesh.db.chat.get_conversations_for_coworker_and_user``).
+    Callers collapse a False to the same 404 as "does not exist" so
+    ownership never becomes an existence oracle.
+    """
+    conv_user_id = getattr(conversation, "user_id", None)
+    if conv_user_id is not None and conv_user_id == user.user_id:
+        return True
+    return user_can(user.role, "coworker.manage")  # type: ignore[arg-type]

--- a/src/webui/v1/auth.py
+++ b/src/webui/v1/auth.py
@@ -28,7 +28,7 @@ from fastapi import APIRouter, Depends, Response
 from rolemesh.auth.permissions import role_capabilities
 from rolemesh.auth.ws_ticket import WsTicketError, issue_ws_ticket
 from rolemesh.db import get_conversation
-from webui.dependencies import get_current_user
+from webui.dependencies import get_current_user, user_can_access_conversation
 from webui.schemas_v1 import (
     AuthConfig,
     Me,
@@ -101,12 +101,21 @@ async def post_ws_ticket(
     ``get_conversation`` returns ``None`` when the tenant_id
     doesn't match — we collapse that to 404 NOT_FOUND rather than
     403 so the existence isn't leaked.
+
+    Within the tenant the per-user ownership rule applies with the
+    same weight: the WS handshake trusts this ticket without
+    re-checking, so minting is where "may this user attach to this
+    conversation" is decided. Without it a member could stream — and
+    send into — another member's conversation that every REST path
+    correctly 404s. Not-owned collapses to the same 404.
     """
     try:
         conv = await get_conversation(body.conversation_id, tenant_id=user.tenant_id)
     except asyncpg.DataError:
         conv = None
-    if conv is None:
+    if conv is None or not user_can_access_conversation(
+        conversation=conv, user=user
+    ):
         raise_error_response(
             "NOT_FOUND",
             "Conversation not found.",

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -24,17 +24,21 @@ import asyncpg
 from fastapi import APIRouter, Depends, Query, Response
 
 from rolemesh.db import (
-    count_conversations_for_coworker,
+    count_conversations_for_coworker_and_user,
     create_channel_binding,
     create_conversation,
     delete_conversation,
     get_channel_binding_for_coworker,
     get_conversation,
-    get_conversations_for_coworker,
+    get_conversations_for_coworker_and_user,
     list_requests_for_conversation,
     tenant_conn,
 )
-from webui.dependencies import get_current_user, require_action
+from webui.dependencies import (
+    get_current_user,
+    require_action,
+    user_can_access_conversation,
+)
 from webui.schemas_v1 import (
     ApprovalRequest,
     Conversation,
@@ -94,13 +98,26 @@ async def _ensure_web_binding(coworker_id: str, tenant_id: str) -> str:
 
 
 async def _get_conversation_or_404(
-    conversation_id: str, tenant_id: str
+    conversation_id: str,
+    tenant_id: str,
+    *,
+    user: AuthenticatedUser,
 ) -> object:
+    """Fetch one conversation; 404 on miss, wrong tenant, or not-owned.
+
+    Catches ``DataError`` (non-UUID id) so bad syntax and a legitimate
+    miss present the same 404. On top of tenant scoping the per-user
+    ownership rule (``user_can_access_conversation``) is enforced:
+    another member's conversation collapses to the SAME 404 as "does
+    not exist" so ownership never leaks existence.
+    """
     try:
         conv = await get_conversation(conversation_id, tenant_id=tenant_id)
     except asyncpg.DataError:
         conv = None
-    if conv is None:
+    if conv is None or not user_can_access_conversation(
+        conversation=conv, user=user
+    ):
         raise_error_response(
             "NOT_FOUND",
             "Conversation not found.",
@@ -125,15 +142,24 @@ async def list_coworker_conversations(
     offset: OffsetParam = 0,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> ConversationPage:
-    """List conversations for a coworker, ordered by ``created_at`` (paged)."""
+    """List the CALLER'S conversations with a coworker (oldest first, paged).
+
+    Chat privacy is per-user: the list is filtered to conversations the
+    caller owns (``conversations.user_id``), so two members chatting
+    with the same coworker never see each other's history. This applies
+    to every role — an admin's list is also just their own; moderation
+    goes through the id-addressed endpoints, which grant
+    ``coworker.manage`` holders access.
+    """
     # USE/SEE enforcement: a member may not enumerate conversations of a
     # coworker they cannot see (another member's private one) — 404.
     await _get_coworker_or_404(coworker_id, user.tenant_id, user=user)
-    convs = await get_conversations_for_coworker(
-        coworker_id, tenant_id=user.tenant_id, limit=limit, offset=offset,
+    convs = await get_conversations_for_coworker_and_user(
+        coworker_id, user.user_id, tenant_id=user.tenant_id,
+        limit=limit, offset=offset,
     )
-    total = await count_conversations_for_coworker(
-        coworker_id, tenant_id=user.tenant_id,
+    total = await count_conversations_for_coworker_and_user(
+        coworker_id, user.user_id, tenant_id=user.tenant_id,
     )
     return ConversationPage(
         items=[_conversation_to_response(c) for c in convs],
@@ -191,7 +217,9 @@ async def get_conversation_endpoint(
     conversation_id: str,
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> Conversation:
-    conv = await _get_conversation_or_404(conversation_id, user.tenant_id)
+    conv = await _get_conversation_or_404(
+        conversation_id, user.tenant_id, user=user
+    )
     return _conversation_to_response(conv)
 
 
@@ -208,7 +236,7 @@ async def delete_conversation_endpoint(
     of the same id surfaces as 404 rather than 204, which matches
     the SPA's expectation when retrying.
     """
-    await _get_conversation_or_404(conversation_id, user.tenant_id)
+    await _get_conversation_or_404(conversation_id, user.tenant_id, user=user)
     await delete_conversation(conversation_id, tenant_id=user.tenant_id)
     return Response(status_code=204)
 
@@ -257,7 +285,7 @@ async def list_conversation_messages(
     intentionally omitted — the WS event stream surfaces live usage;
     persisted history only needs role / content / timestamp for re-render.
     """
-    await _get_conversation_or_404(conversation_id, user.tenant_id)
+    await _get_conversation_or_404(conversation_id, user.tenant_id, user=user)
 
     where = "conversation_id = $1::uuid AND tenant_id = $2::uuid"
     params: list[object] = [conversation_id, user.tenant_id]
@@ -341,7 +369,7 @@ async def list_conversation_approval_requests(
     chat re-renders resolved ✅/❌ cards inline on reload, not just in-flight
     ones. Tenant-scoped: a conversation outside the caller's tenant is 404.
     """
-    await _get_conversation_or_404(conversation_id, user.tenant_id)
+    await _get_conversation_or_404(conversation_id, user.tenant_id, user=user)
     rows = await list_requests_for_conversation(
         conversation_id, tenant_id=user.tenant_id
     )

--- a/tests/webui/test_v1_conversation_ownership.py
+++ b/tests/webui/test_v1_conversation_ownership.py
@@ -1,0 +1,301 @@
+"""Per-user conversation ownership on the ``/api/v1`` surface.
+
+Chat privacy is per-user: a conversation belongs to the member who
+opened it (``conversations.user_id``), and every entrance must agree —
+the per-coworker LIST filter, the id-addressed detail / messages /
+approval-requests / DELETE handlers, and the WS-ticket mint. These
+tests are deliberately adversarial in the same spirit as
+``test_v1_visibility``: the valuable cases are the negative ones.
+
+Bug-bait focus:
+
+* One entrance forgotten — the boundary only exists if ALL entrances
+  enforce it. The WS-ticket mint is the classic miss: every REST path
+  404s but the ticket still signs, and the WS stream (which trusts the
+  ticket payload) hands the foreign conversation over live. Each
+  entrance gets its own assertion so a single regression names itself.
+* 404 not 403 — "exists but not yours" must be indistinguishable from
+  "does not exist" (no existence oracle).
+* Admin escape — ``coworker.manage`` holders reach members' rows by id
+  (moderation/cleanup) but their LIST is still just their own.
+* total/items agreement — the count must apply the same owner +
+  child-exclusion predicate as the page rows.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db import (
+    create_conversation,
+    create_coworker,
+    create_tenant,
+    create_user,
+)
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import get_current_user
+from webui.v1.errors import install_error_handler
+
+# The deny path under test fires before signing, but the allow path
+# (minting your OWN ticket) needs a secret to sign with.
+os.environ.setdefault(
+    "WS_TICKET_SECRET", "v1-ws-ticket-secret-only-for-tests"
+)
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+def _authed(tenant_id: str, user_id: str, role: str = "member") -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id, tenant_id=tenant_id, role=role,  # type: ignore[arg-type]
+        email="x@x.com", name="X",
+    )
+
+
+async def _make_tenant_with_shared_coworker() -> tuple[str, str]:
+    """Tenant + a SHARED coworker every member may use.
+
+    Shared visibility is load-bearing: with the default (private,
+    unattributed) coworker the ``_get_coworker_or_404`` gate would 404
+    members before the ownership rule under test is ever reached.
+    """
+    t = await create_tenant(
+        name="T-own", slug=f"own-{uuid.uuid4().hex[:8]}",
+    )
+    cw = await create_coworker(
+        tenant_id=t.id,
+        name=f"Coworker-{uuid.uuid4().hex[:6]}",
+        folder=f"f-{uuid.uuid4().hex[:8]}",
+        agent_backend="claude",
+        visibility="shared",
+    )
+    return t.id, cw.id
+
+
+async def _make_member(tenant_id: str, role: str = "member") -> str:
+    u = await create_user(
+        tenant_id=tenant_id,
+        name=f"U-{uuid.uuid4().hex[:6]}",
+        email=f"u-{uuid.uuid4().hex[:6]}@x.com",
+        role=role,
+    )
+    return u.id
+
+
+async def _post_conversation(
+    tenant_id: str, user_id: str, coworker_id: str, *, role: str = "member",
+    name: str = "chat",
+) -> dict:
+    app = _build_app(_authed(tenant_id, user_id, role))
+    async with _client(app) as c:
+        resp = await c.post(
+            f"/api/v1/coworkers/{coworker_id}/conversations",
+            json={"name": name},
+        )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# LIST — per-user filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_shows_only_callers_own_conversations() -> None:
+    """Two members × one shared coworker: each list contains only its owner's rows."""
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    a = await _make_member(tid)
+    b = await _make_member(tid)
+    conv_a = await _post_conversation(tid, a, cw_id, name="A's")
+    conv_b = await _post_conversation(tid, b, cw_id, name="B's")
+
+    app_a = _build_app(_authed(tid, a))
+    async with _client(app_a) as c:
+        page = (await c.get(f"/api/v1/coworkers/{cw_id}/conversations")).json()
+    assert [x["id"] for x in page["items"]] == [conv_a["id"]]
+    assert page["total"] == 1, "total must apply the same owner filter as items"
+
+    app_b = _build_app(_authed(tid, b))
+    async with _client(app_b) as c:
+        page = (await c.get(f"/api/v1/coworkers/{cw_id}/conversations")).json()
+    assert [x["id"] for x in page["items"]] == [conv_b["id"]]
+    assert page["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_admin_list_is_also_own_only() -> None:
+    """``coworker.manage`` reaches rows BY ID, but the list stays personal."""
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    member = await _make_member(tid)
+    admin = await _make_member(tid, role="admin")
+    await _post_conversation(tid, member, cw_id, name="member's")
+
+    app = _build_app(_authed(tid, admin, role="admin"))
+    async with _client(app) as c:
+        page = (await c.get(f"/api/v1/coworkers/{cw_id}/conversations")).json()
+    assert page["items"] == [] and page["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_total_excludes_delegation_children() -> None:
+    """A delegation child under the same coworker must not inflate total.
+
+    The child even carries the SAME owner, proving the exclusion rides
+    on ``parent_conversation_id IS NULL`` and not on ownership.
+    """
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    a = await _make_member(tid)
+    parent = await _post_conversation(tid, a, cw_id)
+    await create_conversation(
+        tenant_id=tid,
+        coworker_id=cw_id,
+        channel_binding_id=parent["channel_binding_id"],
+        channel_chat_id=str(uuid.uuid4()),
+        name="delegation child",
+        user_id=a,
+        parent_conversation_id=parent["id"],
+    )
+
+    app = _build_app(_authed(tid, a))
+    async with _client(app) as c:
+        page = (await c.get(f"/api/v1/coworkers/{cw_id}/conversations")).json()
+    assert [x["id"] for x in page["items"]] == [parent["id"]]
+    assert page["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Id-addressed entrances — foreign conversation collapses to 404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_member_cannot_reach_foreign_conversation_via_any_entrance() -> None:
+    """GET / messages / approval-requests / DELETE all 404 for B on A's row."""
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    a = await _make_member(tid)
+    b = await _make_member(tid)
+    conv_id = (await _post_conversation(tid, a, cw_id))["id"]
+
+    app_b = _build_app(_authed(tid, b))
+    async with _client(app_b) as c:
+        for method, path in (
+            ("GET", f"/api/v1/conversations/{conv_id}"),
+            ("GET", f"/api/v1/conversations/{conv_id}/messages"),
+            ("GET", f"/api/v1/conversations/{conv_id}/approval-requests"),
+            ("DELETE", f"/api/v1/conversations/{conv_id}"),
+        ):
+            resp = await c.request(method, path)
+            assert resp.status_code == 404, f"{method} {path}: {resp.text}"
+            assert resp.json()["code"] == "NOT_FOUND"
+
+    # The attempted DELETE must not have removed A's row.
+    app_a = _build_app(_authed(tid, a))
+    async with _client(app_a) as c:
+        assert (await c.get(f"/api/v1/conversations/{conv_id}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_admin_reaches_member_conversation_by_id() -> None:
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    member = await _make_member(tid)
+    admin = await _make_member(tid, role="admin")
+    conv_id = (await _post_conversation(tid, member, cw_id))["id"]
+
+    app = _build_app(_authed(tid, admin, role="admin"))
+    async with _client(app) as c:
+        assert (await c.get(f"/api/v1/conversations/{conv_id}")).status_code == 200
+        assert (
+            await c.get(f"/api/v1/conversations/{conv_id}/messages")
+        ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_ownerless_conversation_member_404_admin_200() -> None:
+    """``user_id IS NULL`` is nobody's: members 404, manage-holders reach it.
+
+    Three-valued logic bait — a naive ``conv.user_id != caller → deny``
+    inverted to ``is None → allow`` would quietly make unowned rows
+    tenant-public.
+    """
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    member = await _make_member(tid)
+    owner = await _make_member(tid, role="owner")
+    seeded = await _post_conversation(tid, member, cw_id)
+    orphan = await create_conversation(
+        tenant_id=tid,
+        coworker_id=cw_id,
+        channel_binding_id=seeded["channel_binding_id"],
+        channel_chat_id=str(uuid.uuid4()),
+        name="orphan",
+        user_id=None,
+    )
+
+    app_m = _build_app(_authed(tid, member))
+    async with _client(app_m) as c:
+        assert (await c.get(f"/api/v1/conversations/{orphan.id}")).status_code == 404
+        page = (await c.get(f"/api/v1/coworkers/{cw_id}/conversations")).json()
+        assert orphan.id not in [x["id"] for x in page["items"]]
+
+    app_o = _build_app(_authed(tid, owner, role="owner"))
+    async with _client(app_o) as c:
+        assert (await c.get(f"/api/v1/conversations/{orphan.id}")).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# WS-ticket mint — the non-REST entrance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_ticket_denied_for_foreign_conversation() -> None:
+    """B must not mint a ticket for A's conversation; A still can.
+
+    The handshake trusts the ticket payload without re-checking, so a
+    mint-side miss silently reopens everything the REST 404s closed:
+    live streaming AND sending into the foreign conversation.
+    """
+    tid, cw_id = await _make_tenant_with_shared_coworker()
+    a = await _make_member(tid)
+    b = await _make_member(tid)
+    conv_id = (await _post_conversation(tid, a, cw_id))["id"]
+
+    app_b = _build_app(_authed(tid, b))
+    async with _client(app_b) as c:
+        resp = await c.post(
+            "/api/v1/auth/ws-ticket", json={"conversation_id": conv_id}
+        )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["code"] == "NOT_FOUND"
+
+    app_a = _build_app(_authed(tid, a))
+    async with _client(app_a) as c:
+        resp = await c.post(
+            "/api/v1/auth/ws-ticket", json={"conversation_id": conv_id}
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ticket"]

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -42,6 +42,11 @@ export interface paths {
          *     bound to one `conversation_id`; the handshake compares it
          *     against the path so it cannot be reused across conversations
          *     (design §4 / 01a Open Question 1).
+         *
+         *     Ownership is enforced at mint time: the conversation must
+         *     belong to the caller (or the caller holds `coworker.manage`).
+         *     A conversation that exists but is another member's returns the
+         *     same 404 as a non-existent one.
          */
         post: operations["createWsTicket"];
         delete?: never;
@@ -253,6 +258,14 @@ export interface paths {
             };
             cookie?: never;
         };
+        /**
+         * List the caller's own conversations with a coworker
+         * @description Chat privacy is per-user: the page contains only conversations
+         *     the caller owns (`user_id` = caller), oldest first. Two members
+         *     chatting with the same coworker never see each other's history;
+         *     this applies to admins' lists too. Delegation child
+         *     conversations are excluded.
+         */
         get: operations["listCoworkerConversations"];
         put?: never;
         post: operations["createCoworkerConversation"];
@@ -271,6 +284,13 @@ export interface paths {
             };
             cookie?: never;
         };
+        /**
+         * @description Ownership-scoped: 404 unless the conversation belongs to the
+         *     caller or the caller holds `coworker.manage`. Another member's
+         *     conversation is indistinguishable from a non-existent one. The
+         *     same rule guards the messages / approval-requests sub-resources,
+         *     DELETE, and WS-ticket minting.
+         */
         get: operations["getConversation"];
         put?: never;
         post?: never;


### PR DESCRIPTION
## Summary

Chat privacy becomes per-user: a conversation belongs to the member who opened it (`conversations.user_id`), not to everyone who can see the coworker it is bound to. Previously any tenant member could list, read, stream, and delete any other member's conversations.

## Changes

- **List filtered by owner** — `GET /coworkers/{id}/conversations` now returns only the caller's own conversations. New `get/count_conversations_for_coworker_and_user` in `db.chat`; the count applies the same owner + child-exclusion predicate, fixing the `total` that previously included delegation children (empty trailing pages). The unfiltered query remains for orchestrator-internal state loading; `count_conversations_for_coworker` is removed (sole caller migrated).
- **Ownership on every id-addressed entrance** — new `user_can_access_conversation` predicate (own ∨ `coworker.manage`; `user_id IS NULL` is nobody's, same three-valued logic as `require_manage_or_owner`). Enforced in `_get_conversation_or_404` (detail / messages / approval-requests / DELETE); a foreign conversation collapses to the same 404 as a non-existent one.
- **WS-ticket mint enforces the same rule** — the WS handshake trusts the ticket payload, so minting is where attach rights are decided; without this, a member could stream into another member's conversation that every REST path correctly 404s.
- **Admin escape** — `coworker.manage` holders (owner/admin/platform_admin) still reach any conversation by id for moderation; their lists stay personal.
- **No more ownerless rows** — orchestrator web inbound no longer auto-creates `user_id IS NULL` conversations; unknown (binding, chat_id) is dropped with a warning. Web rows are minted only by the authenticated POST endpoint.
- **Contract** — `openapi.yaml` descriptions updated (per-user list, id-endpoint ownership, ticket mint), `types.ts` regenerated.

## Testing

- New `tests/webui/test_v1_conversation_ownership.py` (7 tests): foreign-member 404 on all four REST entrances + ws-ticket individually; admin by-id access with personal-only list; ownerless row member-404/owner-200; delegation children excluded from total.
- Affected surface green: webui suite, INV-1 tenant-predicate lint, OpenAPI contract + codegen freshness, loader, IM admission backfill, web persist, hot-reload (526 passed). Remaining failures (safety spacy-model download, db RLS-as-superuser) reproduce on `main` and are environment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_