### PR TITLE
refactor(runs): thread run_id orchestrator→container and echo it on output events (single-writer phase A)

### DIFF
--- a/src/agent_runner/main.py
+++ b/src/agent_runner/main.py
@@ -86,6 +86,13 @@ class ContainerOutput:
     # every unclassified error on the existing retry path (fail-open to
     # retry), and absence on the wire means True for older containers.
     retryable: bool = True
+    # Run attribution (single-writer refactor, phase A): the ``runs`` row
+    # this event belongs to — the run of the prompt the backend was serving
+    # when it emitted the event. Seeded from ``AgentInitData.run_id``,
+    # updated from the ``run_id`` on follow-up input payloads (see
+    # ``_RunAttribution``). None when the turn has no run (scheduled task)
+    # or the orchestrator predates the field.
+    run_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"status": self.status, "result": self.result}
@@ -102,6 +109,9 @@ class ContainerOutput:
         # Same convention: only non-default (False) goes on the wire.
         if not self.retryable:
             d["retryable"] = False
+        # Same convention: absent when there is nothing to attribute.
+        if self.run_id is not None:
+            d["runId"] = self.run_id
         return d
 
 
@@ -139,19 +149,61 @@ def is_retryable_error(exc: BaseException) -> bool:
     return not isinstance(exc, NonRetryableConfigError)
 
 
-async def drain_nats_input(sub: Any) -> list[str]:
-    """Drain any pending input messages from an existing subscription."""
-    messages: list[str] = []
+async def drain_nats_input(sub: Any) -> list[tuple[str, str | None]]:
+    """Drain any pending input messages from an existing subscription.
+
+    Returns ``(text, run_id)`` pairs; ``run_id`` is None on payloads from
+    an orchestrator that predates run attribution.
+    """
+    messages: list[tuple[str, str | None]] = []
     while True:
         try:
             msg = await asyncio.wait_for(sub.next_msg(timeout=0.1), timeout=0.1)
             data = json.loads(msg.data)
             await msg.ack()
             if data.get("type") == "message" and data.get("text"):
-                messages.append(data["text"])
+                rid = data.get("run_id")
+                messages.append(
+                    (data["text"], rid if isinstance(rid, str) and rid else None)
+                )
         except TimeoutError:
             break
     return messages
+
+
+class _RunAttribution:
+    """Maps backend output events to the ``runs`` row they answer.
+
+    The container serves prompts strictly in order: the initial prompt
+    (possibly covering several drained messages — attributed to the LAST
+    drained run, mirroring the orchestrator's ``active_run_id``
+    convention), then queued follow-ups FIFO. Each per-prompt ResultEvent
+    consumes one entry; every other event (progress, error, stop,
+    safety-block) is attributed to the prompt currently being served
+    without consuming it. ``last`` covers events that arrive after the
+    queue drained (e.g. the batch-final marker).
+
+    When a prompt dies mid-serving (error), the remaining queued runs are
+    left un-terminated — parity with pre-refactor behavior, where the
+    retry path re-reads those messages anyway.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[str | None] = []
+        self._last: str | None = None
+
+    def enqueue(self, run_id: str | None) -> None:
+        self._pending.append(run_id)
+
+    def current(self) -> str | None:
+        """Run of the prompt being served right now (non-consuming)."""
+        return self._pending[0] if self._pending else self._last
+
+    def consume(self) -> str | None:
+        """Attribute a per-prompt result and advance to the next prompt."""
+        rid = self._pending.pop(0) if self._pending else self._last
+        self._last = rid
+        return rid
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +373,11 @@ async def run_query_loop(
     # Track session ID from backend events
     session_id: str | None = init.session_id
 
+    # Maps each output event to the ``runs`` row of the prompt being served.
+    # Seeded below (after the input drain) with the initial prompt's run;
+    # follow-up intake points enqueue as messages arrive.
+    attribution = _RunAttribution()
+
     async def on_event(event: BackendEvent) -> None:
         nonlocal session_id
         output, session_id = event_to_output(event, session_id)
@@ -331,6 +388,13 @@ async def run_query_loop(
         elif isinstance(event, ErrorEvent):
             log(f"Backend error: {event.error}")
         if output is not None:
+            # Per-prompt result: consume the queue entry (next event belongs
+            # to the next prompt). Everything else — progress, error, stop,
+            # safety block — describes the prompt still being served.
+            if isinstance(event, ResultEvent):
+                output.run_id = attribution.consume()
+            else:
+                output.run_id = attribution.current()
             await publish_output(js, job_id, output)
 
     # Build the unified hook registry. TranscriptArchiveHandler replaces
@@ -500,10 +564,20 @@ async def run_query_loop(
             "[SCHEDULED TASK - The following message was sent automatically "
             "and is not coming directly from the user or group.]\n\n" + prompt
         )
+    # Run attribution: the merged initial prompt (init + drained messages)
+    # is served as ONE prompt, answered by ONE ResultEvent, so it gets ONE
+    # queue entry. When drained messages carry run ids, the last non-None
+    # one wins — same "last message's run" convention the orchestrator uses
+    # for active_run_id when it batches messages into a single prompt.
+    initial_run_id = init.run_id
     pending = await drain_nats_input(input_sub)
     if pending:
         log(f"Draining {len(pending)} pending NATS messages into initial prompt")
-        prompt += "\n" + "\n".join(pending)
+        prompt += "\n" + "\n".join(text for text, _ in pending)
+        for _, drained_run_id in pending:
+            if drained_run_id is not None:
+                initial_run_id = drained_run_id
+    attribution.enqueue(initial_run_id)
 
     # Main query loop
     try:
@@ -528,6 +602,10 @@ async def run_query_loop(
                         await msg.ack()
                         if data.get("type") == "message" and data.get("text"):
                             text = data["text"]
+                            rid = data.get("run_id")
+                            attribution.enqueue(
+                                rid if isinstance(rid, str) and rid else None
+                            )
                             log(f"Follow-up message received ({len(text)} chars)")
                             await backend.handle_follow_up(text)
                     except TimeoutError:
@@ -561,6 +639,11 @@ async def run_query_loop(
                     result=None,
                     new_session_id=session_id,
                     is_final=True,
+                    # The batch has settled: attribute the marker to the last
+                    # prompt served (attribution.current() falls back to
+                    # ``last`` once the queue is empty). This is the event
+                    # the orchestrator terminal-writes the run from.
+                    run_id=attribution.current(),
                 ),
             )
 
@@ -577,6 +660,10 @@ async def run_query_loop(
                     await msg.ack()
                     if data.get("type") == "message" and data.get("text"):
                         next_message = data["text"]
+                        rid = data.get("run_id")
+                        attribution.enqueue(
+                            rid if isinstance(rid, str) and rid else None
+                        )
                         break
                 except TimeoutError:
                     pass

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -111,6 +111,8 @@ def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
     # the classification can never accidentally suppress a retry.
     retryable_val = raw.get("retryable")
     retryable = bool(retryable_val) if isinstance(retryable_val, bool) else True
+    # Run attribution echo — absent on events from older containers.
+    run_id_val = raw.get("runId")
     return AgentOutput(
         status=str(raw.get("status", "error")),  # type: ignore[arg-type]
         result=str(result_val) if result_val is not None else None,
@@ -119,6 +121,7 @@ def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
         metadata=meta_val if isinstance(meta_val, dict) else None,
         is_final=is_final,
         retryable=retryable,
+        run_id=str(run_id_val) if isinstance(run_id_val, str) and run_id_val else None,
     )
 
 
@@ -457,6 +460,7 @@ class ContainerAgentExecutor:
             conversation_id=conversation_id,
             user_id=inp.user_id,
             session_id=inp.session_id,
+            run_id=inp.run_id,
             is_scheduled_task=inp.is_scheduled_task,
             assistant_name=inp.assistant_name,
             system_prompt=effective_system_prompt,

--- a/src/rolemesh/agent/executor.py
+++ b/src/rolemesh/agent/executor.py
@@ -31,6 +31,10 @@ class AgentInput:
     assistant_name: str | None = None
     system_prompt: str | None = None
     role_config: dict[str, object] | None = None
+    # The ``runs`` row this prompt answers (None when the turn has no run,
+    # e.g. scheduled tasks). Threaded into AgentInitData so the container
+    # can echo it on output events — see AgentOutput.run_id.
+    run_id: str | None = None
 
 
 # Progress statuses are transient UX indicators; terminal statuses carry the
@@ -78,6 +82,14 @@ class AgentOutput:
     error: str | None = None
     metadata: dict[str, object] | None = None
     is_final: bool = True
+    # Run attribution echoed by the container: which ``runs`` row this
+    # event belongs to. The container tracks the run of the prompt it is
+    # currently serving (initial run from AgentInitData, follow-ups from
+    # the input payload) so batch replies attribute correctly instead of
+    # all landing on whatever the orchestrator's closure last saw. None =
+    # older container or a turn with no run; consumers fall back to their
+    # legacy closure-tracked id.
+    run_id: str | None = None
     # Only meaningful for status="error". False marks a deterministic
     # configuration error the container classified at the source
     # (pi.ai.types.NonRetryableConfigError): the orchestrator fails the

--- a/src/rolemesh/container/scheduler.py
+++ b/src/rolemesh/container/scheduler.py
@@ -547,7 +547,9 @@ class GroupQueue:
         state.idle_handle = None
         self._drain_group(group_jid)
 
-    def send_message(self, group_jid: str, text: str) -> bool:
+    def send_message(
+        self, group_jid: str, text: str, run_id: str | None = None
+    ) -> bool:
         """Deliver a message to this group's live container via NATS.
 
         Two cases (slot-follows-turn rework):
@@ -558,6 +560,11 @@ class GroupQueue:
           It needs turn admission: if granted, acquire a turn slot, leave the
           warm pool, cancel idle reaping, then deliver; if denied, return False
           so the caller queues it for a later drain.
+
+        ``run_id`` is the ``runs`` row this message answers; the container
+        echoes it back on output events so the orchestrator terminal-writes
+        the right run (single-writer refactor, phase A). None keeps the
+        legacy payload shape for callers with nothing to attribute.
 
         Returns False when there is no live container, it is a task container,
         no transport is wired, or a warm resume is refused by admission.
@@ -584,9 +591,12 @@ class GroupQueue:
             async def _send() -> None:
                 assert self._transport is not None
                 assert state.job_id is not None
+                payload: dict[str, str] = {"type": "message", "text": text}
+                if run_id is not None:
+                    payload["run_id"] = run_id
                 await self._transport.js.publish(
                     f"agent.{state.job_id}.input",
-                    json.dumps({"type": "message", "text": text}).encode(),
+                    json.dumps(payload).encode(),
                 )
 
             bg = asyncio.ensure_future(_send())

--- a/src/rolemesh/ipc/protocol.py
+++ b/src/rolemesh/ipc/protocol.py
@@ -49,6 +49,13 @@ class AgentInitData:
     conversation_id: str = ""
     user_id: str = ""
     session_id: str | None = None
+    # Run attribution (single-writer refactor, phase A): the ``runs`` row
+    # this initial prompt answers. The container echoes it (and the ids of
+    # queued follow-ups) back on every output event so the orchestrator can
+    # terminal-write the RIGHT run without relying on a closure variable
+    # that goes stale on warm-container follow-ups. None = older
+    # orchestrator or a turn with no run (scheduled task).
+    run_id: str | None = None
     is_scheduled_task: bool = False
     assistant_name: str | None = None
     system_prompt: str | None = None

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1013,10 +1013,16 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
     # single-active-run model as ws_stream). Writing the terminal status here, at
     # is_final/error, means a browser that disconnected mid-turn no longer
     # strands the row at 'running'. Idempotent with the WS-side writer via the
-    # lifecycle helper's WHERE status='running' guard. (Limitation: follow-ups
-    # piped into a warm container via send_message are not threaded here, so
-    # their runs still rely on the WS path / reaper — the dominant
-    # disconnect-mid-cold-start case is covered.)
+    # lifecycle helper's WHERE status='running' guard.
+    #
+    # Attribution precedence (single-writer refactor, phase A): the container
+    # now echoes the run of the prompt it actually served on each output
+    # event (AgentOutput.run_id — seeded via AgentInitData, updated from
+    # follow-up input payloads), so ``result.run_id or active_run_id`` at the
+    # terminal-write sites prefers the echoed id. The closure value below is
+    # the fallback for older containers and covers this turn's cold start;
+    # it goes stale when follow-ups are piped into a warm container, which
+    # is exactly what the echo fixes.
     active_run_id = next((m.run_id for m in reversed(missed_messages) if m.run_id), None)
 
     previous_cursor = conv_state.last_agent_timestamp
@@ -1102,7 +1108,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.is_final:
                 _queue.notify_idle(conversation_id)
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={
@@ -1202,7 +1208,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 _queue.notify_idle(conversation_id)
                 usage_dict = result.metadata.get("usage") if result.metadata else None
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=True,
                     usage=usage_dict if isinstance(usage_dict, dict) else None,
@@ -1224,7 +1230,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.retryable:
                 had_error = True
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={"code": "AGENT_ERROR", "message": result.error or "agent run failed"},
@@ -1236,13 +1242,13 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 # once with a user-visible explanation.
                 non_retryable_error = result.error or "agent configuration error"
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={"code": "CONFIG_ERROR", "message": non_retryable_error},
                 )
 
-    output = await _run_agent(cw_state, conv_state, prompt, _on_output)
+    output = await _run_agent(cw_state, conv_state, prompt, _on_output, run_id=active_run_id)
 
     # Stop typing
     if binding and gw:
@@ -1318,8 +1324,14 @@ async def _run_agent(
     conv_state: ConversationState,
     prompt: str,
     on_output: Callable[[AgentOutput], Awaitable[None]] | None = None,
+    run_id: str | None = None,
 ) -> str:
-    """Run agent in a container. Returns 'success' or 'error'."""
+    """Run agent in a container. Returns 'success' or 'error'.
+
+    ``run_id`` is the ``runs`` row the initial prompt answers; it seeds the
+    container's run attribution (AgentInitData.run_id) so output events echo
+    the right run back. None for turns with no run (scheduled tasks).
+    """
     config = cw_state.config
     conv = conv_state.conversation
     permissions = config.permissions
@@ -1384,6 +1396,7 @@ async def _run_agent(
                 tenant_id=config.tenant_id,
                 coworker_id=config.id,
                 conversation_id=conv.id,
+                run_id=run_id,
             ),
             lambda container_name, job_id: _queue.register_process(
                 conv.id, container_name, config.folder, job_id
@@ -1757,7 +1770,16 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                     )
                     if all_pending:
                         formatted = format_messages(all_pending, TIMEZONE)
-                        if _queue.send_message(conv_id, formatted):
+                        # Same "last message's run" convention as _process_
+                        # conversation_messages' active_run_id. The container
+                        # enqueues this id and echoes it on the outputs that
+                        # answer this batch — the warm-container follow-up is
+                        # exactly the case the stale closure could not cover.
+                        pipe_run_id = next(
+                            (m.run_id for m in reversed(all_pending) if m.run_id),
+                            None,
+                        )
+                        if _queue.send_message(conv_id, formatted, run_id=pipe_run_id):
                             logger.debug("Piped messages to active container", conv_id=conv_id)
                             conv_state.last_agent_timestamp = all_pending[-1].timestamp
                             await update_conversation_last_invocation(

--- a/tests/container/test_scheduler.py
+++ b/tests/container/test_scheduler.py
@@ -92,6 +92,62 @@ async def test_interrupt_current_turn_active_no_transport() -> None:
     assert state.job_id == "job-abc"
 
 
+class _CapturingJs:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append((subject, data))
+
+
+class _CapturingTransport:
+    def __init__(self) -> None:
+        self.js = _CapturingJs()
+
+
+async def test_send_message_includes_run_id_in_payload() -> None:
+    """Run attribution (single-writer refactor, phase A): the input payload
+    carries the run the piped message answers so the container can echo it
+    on output events."""
+    import json
+
+    queue = GroupQueue()
+    transport = _CapturingTransport()
+    queue._transport = transport  # type: ignore[assignment]
+    state = queue._get_group("group1")
+    state.active = True
+    state.job_id = "job-abc"
+    state.processing = True  # mid-turn: skips warm-resume admission
+
+    assert queue.send_message("group1", "hello", run_id="run-1") is True
+    await asyncio.sleep(0)  # let the background publish run
+
+    subject, data = transport.js.published[0]
+    assert subject == "agent.job-abc.input"
+    assert json.loads(data) == {"type": "message", "text": "hello", "run_id": "run-1"}
+    await queue.shutdown()
+
+
+async def test_send_message_without_run_id_keeps_legacy_payload() -> None:
+    """No attribution → byte-identical payload shape to before the change."""
+    import json
+
+    queue = GroupQueue()
+    transport = _CapturingTransport()
+    queue._transport = transport  # type: ignore[assignment]
+    state = queue._get_group("group1")
+    state.active = True
+    state.job_id = "job-abc"
+    state.processing = True
+
+    assert queue.send_message("group1", "hello") is True
+    await asyncio.sleep(0)
+
+    _subject, data = transport.js.published[0]
+    assert json.loads(data) == {"type": "message", "text": "hello"}
+    await queue.shutdown()
+
+
 async def test_enqueue_message_while_active() -> None:
     queue = GroupQueue()
     call_count = 0

--- a/tests/ipc/test_protocol.py
+++ b/tests/ipc/test_protocol.py
@@ -54,6 +54,31 @@ def test_agent_init_data_optional_fields() -> None:
     assert restored.system_prompt is None
     assert restored.role_config is None
     assert restored.user_id == ""
+    assert restored.run_id is None
+
+
+def test_agent_init_data_run_id_roundtrip() -> None:
+    """Run attribution seed (single-writer refactor, phase A) survives the
+    KV wire, and its absence — an orchestrator predating the field —
+    deserializes to None rather than erroring."""
+    perms = AgentPermissions().to_dict()
+    init = AgentInitData(
+        prompt="Test",
+        group_folder="group",
+        chat_jid="jid",
+        permissions=perms,
+        run_id="run-abc",
+    )
+    restored = AgentInitData.deserialize(init.serialize())
+    assert restored.run_id == "run-abc"
+
+    # Payload from an older orchestrator: no run_id key at all.
+    import json
+
+    raw = json.loads(init.serialize())
+    del raw["run_id"]
+    legacy = AgentInitData.deserialize(json.dumps(raw).encode())
+    assert legacy.run_id is None
 
 
 def test_agent_init_data_frozen() -> None:

--- a/tests/orchestration/test_run_attribution_orchestrator.py
+++ b/tests/orchestration/test_run_attribution_orchestrator.py
@@ -1,0 +1,347 @@
+"""Orchestrator side of run attribution (single-writer refactor, phase A).
+
+``_process_conversation_messages`` used to terminal-write whatever run its
+closure captured at turn start (``active_run_id``) — correct for the cold
+start, stale for follow-ups piped into a warm container. The container now
+echoes the run of the prompt it actually served on each output event
+(``AgentOutput.run_id``), and the terminal-write sites prefer that echo:
+``result.run_id or active_run_id``.
+
+The contract under test:
+
+* The initial prompt's run is threaded into ``AgentInput.run_id`` so the
+  container can seed its attribution.
+* An echoed run_id wins over the closure at every terminal-write site
+  (success, retryable error, non-retryable error).
+* No echo (older container) → the closure fallback keeps today's
+  behavior byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rolemesh.core.orchestrator_state import (
+    ConversationState,
+    CoworkerState,
+    OrchestratorState,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+    from rolemesh.agent import AgentOutput
+    from rolemesh.core.types import Conversation
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pg_url: str) -> Path:
+    data_dir = tmp_path / "data"
+    groups_dir = tmp_path / "groups"
+    monkeypatch.setattr("rolemesh.core.config.DATA_DIR", data_dir)
+    monkeypatch.setattr("rolemesh.core.config.GROUPS_DIR", groups_dir)
+    monkeypatch.setattr("rolemesh.core.config.STORE_DIR", tmp_path / "store")
+    monkeypatch.setattr("rolemesh.core.config.TIMEZONE", "UTC")
+    monkeypatch.setattr("rolemesh.core.group_folder.DATA_DIR", data_dir)
+    monkeypatch.setattr("rolemesh.core.group_folder.GROUPS_DIR", groups_dir)
+
+    from rolemesh.db import _init_test_database
+
+    await _init_test_database(pg_url)
+
+    yield tmp_path
+
+    from rolemesh.db import close_database
+
+    await close_database()
+
+
+# ---------------------------------------------------------------------------
+# Harness (same shape as test_non_retryable_agent_errors, kept self-contained)
+# ---------------------------------------------------------------------------
+
+
+class EchoExecutor:
+    """Executor that emits one AgentOutput built by the test, and records
+    the AgentInput it was given (to assert run_id threading)."""
+
+    def __init__(self, output: AgentOutput) -> None:
+        self._output = output
+        self.inputs: list[object] = []
+
+    @property
+    def name(self) -> str:
+        return "mock"
+
+    async def execute(
+        self,
+        inp: object,
+        on_process: Callable[..., None],
+        on_output: Callable[..., Awaitable[None]] | None = None,
+    ) -> object:
+        self.inputs.append(inp)
+        on_process("mock-container", f"job-{uuid.uuid4().hex[:6]}")
+        if on_output:
+            await on_output(self._output)
+        return self._output
+
+
+@dataclass
+class MockGateway:
+    _channel_type: str = "telegram"
+    sent: list[tuple[str, str, str]] = field(default_factory=list)
+
+    @property
+    def channel_type(self) -> str:
+        return self._channel_type
+
+    async def send_message(self, binding_id: str, chat_id: str, text: str) -> None:
+        self.sent.append((binding_id, chat_id, text))
+
+    async def set_typing(self, binding_id: str, chat_id: str, is_typing: bool) -> None:
+        pass
+
+
+async def _seed_scenario(
+    executor: object, gateway: MockGateway, *, bind_run: bool
+) -> tuple[str, Conversation, str | None]:
+    """Tenant + coworker + telegram conversation + one unanswered message.
+
+    ``bind_run=True`` creates a real ``runs`` row (messages.run_id has an
+    FK) and binds the message to it — that id becomes the closure's
+    ``active_run_id``. Returns it as the third element (None otherwise)."""
+    import rolemesh.main as m
+    from rolemesh.db import (
+        create_channel_binding,
+        create_conversation,
+        create_coworker,
+        create_tenant,
+        store_message,
+        tenant_conn,
+    )
+    from rolemesh.runs.lifecycle import create_run
+
+    t = await create_tenant(name="T", slug=f"attr-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="Bot", folder=f"f-{uuid.uuid4().hex[:8]}"
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id,
+        tenant_id=t.id,
+        channel_type="telegram",
+        credentials={"bot_token": "tok"},
+    )
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id="chat-1",
+    )
+    run_id: str | None = None
+    if bind_run:
+        async with tenant_conn(t.id) as conn:
+            run_id = await create_run(
+                tenant_id=t.id, conversation_id=conv.id, conn=conn
+            )
+    await store_message(
+        tenant_id=t.id,
+        conversation_id=conv.id,
+        msg_id=f"msg-{uuid.uuid4().hex[:8]}",
+        sender="user-1",
+        sender_name="Alice",
+        content="hello",
+        timestamp="2024-06-01T12:00:01+00:00",
+        run_id=run_id,
+    )
+
+    cw_state = CoworkerState.from_coworker(cw)
+    cw_state.channel_bindings[binding.channel_type] = binding
+    cw_state.conversations[conv.id] = ConversationState(conversation=conv)
+    state = OrchestratorState()
+    state.coworkers[cw.id] = cw_state
+
+    m._state = state
+    m._executor = executor  # type: ignore[assignment]
+    m._executors = {"claude": executor, "pi": executor}  # type: ignore[assignment]
+    m._gateways = {"telegram": gateway}  # type: ignore[assignment]
+    m._queue = m.GroupQueue()
+    m._queue.set_process_messages_fn(m._process_conversation_messages)
+    m._transport = None
+    return cw.id, conv, run_id
+
+
+def _capture_terminations(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    import rolemesh.main as m
+
+    calls: list[dict[str, object]] = []
+
+    async def _fake_terminate(
+        run_id: str | None,
+        tenant_id: str,
+        *,
+        success: bool,
+        usage: dict[str, object] | None = None,
+        error: dict[str, object] | None = None,
+    ) -> None:
+        calls.append(
+            {"run_id": run_id, "success": success, "error": error}
+        )
+
+    monkeypatch.setattr(m, "_terminate_run_safe", _fake_terminate)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# run_id threading into the container
+# ---------------------------------------------------------------------------
+
+
+async def test_active_run_id_threaded_into_agent_input(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(status="success", result="hi", is_final=True)
+    )
+    _cw_id, conv, closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert len(executor.inputs) == 1
+    assert executor.inputs[0].run_id == closure_run, (
+        "the closure's active_run_id must seed the container's attribution"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Echo wins over the closure at every terminal-write site
+# ---------------------------------------------------------------------------
+
+
+async def test_success_prefers_echoed_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The warm-follow-up case in miniature: the container answers a NEWER
+    run than the one the closure captured — the echo must win, or the new
+    run's row is stranded while the old row double-terminates as a no-op."""
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(
+            status="success", result="hi", is_final=True, run_id="run-echo"
+        )
+    )
+    _cw_id, conv, closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert closure_run is not None
+    assert [c["run_id"] for c in calls if c["success"]] == ["run-echo"]
+
+
+async def test_retryable_error_prefers_echoed_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(
+            status="error", result=None, error="boom", run_id="run-echo"
+        )
+    )
+    _cw_id, conv, _closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    await m._process_conversation_messages(conv.id)
+    failures = [c for c in calls if not c["success"]]
+    assert [c["run_id"] for c in failures] == ["run-echo"]
+
+
+async def test_non_retryable_error_prefers_echoed_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(
+            status="error",
+            result=None,
+            error="bad config",
+            retryable=False,
+            run_id="run-echo",
+        )
+    )
+    _cw_id, conv, _closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    failures = [c for c in calls if not c["success"]]
+    assert [c["run_id"] for c in failures] == ["run-echo"]
+    assert failures[0]["error"] == {"code": "CONFIG_ERROR", "message": "bad config"}
+
+
+# ---------------------------------------------------------------------------
+# Fallback: no echo → closure behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_no_echo_falls_back_to_closure_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Events from an older container carry no run_id — the pre-refactor
+    closure attribution must keep working unchanged."""
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(status="success", result="hi", is_final=True)
+    )
+    _cw_id, conv, closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert closure_run is not None
+    assert [c["run_id"] for c in calls if c["success"]] == [closure_run]
+
+
+async def test_no_echo_no_closure_terminates_nothing(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IM turns have no run at all: the terminal write must stay a no-op
+    (run_id=None reaches _terminate_run_safe, whose guard returns early —
+    here we just assert None is what's passed)."""
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(status="success", result="hi", is_final=True)
+    )
+    _cw_id, conv, _closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=False
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert [c["run_id"] for c in calls if c["success"]] == [None]

--- a/tests/test_agent_runner/test_nats_bridge.py
+++ b/tests/test_agent_runner/test_nats_bridge.py
@@ -245,18 +245,25 @@ class TestChannel3FollowUpInput:
         _nc, js = nats_conn
         job_id = _unique_job_id()
 
-        # Publish 3 pending messages
+        # Publish 3 pending messages; one carries run attribution.
         for i in range(3):
+            payload: dict[str, str] = {"type": "message", "text": f"pending-{i}"}
+            if i == 1:
+                payload["run_id"] = "run-1"
             await js.publish(
                 f"agent.{job_id}.input",
-                json.dumps({"type": "message", "text": f"pending-{i}"}).encode(),
+                json.dumps(payload).encode(),
             )
         await asyncio.sleep(0.1)
 
         sub = await js.subscribe(f"agent.{job_id}.input")
         messages = await drain_nats_input(sub)
         await sub.unsubscribe()
-        assert messages == ["pending-0", "pending-1", "pending-2"]
+        assert messages == [
+            ("pending-0", None),
+            ("pending-1", "run-1"),
+            ("pending-2", None),
+        ]
 
     async def test_drain_empty_returns_empty(self, nats_conn: tuple) -> None:
         _nc, js = nats_conn
@@ -528,6 +535,59 @@ class TestBridgeFullCycle:
             assert "run backup" in backend.prompts[0]
         finally:
             bridge_mod._create_backend = original_create
+
+    async def test_run_id_echoed_on_results(self, nats_conn: tuple) -> None:
+        """Attribution end-to-end: the initial prompt's run (from
+        AgentInitData) is echoed on its result and on the batch-final
+        marker; a between-query follow-up carrying a different run_id gets
+        ITS run echoed — the exact case the orchestrator's stale closure
+        used to misattribute."""
+        nc, js = nats_conn
+        job_id = _unique_job_id()
+        init = _make_init(job_id, prompt="first question", run_id="run-cold")
+
+        backend = FakeBackend()
+        backend.prompt_delay = 0.05
+
+        sub = await js.subscribe(f"agent.{job_id}.results")
+
+        import agent_runner.main as bridge_mod
+        original_create = bridge_mod._create_backend
+
+        bridge_mod._create_backend = lambda _: backend
+        try:
+            loop_task = asyncio.create_task(run_query_loop(init, nc, js, job_id))
+
+            # Wait for first query to finish, then send a follow-up bound
+            # to a different run (warm-container continuation).
+            await asyncio.sleep(0.3)
+            await js.publish(
+                f"agent.{job_id}.input",
+                json.dumps(
+                    {"type": "message", "text": "second question", "run_id": "run-warm"}
+                ).encode(),
+            )
+            await asyncio.sleep(0.3)
+
+            await nc.request(f"agent.{job_id}.shutdown", b"", timeout=2)
+            await asyncio.wait_for(loop_task, timeout=5)
+
+            results: list[dict] = []
+            with contextlib.suppress(Exception):
+                while True:
+                    msg = await asyncio.wait_for(sub.next_msg(timeout=1), timeout=2)
+                    await msg.ack()
+                    results.append(json.loads(msg.data))
+
+            successes = [r for r in results if r.get("status") == "success"]
+            # First query: per-prompt result + batch-final marker → run-cold.
+            # Second query: same pair → run-warm.
+            assert [r.get("runId") for r in successes] == [
+                "run-cold", "run-cold", "run-warm", "run-warm",
+            ]
+        finally:
+            bridge_mod._create_backend = original_create
+            await sub.unsubscribe()
 
     async def test_second_prompt_after_follow_up_message(self, nats_conn: tuple) -> None:
         """After first query ends, a new NATS input message triggers a second prompt."""

--- a/tests/test_agent_runner/test_run_attribution.py
+++ b/tests/test_agent_runner/test_run_attribution.py
@@ -1,0 +1,163 @@
+"""Run attribution in the agent runner (single-writer refactor, phase A).
+
+The orchestrator's terminal-write closure (``active_run_id``) goes stale
+when follow-ups are piped into a warm container: the closure was captured
+at cold start and never learns about the newer runs. The fix is to make
+the container itself track which ``runs`` row each prompt answers — seeded
+from ``AgentInitData.run_id``, updated from the ``run_id`` on follow-up
+input payloads — and echo it on every output event.
+
+Bug-bait focus:
+
+* FIFO discipline: batch replies must attribute one queue entry per
+  ResultEvent, in arrival order — off-by-one here terminal-writes the
+  WRONG run, which the WHERE status='running' guard then makes permanent.
+* Non-consuming reads: progress/error/stop events describe the prompt
+  still being served; consuming on them would shift the whole batch.
+* Wire shape stays legacy-compatible: ``runId`` appears in the JSON only
+  when there is something to attribute, mirroring isFinal/retryable.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from agent_runner.main import ContainerOutput, _RunAttribution, drain_nats_input
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# _RunAttribution semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_single_prompt_consume_then_fallback_to_last() -> None:
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    assert a.current() == "run-1"
+    assert a.current() == "run-1", "current() must not consume"
+    assert a.consume() == "run-1"
+    # Queue drained: the batch-final marker (and any straggler event)
+    # still attributes to the last prompt served.
+    assert a.current() == "run-1"
+    assert a.consume() == "run-1"
+
+
+async def test_fifo_across_batched_prompts() -> None:
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    a.enqueue("run-2")
+    a.enqueue("run-3")
+    assert a.current() == "run-1"
+    assert a.consume() == "run-1"
+    assert a.current() == "run-2", "after consuming, events belong to the next prompt"
+    assert a.consume() == "run-2"
+    assert a.consume() == "run-3"
+    assert a.current() == "run-3"
+
+
+async def test_none_entries_flow_through() -> None:
+    """A prompt with no run (scheduled task, legacy orchestrator) must
+    yield None — not resurrect a stale earlier id."""
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    a.enqueue(None)
+    assert a.consume() == "run-1"
+    assert a.current() is None
+    assert a.consume() is None
+    assert a.current() is None, "last must track the None, not keep run-1"
+
+
+async def test_empty_attribution_yields_none() -> None:
+    a = _RunAttribution()
+    assert a.current() is None
+    assert a.consume() is None
+
+
+async def test_error_mid_batch_attributes_to_prompt_being_served() -> None:
+    """An error while serving prompt 1 of a batch must attribute to run-1
+    (non-consuming) — the queued run-2 stays untouched for the retry path."""
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    a.enqueue("run-2")
+    assert a.current() == "run-1", "error event attributes to the in-flight prompt"
+    assert a.current() == "run-1", "and does not advance the queue"
+
+
+# ---------------------------------------------------------------------------
+# Input drain: (text, run_id) pairs
+# ---------------------------------------------------------------------------
+
+
+class _FakeMsg:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.data = json.dumps(payload).encode()
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+
+class _FakeSub:
+    def __init__(self, msgs: list[_FakeMsg]) -> None:
+        self._msgs = list(msgs)
+
+    async def next_msg(self, timeout: float = 0.1) -> _FakeMsg:
+        if not self._msgs:
+            raise TimeoutError
+        return self._msgs.pop(0)
+
+
+async def test_drain_returns_text_and_run_id_pairs() -> None:
+    sub = _FakeSub(
+        [
+            _FakeMsg({"type": "message", "text": "a", "run_id": "run-1"}),
+            _FakeMsg({"type": "message", "text": "b"}),
+            _FakeMsg({"type": "message", "text": "c", "run_id": "run-3"}),
+        ]
+    )
+    assert await drain_nats_input(sub) == [
+        ("a", "run-1"),
+        ("b", None),
+        ("c", "run-3"),
+    ]
+
+
+async def test_drain_junk_run_id_becomes_none() -> None:
+    """A non-string or empty run_id must not leak into attribution."""
+    sub = _FakeSub(
+        [
+            _FakeMsg({"type": "message", "text": "a", "run_id": 42}),
+            _FakeMsg({"type": "message", "text": "b", "run_id": ""}),
+        ]
+    )
+    assert await drain_nats_input(sub) == [("a", None), ("b", None)]
+
+
+async def test_drain_skips_non_message_payloads() -> None:
+    sub = _FakeSub(
+        [
+            _FakeMsg({"type": "ping"}),
+            _FakeMsg({"type": "message", "text": "real", "run_id": "run-1"}),
+        ]
+    )
+    assert await drain_nats_input(sub) == [("real", "run-1")]
+
+
+# ---------------------------------------------------------------------------
+# Wire shape
+# ---------------------------------------------------------------------------
+
+
+async def test_run_id_absent_from_wire_when_none() -> None:
+    """No attribution → serialize exactly as before this change."""
+    d = ContainerOutput(status="success", result="ok").to_dict()
+    assert "runId" not in d
+
+
+async def test_run_id_emitted_when_set() -> None:
+    d = ContainerOutput(status="success", result="ok", run_id="run-1").to_dict()
+    assert d["runId"] == "run-1"


### PR DESCRIPTION
## Background

The orchestrator's INV-6 terminal writes attribute to a closure variable (`active_run_id`) captured at turn start. That is correct for the cold start but **goes stale when follow-ups are piped into a warm container** via `send_message` — those turns' runs today rely on the WS path or the reaper, and a batch answered by a warm container can terminal-write the wrong run.

This is **phase A of the single-writer refactor** (agreed sequence: stopgap #128 → PR-A → bake → PR-B). It is purely additive: the container learns which `runs` row each prompt answers and echoes it back on every output event, and the orchestrator prefers the echo over its closure. Dual writers (WS + orchestrator) are intentionally unchanged here; phase B removes the WS-side DB writes once this attribution has baked.

## Changes

**Threading in (orchestrator → container)**
- `AgentInitData.run_id` / `AgentInput.run_id`: seed the initial prompt's run (additive; `from_dict_filter_unknown` keeps older containers compatible)
- `GroupQueue.send_message(run_id=...)`: warm-pipe input payloads carry the run of the batch they deliver ("last message's run" convention, same as `active_run_id`); payload shape unchanged when there is nothing to attribute

**Tracking (agent_runner)**
- New `_RunAttribution` FIFO maps backend events to the prompt being served: per-prompt `ResultEvent`s consume one queue entry; progress/error/stop/safety events attribute non-consuming to the in-flight prompt; the batch-final marker uses the last prompt served
- `drain_nats_input` returns `(text, run_id)` pairs; drained messages merged into the initial prompt attribute to the last non-None drained run
- Echoed as `"runId"` on the results wire — absent when None, mirroring the `isFinal`/`retryable` convention, so legacy wire bytes are unchanged

**Echo back (container → orchestrator)**
- `AgentOutput.run_id` parsed from the wire (junk/empty → None)
- All four `_terminate_run_safe` sites now use `result.run_id or active_run_id` — echo wins, closure is the fallback for older containers (byte-for-byte today's behavior when no echo)

## Compatibility

| Pairing | Behavior |
|---|---|
| new orchestrator + new container | echo attribution (fixes warm-follow-up staleness) |
| new orchestrator + old container | no echo → closure fallback, unchanged |
| old orchestrator + new container | no seed/no payload run_id → echoes None → wire key absent |

## Tests

- `tests/test_agent_runner/test_run_attribution.py`: `_RunAttribution` FIFO/non-consuming/fallback semantics, drain tuple parsing, wire-shape conventions
- `tests/orchestration/test_run_attribution_orchestrator.py`: run_id threaded into `AgentInput`; echo wins at success / retryable-error / non-retryable-error terminal writes; no-echo falls back to closure; no-run turns pass None
- `tests/container/test_scheduler.py`: `send_message` payload carries `run_id` when given, byte-identical legacy payload when not
- `tests/ipc/test_protocol.py`: KV roundtrip + legacy payload without the field
- `tests/test_agent_runner/test_nats_bridge.py` (integration): end-to-end echo across initial prompt and between-query follow-up

Suite run (`tests/test_agent_runner tests/ipc tests/container tests/orchestration tests/runs tests/webui`): **1635 passed, 13 failed** — all 13 are webui safety tests failing identically on origin/main in this environment (spacy model download blocked by proxy), verified by stash-and-rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_