### PR TITLE
fix(pi): don't fail a completed turn on late-stream errors; fix Bedrock stop-reason fallback

### DIFF
--- a/src/pi/ai/providers/amazon_bedrock.py
+++ b/src/pi/ai/providers/amazon_bedrock.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 import os
 import re
 import time
@@ -56,6 +57,8 @@ from pi.ai.types import (
 )
 from pi.ai.utils.json_parse import parse_streaming_json
 from pi.ai.utils.sanitize_unicode import sanitize_surrogates
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -108,6 +111,10 @@ def stream_bedrock(
     partial_json: dict[int, str] = {}
 
     async def _do_stream() -> None:
+        # Set when the Converse terminal marker (messageStop) has been
+        # processed — from that point the assistant turn is complete
+        # and a later transport failure must not fail the whole turn.
+        saw_message_stop = False
         try:
             region = (
                 options.region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
@@ -182,21 +189,27 @@ def stream_bedrock(
             # Process the event stream - iterate in executor since boto3 streaming is sync
             event_stream = response.get("stream", [])
 
-            def _iter_events() -> list[dict[str, Any]]:
+            def _iter_events() -> list[Any]:
                 """Collect a batch of events from the sync iterator."""
-                events: list[dict[str, Any]] = []
+                events: list[Any] = []
                 try:
                     for item in event_stream:
                         events.append(item)
                 except Exception as exc:
-                    events.append({"_error": str(exc)})
+                    # Preserve the exception OBJECT. Flattening to
+                    # str(exc) loses the type, and the common tail
+                    # exceptions here (TimeoutError / socket.timeout
+                    # while draining the stream) stringify to "" —
+                    # which left an undebuggable empty errorMessage
+                    # in session files.
+                    events.append(exc)
                 return events
 
             events = await loop.run_in_executor(None, _iter_events)
 
             for item in events:
-                if "_error" in item:
-                    raise RuntimeError(item["_error"])
+                if isinstance(item, Exception):
+                    raise item
 
                 if "messageStart" in item:
                     msg_start = item["messageStart"]
@@ -212,6 +225,7 @@ def stream_bedrock(
                 elif "messageStop" in item:
                     msg_stop = item["messageStop"]
                     output.stop_reason = _map_stop_reason(msg_stop.get("stopReason"))
+                    saw_message_stop = True
                 elif "metadata" in item:
                     _handle_metadata(item["metadata"], model, output)
                 elif "internalServerException" in item:
@@ -235,8 +249,34 @@ def stream_bedrock(
             stream.end()
 
         except Exception as exc:
-            output.stop_reason = "aborted" if (options.signal is not None and options.signal.is_set()) else "error"
-            output.error_message = str(exc)
+            aborted = options.signal is not None and options.signal.is_set()
+            if (
+                saw_message_stop
+                and not aborted
+                and output.stop_reason not in ("error", "aborted")
+            ):
+                # The turn already completed (messageStop arrived with a
+                # normal terminal reason); only the tail failed — e.g. a
+                # read timeout while draining the stream before the
+                # final ``metadata`` (usage) event. Degrade instead of
+                # discarding a fully delivered response: usage may be
+                # missing, but the reply and the real stop reason stand.
+                # The stop_reason guard keeps refusal/guardrail stops
+                # (mapped to "error") on the error path.
+                _log.warning(
+                    "Bedrock stream failed after messageStop; keeping "
+                    "completed turn (stop_reason=%s): %r",
+                    output.stop_reason,
+                    exc,
+                )
+                stream.push(DoneEvent(reason=output.stop_reason, message=output))
+                stream.end()
+                return
+            output.stop_reason = "aborted" if aborted else "error"
+            # ``or repr(exc)``: TimeoutError / socket.timeout stringify
+            # to "" — never record an empty diagnostic.
+            output.error_message = str(exc) or repr(exc)
+            _log.exception("Bedrock stream failed")
             stream.push(ErrorEvent(reason=output.stop_reason, error=output))
             stream.end()
 

--- a/src/pi/ai/providers/amazon_bedrock.py
+++ b/src/pi/ai/providers/amazon_bedrock.py
@@ -527,7 +527,18 @@ def _map_stop_reason(reason: str | None) -> StopReason:
         return "length"
     if reason == "tool_use":
         return "toolUse"
-    return "error"
+    if reason in ("guardrail_intervened", "content_filtered"):
+        # Deliberate error mapping — the Bedrock analogue of the
+        # Anthropic mapper's refusal/"sensitive" entries.
+        return "error"
+    # Unknown values must NOT fall back to "error": Bedrock grows new
+    # stopReason enums over time (per-model/per-feature), and "error"
+    # here trips the pre-Done sentinel in ``_do_stream``, converting a normal
+    # completion (full content delivered) into a failed run with
+    # "An unknown error occurred". Match the Anthropic mapper: default
+    # to "stop" and log the raw value so a mapping can be added.
+    _log.warning("Unknown Bedrock stopReason %r, defaulting to 'stop'", reason)
+    return "stop"
 
 
 def _convert_messages(

--- a/src/pi/ai/providers/anthropic.py
+++ b/src/pi/ai/providers/anthropic.py
@@ -545,6 +545,12 @@ async def stream_anthropic(
         timestamp=int(time.time() * 1000),
     )
 
+    # Set once the API's terminal signal (message_delta carrying a
+    # stop_reason) has been processed — from that point the assistant
+    # turn is complete and a later transport failure must not fail
+    # the whole turn.
+    saw_terminal = False
+
     try:
         api_key = (options.api_key if options and options.api_key else None) or get_env_api_key(model.provider) or ""
 
@@ -699,6 +705,13 @@ async def stream_anthropic(
                     delta = event.delta
                     if getattr(delta, "stop_reason", None):
                         output.stop_reason = _map_stop_reason(delta.stop_reason)
+                        # Terminal signal received — the turn is
+                        # complete from here on (see except below).
+                        # Explicit flag rather than checking
+                        # output.stop_reason: its default is already
+                        # "stop", which would be indistinguishable
+                        # from "never heard back".
+                        saw_terminal = True
                     usage = event.usage
                     if getattr(usage, "input_tokens", None) is not None:
                         output.usage.input = usage.input_tokens
@@ -725,12 +738,33 @@ async def stream_anthropic(
         )
 
     except Exception as exc:
-        output.stop_reason = (
-            "aborted"
-            if options and options.signal is not None and options.signal.is_set()
-            else "error"
+        aborted = bool(
+            options and options.signal is not None and options.signal.is_set()
         )
-        output.error_message = str(exc)
+        if (
+            saw_terminal
+            and not aborted
+            and output.stop_reason not in ("error", "aborted")
+        ):
+            # The turn already completed (the API sent its terminal
+            # stop_reason); only the tail failed — e.g. a timeout while
+            # the SDK closed the stream. Degrade instead of discarding
+            # a fully delivered response. The stop_reason guard keeps
+            # refusal/"sensitive" stops (mapped to "error") on the
+            # error path.
+            _log.warning(
+                "Anthropic stream failed after terminal stop_reason=%s; "
+                "keeping completed turn: %r",
+                output.stop_reason,
+                exc,
+            )
+            yield DoneEvent(reason=output.stop_reason, message=output)
+            return
+        output.stop_reason = "aborted" if aborted else "error"
+        # ``or repr(exc)``: timeout-family exceptions stringify to "" —
+        # never record an empty diagnostic.
+        output.error_message = str(exc) or repr(exc)
+        _log.exception("Anthropic stream failed")
         yield ErrorEvent(reason=output.stop_reason, error=output)
 
 

--- a/tests/test_agent_runner/test_pi_stream_tail_error.py
+++ b/tests/test_agent_runner/test_pi_stream_tail_error.py
@@ -148,6 +148,40 @@ async def test_bedrock_error_mapped_stop_reason_is_not_rescued() -> None:
     assert final.error.stop_reason == "error"
 
 
+@pytest.mark.asyncio
+async def test_bedrock_unknown_stop_reason_is_a_normal_completion() -> None:
+    """Latent twin of the tail-error bug: Bedrock grows new stopReason
+    enums (per-model/per-feature), and the mapper used to fall back to
+    "error" — which tripped the pre-Done sentinel and converted a CLEAN
+    stream with full content into a failed run reading "An unknown
+    error occurred" (with non-zero usage — a different signature than
+    the transport-tail incident). Unknown must default to "stop"."""
+    stop = {"messageStop": {"stopReason": "some_future_reason"}}
+    metadata = {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}}
+    final = await _bedrock_final([*_BEDROCK_BODY, stop, metadata], None)
+    assert isinstance(final, DoneEvent)
+    assert final.message.stop_reason == "stop"
+    assert _text(final.message) == "Hello, world!"
+    # Clean stream: metadata was processed, usage must be populated.
+    assert final.message.usage.input == 10
+    assert final.message.usage.output == 5
+
+
+def test_bedrock_stop_reason_mapping_contract() -> None:
+    """Explicit mapping table: guardrail/content-filter are DELIBERATE
+    error mappings (the Anthropic mapper's refusal/"sensitive"
+    analogues); unknown values are normal completions, not errors."""
+    from pi.ai.providers.amazon_bedrock import _map_stop_reason
+
+    assert _map_stop_reason("end_turn") == "stop"
+    assert _map_stop_reason("tool_use") == "toolUse"
+    assert _map_stop_reason("max_tokens") == "length"
+    assert _map_stop_reason("guardrail_intervened") == "error"
+    assert _map_stop_reason("content_filtered") == "error"
+    assert _map_stop_reason("some_future_reason") == "stop"
+    assert _map_stop_reason(None) == "stop"
+
+
 # ---------------------------------------------------------------------------
 # Anthropic
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_runner/test_pi_stream_tail_error.py
+++ b/tests/test_agent_runner/test_pi_stream_tail_error.py
@@ -1,0 +1,251 @@
+"""Late-stream failures must not discard an already-complete turn.
+
+Production bug: both Bedrock and Anthropic-direct returned the full
+reply text, yet pi recorded ``stop_reason="error"`` with an EMPTY
+``error_message`` and (for Bedrock) usage input=0/output=0. Mechanism:
+
+* The provider ``except`` blocks unconditionally overwrote
+  ``stop_reason`` — even when the wire's terminal marker
+  (``messageStop`` / ``message_delta.stop_reason``) had already been
+  processed and the turn was complete. A transport hiccup while
+  draining the stream tail (before Bedrock's final ``metadata`` usage
+  event) failed the whole turn.
+* ``error_message = str(exc)`` — timeout-family exceptions
+  (``TimeoutError``, ``socket.timeout``) stringify to ``""``, leaving
+  an undebuggable empty diagnostic. Bedrock additionally flattened
+  the exception to a string inside ``_iter_events``, losing the type.
+
+The same stop-reason overwrite exists in the upstream TS project
+(reported there); the empty-diagnostic half was a port regression.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# pi.ai providers depend on extras (boto3 etc.). If the dev env
+# doesn't have them installed, skip cleanly rather than blowing up
+# at import time. The container that actually runs Pi backend has
+# boto3 baked in.
+boto3 = pytest.importorskip("boto3")
+
+from pi.ai.providers.amazon_bedrock import BedrockOptions, stream_bedrock  # noqa: E402
+from pi.ai.providers.anthropic import AnthropicOptions, stream_anthropic  # noqa: E402
+from pi.ai.types import (  # noqa: E402
+    Context,
+    DoneEvent,
+    ErrorEvent,
+    Model,
+    TextContent,
+    UserMessage,
+)
+
+
+def _text(msg: Any) -> str:
+    return "".join(getattr(b, "text", "") for b in msg.content)
+
+
+async def _final_event(stream: Any) -> DoneEvent | ErrorEvent:
+    async for ev in stream:
+        if isinstance(ev, (DoneEvent, ErrorEvent)):
+            return ev
+    raise AssertionError("stream ended without DoneEvent/ErrorEvent")
+
+
+# ---------------------------------------------------------------------------
+# Bedrock
+# ---------------------------------------------------------------------------
+
+_BEDROCK_BODY = [
+    {"messageStart": {"role": "assistant"}},
+    {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+    {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hello, "}}},
+    {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "world!"}}},
+    {"contentBlockStop": {"contentBlockIndex": 0}},
+]
+_BEDROCK_STOP = {"messageStop": {"stopReason": "end_turn"}}
+
+
+class _FakeConverseStream:
+    """Yields the given events, then raises ``tail_exc`` (if set)."""
+
+    def __init__(self, events: list[dict[str, Any]], tail_exc: Exception | None) -> None:
+        self._events = events
+        self._tail_exc = tail_exc
+
+    def __iter__(self) -> Any:
+        yield from self._events
+        if self._tail_exc is not None:
+            raise self._tail_exc
+
+
+async def _bedrock_final(
+    events: list[dict[str, Any]], tail_exc: Exception | None
+) -> DoneEvent | ErrorEvent:
+    """Run stream_bedrock against a fake converse_stream and return the
+    terminal event. The boto3 patch must stay active while the stream is
+    CONSUMED — client construction happens inside the async task, not at
+    call time."""
+    fake_client = SimpleNamespace(
+        converse_stream=lambda **kwargs: {"stream": _FakeConverseStream(events, tail_exc)}
+    )
+    model = Model(id="anthropic.claude-x", api="bedrock-converse-stream", provider="amazon-bedrock")
+    ctx = Context(messages=[UserMessage(content=[TextContent(text="hi")])])
+    with patch("pi.ai.providers.amazon_bedrock.boto3") as fake_boto3:
+        fake_boto3.client.return_value = fake_client
+        return await _final_event(stream_bedrock(model, ctx, BedrockOptions()))
+
+
+@pytest.mark.asyncio
+async def test_bedrock_tail_error_after_message_stop_keeps_completed_turn() -> None:
+    """THE production repro: full reply + messageStop(end_turn) arrive,
+    then the transport dies before the final ``metadata`` (usage) event
+    with a TimeoutError (str() == ""). Must now finish as Done with the
+    real stop reason — not stop_reason='error', error_message=''."""
+    final = await _bedrock_final([*_BEDROCK_BODY, _BEDROCK_STOP], TimeoutError())
+    assert isinstance(final, DoneEvent)
+    assert final.message.stop_reason == "stop"
+    assert _text(final.message) == "Hello, world!"
+    assert final.message.error_message is None
+    # Usage may legitimately be missing (metadata never arrived);
+    # missing usage beats discarding a delivered response.
+    assert final.message.usage.input == 0
+
+
+@pytest.mark.asyncio
+async def test_bedrock_midstream_error_still_fails_with_typed_diagnostic() -> None:
+    """A failure BEFORE messageStop is a real failure — and the recorded
+    diagnostic must never be empty (TimeoutError stringifies to "")."""
+    final = await _bedrock_final(list(_BEDROCK_BODY), TimeoutError())
+    assert isinstance(final, ErrorEvent)
+    assert final.error.stop_reason == "error"
+    assert final.error.error_message  # non-empty
+    assert "TimeoutError" in final.error.error_message
+
+
+@pytest.mark.asyncio
+async def test_bedrock_midstream_error_message_preserved_verbatim() -> None:
+    """Exceptions that DO carry a message keep it as-is (the repr
+    fallback only kicks in for empty-str exceptions)."""
+    final = await _bedrock_final(list(_BEDROCK_BODY), ValueError("throttled by proxy"))
+    assert isinstance(final, ErrorEvent)
+    assert final.error.error_message == "throttled by proxy"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_error_mapped_stop_reason_is_not_rescued() -> None:
+    """Guard rail: a messageStop whose wire reason maps to 'error'
+    (refusal/guardrail/unknown) must stay on the error path even when
+    the tail also fails — the degrade branch only covers turns that
+    ended with a NORMAL terminal reason."""
+    stop = {"messageStop": {"stopReason": "guardrail_intervened"}}
+    final = await _bedrock_final([*_BEDROCK_BODY, stop], TimeoutError())
+    assert isinstance(final, ErrorEvent)
+    assert final.error.stop_reason == "error"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+class _FakeSDKStream:
+    """Mimics the anthropic SDK's ``client.messages.stream`` context
+    manager + async iterator: yields ``events``, then raises
+    ``tail_exc`` (if set) instead of a clean end."""
+
+    def __init__(self, events: list[Any], tail_exc: Exception | None) -> None:
+        self._events = list(events)
+        self._tail_exc = tail_exc
+        self._i = 0
+
+    async def __aenter__(self) -> _FakeSDKStream:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+    def __aiter__(self) -> _FakeSDKStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._i < len(self._events):
+            ev = self._events[self._i]
+            self._i += 1
+            return ev
+        if self._tail_exc is not None:
+            raise self._tail_exc
+        raise StopAsyncIteration
+
+
+def _anthropic_sdk_events(*, with_terminal: bool) -> list[Any]:
+    usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=5,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    events: list[Any] = [
+        SimpleNamespace(type="message_start", message=SimpleNamespace(usage=usage)),
+        SimpleNamespace(type="content_block_start", index=0, content_block=SimpleNamespace(type="text")),
+        SimpleNamespace(
+            type="content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="text_delta", text="Hello, world!"),
+        ),
+        SimpleNamespace(type="content_block_stop", index=0),
+    ]
+    if with_terminal:
+        events.append(
+            SimpleNamespace(
+                type="message_delta",
+                delta=SimpleNamespace(stop_reason="end_turn"),
+                usage=usage,
+            )
+        )
+    return events
+
+
+async def _anthropic_final(
+    events: list[Any], tail_exc: Exception | None
+) -> DoneEvent | ErrorEvent:
+    """Run stream_anthropic against a fake SDK stream and return the
+    terminal event. The patch must stay active while the generator is
+    consumed — _create_client runs on first iteration, not at call time."""
+    fake_client = SimpleNamespace(
+        messages=SimpleNamespace(stream=lambda **kwargs: _FakeSDKStream(events, tail_exc))
+    )
+    model = Model(id="claude-test", api="anthropic-messages", provider="anthropic")
+    ctx = Context(messages=[UserMessage(content=[TextContent(text="hi")])])
+    with patch(
+        "pi.ai.providers.anthropic._create_client", return_value=(fake_client, False)
+    ):
+        return await _final_event(
+            stream_anthropic(model, ctx, AnthropicOptions(api_key="test-key"))
+        )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_tail_error_after_terminal_keeps_completed_turn() -> None:
+    """Anthropic twin of the Bedrock repro. Usage arrives with
+    message_delta (before the failure), so it must survive too."""
+    final = await _anthropic_final(_anthropic_sdk_events(with_terminal=True), TimeoutError())
+    assert isinstance(final, DoneEvent)
+    assert final.message.stop_reason == "stop"
+    assert _text(final.message) == "Hello, world!"
+    assert final.message.error_message is None
+    assert final.message.usage.input == 10
+    assert final.message.usage.output == 5
+
+
+@pytest.mark.asyncio
+async def test_anthropic_midstream_error_still_fails_with_typed_diagnostic() -> None:
+    final = await _anthropic_final(_anthropic_sdk_events(with_terminal=False), TimeoutError())
+    assert isinstance(final, ErrorEvent)
+    assert final.error.stop_reason == "error"
+    assert final.error.error_message
+    assert "TimeoutError" in final.error.error_message


### PR DESCRIPTION
## Problem

Production incident: both Bedrock and Anthropic-direct returned the **full reply text**, yet pi recorded `stop_reason="error"` with an **empty** `error_message`; the orchestrator took the error branch (polluting run state and, post-#126, entering the retry/backoff ladder), and Bedrock usage was recorded as input=0/output=0.

Reproduced exactly with a fake stream: full content + `messageStop(end_turn)` delivered, then a `TimeoutError()` (whose `str()` is `""`) raised while draining the stream tail before Bedrock's final `metadata` (usage) event.

Note: the originally suspected mechanism (agent_loop's "Stream ended without a done event" fallback) was ruled out — that path only fires when *nothing* was streamed and never produces an empty message. The defects are in the provider stream adapters.

## Root causes and fixes (3 defects)

### 1. A tail exception overwrote an already-complete turn (both providers)

The `except` blocks unconditionally set `stop_reason="error"` — even when the wire's terminal marker (`messageStop` / `message_delta` carrying `stop_reason`) had already been processed and the turn was complete. Bedrock's usage arrives in the `metadata` event *after* `messageStop`, which is exactly why usage stayed 0/0 there and not on Anthropic (whose usage rides the earlier `message_delta`) — the observed 0/0 pins the failure to that window.

**Fix**: track the terminal marker with an explicit flag (the `stop_reason` field can't serve — its default is already `"stop"`). On a tail exception after a *normal* terminal reason: log a warning and emit `DoneEvent` with the real stop reason. Usage may be missing; that beats discarding a fully delivered, fully billed response. Guards: user aborts and error-mapped terminal reasons (refusal/guardrail) stay on the error path.

### 2. Empty, type-less diagnostics (port regression)

`error_message = str(exc)` — timeout-family exceptions (`TimeoutError`, `socket.timeout`) stringify to `""`, and the except blocks never logged, so production sessions carried no clue at all. Bedrock's `_iter_events` additionally flattened the exception to `{"_error": str(exc)}`, destroying the type before the except even saw it. Upstream's `formatBedrockError`/`normalizeProviderError` layer was dropped in the Python port.

**Fix**: `_iter_events` preserves the exception *object* (re-raised as-is on replay); `error_message` falls back to `repr(exc)` when `str(exc)` is empty; `log.exception` on the real-error path.

### 3. Unknown Bedrock stopReason enums treated as errors (latent twin)

`_map_stop_reason` fell back to `"error"` for anything outside its four known cases. Bedrock grows new enums over time; the fallback tripped the pre-Done sentinel, converting a **clean** stream with full content into a failed run reading "An unknown error occurred" (with non-zero usage — a distinct signature from the incident above, searchable in production logs to check whether this one has fired too).

**Fix**: `guardrail_intervened`/`content_filtered` become explicit, deliberate error mappings (the analogues of the Anthropic mapper's `refusal`/`"sensitive"` entries); unknown values default to `"stop"` with a warning log carrying the raw value — matching the Anthropic mapper's existing behavior.

## Upstream relationship

`src/pi` is a Python port of [earendil-works/pi](https://github.com/earendil-works/pi). Defect 1 exists identically in the upstream TS code (`bedrock-converse-stream.ts` / `anthropic-messages.ts` catch blocks) and has been reported upstream; defect 3's `return "error"` fallback also exists upstream. Defect 2 is a port regression. The pre-Done sentinel checks were deliberately kept (upstream has them verbatim; the guarded-degrade approach fixes the incident with minimal divergence from the vendored source).

## Tests (8, in `tests/test_agent_runner/test_pi_stream_tail_error.py`)

- Production repro: full reply + tail `TimeoutError` → `Done` with real stop reason (Bedrock & Anthropic; Anthropic also asserts usage survives).
- Mid-stream failures still fail, with a typed, non-empty diagnostic; exceptions that carry a message keep it verbatim.
- Error-mapped stop reasons (guardrail) are not rescued by the degrade path.
- Unknown enum on a clean stream completes as `Done` with populated usage; a mapping-contract unit test pins the explicit table.
- Reverse check: 4 of the 6 tail-error tests fail on the unfixed code; the 2 invariant tests pass on both.

`tests/test_agent_runner/` suite: 361 passed. CI-scope `ruff check src/ tests/` green.

## Out of scope (noted, not changed)

- `_iter_events`' collect-then-replay defeats incremental streaming for Bedrock (latency issue, independent of correctness).
- The suspected first cause of the tail exceptions themselves — the egress credential proxy's stream-close behavior (fingerprint to check: a fixed ~60s gap between last token and run finalization) — is a separate investigation; this fix is correct regardless of where the tail exception comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqG8e3i9x49S3TRHwv9QoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqG8e3i9x49S3TRHwv9QoD)_