### PR TITLE
fix(ws): reflect authoritative run status in the done terminal frame

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4276,6 +4276,14 @@ components:
 
     WsServerEventRunCompleted:
       type: object
+      description: >-
+        Sent only when the run actually reached `completed` (or the
+        terminal write could not be confirmed). When the underlying run
+        was already terminal `failed`/`awaiting_reauth` — e.g. the
+        orchestrator recorded an agent error after partial output
+        streamed — the stream ends with `event.run.error` carrying the
+        run's recorded error instead, matching what
+        `GET /api/v1/runs/{id}` reports.
       required: [type, run_id]
       properties:
         type: { type: string, enum: [event.run.completed] }

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -59,6 +59,7 @@ from rolemesh.db import (
 from rolemesh.ipc.web_protocol import WebInboundMessage
 from rolemesh.runs import (
     create_run,
+    get_run,
     terminate_run_via_ws_completed,
     terminate_run_via_ws_error,
 )
@@ -359,23 +360,30 @@ def _build_approval_frame_or_none(
 
 async def _terminate_run_completed(
     *, run_id: str, tenant_id: str, usage: Any | None
-) -> None:
+) -> bool | None:
     """Fire INV-6 path 1 (ws_completed) inside a tenant-scoped txn.
 
-    Wrapped in :class:`contextlib.suppress` so a transient DB
-    hiccup never crashes the forwarding loop — the run row stays
-    ``running`` and a future GET ``/api/v1/runs/{id}`` will report
-    the (now-incorrect) state until the operator notices. The
-    lifecycle helper's ``WHERE status='running'`` guard makes the
-    UPDATE idempotent in case the NATS chunk redelivers and we run
-    here twice.
+    Returns the lifecycle helper's outcome: ``True`` when THIS call
+    moved the row to ``completed``, ``False`` when the row was already
+    terminal (the ``WHERE status='running'`` guard did not match —
+    e.g. the orchestrator marked it ``failed`` after partial output
+    streamed), ``None`` on a DB error. The caller uses ``False`` to
+    reflect the authoritative state in the frame it sends instead of
+    blindly certifying success.
+
+    Exceptions are swallowed so a transient DB hiccup never crashes
+    the forwarding loop — the run row stays ``running`` and a future
+    GET ``/api/v1/runs/{id}`` will report the (now-incorrect) state
+    until the operator notices. The lifecycle helper's guard makes
+    the UPDATE idempotent in case the NATS chunk redelivers and we
+    run here twice.
     """
     usage_dict: dict[str, Any] | None = (
         usage if isinstance(usage, dict) else None
     )
     try:
         async with tenant_conn(tenant_id) as conn:
-            await terminate_run_via_ws_completed(
+            return await terminate_run_via_ws_completed(
                 run_id=run_id, usage=usage_dict, conn=conn
             )
     except Exception:  # noqa: BLE001
@@ -385,6 +393,65 @@ async def _terminate_run_completed(
             run_id=run_id,
             exc_info=True,
         )
+        return None
+
+
+async def _get_run_snapshot(run_id: str, tenant_id: str) -> dict[str, Any] | None:
+    """Best-effort read of the authoritative run row (status + error).
+
+    Only consulted on the cold path — a ``done`` frame whose
+    completed-write lost to an earlier terminal writer. ``None`` on
+    any failure; the caller then falls back to the legacy frame.
+    """
+    try:
+        async with tenant_conn(tenant_id) as conn:
+            return await get_run(run_id=run_id, tenant_id=tenant_id, conn=conn)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ws_stream: run snapshot lookup failed",
+            run_id=run_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _done_frame(
+    run_id: str, tenant_id: str, transitioned: bool | None
+) -> dict[str, Any]:
+    """Pick the terminal WS frame for a ``done`` stream chunk.
+
+    ``transitioned`` is the completed-terminator's outcome. ``True``
+    (this call moved the row to ``completed``) and ``None`` (DB
+    hiccup — keep legacy best-effort behavior) emit
+    ``event.run.completed``. ``False`` means the ``WHERE
+    status='running'`` guard did not match: another terminal writer
+    beat this ``done`` — typically the orchestrator marking
+    AGENT_ERROR after partial output already streamed (e.g. a
+    provider content-filter kill mid-generation). The frame must then
+    reflect the AUTHORITATIVE row, not the stream's optimism: a
+    failed run whose stream ends with ``completed`` shows the user a
+    truncated answer under a green check, and only the (rarely
+    consulted) ``GET /api/v1/runs/{id}`` disagrees.
+
+    Only ``failed`` / ``awaiting_reauth`` divert to an error frame —
+    a redelivered ``done`` on an already-completed/stopped/cancelled
+    row must NOT morph into a phantom error, and a lookup failure
+    falls back to the legacy completed frame.
+    """
+    if transitioned is False:
+        snapshot = await _get_run_snapshot(run_id, tenant_id)
+        status = (snapshot or {}).get("status")
+        if status in ("failed", "awaiting_reauth"):
+            err = (snapshot or {}).get("error")
+            err = err if isinstance(err, dict) else {}
+            return {
+                "type": "event.run.error",
+                "run_id": run_id,
+                "code": str(err.get("code") or "AGENT_ERROR"),
+                "message": str(err.get("message") or "run failed"),
+                "details": err,
+            }
+    return {"type": "event.run.completed", "run_id": run_id}
 
 
 async def _terminate_run_errored(
@@ -540,19 +607,20 @@ async def stream(
                     # mid-UPDATE doesn't strand the row. Lifecycle
                     # helper is idempotent on the ``WHERE
                     # status='running'`` guard, so re-delivery is safe.
-                    await asyncio.shield(
+                    transitioned = await asyncio.shield(
                         _terminate_run_completed(
                             run_id=run_id,
                             tenant_id=payload.tenant_id,
                             usage=data.get("usage"),
                         )
                     )
+                    # Frame reflects the AUTHORITATIVE row, not the
+                    # stream's optimism — see ``_done_frame``.
                     await _send_event(
                         ws,
-                        {
-                            "type": "event.run.completed",
-                            "run_id": run_id,
-                        },
+                        await _done_frame(
+                            run_id, payload.tenant_id, transitioned
+                        ),
                     )
                 elif kind == "status":
                     # Per-turn progress indicator (running / tool_use /

--- a/tests/webui/test_ws_terminators_inv6.py
+++ b/tests/webui/test_ws_terminators_inv6.py
@@ -247,3 +247,107 @@ async def test_helpers_swallow_db_errors_to_keep_forwarder_alive() -> None:
         tenant_id=tenant_id,
         error={"code": "X"},
     )
+
+
+# ---------------------------------------------------------------------------
+# fix/ws-completed-frame-on-failed-run — the ``done`` frame must reflect
+# the AUTHORITATIVE run row, not the stream's optimism.
+#
+# Field trace that motivated this: a provider content-filter killed the
+# stream mid-generation AFTER partial output reached the browser; the
+# orchestrator marked the run failed (AGENT_ERROR), but a ``done`` chunk
+# still arrived and the WS blindly emitted ``event.run.completed`` — a
+# truncated answer under a green check, contradicted only by
+# ``GET /api/v1/runs/{id}``. The completed-terminator's idempotent guard
+# already refused the second write; the frame just never consulted it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_helper_returns_true_on_transition() -> None:
+    tenant_id, run_id = await _seed_run()
+    transitioned = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert transitioned is True
+
+
+@pytest.mark.asyncio
+async def test_completed_helper_returns_false_when_already_failed() -> None:
+    """The lost-race signal the frame selection rides on."""
+    tenant_id, run_id = await _seed_run()
+    await _terminate_run_errored(
+        run_id=run_id,
+        tenant_id=tenant_id,
+        error={"code": "AGENT_ERROR", "message": "content filter"},
+    )
+    transitioned = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert transitioned is False
+    row = await _read_run(tenant_id, run_id)
+    assert row["status"] == "failed", "authoritative status must survive"
+
+
+@pytest.mark.asyncio
+async def test_done_frame_reports_error_when_row_already_failed() -> None:
+    """The observed bug: failed row + done chunk → error frame, not completed."""
+    from webui.v1.ws_stream import _done_frame
+
+    tenant_id, run_id = await _seed_run()
+    await _terminate_run_errored(
+        run_id=run_id,
+        tenant_id=tenant_id,
+        error={
+            "code": "AGENT_ERROR",
+            "message": "Output blocked by content filtering policy",
+        },
+    )
+    transitioned = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    frame = await _done_frame(run_id, tenant_id, transitioned)
+
+    assert frame["type"] == "event.run.error"
+    assert frame["run_id"] == run_id
+    assert frame["code"] == "AGENT_ERROR"
+    assert "content filtering" in frame["message"]
+
+
+@pytest.mark.asyncio
+async def test_done_frame_redelivery_on_completed_row_stays_completed() -> None:
+    """NATS redelivery of ``done`` on an already-completed row must NOT
+    morph into a phantom error — the idempotent-redelivery contract."""
+    from webui.v1.ws_stream import _done_frame
+
+    tenant_id, run_id = await _seed_run()
+    first = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert first is True
+    redelivered = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert redelivered is False
+    frame = await _done_frame(run_id, tenant_id, redelivered)
+    assert frame["type"] == "event.run.completed"
+
+
+@pytest.mark.asyncio
+async def test_done_frame_happy_path_skips_row_lookup() -> None:
+    """transitioned=True → completed frame with no extra DB read."""
+    from webui.v1.ws_stream import _done_frame
+
+    frame = await _done_frame(str(uuid.uuid4()), str(uuid.uuid4()), True)
+    assert frame["type"] == "event.run.completed"
+
+
+@pytest.mark.asyncio
+async def test_done_frame_lookup_miss_falls_back_to_completed() -> None:
+    """transitioned=False but the row can't be read (unknown id) → keep
+    the legacy completed frame rather than fabricating an error."""
+    from webui.v1.ws_stream import _done_frame
+
+    tenant_id, _run_id = await _seed_run()
+    frame = await _done_frame(str(uuid.uuid4()), tenant_id, False)
+    assert frame["type"] == "event.run.completed"

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2689,6 +2689,7 @@ export interface components {
              */
             delta: string;
         };
+        /** @description Sent only when the run actually reached `completed` (or the terminal write could not be confirmed). When the underlying run was already terminal `failed`/`awaiting_reauth` — e.g. the orchestrator recorded an agent error after partial output streamed — the stream ends with `event.run.error` carrying the run's recorded error instead, matching what `GET /api/v1/runs/{id}` reports. */
         WsServerEventRunCompleted: {
             /**
              * @description discriminator enum property added by openapi-typescript


### PR DESCRIPTION
## Summary

Field trace: a provider content filter killed a Bedrock stream mid-generation **after** partial output had reached the browser. The orchestrator recorded the run as `failed` (`AGENT_ERROR`), but a `done` chunk still arrived on the gateway stream and the WS forwarder blindly emitted `event.run.completed` — the user saw a truncated answer under a success frame, contradicted only by `GET /api/v1/runs/{id}`.

The information needed to do better already existed: the completed-terminator's idempotent `WHERE status='running'` guard refused the second write (the row stayed correctly `failed`) — the forwarder just discarded that outcome and sent the success frame regardless.

## Changes

- `_terminate_run_completed` now returns the lifecycle helper's outcome (`True` = transitioned, `False` = row already terminal, `None` = DB error / legacy best-effort).
- New `_done_frame` picks the terminal frame from that outcome: on a lost race it reads the authoritative row and, when the run is `failed`/`awaiting_reauth`, emits `event.run.error` carrying the run's recorded error — a frame the SPA already renders, no client contract change. A redelivered `done` on an already-completed/stopped/cancelled row keeps emitting `completed` (idempotent redelivery must not morph into a phantom error); a failed row lookup falls back to the legacy completed frame.
- `openapi.yaml` documents the completed-frame semantics; `types.ts` regenerated.

## Scope note (stopgap by design)

This is the **reconciliation layer**: it guarantees the terminal frame agrees with the authoritative run row for the observed ordering (error write wins, `done` arrives after). The root cause — one `done` signal conflating bubble finalization with run success, and dual writers on the run row — is addressed by the follow-up single-writer refactor (run_id threading + explicit terminal chunks), after which this layer is removed. The reverse race (a partial-output `completed` write beating the error event) is likewise resolved by that refactor, not by this PR.

## Testing

- 6 new tests in `test_ws_terminators_inv6.py` (real DB), including a verbatim reproduction of the field trace: row pre-marked failed with a content-filtering error + `done` arrives → client receives `event.run.error`, not `completed`. Idempotent redelivery, happy-path no-lookup, and lookup-miss fallback each pinned.
- Regression: all WS suites + runs lifecycle + REST runs + OpenAPI contract/codegen — 101 passed; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_