### PR TITLE
fix(orchestrator): fail fast on non-retryable agent errors

### DIFF
--- a/src/agent_runner/main.py
+++ b/src/agent_runner/main.py
@@ -79,6 +79,13 @@ class ContainerOutput:
     # this to a dedicated WS frame without writing to the messages
     # table — blocks are already audited in safety_decisions.
     is_final: bool = True
+    # Only meaningful for status="error". False means the failure is a
+    # deterministic configuration error (pi.ai.types.NonRetryableConfigError):
+    # the orchestrator should fail the message once and surface it to the
+    # user instead of walking the retry/backoff ladder. Default True keeps
+    # every unclassified error on the existing retry path (fail-open to
+    # retry), and absence on the wire means True for older containers.
+    retryable: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"status": self.status, "result": self.result}
@@ -92,6 +99,9 @@ class ContainerOutput:
         # consumers keep seeing the same JSON shape.
         if not self.is_final:
             d["isFinal"] = False
+        # Same convention: only non-default (False) goes on the wire.
+        if not self.retryable:
+            d["retryable"] = False
         return d
 
 
@@ -110,6 +120,23 @@ async def publish_output(js: JetStreamContext, job_id: str, output: ContainerOut
         f"agent.{job_id}.results",
         json.dumps(output.to_dict()).encode(),
     )
+
+
+def is_retryable_error(exc: BaseException) -> bool:
+    """Classify an exception that killed the agent turn.
+
+    Whitelist-by-type: only ``pi.ai.types.NonRetryableConfigError`` (raised
+    at deterministic local validation points — provider tool-name/schema
+    checks, unresolvable model ids) is non-retryable. Everything else —
+    including errors we can't classify because the ``pi`` package isn't
+    importable in this runtime — stays retryable, so a transient fault can
+    never be misclassified as permanent (fail-open to retry).
+    """
+    try:
+        from pi.ai.types import NonRetryableConfigError
+    except ImportError:  # runtime without the pi package
+        return True
+    return not isinstance(exc, NonRetryableConfigError)
 
 
 async def drain_nats_input(sub: Any) -> list[str]:
@@ -602,10 +629,16 @@ async def main() -> None:
         await run_query_loop(init, nc, js, JOB_ID)
     except Exception as exc:  # noqa: BLE001
         error_message = str(exc)
-        log(f"Agent error: {error_message}")
+        retryable = is_retryable_error(exc)
+        log(f"Agent error (retryable={retryable}): {error_message}")
         await publish_output(
             js, JOB_ID,
-            ContainerOutput(status="error", result=None, error=error_message),
+            ContainerOutput(
+                status="error",
+                result=None,
+                error=error_message,
+                retryable=retryable,
+            ),
         )
         await nc.close()
         sys.exit(1)

--- a/src/agent_runner/pi_backend.py
+++ b/src/agent_runner/pi_backend.py
@@ -564,7 +564,18 @@ class PiBackend:
                         _log(f"Routing {model.provider} through proxy: {proxy_url}")
                 _log(f"Using model: {model.provider}/{model.id}")
             else:
-                _log(f"Warning: model '{model_id}' not found in any provider")
+                # The coworker names a model no provider knows. Previously
+                # this warned and silently fell back to the session default
+                # model — running the WRONG model without telling anyone.
+                # It is a deterministic configuration error: fail once,
+                # non-retryable, so the orchestrator surfaces it to the
+                # user instead of retrying (or silently mis-serving).
+                from pi.ai.types import NonRetryableConfigError
+
+                raise NonRetryableConfigError(
+                    f"Model '{model_id}' (PI_MODEL_ID) not found in any "
+                    f"provider — check the coworker's model configuration."
+                )
 
         # Extension runner injection point. Ref is adopted by
         # create_agent_session() so tools get wrapped with lazy

--- a/src/pi/ai/providers/amazon_bedrock.py
+++ b/src/pi/ai/providers/amazon_bedrock.py
@@ -30,6 +30,7 @@ from pi.ai.types import (
     ErrorEvent,
     ImageContent,
     Model,
+    NonRetryableConfigError,
     SimpleStreamOptions,
     StartEvent,
     StopReason,
@@ -665,7 +666,11 @@ def _convert_tool_config(
 
     for tool in tools:
         if not _BEDROCK_TOOL_NAME_RE.match(tool.name):
-            raise ValueError(
+            # NonRetryableConfigError: the name is a static property of the
+            # configuration — respawning the agent cannot change it, so the
+            # orchestrator should fail the message once instead of walking
+            # the retry/backoff ladder.
+            raise NonRetryableConfigError(
                 f"Bedrock Converse: tool name {tool.name!r} is invalid "
                 f"(len={len(tool.name)}). Must match "
                 f"^[a-zA-Z][a-zA-Z0-9_-]{{0,63}}$ — at most 64 chars, "

--- a/src/pi/ai/types.py
+++ b/src/pi/ai/types.py
@@ -9,6 +9,30 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Literal
 
+# --- Errors ---
+
+
+class NonRetryableConfigError(ValueError):
+    """Deterministic configuration error — retrying cannot succeed.
+
+    Raised at local validation points where the failure is a property
+    of the coworker/tool configuration, not of the environment: a tool
+    name violating a provider contract, a model id that resolves to no
+    provider, a schema the provider rejects before any network call.
+    The agent runner propagates this classification to the orchestrator
+    (``retryable=False`` on the error event) so the message fails once,
+    surfaces a clear error to the user, and skips the retry/backoff
+    ladder that exists for transient faults.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` call
+    sites keep working. Keep this for errors that are provably
+    deterministic — anything that *might* be transient (401 from an
+    expiring token, 5xx, timeouts) must NOT use it: a transient error
+    misclassified as permanent silently drops a recoverable message,
+    which is worse than a permanent error being retried six times.
+    """
+
+
 # --- API and Provider enums ---
 
 

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -106,6 +106,11 @@ def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
     # (False) to say; absence means True (legacy single-reply-per-turn).
     is_final_val = raw.get("isFinal")
     is_final = bool(is_final_val) if isinstance(is_final_val, bool) else True
+    # Same wire convention as isFinal: only an explicit False means
+    # non-retryable; absence (older containers) defaults to retryable so
+    # the classification can never accidentally suppress a retry.
+    retryable_val = raw.get("retryable")
+    retryable = bool(retryable_val) if isinstance(retryable_val, bool) else True
     return AgentOutput(
         status=str(raw.get("status", "error")),  # type: ignore[arg-type]
         result=str(result_val) if result_val is not None else None,
@@ -113,6 +118,7 @@ def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
         error=str(err_val) if err_val is not None else None,
         metadata=meta_val if isinstance(meta_val, dict) else None,
         is_final=is_final,
+        retryable=retryable,
     )
 
 

--- a/src/rolemesh/agent/executor.py
+++ b/src/rolemesh/agent/executor.py
@@ -78,6 +78,13 @@ class AgentOutput:
     error: str | None = None
     metadata: dict[str, object] | None = None
     is_final: bool = True
+    # Only meaningful for status="error". False marks a deterministic
+    # configuration error the container classified at the source
+    # (pi.ai.types.NonRetryableConfigError): the orchestrator fails the
+    # message once, surfaces the error to the user, and skips the
+    # retry/backoff ladder. Default True — an unmarked error (including
+    # every event from older containers) keeps the existing retry path.
+    retryable: bool = True
 
     def is_progress(self) -> bool:
         return self.status in PROGRESS_STATUSES

--- a/src/rolemesh/container/scheduler.py
+++ b/src/rolemesh/container/scheduler.py
@@ -111,6 +111,7 @@ class GroupQueue:
         self._process_messages_fn: Callable[[str], Awaitable[bool]] | None = None
         self._on_queued: Callable[[str], Awaitable[None]] | None = None
         self._on_container_starting: Callable[[str], Awaitable[None]] | None = None
+        self._on_messages_dropped: Callable[[str], Awaitable[None]] | None = None
         self._shutting_down: bool = False
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._transport = transport
@@ -218,6 +219,17 @@ class GroupQueue:
         off the waiting queue.
         """
         self._on_container_starting = fn
+
+    def set_on_messages_dropped(self, fn: Callable[[str], Awaitable[None]]) -> None:
+        """Callback invoked when the retry budget is exhausted and the
+        group's messages are dropped.
+
+        This is the terminal outcome of the retryable-error path — without
+        it the drop is invisible to the user (the UI spins until it gives
+        up). The orchestrator wires this to push an explanatory message
+        into the conversation's channel.
+        """
+        self._on_messages_dropped = fn
 
     def _fire(self, cb: Callable[[str], Awaitable[None]] | None, group_jid: str) -> None:
         if cb is None:
@@ -758,8 +770,10 @@ class GroupQueue:
                 "Max retries exceeded, dropping messages",
                 group_jid=group_jid,
                 retry_count=state.retry_count,
+                action="drop",
             )
             state.retry_count = 0
+            self._fire(self._on_messages_dropped, group_jid)
             return
 
         delay_s = (_BASE_RETRY_MS * math.pow(2, state.retry_count - 1)) / 1000.0

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1045,9 +1045,14 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
 
     had_error = False
     output_sent_to_user = False
+    # Set when the container reports a deterministic configuration error
+    # (status="error", retryable=False). Carries the error text; the post-run
+    # branch drops the message once with a user-visible explanation instead
+    # of walking the retry/backoff ladder.
+    non_retryable_error: str | None = None
 
     async def _on_output(result: AgentOutput) -> None:
-        nonlocal had_error, output_sent_to_user
+        nonlocal had_error, output_sent_to_user, non_retryable_error
         # Progress events (running / tool_use / queued / container_starting)
         # are transient UX indicators — route to web gateway as status and
         # early-return. Don't touch idle timer or notify_idle.
@@ -1216,13 +1221,26 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                     await gw.send_stream_done(binding.id, conv.channel_chat_id)
             _queue.notify_idle(conversation_id)
         if result.status == "error":
-            had_error = True
-            await _terminate_run_safe(
-                active_run_id,
-                conv.tenant_id,
-                success=False,
-                error={"code": "AGENT_ERROR", "message": result.error or "agent run failed"},
-            )
+            if result.retryable:
+                had_error = True
+                await _terminate_run_safe(
+                    active_run_id,
+                    conv.tenant_id,
+                    success=False,
+                    error={"code": "AGENT_ERROR", "message": result.error or "agent run failed"},
+                )
+            else:
+                # Deterministic configuration error, classified at the source
+                # (pi.ai.types.NonRetryableConfigError). Respawning cannot fix
+                # it — record it and let the post-run branch drop the message
+                # once with a user-visible explanation.
+                non_retryable_error = result.error or "agent configuration error"
+                await _terminate_run_safe(
+                    active_run_id,
+                    conv.tenant_id,
+                    success=False,
+                    error={"code": "CONFIG_ERROR", "message": non_retryable_error},
+                )
 
     output = await _run_agent(cw_state, conv_state, prompt, _on_output)
 
@@ -1231,6 +1249,32 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
         with contextlib.suppress(OSError, RuntimeError, TypeError, ValueError):
             await gw.set_typing(binding.id, conv.channel_chat_id, False)
     _queue.cancel_idle_timer(conversation_id)
+
+    if non_retryable_error is not None:
+        # Checked BEFORE the retryable branch: the container exiting after a
+        # config error also makes ``output == "error"``, and the retryable
+        # branch would roll the cursor back into the retry ladder. Here the
+        # message is consumed as-is (no rollback → scheduler sees success →
+        # no backoff, no new pod) and the user gets an explanation instead
+        # of a silent drop after six identical failures.
+        logger.error(
+            "Agent error",
+            coworker=config.name,
+            retryable=False,
+            action="drop",
+            error=non_retryable_error[:200],
+        )
+        await _notify_conversation_error(
+            cw_state,
+            conv,
+            binding,
+            gw,
+            "⚠️ Configuration error: "
+            f"{non_retryable_error[:200]}\n\n"
+            "This failure is deterministic and will not be retried — "
+            "please fix the coworker's configuration.",
+        )
+        return True
 
     if output == "error" or had_error:
         if output_sent_to_user:
@@ -1243,7 +1287,12 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
         await update_conversation_last_invocation(
             conv.id, previous_cursor, tenant_id=conv.tenant_id
         )
-        logger.warning("Agent error, rolled back message cursor for retry", coworker=config.name)
+        logger.warning(
+            "Agent error, rolled back message cursor for retry",
+            coworker=config.name,
+            retryable=True,
+            action="schedule_retry",
+        )
         return False
 
     return True
@@ -2192,6 +2241,7 @@ async def main() -> None:
     _queue.set_process_messages_fn(_process_conversation_messages)
     _queue.set_on_queued(_emit_queued_status)
     _queue.set_on_container_starting(_emit_container_starting_status)
+    _queue.set_on_messages_dropped(_notify_messages_dropped)
     _web_gw.set_on_stop(_handle_web_stop)
     await _recover_pending_messages()
 
@@ -2364,6 +2414,68 @@ async def _persist_web_assistant_message(
         timestamp=datetime.now(UTC).isoformat(),
         is_from_me=True,
         is_bot_message=True,
+    )
+
+
+async def _notify_conversation_error(
+    cw_state: CoworkerState,
+    conv: Conversation,
+    binding: ChannelBinding | None,
+    gw: object,
+    text: str,
+) -> None:
+    """Deliver an error explanation into the conversation's channel.
+
+    Used when a message is dropped without an assistant reply (non-retryable
+    config error, retry budget exhausted) so the user sees WHY instead of a
+    silent spinner. Sent as an ordinary bot message — persisted for web so
+    it survives a reload — and best-effort: a delivery failure must not mask
+    the original error path.
+    """
+    if not (binding and gw):
+        logger.warning(
+            "No channel to deliver agent error notice",
+            conversation_id=conv.id,
+            coworker=cw_state.config.name,
+        )
+        return
+    with contextlib.suppress(OSError, RuntimeError, TypeError, ValueError):
+        await gw.send_message(binding.id, conv.channel_chat_id, text)  # type: ignore[attr-defined]
+        if isinstance(gw, WebNatsGateway):
+            await _persist_web_assistant_message(conv, cw_state.config.name, text)
+            # Finalize the streaming bubble so the SPA exits the spinner.
+            await gw.send_stream_done(binding.id, conv.channel_chat_id)
+
+
+async def _notify_messages_dropped(conversation_id: str) -> None:
+    """Scheduler callback: retry budget exhausted, messages dropped.
+
+    The other half of the failure UX: non-retryable errors explain
+    themselves inline (``_process_conversation_messages``), but a RETRYABLE
+    error that survives every backoff attempt used to end in a silent drop —
+    the user's spinner just never resolved. Push the explanation through the
+    conversation's channel so both terminal outcomes are visible.
+    """
+    for cw_state in _state.coworkers.values():
+        conv_state = cw_state.conversations.get(conversation_id)
+        if conv_state is None:
+            continue
+        conv = conv_state.conversation
+        channel_type = _get_channel_type_for_conv(cw_state, conv)
+        binding = cw_state.channel_bindings.get(channel_type)
+        gw = _gateways.get(channel_type) if binding else None
+        await _notify_conversation_error(
+            cw_state,
+            conv,
+            binding,
+            gw,
+            "⚠️ The agent failed repeatedly and this message was dropped "
+            "after exhausting all retries. Check the coworker's logs and "
+            "configuration, then send the message again.",
+        )
+        return
+    logger.warning(
+        "Messages dropped for unknown conversation", conversation_id=conversation_id
     )
 
 

--- a/tests/orchestration/test_non_retryable_agent_errors.py
+++ b/tests/orchestration/test_non_retryable_agent_errors.py
@@ -1,0 +1,288 @@
+"""Retryable vs non-retryable agent failures (orchestrator decision).
+
+The orchestrator's only failure semantics used to be "roll back the
+cursor and walk the 5→10→20→40→80s backoff ladder". That is right for
+transient faults (pod crash, NATS blip, upstream 5xx) and physically
+wrong for deterministic configuration errors (a tool name violating a
+provider contract, an unresolvable model id): six fresh pods hit the
+identical wall and the message is silently dropped ~minutes later.
+
+The contract under test:
+
+* ``status="error", retryable=False`` → message consumed ONCE (no
+  cursor rollback, ``_process_conversation_messages`` returns True so
+  the scheduler never schedules a retry), and an explanatory bot
+  message reaches the conversation's channel.
+* ``status="error"`` with retryable unset/True → the EXISTING path,
+  byte-for-byte: cursor rolled back, False returned, no bot message.
+  This is the fail-open default — anything unclassified must retry.
+* Retry budget exhaustion → the scheduler fires the dropped callback
+  so the retryable path's terminal outcome is also user-visible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rolemesh.core.orchestrator_state import (
+    ConversationState,
+    CoworkerState,
+    OrchestratorState,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+    from rolemesh.core.types import Conversation
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pg_url: str) -> Path:
+    data_dir = tmp_path / "data"
+    groups_dir = tmp_path / "groups"
+    monkeypatch.setattr("rolemesh.core.config.DATA_DIR", data_dir)
+    monkeypatch.setattr("rolemesh.core.config.GROUPS_DIR", groups_dir)
+    monkeypatch.setattr("rolemesh.core.config.STORE_DIR", tmp_path / "store")
+    monkeypatch.setattr("rolemesh.core.config.TIMEZONE", "UTC")
+    monkeypatch.setattr("rolemesh.core.group_folder.DATA_DIR", data_dir)
+    monkeypatch.setattr("rolemesh.core.group_folder.GROUPS_DIR", groups_dir)
+
+    from rolemesh.db import _init_test_database
+
+    await _init_test_database(pg_url)
+
+    yield tmp_path
+
+    from rolemesh.db import close_database
+
+    await close_database()
+
+
+# ---------------------------------------------------------------------------
+# Minimal harness (same shape as test_multi_tenant_e2e, kept self-contained)
+# ---------------------------------------------------------------------------
+
+
+class ErrorExecutor:
+    """Executor whose turn ends in status="error" with a chosen retryable."""
+
+    def __init__(self, *, retryable: bool, error: str = "boom") -> None:
+        self._retryable = retryable
+        self._error = error
+
+    @property
+    def name(self) -> str:
+        return "mock"
+
+    async def execute(
+        self,
+        inp: object,
+        on_process: Callable[..., None],
+        on_output: Callable[..., Awaitable[None]] | None = None,
+    ) -> object:
+        from rolemesh.agent import AgentOutput
+
+        on_process("mock-container", f"job-{uuid.uuid4().hex[:6]}")
+        output = AgentOutput(
+            status="error", result=None, error=self._error, retryable=self._retryable
+        )
+        if on_output:
+            await on_output(output)
+        return output
+
+
+@dataclass
+class MockGateway:
+    _channel_type: str = "telegram"
+    sent: list[tuple[str, str, str]] = field(default_factory=list)
+
+    @property
+    def channel_type(self) -> str:
+        return self._channel_type
+
+    async def send_message(self, binding_id: str, chat_id: str, text: str) -> None:
+        self.sent.append((binding_id, chat_id, text))
+
+    async def set_typing(self, binding_id: str, chat_id: str, is_typing: bool) -> None:
+        pass
+
+
+async def _seed_scenario(executor: object, gateway: MockGateway) -> tuple[str, Conversation]:
+    """Tenant + coworker + telegram conversation + one unanswered message."""
+    import rolemesh.main as m
+    from rolemesh.db import (
+        create_channel_binding,
+        create_conversation,
+        create_coworker,
+        create_tenant,
+        store_message,
+    )
+
+    t = await create_tenant(name="T", slug=f"nre-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="Bot", folder=f"f-{uuid.uuid4().hex[:8]}"
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id,
+        tenant_id=t.id,
+        channel_type="telegram",
+        credentials={"bot_token": "tok"},
+    )
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id="chat-1",
+    )
+    await store_message(
+        tenant_id=t.id,
+        conversation_id=conv.id,
+        msg_id=f"msg-{uuid.uuid4().hex[:8]}",
+        sender="user-1",
+        sender_name="Alice",
+        content="hello",
+        timestamp="2024-06-01T12:00:01+00:00",
+    )
+
+    cw_state = CoworkerState.from_coworker(cw)
+    cw_state.channel_bindings[binding.channel_type] = binding
+    cw_state.conversations[conv.id] = ConversationState(conversation=conv)
+    state = OrchestratorState()
+    state.coworkers[cw.id] = cw_state
+
+    m._state = state
+    m._executor = executor  # type: ignore[assignment]
+    m._executors = {"claude": executor, "pi": executor}  # type: ignore[assignment]
+    m._gateways = {"telegram": gateway}  # type: ignore[assignment]
+    m._queue = m.GroupQueue()
+    m._queue.set_process_messages_fn(m._process_conversation_messages)
+    m._transport = None
+    return cw.id, conv
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator decision branch
+# ---------------------------------------------------------------------------
+
+
+async def test_non_retryable_error_consumes_message_and_notifies(env: Path) -> None:
+    """retryable=False → single failure: True returned (no retry), cursor NOT
+    rolled back, and the user sees a configuration-error message."""
+    import rolemesh.main as m
+
+    gateway = MockGateway()
+    executor = ErrorExecutor(
+        retryable=False, error="Bedrock Converse: tool name 'x'*70 is invalid"
+    )
+    cw_id, conv = await _seed_scenario(executor, gateway)
+
+    result = await m._process_conversation_messages(conv.id)
+
+    assert result is True, "non-retryable error must consume the message"
+    conv_state = m._state.coworkers[cw_id].conversations[conv.id]
+    assert conv_state.last_agent_timestamp == "2024-06-01T12:00:01+00:00", (
+        "cursor must NOT be rolled back — rollback re-queues the message"
+    )
+    error_notices = [text for (_b, _c, text) in gateway.sent if "Configuration error" in text]
+    assert error_notices, f"user must see the config error; sent={gateway.sent}"
+    assert "Bedrock Converse" in error_notices[0]
+
+
+async def test_retryable_error_rolls_back_cursor_for_retry(env: Path) -> None:
+    """retryable=True (explicit or default) → existing behavior untouched:
+    False returned, cursor rolled back, no bot-side error message."""
+    import rolemesh.main as m
+
+    gateway = MockGateway()
+    executor = ErrorExecutor(retryable=True, error="Container crashed")
+    cw_id, conv = await _seed_scenario(executor, gateway)
+
+    result = await m._process_conversation_messages(conv.id)
+
+    assert result is False, "retryable error must go to the retry ladder"
+    conv_state = m._state.coworkers[cw_id].conversations[conv.id]
+    assert conv_state.last_agent_timestamp != "2024-06-01T12:00:01+00:00", (
+        "cursor must be rolled back so the retry re-reads the message"
+    )
+    assert not gateway.sent, "retryable path must not message the user per-attempt"
+
+
+async def test_default_agent_output_is_retryable(env: Path) -> None:
+    """An AgentOutput built without the new field keeps retry semantics —
+    the wire default protects events from older containers."""
+    from rolemesh.agent import AgentOutput
+
+    out = AgentOutput(status="error", result=None, error="x")
+    assert out.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Wire parsing (orchestrator side of the NATS event)
+# ---------------------------------------------------------------------------
+
+
+async def test_parse_container_output_retryable_false() -> None:
+    from rolemesh.agent.container_executor import _parse_container_output
+
+    parsed = _parse_container_output(
+        {"status": "error", "result": None, "error": "cfg", "retryable": False}
+    )
+    assert parsed.retryable is False
+
+
+async def test_parse_container_output_retryable_absent_defaults_true() -> None:
+    """Events from older containers carry no field — must stay retryable."""
+    from rolemesh.agent.container_executor import _parse_container_output
+
+    parsed = _parse_container_output({"status": "error", "result": None, "error": "x"})
+    assert parsed.retryable is True
+
+
+async def test_parse_container_output_retryable_junk_defaults_true() -> None:
+    """A non-bool value must not be truth-coerced into suppressing retries."""
+    from rolemesh.agent.container_executor import _parse_container_output
+
+    parsed = _parse_container_output(
+        {"status": "error", "result": None, "retryable": "false"}
+    )
+    assert parsed.retryable is True
+
+
+# ---------------------------------------------------------------------------
+# Scheduler: retry exhaustion fires the dropped callback
+# ---------------------------------------------------------------------------
+
+
+async def test_retry_exhaustion_fires_dropped_callback() -> None:
+    from rolemesh.container.scheduler import _MAX_RETRIES, GroupQueue
+
+    q = GroupQueue()
+    dropped: list[str] = []
+
+    async def _on_dropped(group_jid: str) -> None:
+        dropped.append(group_jid)
+
+    q.set_on_messages_dropped(_on_dropped)
+    state = q._get_group("conv-1")
+
+    # Below the budget: schedules a backoff, no drop.
+    q._schedule_retry("conv-1", state)
+    await asyncio.sleep(0)
+    assert dropped == []
+
+    # Exhaust the budget: the drop callback must fire exactly once.
+    state.retry_count = _MAX_RETRIES
+    q._schedule_retry("conv-1", state)
+    await asyncio.sleep(0)
+    assert dropped == ["conv-1"]
+    assert state.retry_count == 0, "budget resets so a future message can run"
+
+    await q.shutdown()

--- a/tests/test_agent_runner/test_error_retryability.py
+++ b/tests/test_agent_runner/test_error_retryability.py
@@ -1,0 +1,86 @@
+"""Container-side error classification (retryable vs non-retryable).
+
+The agent runner is the one place that can classify a failure at the
+source: ``pi.ai.types.NonRetryableConfigError`` marks deterministic
+configuration errors raised at local validation points; everything else
+stays retryable (fail-open — a transient fault misclassified as
+permanent silently drops a recoverable message, which is worse than a
+permanent fault being retried).
+
+Bug-bait focus:
+
+* Whitelist-by-type, not by message: a plain ValueError with a scary
+  message must remain retryable.
+* Wire shape stays legacy-compatible: ``retryable`` only appears in the
+  JSON when False, mirroring the ``isFinal`` convention, so older
+  orchestrators keep seeing the exact same payloads for every
+  retryable outcome.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_runner.main import ContainerOutput, is_retryable_error
+from pi.ai.types import NonRetryableConfigError
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_config_error_is_non_retryable() -> None:
+    assert is_retryable_error(NonRetryableConfigError("bad tool name")) is False
+
+
+def test_plain_value_error_stays_retryable() -> None:
+    # Same base class, not whitelisted — message content must not matter.
+    assert is_retryable_error(ValueError("tool name invalid")) is True
+
+
+def test_runtime_and_os_errors_stay_retryable() -> None:
+    assert is_retryable_error(RuntimeError("NATS gone")) is True
+    assert is_retryable_error(OSError("connection reset")) is True
+
+
+def test_subclass_of_config_error_is_non_retryable() -> None:
+    class ProviderSchemaError(NonRetryableConfigError):
+        pass
+
+    assert is_retryable_error(ProviderSchemaError("x")) is False
+
+
+# ---------------------------------------------------------------------------
+# Wire shape
+# ---------------------------------------------------------------------------
+
+
+def test_retryable_true_is_omitted_from_wire() -> None:
+    """Default (retryable) errors serialize exactly as before this change."""
+    d = ContainerOutput(status="error", result=None, error="x").to_dict()
+    assert "retryable" not in d
+
+
+def test_retryable_false_is_emitted() -> None:
+    d = ContainerOutput(
+        status="error", result=None, error="x", retryable=False
+    ).to_dict()
+    assert d["retryable"] is False
+
+
+# ---------------------------------------------------------------------------
+# Source raise sites
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_tool_name_guard_raises_config_error() -> None:
+    """The provider's local tool-name validation is the canonical
+    non-retryable source — the exact failure that used to burn the whole
+    retry ladder."""
+    boto3 = pytest.importorskip("boto3")  # noqa: F841 — provider needs it at import
+    from pi.ai.providers.amazon_bedrock import _convert_tool_config
+    from pi.ai.types import Tool
+
+    bad = Tool(name="x" * 70, description="d", parameters={"type": "object"})
+    with pytest.raises(NonRetryableConfigError):
+        _convert_tool_config([bad], "auto")


### PR DESCRIPTION
## Summary

The orchestrator's only failure semantics were "roll back the message cursor and walk the 5→10→20→40→80s backoff ladder" — right for transient faults (pod crash, NATS blip, upstream 5xx), physically wrong for deterministic configuration errors (a tool name violating a provider contract, an unresolvable model id): six fresh pods hit the identical wall, the message was silently dropped minutes later, and the UI spun the whole time.

Agents already publish an explicit `status="error"` NATS event and exit cleanly; what was missing is a **retryable classification** on that event and an orchestrator branch that honours it.

## Design principles

- **Fail-open to retry**: classification is a whitelist by exception *type* (`pi.ai.types.NonRetryableConfigError`), never by message text. Absence of the field, non-bool junk, unclassified exceptions, runtimes without `pi` importable, fully silent pods (idle-timeout fallback) — all default to retryable. A transient fault misclassified as permanent silently drops a recoverable message, which is worse than a permanent fault retried six times.
- **Classify at the source**: only the raising code knows whether a failure is deterministic.

## Changes

- **`pi.ai.types.NonRetryableConfigError`** (subclasses `ValueError` — existing `except ValueError` sites unaffected). Raised at two deterministic validation points: the Bedrock tool-name/schema guard (`_convert_tool_config`), and pi_backend model resolution — the latter previously **warned and silently fell back to the default model** when `PI_MODEL_ID` resolved to nothing (running the wrong model without telling anyone); it now fails once, loudly.
- **Protocol**: `ContainerOutput` / `AgentOutput` gain `retryable: bool = True`. Wire convention mirrors `isFinal`: only an explicit `False` is emitted, absence parses as `True` — rolling upgrades are safe in both directions (401/credential errors deliberately NOT whitelisted in v1: token-expiry 401s are transient).
- **Orchestrator branch**: `status=error, retryable=False` → run marked failed with code `CONFIG_ERROR`, message consumed (no cursor rollback → no backoff, no new pod), and an explanatory bot message delivered into the conversation's channel (persisted for web, stream bubble finalized). Logs distinguish the outcomes: `retryable=False action=drop` vs `retryable=True action=schedule_retry`.
- **Retry exhaustion is no longer silent either**: `GroupQueue` fires a new `on_messages_dropped` callback after the budget is exhausted, and the orchestrator pushes an explanation — both terminal failure outcomes are now user-visible.
- **Untouched**: backoff ladder, cursor rollback, idle-timeout fallback, pod lifecycle.

## Effect

A coworker hitting a deterministic config error goes from "minutes of retries + 6 pods + silent drop" to "seconds: single failure + visible `Configuration error: …` in the conversation". Transient-fault behavior is byte-for-byte unchanged.

## Testing

- 14 new tests (`tests/orchestration/test_non_retryable_agent_errors.py`, `tests/test_agent_runner/test_error_retryability.py`): the three orchestrator branches (False → consume+notify+no rollback; True → rollback, no notice, old behavior; missing field → retryable), wire parsing defenses (absent/junk values), scheduler exhaustion callback, whitelist-by-type (a plain `ValueError` with a scary message stays retryable), Bedrock guard raise type.
- Regression: orchestration / multi-tenant e2e / agent_runner / run lifecycle / user flow / runs / core suites — **703 passed, 0 failed**; `ruff check` clean.

## Note

Small textual conflict with #125 (`fix/mcp-tool-name-length`) at the same `raise` statement in `amazon_bedrock.py` — #125 rewrites the message text, this PR changes the exception class. Either merge order works; the later branch needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_