### PR TITLE
feat(webui): cross-coworker conversation list (GET /api/v1/conversations)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -447,6 +447,33 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/conversations:
+    get:
+      tags: [Conversations]
+      operationId: listUserConversations
+      summary: List the caller's conversations across all coworkers (newest first)
+      description: |
+        The unified per-user chat history — every top-level conversation
+        the caller owns, across all coworkers, merged and ordered
+        newest-first. Each row carries its `coworker_id` so the client
+        can badge it and route sends. Ownership is the filter
+        (`conversations.user_id` = caller); delegation child
+        conversations and ownerless rows are excluded, and no
+        coworker-visibility check applies. The per-coworker list
+        endpoint remains for the scoped, oldest-first view.
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - { $ref: '#/components/parameters/LimitParam' }
+        - { $ref: '#/components/parameters/OffsetParam' }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ConversationPage' }
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/v1/conversations/{id}:
     parameters:
       - $ref: '#/components/parameters/IdInPath'

--- a/src/rolemesh/db/chat.py
+++ b/src/rolemesh/db/chat.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "count_conversations_for_coworker_and_user",
+    "count_conversations_for_user",
     "create_channel_binding",
     "create_conversation",
     "delete_channel_binding",
@@ -39,6 +40,7 @@ __all__ = [
     "get_conversation_for_notification",
     "get_conversations_for_coworker",
     "get_conversations_for_coworker_and_user",
+    "get_conversations_for_user",
     "get_messages_since",
     "get_new_messages_for_conversations",
     "get_session",
@@ -489,6 +491,53 @@ async def count_conversations_for_coworker_and_user(
             "AND tenant_id = $3::uuid "
             "AND parent_conversation_id IS NULL",
             coworker_id,
+            user_id,
+            tenant_id,
+        )
+    return int(row["n"]) if row else 0
+
+
+async def get_conversations_for_user(
+    user_id: str, *, tenant_id: str, limit: int | None = None, offset: int = 0,
+) -> list[Conversation]:
+    """Cross-coworker conversation list for one user (newest first).
+
+    Backs the unified per-user chat history
+    (``GET /api/v1/conversations``): every top-level conversation the
+    user owns, regardless of which coworker it is bound to. Newest
+    first — this is a "recent chats" surface, unlike the oldest-first
+    per-coworker list. Delegation children are excluded like every
+    user-facing list; ownerless rows (``user_id IS NULL``) can never
+    match. Served by the partial index ``conversations_by_user``.
+    """
+    sql = (
+        "SELECT * FROM conversations "
+        "WHERE user_id = $1::uuid AND tenant_id = $2::uuid "
+        "AND parent_conversation_id IS NULL "
+        "ORDER BY created_at DESC, id DESC"
+    )
+    params: list[object] = [user_id, tenant_id]
+    if limit is not None:
+        params.extend((limit, offset))
+        sql += f" LIMIT ${len(params) - 1} OFFSET ${len(params)}"
+    async with tenant_conn(tenant_id) as conn:
+        rows = await conn.fetch(sql, *params)
+    return [_record_to_conversation(row) for row in rows]
+
+
+async def count_conversations_for_user(
+    user_id: str, *, tenant_id: str,
+) -> int:
+    """Pagination-envelope total for the unified per-user list.
+
+    Applies the exact predicate of :func:`get_conversations_for_user`
+    so ``total`` always equals the rows a full page-walk yields.
+    """
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT COUNT(*) AS n FROM conversations "
+            "WHERE user_id = $1::uuid AND tenant_id = $2::uuid "
+            "AND parent_conversation_id IS NULL",
             user_id,
             tenant_id,
         )

--- a/src/rolemesh/db/schema.py
+++ b/src/rolemesh/db/schema.py
@@ -932,6 +932,20 @@ async def _create_schema(conn: asyncpg.pool.PoolConnectionProxy[asyncpg.Record])
         "WHERE parent_conversation_id IS NOT NULL"
     )
 
+    # Per-user chat history: both user-facing list queries — the
+    # unified cross-coworker list (``GET /api/v1/conversations``) and
+    # the per-coworker list (filtered by owner since the per-user
+    # privacy change) — select on (tenant, user), the former ordered
+    # newest-first. Partial: ownerless rows (user_id IS NULL) and
+    # delegation children never enter those lists, so they stay out of
+    # the index. Depends on the user_id and parent_conversation_id
+    # columns added above.
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS conversations_by_user "
+        "ON conversations(tenant_id, user_id, created_at DESC) "
+        "WHERE user_id IS NOT NULL AND parent_conversation_id IS NULL"
+    )
+
     # Frontdesk v1.2: is_frontdesk marks a super_agent coworker as the
     # single user-facing entry point. routing_description is a
     # capability card written by domain agents, read by the frontdesk

--- a/src/webui/v1/conversations.py
+++ b/src/webui/v1/conversations.py
@@ -25,12 +25,14 @@ from fastapi import APIRouter, Depends, Query, Response
 
 from rolemesh.db import (
     count_conversations_for_coworker_and_user,
+    count_conversations_for_user,
     create_channel_binding,
     create_conversation,
     delete_conversation,
     get_channel_binding_for_coworker,
     get_conversation,
     get_conversations_for_coworker_and_user,
+    get_conversations_for_user,
     list_requests_for_conversation,
     tenant_conn,
 )
@@ -203,6 +205,42 @@ async def create_coworker_conversation(
         user_id=user.user_id,
     )
     return _conversation_to_response(conv)
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/conversations
+# ---------------------------------------------------------------------------
+
+
+@conversations_router.get("", response_model=ConversationPage)
+async def list_user_conversations(
+    limit: LimitParam = DEFAULT_PAGE_LIMIT,
+    offset: OffsetParam = 0,
+    user: AuthenticatedUser = Depends(get_current_user),
+) -> ConversationPage:
+    """List the caller's conversations across ALL coworkers (newest first).
+
+    The unified per-user chat history: one list, every coworker's
+    conversations merged, each row still carrying its ``coworker_id``
+    so the client can badge it and route sends. Ownership IS the
+    filter — no coworker-visibility check applies, so a conversation
+    the caller opened stays listed even if the coworker was later
+    unshared. Delegation children and ownerless rows never appear
+    (see ``get_conversations_for_user``). The per-coworker endpoint
+    above remains for the scoped, oldest-first view.
+    """
+    convs = await get_conversations_for_user(
+        user.user_id, tenant_id=user.tenant_id, limit=limit, offset=offset,
+    )
+    total = await count_conversations_for_user(
+        user.user_id, tenant_id=user.tenant_id,
+    )
+    return ConversationPage(
+        items=[_conversation_to_response(c) for c in convs],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/webui/test_v1_default_deny.py
+++ b/tests/webui/test_v1_default_deny.py
@@ -60,6 +60,9 @@ AUTH_ONLY_V1_ROUTES: dict[tuple[str, str], str] = {
         "Read of one tenant coworker.",
     ("GET", "/api/v1/coworkers/{coworker_id}/conversations"):
         "Read of a coworker's conversations within the tenant.",
+    ("GET", "/api/v1/conversations"):
+        "Unified list of the caller's OWN conversations; the DB query "
+        "filters on user_id so nothing beyond the caller's rows can leak.",
     ("GET", "/api/v1/coworkers/{coworker_id}/bindings"):
         "Read of a coworker's channel bindings (write-only creds omitted).",
     ("GET", "/api/v1/coworkers/{coworker_id}/bindings/{binding_id}"):

--- a/tests/webui/test_v1_user_conversations.py
+++ b/tests/webui/test_v1_user_conversations.py
@@ -1,0 +1,239 @@
+"""``GET /api/v1/conversations`` — the unified per-user chat history.
+
+One list, every coworker's conversations merged, newest first, owned
+by the caller. Complements ``test_v1_conversation_ownership`` (which
+proves the boundary on the id-addressed entrances); here the bug-bait
+is the LIST semantics themselves:
+
+* Merge — rows from MULTIPLE coworkers appear in one page, each
+  carrying its ``coworker_id`` (the client's badge/routing key).
+* Order — newest-first. The per-coworker endpoint is oldest-first; a
+  copy-paste of its ORDER BY would pass every other assertion.
+* Filter — ownership only: another member's rows, delegation children,
+  and ownerless (``user_id IS NULL``) rows never appear, but the
+  caller's rows survive the bound coworker turning private (ownership
+  is the filter, not coworker visibility).
+* Envelope — ``total`` applies the exact list predicate, and
+  offset/limit walks the full set without gaps or duplicates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from rolemesh.auth.provider import AuthenticatedUser
+from rolemesh.db import (
+    create_conversation,
+    create_coworker,
+    create_tenant,
+    create_user,
+    tenant_conn,
+)
+from webui.api_v1 import router as api_v1_router
+from webui.dependencies import get_current_user
+from webui.v1.errors import install_error_handler
+
+pytestmark = pytest.mark.usefixtures("test_db")
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _build_app(user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+    app.include_router(api_v1_router)
+
+    async def _return_user() -> AuthenticatedUser:
+        return user
+
+    app.dependency_overrides[get_current_user] = _return_user
+    return app
+
+
+def _authed(tenant_id: str, user_id: str, role: str = "member") -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id, tenant_id=tenant_id, role=role,  # type: ignore[arg-type]
+        email="x@x.com", name="X",
+    )
+
+
+async def _make_tenant() -> str:
+    t = await create_tenant(name="T-uni", slug=f"uni-{uuid.uuid4().hex[:8]}")
+    return t.id
+
+
+async def _make_member(tenant_id: str, role: str = "member") -> str:
+    u = await create_user(
+        tenant_id=tenant_id,
+        name=f"U-{uuid.uuid4().hex[:6]}",
+        email=f"u-{uuid.uuid4().hex[:6]}@x.com",
+        role=role,
+    )
+    return u.id
+
+
+async def _make_shared_coworker(tenant_id: str) -> str:
+    cw = await create_coworker(
+        tenant_id=tenant_id,
+        name=f"CW-{uuid.uuid4().hex[:6]}",
+        folder=f"f-{uuid.uuid4().hex[:8]}",
+        agent_backend="claude",
+        visibility="shared",
+    )
+    return cw.id
+
+
+async def _post_conversation(
+    tenant_id: str, user_id: str, coworker_id: str, *, name: str,
+) -> dict:
+    app = _build_app(_authed(tenant_id, user_id))
+    async with _client(app) as c:
+        resp = await c.post(
+            f"/api/v1/coworkers/{coworker_id}/conversations",
+            json={"name": name},
+        )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _stamp_created_at(
+    tenant_id: str, conv_id: str, created_at: datetime
+) -> None:
+    """Pin created_at so ordering assertions can't flake on same-µs inserts."""
+    async with tenant_conn(tenant_id) as conn:
+        await conn.execute(
+            "UPDATE conversations SET created_at = $1 "
+            "WHERE id = $2::uuid AND tenant_id = $3::uuid",
+            created_at,
+            conv_id,
+            tenant_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_merges_coworkers_newest_first_with_coworker_ids() -> None:
+    tid = await _make_tenant()
+    uid = await _make_member(tid)
+    cw1 = await _make_shared_coworker(tid)
+    cw2 = await _make_shared_coworker(tid)
+
+    base = datetime.now(UTC)
+    conv_old = await _post_conversation(tid, uid, cw1, name="old")
+    conv_mid = await _post_conversation(tid, uid, cw2, name="mid")
+    conv_new = await _post_conversation(tid, uid, cw1, name="new")
+    for i, conv in enumerate((conv_old, conv_mid, conv_new)):
+        await _stamp_created_at(tid, conv["id"], base + timedelta(seconds=i))
+
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        page = (await c.get("/api/v1/conversations")).json()
+
+    assert [x["id"] for x in page["items"]] == [
+        conv_new["id"], conv_mid["id"], conv_old["id"],
+    ], "expected newest-first across coworkers"
+    assert [x["coworker_id"] for x in page["items"]] == [cw1, cw2, cw1]
+    assert page["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_excludes_foreign_children_and_ownerless_rows() -> None:
+    """Only the caller's own top-level rows; total agrees with items.
+
+    Seeds one of each excluded kind — another member's conversation, a
+    delegation child OWNED BY THE CALLER (so the exclusion provably
+    rides on ``parent_conversation_id``), and an ownerless row — plus
+    exactly one legitimate row.
+    """
+    tid = await _make_tenant()
+    a = await _make_member(tid)
+    b = await _make_member(tid)
+    cw = await _make_shared_coworker(tid)
+
+    mine = await _post_conversation(tid, a, cw, name="mine")
+    await _post_conversation(tid, b, cw, name="b's")
+    await create_conversation(
+        tenant_id=tid,
+        coworker_id=cw,
+        channel_binding_id=mine["channel_binding_id"],
+        channel_chat_id=str(uuid.uuid4()),
+        name="delegation child",
+        user_id=a,
+        parent_conversation_id=mine["id"],
+    )
+    await create_conversation(
+        tenant_id=tid,
+        coworker_id=cw,
+        channel_binding_id=mine["channel_binding_id"],
+        channel_chat_id=str(uuid.uuid4()),
+        name="ownerless",
+        user_id=None,
+    )
+
+    app = _build_app(_authed(tid, a))
+    async with _client(app) as c:
+        page = (await c.get("/api/v1/conversations")).json()
+    assert [x["id"] for x in page["items"]] == [mine["id"]]
+    assert page["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_owned_row_survives_coworker_turning_private() -> None:
+    """Ownership is the filter — NOT coworker visibility.
+
+    A coworker-visibility JOIN (the per-coworker endpoint's gate)
+    would silently drop the caller's own history the moment an admin
+    unshares the coworker.
+    """
+    tid = await _make_tenant()
+    uid = await _make_member(tid)
+    cw = await _make_shared_coworker(tid)
+    conv = await _post_conversation(tid, uid, cw, name="mine")
+
+    async with tenant_conn(tid) as conn:
+        await conn.execute(
+            "UPDATE coworkers SET visibility = 'private' "
+            "WHERE id = $1::uuid AND tenant_id = $2::uuid",
+            cw,
+            tid,
+        )
+
+    app = _build_app(_authed(tid, uid))
+    async with _client(app) as c:
+        page = (await c.get("/api/v1/conversations")).json()
+    assert [x["id"] for x in page["items"]] == [conv["id"]]
+
+
+@pytest.mark.asyncio
+async def test_offset_limit_walks_full_set_without_gaps() -> None:
+    tid = await _make_tenant()
+    uid = await _make_member(tid)
+    cw = await _make_shared_coworker(tid)
+
+    base = datetime.now(UTC)
+    ids: list[str] = []
+    for i in range(5):
+        conv = await _post_conversation(tid, uid, cw, name=f"c{i}")
+        await _stamp_created_at(tid, conv["id"], base + timedelta(seconds=i))
+        ids.append(conv["id"])
+    expected = list(reversed(ids))  # newest first
+
+    app = _build_app(_authed(tid, uid))
+    walked: list[str] = []
+    async with _client(app) as c:
+        for offset in range(0, 6, 2):
+            page = (
+                await c.get(f"/api/v1/conversations?limit=2&offset={offset}")
+            ).json()
+            assert page["total"] == 5
+            assert page["limit"] == 2 and page["offset"] == offset
+            walked.extend(x["id"] for x in page["items"])
+    assert walked == expected

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -275,6 +275,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/conversations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the caller's conversations across all coworkers (newest first)
+         * @description The unified per-user chat history — every top-level conversation
+         *     the caller owns, across all coworkers, merged and ordered
+         *     newest-first. Each row carries its `coworker_id` so the client
+         *     can badge it and route sends. Ownership is the filter
+         *     (`conversations.user_id` = caller); delegation child
+         *     conversations and ownerless rows are excluded, and no
+         *     coworker-visibility check applies. The per-coworker list
+         *     endpoint remains for the scoped, oldest-first view.
+         */
+        get: operations["listUserConversations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/conversations/{id}": {
         parameters: {
             query?: never;
@@ -3569,6 +3596,32 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             404: components["responses"]["NotFound"];
+        };
+    };
+    listUserConversations: {
+        parameters: {
+            query?: {
+                /** @description Maximum number of items to return (default 50, max 200). */
+                limit?: components["parameters"]["LimitParam"];
+                /** @description Number of items to skip from the start of the ordered set. */
+                offset?: components["parameters"]["OffsetParam"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConversationPage"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
         };
     };
     getConversation: {


### PR DESCRIPTION
## Summary

The unified per-user chat history: every top-level conversation the caller owns, across all coworkers, in one newest-first page. Stacked on #123 (per-user ownership boundary) — base is `feat/conversation-ownership` so this diff shows only its own increment; retarget to `main` after #123 merges.

## Changes

- **New endpoint** `GET /api/v1/conversations` returning the standard `ConversationPage` envelope; each row carries its `coworker_id` as the client's badge / routing key. Ownership is the filter — no coworker-visibility check, so a caller's history survives the bound coworker turning private.
- **DB** — `get/count_conversations_for_user` in `db.chat`: newest-first (`created_at DESC, id DESC`), identical owner + child-exclusion predicate in list and count, ownerless rows excluded. Note the deliberate order difference: this is a "recent chats" surface, while the per-coworker endpoint stays oldest-first.
- **Index** — partial `conversations_by_user (tenant_id, user_id, created_at DESC) WHERE user_id IS NOT NULL AND parent_conversation_id IS NULL`, serving both per-user list queries.
- **Default-deny allowlist** — route added to `AUTH_ONLY_V1_ROUTES` (the meta-test caught it): auth-only is enough because the query is hard-scoped to the caller's `user_id`.
- **Contract** — `/api/v1/conversations` added to `openapi.yaml`, `types.ts` regenerated.

## Testing

- New `tests/webui/test_v1_user_conversations.py` (4 tests): cross-coworker merge newest-first with `coworker_id`s; exclusion of foreign/child/ownerless rows with `total` agreement; owned row survives coworker turning private; offset/limit walks the full set without gaps.
- Conversations + contract + default-deny + INV-1 surface: 113 passed; broader affected surface 521 passed (remaining failures are the environment-only ones already reproduced on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_