### PR TITLE
refactor(runs): single terminal writer + explicit run-terminal frames (single-writer phase B)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4276,6 +4276,14 @@ components:
 
     WsServerEventRunCompleted:
       type: object
+      description: >-
+        Sent only when the run actually reached `completed` (or the
+        terminal write could not be confirmed). When the underlying run
+        was already terminal `failed`/`awaiting_reauth` — e.g. the
+        orchestrator recorded an agent error after partial output
+        streamed — the stream ends with `event.run.error` carrying the
+        run's recorded error instead, matching what
+        `GET /api/v1/runs/{id}` reports.
       required: [type, run_id]
       properties:
         type: { type: string, enum: [event.run.completed] }

--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4274,16 +4274,33 @@ components:
             event. Always a (possibly empty) string — never a chunk
             schema or structured content.
 
+    WsServerEventRunOutputDone:
+      type: object
+      description: >-
+        One assistant reply (one chat bubble) is complete. In a batched
+        turn — the user queued follow-ups while the agent was busy —
+        several of these arrive before the single run-terminal event, one
+        per reply, so the client can close each bubble separately. Says
+        nothing about the run's terminal state: the run may still be
+        serving queued messages. Run-level state changes ride
+        `event.run.completed` / `event.run.error` exclusively.
+      required: [type, run_id]
+      properties:
+        type: { type: string, enum: [event.run.output_done] }
+        run_id: { type: string, format: uuid }
+
     WsServerEventRunCompleted:
       type: object
       description: >-
-        Sent only when the run actually reached `completed` (or the
-        terminal write could not be confirmed). When the underlying run
-        was already terminal `failed`/`awaiting_reauth` — e.g. the
+        The run reached its terminal state `completed`. Emitted exactly
+        once per run, projected from the orchestrator's explicit
+        run-terminal marker which is published AFTER the terminal DB
+        write (single-writer refactor) — so this event can never
+        contradict `GET /api/v1/runs/{id}`. When the underlying run was
+        already terminal `failed`/`awaiting_reauth` — e.g. the
         orchestrator recorded an agent error after partial output
         streamed — the stream ends with `event.run.error` carrying the
-        run's recorded error instead, matching what
-        `GET /api/v1/runs/{id}` reports.
+        run's recorded error instead.
       required: [type, run_id]
       properties:
         type: { type: string, enum: [event.run.completed] }
@@ -4543,6 +4560,7 @@ components:
       oneOf:
         - $ref: '#/components/schemas/WsServerEventRunStarted'
         - $ref: '#/components/schemas/WsServerEventRunToken'
+        - $ref: '#/components/schemas/WsServerEventRunOutputDone'
         - $ref: '#/components/schemas/WsServerEventRunCompleted'
         - $ref: '#/components/schemas/WsServerEventRunError'
         - $ref: '#/components/schemas/WsServerEventRunProgress'
@@ -4558,6 +4576,7 @@ components:
         mapping:
           event.run.started: '#/components/schemas/WsServerEventRunStarted'
           event.run.token: '#/components/schemas/WsServerEventRunToken'
+          event.run.output_done: '#/components/schemas/WsServerEventRunOutputDone'
           event.run.completed: '#/components/schemas/WsServerEventRunCompleted'
           event.run.error: '#/components/schemas/WsServerEventRunError'
           event.run.progress: '#/components/schemas/WsServerEventRunProgress'

--- a/src/agent_runner/main.py
+++ b/src/agent_runner/main.py
@@ -86,6 +86,13 @@ class ContainerOutput:
     # every unclassified error on the existing retry path (fail-open to
     # retry), and absence on the wire means True for older containers.
     retryable: bool = True
+    # Run attribution (single-writer refactor, phase A): the ``runs`` row
+    # this event belongs to — the run of the prompt the backend was serving
+    # when it emitted the event. Seeded from ``AgentInitData.run_id``,
+    # updated from the ``run_id`` on follow-up input payloads (see
+    # ``_RunAttribution``). None when the turn has no run (scheduled task)
+    # or the orchestrator predates the field.
+    run_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"status": self.status, "result": self.result}
@@ -102,6 +109,9 @@ class ContainerOutput:
         # Same convention: only non-default (False) goes on the wire.
         if not self.retryable:
             d["retryable"] = False
+        # Same convention: absent when there is nothing to attribute.
+        if self.run_id is not None:
+            d["runId"] = self.run_id
         return d
 
 
@@ -139,19 +149,61 @@ def is_retryable_error(exc: BaseException) -> bool:
     return not isinstance(exc, NonRetryableConfigError)
 
 
-async def drain_nats_input(sub: Any) -> list[str]:
-    """Drain any pending input messages from an existing subscription."""
-    messages: list[str] = []
+async def drain_nats_input(sub: Any) -> list[tuple[str, str | None]]:
+    """Drain any pending input messages from an existing subscription.
+
+    Returns ``(text, run_id)`` pairs; ``run_id`` is None on payloads from
+    an orchestrator that predates run attribution.
+    """
+    messages: list[tuple[str, str | None]] = []
     while True:
         try:
             msg = await asyncio.wait_for(sub.next_msg(timeout=0.1), timeout=0.1)
             data = json.loads(msg.data)
             await msg.ack()
             if data.get("type") == "message" and data.get("text"):
-                messages.append(data["text"])
+                rid = data.get("run_id")
+                messages.append(
+                    (data["text"], rid if isinstance(rid, str) and rid else None)
+                )
         except TimeoutError:
             break
     return messages
+
+
+class _RunAttribution:
+    """Maps backend output events to the ``runs`` row they answer.
+
+    The container serves prompts strictly in order: the initial prompt
+    (possibly covering several drained messages — attributed to the LAST
+    drained run, mirroring the orchestrator's ``active_run_id``
+    convention), then queued follow-ups FIFO. Each per-prompt ResultEvent
+    consumes one entry; every other event (progress, error, stop,
+    safety-block) is attributed to the prompt currently being served
+    without consuming it. ``last`` covers events that arrive after the
+    queue drained (e.g. the batch-final marker).
+
+    When a prompt dies mid-serving (error), the remaining queued runs are
+    left un-terminated — parity with pre-refactor behavior, where the
+    retry path re-reads those messages anyway.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[str | None] = []
+        self._last: str | None = None
+
+    def enqueue(self, run_id: str | None) -> None:
+        self._pending.append(run_id)
+
+    def current(self) -> str | None:
+        """Run of the prompt being served right now (non-consuming)."""
+        return self._pending[0] if self._pending else self._last
+
+    def consume(self) -> str | None:
+        """Attribute a per-prompt result and advance to the next prompt."""
+        rid = self._pending.pop(0) if self._pending else self._last
+        self._last = rid
+        return rid
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +373,11 @@ async def run_query_loop(
     # Track session ID from backend events
     session_id: str | None = init.session_id
 
+    # Maps each output event to the ``runs`` row of the prompt being served.
+    # Seeded below (after the input drain) with the initial prompt's run;
+    # follow-up intake points enqueue as messages arrive.
+    attribution = _RunAttribution()
+
     async def on_event(event: BackendEvent) -> None:
         nonlocal session_id
         output, session_id = event_to_output(event, session_id)
@@ -331,6 +388,13 @@ async def run_query_loop(
         elif isinstance(event, ErrorEvent):
             log(f"Backend error: {event.error}")
         if output is not None:
+            # Per-prompt result: consume the queue entry (next event belongs
+            # to the next prompt). Everything else — progress, error, stop,
+            # safety block — describes the prompt still being served.
+            if isinstance(event, ResultEvent):
+                output.run_id = attribution.consume()
+            else:
+                output.run_id = attribution.current()
             await publish_output(js, job_id, output)
 
     # Build the unified hook registry. TranscriptArchiveHandler replaces
@@ -500,10 +564,20 @@ async def run_query_loop(
             "[SCHEDULED TASK - The following message was sent automatically "
             "and is not coming directly from the user or group.]\n\n" + prompt
         )
+    # Run attribution: the merged initial prompt (init + drained messages)
+    # is served as ONE prompt, answered by ONE ResultEvent, so it gets ONE
+    # queue entry. When drained messages carry run ids, the last non-None
+    # one wins — same "last message's run" convention the orchestrator uses
+    # for active_run_id when it batches messages into a single prompt.
+    initial_run_id = init.run_id
     pending = await drain_nats_input(input_sub)
     if pending:
         log(f"Draining {len(pending)} pending NATS messages into initial prompt")
-        prompt += "\n" + "\n".join(pending)
+        prompt += "\n" + "\n".join(text for text, _ in pending)
+        for _, drained_run_id in pending:
+            if drained_run_id is not None:
+                initial_run_id = drained_run_id
+    attribution.enqueue(initial_run_id)
 
     # Main query loop
     try:
@@ -528,6 +602,10 @@ async def run_query_loop(
                         await msg.ack()
                         if data.get("type") == "message" and data.get("text"):
                             text = data["text"]
+                            rid = data.get("run_id")
+                            attribution.enqueue(
+                                rid if isinstance(rid, str) and rid else None
+                            )
                             log(f"Follow-up message received ({len(text)} chars)")
                             await backend.handle_follow_up(text)
                     except TimeoutError:
@@ -561,6 +639,11 @@ async def run_query_loop(
                     result=None,
                     new_session_id=session_id,
                     is_final=True,
+                    # The batch has settled: attribute the marker to the last
+                    # prompt served (attribution.current() falls back to
+                    # ``last`` once the queue is empty). This is the event
+                    # the orchestrator terminal-writes the run from.
+                    run_id=attribution.current(),
                 ),
             )
 
@@ -577,6 +660,10 @@ async def run_query_loop(
                     await msg.ack()
                     if data.get("type") == "message" and data.get("text"):
                         next_message = data["text"]
+                        rid = data.get("run_id")
+                        attribution.enqueue(
+                            rid if isinstance(rid, str) and rid else None
+                        )
                         break
                 except TimeoutError:
                     pass

--- a/src/rolemesh/agent/container_executor.py
+++ b/src/rolemesh/agent/container_executor.py
@@ -111,6 +111,8 @@ def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
     # the classification can never accidentally suppress a retry.
     retryable_val = raw.get("retryable")
     retryable = bool(retryable_val) if isinstance(retryable_val, bool) else True
+    # Run attribution echo — absent on events from older containers.
+    run_id_val = raw.get("runId")
     return AgentOutput(
         status=str(raw.get("status", "error")),  # type: ignore[arg-type]
         result=str(result_val) if result_val is not None else None,
@@ -119,6 +121,7 @@ def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
         metadata=meta_val if isinstance(meta_val, dict) else None,
         is_final=is_final,
         retryable=retryable,
+        run_id=str(run_id_val) if isinstance(run_id_val, str) and run_id_val else None,
     )
 
 
@@ -457,6 +460,7 @@ class ContainerAgentExecutor:
             conversation_id=conversation_id,
             user_id=inp.user_id,
             session_id=inp.session_id,
+            run_id=inp.run_id,
             is_scheduled_task=inp.is_scheduled_task,
             assistant_name=inp.assistant_name,
             system_prompt=effective_system_prompt,

--- a/src/rolemesh/agent/executor.py
+++ b/src/rolemesh/agent/executor.py
@@ -31,6 +31,10 @@ class AgentInput:
     assistant_name: str | None = None
     system_prompt: str | None = None
     role_config: dict[str, object] | None = None
+    # The ``runs`` row this prompt answers (None when the turn has no run,
+    # e.g. scheduled tasks). Threaded into AgentInitData so the container
+    # can echo it on output events — see AgentOutput.run_id.
+    run_id: str | None = None
 
 
 # Progress statuses are transient UX indicators; terminal statuses carry the
@@ -78,6 +82,14 @@ class AgentOutput:
     error: str | None = None
     metadata: dict[str, object] | None = None
     is_final: bool = True
+    # Run attribution echoed by the container: which ``runs`` row this
+    # event belongs to. The container tracks the run of the prompt it is
+    # currently serving (initial run from AgentInitData, follow-ups from
+    # the input payload) so batch replies attribute correctly instead of
+    # all landing on whatever the orchestrator's closure last saw. None =
+    # older container or a turn with no run; consumers fall back to their
+    # legacy closure-tracked id.
+    run_id: str | None = None
     # Only meaningful for status="error". False marks a deterministic
     # configuration error the container classified at the source
     # (pi.ai.types.NonRetryableConfigError): the orchestrator fails the

--- a/src/rolemesh/channels/web_nats_gateway.py
+++ b/src/rolemesh/channels/web_nats_gateway.py
@@ -187,6 +187,47 @@ class WebNatsGateway:
             chunk.to_bytes(),
         )
 
+    async def send_run_completed(
+        self, binding_id: str, chat_id: str, *, run_id: str
+    ) -> None:
+        """Publish the run-terminal success marker (single-writer, phase B).
+
+        Emitted by the orchestrator exactly once per run, AFTER the
+        terminal DB write, so the WS projection (``event.run.completed``)
+        can never contradict ``GET /api/v1/runs/{id}``. Rides the same
+        ``web.stream.*`` subject as text/done so it stays ordered after
+        the tokens it certifies.
+        """
+        chunk = WebStreamChunk(
+            type="run_completed", content=json.dumps({"run_id": run_id})
+        )
+        await self._transport.js.publish(
+            f"web.stream.{binding_id}.{chat_id}",
+            chunk.to_bytes(),
+        )
+
+    async def send_run_error(
+        self,
+        binding_id: str,
+        chat_id: str,
+        *,
+        run_id: str,
+        error: dict[str, object],
+    ) -> None:
+        """Publish the run-terminal failure marker (single-writer, phase B).
+
+        ``error`` mirrors the runs row's error JSONB ({code, message, ...}).
+        Same ordering and once-per-run contract as ``send_run_completed``.
+        """
+        chunk = WebStreamChunk(
+            type="run_error",
+            content=json.dumps({"run_id": run_id, "error": error}),
+        )
+        await self._transport.js.publish(
+            f"web.stream.{binding_id}.{chat_id}",
+            chunk.to_bytes(),
+        )
+
     async def send_safety_block(
         self,
         binding_id: str,

--- a/src/rolemesh/container/scheduler.py
+++ b/src/rolemesh/container/scheduler.py
@@ -547,7 +547,9 @@ class GroupQueue:
         state.idle_handle = None
         self._drain_group(group_jid)
 
-    def send_message(self, group_jid: str, text: str) -> bool:
+    def send_message(
+        self, group_jid: str, text: str, run_id: str | None = None
+    ) -> bool:
         """Deliver a message to this group's live container via NATS.
 
         Two cases (slot-follows-turn rework):
@@ -558,6 +560,11 @@ class GroupQueue:
           It needs turn admission: if granted, acquire a turn slot, leave the
           warm pool, cancel idle reaping, then deliver; if denied, return False
           so the caller queues it for a later drain.
+
+        ``run_id`` is the ``runs`` row this message answers; the container
+        echoes it back on output events so the orchestrator terminal-writes
+        the right run (single-writer refactor, phase A). None keeps the
+        legacy payload shape for callers with nothing to attribute.
 
         Returns False when there is no live container, it is a task container,
         no transport is wired, or a warm resume is refused by admission.
@@ -584,9 +591,12 @@ class GroupQueue:
             async def _send() -> None:
                 assert self._transport is not None
                 assert state.job_id is not None
+                payload: dict[str, str] = {"type": "message", "text": text}
+                if run_id is not None:
+                    payload["run_id"] = run_id
                 await self._transport.js.publish(
                     f"agent.{state.job_id}.input",
-                    json.dumps({"type": "message", "text": text}).encode(),
+                    json.dumps(payload).encode(),
                 )
 
             bg = asyncio.ensure_future(_send())

--- a/src/rolemesh/ipc/protocol.py
+++ b/src/rolemesh/ipc/protocol.py
@@ -49,6 +49,13 @@ class AgentInitData:
     conversation_id: str = ""
     user_id: str = ""
     session_id: str | None = None
+    # Run attribution (single-writer refactor, phase A): the ``runs`` row
+    # this initial prompt answers. The container echoes it (and the ids of
+    # queued follow-ups) back on every output event so the orchestrator can
+    # terminal-write the RIGHT run without relying on a closure variable
+    # that goes stale on warm-container follow-ups. None = older
+    # orchestrator or a turn with no run (scheduled task).
+    run_id: str | None = None
     is_scheduled_task: bool = False
     assistant_name: str | None = None
     system_prompt: str | None = None

--- a/src/rolemesh/ipc/web_protocol.py
+++ b/src/rolemesh/ipc/web_protocol.py
@@ -48,13 +48,26 @@ class WebStreamChunk:
     """Streaming chunk from Orchestrator to FastAPI (web.stream.{binding_id}.{chat_id}).
 
     type="text"           — content carries a text fragment
-    type="done"           — end-of-stream marker (content ignored)
+    type="done"           — end-of-OUTPUT marker: one assistant reply
+                            (one chat bubble) is complete (content
+                            ignored). Emitted once per reply in a
+                            batched turn — it says nothing about the
+                            run's terminal state.
     type="status"         — content carries a JSON-encoded progress payload
     type="safety_blocked" — content carries a JSON-encoded safety block
                             payload with keys {reason, stage, rule_id?}
+    type="run_completed"  — run-terminal marker (single-writer refactor,
+                            phase B): the orchestrator terminal-wrote the
+                            run and it ended ``completed``. content is
+                            JSON ``{run_id}``. Emitted exactly once per
+                            run, after the terminal DB write, so the
+                            frame can never contradict ``GET /runs/{id}``.
+    type="run_error"      — run-terminal marker, failure side. content is
+                            JSON ``{run_id, error: {code, message, ...}}``
+                            mirroring the authoritative runs row.
     """
 
-    type: str  # "text" | "done" | "status" | "safety_blocked"
+    type: str  # "text" | "done" | "status" | "safety_blocked" | "run_completed" | "run_error"
     content: str = ""
 
     def to_bytes(self) -> bytes:

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1013,10 +1013,16 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
     # single-active-run model as ws_stream). Writing the terminal status here, at
     # is_final/error, means a browser that disconnected mid-turn no longer
     # strands the row at 'running'. Idempotent with the WS-side writer via the
-    # lifecycle helper's WHERE status='running' guard. (Limitation: follow-ups
-    # piped into a warm container via send_message are not threaded here, so
-    # their runs still rely on the WS path / reaper — the dominant
-    # disconnect-mid-cold-start case is covered.)
+    # lifecycle helper's WHERE status='running' guard.
+    #
+    # Attribution precedence (single-writer refactor, phase A): the container
+    # now echoes the run of the prompt it actually served on each output
+    # event (AgentOutput.run_id — seeded via AgentInitData, updated from
+    # follow-up input payloads), so ``result.run_id or active_run_id`` at the
+    # terminal-write sites prefers the echoed id. The closure value below is
+    # the fallback for older containers and covers this turn's cold start;
+    # it goes stale when follow-ups are piped into a warm container, which
+    # is exactly what the echo fixes.
     active_run_id = next((m.run_id for m in reversed(missed_messages) if m.run_id), None)
 
     previous_cursor = conv_state.last_agent_timestamp
@@ -1102,7 +1108,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.is_final:
                 _queue.notify_idle(conversation_id)
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={
@@ -1202,7 +1208,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 _queue.notify_idle(conversation_id)
                 usage_dict = result.metadata.get("usage") if result.metadata else None
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=True,
                     usage=usage_dict if isinstance(usage_dict, dict) else None,
@@ -1224,7 +1230,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.retryable:
                 had_error = True
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={"code": "AGENT_ERROR", "message": result.error or "agent run failed"},
@@ -1236,13 +1242,13 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 # once with a user-visible explanation.
                 non_retryable_error = result.error or "agent configuration error"
                 await _terminate_run_safe(
-                    active_run_id,
+                    result.run_id or active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={"code": "CONFIG_ERROR", "message": non_retryable_error},
                 )
 
-    output = await _run_agent(cw_state, conv_state, prompt, _on_output)
+    output = await _run_agent(cw_state, conv_state, prompt, _on_output, run_id=active_run_id)
 
     # Stop typing
     if binding and gw:
@@ -1318,8 +1324,14 @@ async def _run_agent(
     conv_state: ConversationState,
     prompt: str,
     on_output: Callable[[AgentOutput], Awaitable[None]] | None = None,
+    run_id: str | None = None,
 ) -> str:
-    """Run agent in a container. Returns 'success' or 'error'."""
+    """Run agent in a container. Returns 'success' or 'error'.
+
+    ``run_id`` is the ``runs`` row the initial prompt answers; it seeds the
+    container's run attribution (AgentInitData.run_id) so output events echo
+    the right run back. None for turns with no run (scheduled tasks).
+    """
     config = cw_state.config
     conv = conv_state.conversation
     permissions = config.permissions
@@ -1384,6 +1396,7 @@ async def _run_agent(
                 tenant_id=config.tenant_id,
                 coworker_id=config.id,
                 conversation_id=conv.id,
+                run_id=run_id,
             ),
             lambda container_name, job_id: _queue.register_process(
                 conv.id, container_name, config.folder, job_id
@@ -1757,7 +1770,16 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                     )
                     if all_pending:
                         formatted = format_messages(all_pending, TIMEZONE)
-                        if _queue.send_message(conv_id, formatted):
+                        # Same "last message's run" convention as _process_
+                        # conversation_messages' active_run_id. The container
+                        # enqueues this id and echoes it on the outputs that
+                        # answer this batch — the warm-container follow-up is
+                        # exactly the case the stale closure could not cover.
+                        pipe_run_id = next(
+                            (m.run_id for m in reversed(all_pending) if m.run_id),
+                            None,
+                        )
+                        if _queue.send_message(conv_id, formatted, run_id=pipe_run_id):
                             logger.debug("Piped messages to active container", conv_id=conv_id)
                             conv_state.last_agent_timestamp = all_pending[-1].timestamp
                             await update_conversation_last_invocation(

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -99,6 +99,7 @@ from rolemesh.db import (
     store_message as db_store_message,
 )
 from rolemesh.runs import (
+    get_run,
     terminate_run_via_ws_completed,
     terminate_run_via_ws_error,
 )
@@ -964,25 +965,134 @@ async def _terminate_run_safe(
     success: bool,
     usage: dict[str, object] | None = None,
     error: dict[str, object] | None = None,
-) -> None:
-    """Write a run's terminal status server-side (INV-6 path 1/2), suppressing
+) -> bool | None:
+    """Write a run's terminal status server-side (INV-6 paths 1/2), suppressing
     errors so a DB hiccup never crashes the processing loop. No-op when there is
-    no run_id (IM channels, or a turn with no associated run)."""
+    no run_id (IM channels, or a turn with no associated run).
+
+    Single-writer refactor (phase B): this is now the ONLY writer for
+    paths 1/2 — the WS handler no longer touches the runs table.
+
+    Returns the lifecycle helper's outcome: ``True`` when THIS call moved
+    the row to terminal, ``False`` when the ``WHERE status='running'``
+    guard did not match (an earlier terminal writer won — e.g. the run
+    failed mid-batch and the batch-final marker's completed write lost),
+    ``None`` when there was nothing to write or the write errored. The
+    caller uses ``False`` to mirror the authoritative row in the frame it
+    emits instead of blindly certifying its own intent.
+    """
     if not run_id:
-        return
+        return None
     try:
         async with tenant_conn(tenant_id) as conn:
             if success:
-                await terminate_run_via_ws_completed(run_id=run_id, usage=usage, conn=conn)
-            else:
-                await terminate_run_via_ws_error(
-                    run_id=run_id,
-                    error=error or {"code": "AGENT_ERROR", "message": "agent run failed"},
-                    conn=conn,
+                return await terminate_run_via_ws_completed(
+                    run_id=run_id, usage=usage, conn=conn
                 )
+            return await terminate_run_via_ws_error(
+                run_id=run_id,
+                error=error or {"code": "AGENT_ERROR", "message": "agent run failed"},
+                conn=conn,
+            )
     except Exception:  # noqa: BLE001 — terminal write must never crash the loop
         logger.warning(
             "orchestrator-side run terminator failed (run stays 'running')",
+            run_id=run_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _run_terminal_error_or_none(
+    run_id: str,
+    tenant_id: str,
+    *,
+    transitioned: bool | None,
+    intent_error: dict[str, object] | None,
+) -> dict[str, object] | None:
+    """Pick what the run-terminal frame must report: ``None`` for
+    completed, an error dict for a failure.
+
+    ``transitioned`` is `_terminate_run_safe`'s outcome for the write this
+    frame certifies; ``intent_error`` is what that write TRIED to record
+    (``None`` for a completed write). When the write won (``True``) or
+    could not be confirmed (``None`` — DB hiccup, keep legacy best-effort
+    optimism), the intent is the truth. When it LOST (``False``), an
+    earlier terminal writer owns the row — e.g. the run failed on a
+    content-filter kill mid-batch and this is the batch-final marker's
+    completed write — so read the row and mirror it: ``failed`` /
+    ``awaiting_reauth`` report the row's recorded error, every other
+    terminal state (a redelivered write on an already-completed or
+    cancelled row) reports completed rather than fabricating a phantom
+    error. A snapshot miss falls back to the intent.
+
+    This is the #128 stopgap's ``_done_frame`` logic relocated to the
+    single writer, where the race is decided — the WS no longer infers
+    terminal state from stream chunks at all.
+    """
+    if transitioned is not False:
+        return intent_error
+    snapshot: dict[str, object] | None = None
+    try:
+        async with tenant_conn(tenant_id) as conn:
+            snapshot = await get_run(run_id=run_id, tenant_id=tenant_id, conn=conn)
+    except Exception:  # noqa: BLE001 — frame selection must never crash the loop
+        logger.warning(
+            "run snapshot lookup failed; terminal frame keeps write intent",
+            run_id=run_id,
+            exc_info=True,
+        )
+    if snapshot is None:
+        return intent_error
+    status = snapshot.get("status")
+    if status in ("failed", "awaiting_reauth"):
+        err = snapshot.get("error")
+        return err if isinstance(err, dict) else {}
+    return None
+
+
+async def _terminate_and_emit_run_terminal(
+    gw: object,
+    binding: object,
+    chat_id: str,
+    *,
+    run_id: str | None,
+    tenant_id: str,
+    success: bool,
+    usage: dict[str, object] | None = None,
+    error: dict[str, object] | None = None,
+) -> None:
+    """Terminal-write a run AND publish the explicit run-terminal chunk
+    (single-writer refactor, phase B).
+
+    Ordering is load-bearing: the DB write happens first, then the frame
+    mirrors the authoritative outcome — so a browser can never see
+    ``event.run.completed`` while ``GET /runs/{id}`` says ``failed``
+    (the field trace that motivated #128). Non-web channels and turns
+    with no run write the DB only; there is no stream to notify.
+    """
+    transitioned = await _terminate_run_safe(
+        run_id, tenant_id, success=success, usage=usage, error=error
+    )
+    if not run_id or binding is None or not isinstance(gw, WebNatsGateway):
+        return
+    intent_error = None if success else (
+        error or {"code": "AGENT_ERROR", "message": "agent run failed"}
+    )
+    frame_error = await _run_terminal_error_or_none(
+        run_id, tenant_id, transitioned=transitioned, intent_error=intent_error
+    )
+    try:
+        if frame_error is None:
+            await gw.send_run_completed(binding.id, chat_id, run_id=run_id)  # type: ignore[attr-defined]
+        else:
+            await gw.send_run_error(
+                binding.id, chat_id, run_id=run_id, error=frame_error  # type: ignore[attr-defined]
+            )
+    except (OSError, RuntimeError):
+        logger.warning(
+            "run-terminal chunk publish failed (DB already terminal; "
+            "client reconciles via GET /runs/{id})",
             run_id=run_id,
             exc_info=True,
         )
@@ -1008,12 +1118,15 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
 
     prompt = format_messages(missed_messages, TIMEZONE)
 
-    # INV-6 path 1/2 (server-side): the run this turn answers. Web sends carry a
-    # run_id on the inbound message; the most recent one is the active run (same
-    # single-active-run model as ws_stream). Writing the terminal status here, at
-    # is_final/error, means a browser that disconnected mid-turn no longer
-    # strands the row at 'running'. Idempotent with the WS-side writer via the
-    # lifecycle helper's WHERE status='running' guard.
+    # INV-6 paths 1/2 (server-side): the run this turn answers. Web sends carry
+    # a run_id on the inbound message; the most recent one is the active run
+    # (same single-active-run model as ws_stream). Since the single-writer
+    # refactor (phase B) the orchestrator is the ONLY terminal writer for these
+    # paths — the WS handler forwards frames but never touches the runs table —
+    # so a browser that disconnected mid-turn cannot strand the row at
+    # 'running'. The lifecycle helper's WHERE status='running' guard still
+    # makes double-termination across the orchestrator's own sites safe
+    # (first write wins).
     #
     # Attribution precedence (single-writer refactor, phase A): the container
     # now echoes the run of the prompt it actually served on each output
@@ -1092,6 +1205,25 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 rule_id=rule_id,
                 chars=len(reason),
             )
+            # Write-only site, and write-FIRST: the single-writer rule is
+            # "frames follow the DB" — the terminal row must exist before
+            # any frame that implies it. The safety chunk below is the
+            # user-facing frame, and the batch-final marker that follows a
+            # safety block mirrors this row into the run-terminal frame
+            # (its completed write loses to this one, so the marker emits
+            # run_error SAFETY_BLOCKED).
+            if result.is_final:
+                await _terminate_run_safe(
+                    result.run_id or active_run_id,
+                    conv.tenant_id,
+                    success=False,
+                    error={
+                        "code": "SAFETY_BLOCKED",
+                        "message": reason,
+                        "stage": stage,
+                        "rule_id": rule_id if isinstance(rule_id, str) else None,
+                    },
+                )
             if binding and isinstance(gw, WebNatsGateway):
                 with contextlib.suppress(OSError, RuntimeError, TypeError, ValueError):
                     await gw.send_safety_block(
@@ -1107,17 +1239,6 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             _reset_idle_timer()
             if result.is_final:
                 _queue.notify_idle(conversation_id)
-                await _terminate_run_safe(
-                    result.run_id or active_run_id,
-                    conv.tenant_id,
-                    success=False,
-                    error={
-                        "code": "SAFETY_BLOCKED",
-                        "message": reason,
-                        "stage": stage,
-                        "rule_id": rule_id if isinstance(rule_id, str) else None,
-                    },
-                )
             return
         if result.result:
             raw = result.result
@@ -1207,9 +1328,18 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.is_final:
                 _queue.notify_idle(conversation_id)
                 usage_dict = result.metadata.get("usage") if result.metadata else None
-                await _terminate_run_safe(
-                    result.run_id or active_run_id,
-                    conv.tenant_id,
+                # Single-writer (phase B): terminal write + explicit
+                # run-terminal chunk in one ordered step. When the
+                # completed write loses to an earlier failure (e.g. a
+                # content-filter kill mid-batch already marked the run
+                # failed), the emitted chunk mirrors the row — the SPA
+                # sees event.run.error, matching GET /runs/{id}.
+                await _terminate_and_emit_run_terminal(
+                    gw,
+                    binding,
+                    conv.channel_chat_id,
+                    run_id=result.run_id or active_run_id,
+                    tenant_id=conv.tenant_id,
                     success=True,
                     usage=usage_dict if isinstance(usage_dict, dict) else None,
                 )
@@ -1229,6 +1359,14 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
         if result.status == "error":
             if result.retryable:
                 had_error = True
+                # Write-only site — deliberately NO run-terminal frame.
+                # The retry ladder may still produce an answer on a fresh
+                # container; pushing event.run.error now would flash a
+                # terminal error at the user per attempt. The row is
+                # already failed (first-write-wins), so whichever later
+                # write certifies the turn (the retry's batch-final
+                # marker) loses the race and mirrors THIS row into the
+                # frame — the stream still ends truthfully.
                 await _terminate_run_safe(
                     result.run_id or active_run_id,
                     conv.tenant_id,
@@ -1239,11 +1377,16 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 # Deterministic configuration error, classified at the source
                 # (pi.ai.types.NonRetryableConfigError). Respawning cannot fix
                 # it — record it and let the post-run branch drop the message
-                # once with a user-visible explanation.
+                # once with a user-visible explanation. Unlike the retryable
+                # branch, the container is done and no batch-final marker is
+                # coming, so this site emits the run-terminal frame itself.
                 non_retryable_error = result.error or "agent configuration error"
-                await _terminate_run_safe(
-                    result.run_id or active_run_id,
-                    conv.tenant_id,
+                await _terminate_and_emit_run_terminal(
+                    gw,
+                    binding,
+                    conv.channel_chat_id,
+                    run_id=result.run_id or active_run_id,
+                    tenant_id=conv.tenant_id,
                     success=False,
                     error={"code": "CONFIG_ERROR", "message": non_retryable_error},
                 )

--- a/src/rolemesh/runs/terminators.py
+++ b/src/rolemesh/runs/terminators.py
@@ -22,12 +22,17 @@ guarantee — comment out the ``update_run_terminal`` call inside
 one wrapper, watch pytest turn red — is what makes this list
 load-bearing rather than informational.
 
-Wire-up status (2026-05-20, post 01b):
+Wire-up status (2026-07-16, single-writer refactor phase B):
 
-* Paths 1, 2 (WS completed / error) — orchestrator NATS handler
-  + 01b WS forwarding path (see :mod:`webui.v1.ws_stream`). The
-  webui forwards stream events; the orchestrator-side terminal
-  writer calls one of these wrappers.
+* Paths 1, 2 (turn completed / error) — the orchestrator's
+  ``_on_output`` terminal sites are the ONLY callers
+  (``rolemesh.main._terminate_run_safe``). The WS handler
+  (:mod:`webui.v1.ws_stream`) is a pure frame projection and never
+  writes the runs table; the orchestrator publishes explicit
+  ``run_completed`` / ``run_error`` stream chunks AFTER the write
+  so the browser frame mirrors the row. (The ``via_ws`` names are
+  historical — kept because they name the *path semantics* in the
+  design's seven-path table, not the caller.)
 * Path 3 (HTTP cancel) — :mod:`webui.v1.runs` publishes
   ``web.run.cancel.{run_id}``; the orchestrator-side subscriber
   calls :func:`terminate_run_via_user_cancel`.

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1091,6 +1091,19 @@ class WsServerEventRunToken(BaseModel):
     delta: str
 
 
+class WsServerEventRunOutputDone(BaseModel):
+    """One assistant reply (bubble) finished — NOT a run-terminal event.
+
+    Several arrive per run when follow-ups were batched; the run-level
+    terminal is exclusively event.run.completed / event.run.error
+    (single-writer refactor, phase B).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["event.run.output_done"]
+    run_id: str
+
+
 class WsServerEventRunCompleted(BaseModel):
     model_config = ConfigDict(extra="forbid")
     type: Literal["event.run.completed"]
@@ -1247,6 +1260,7 @@ class WsServerEventDelegationCompleted(BaseModel):
 WsServerEventModel = (
     WsServerEventRunStarted
     | WsServerEventRunToken
+    | WsServerEventRunOutputDone
     | WsServerEventRunCompleted
     | WsServerEventRunError
     | WsServerEventRunProgress

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -57,12 +57,7 @@ from rolemesh.db import (
     tenant_conn,
 )
 from rolemesh.ipc.web_protocol import WebInboundMessage
-from rolemesh.runs import (
-    create_run,
-    get_run,
-    terminate_run_via_ws_completed,
-    terminate_run_via_ws_error,
-)
+from rolemesh.runs import create_run
 from webui.v1.idempotency import cache as idempotency_cache
 from webui.v1.run_events import publish_run_cancel
 
@@ -358,117 +353,39 @@ def _build_approval_frame_or_none(
     return None
 
 
-async def _terminate_run_completed(
-    *, run_id: str, tenant_id: str, usage: Any | None
-) -> bool | None:
-    """Fire INV-6 path 1 (ws_completed) inside a tenant-scoped txn.
+def _run_terminal_frame_or_none(
+    kind: str, active_run_id: str, content: str
+) -> dict[str, Any] | None:
+    """Project an explicit run-terminal chunk (``run_completed`` /
+    ``run_error``) to its ``event.run.*`` frame.
 
-    Returns the lifecycle helper's outcome: ``True`` when THIS call
-    moved the row to ``completed``, ``False`` when the row was already
-    terminal (the ``WHERE status='running'`` guard did not match —
-    e.g. the orchestrator marked it ``failed`` after partial output
-    streamed), ``None`` on a DB error. The caller uses ``False`` to
-    reflect the authoritative state in the frame it sends instead of
-    blindly certifying success.
+    Single-writer refactor (phase B): the orchestrator terminal-writes
+    the runs row and THEN publishes one of these chunks mirroring the
+    authoritative outcome, so this projection is a dumb pipe — no DB
+    read, no write, no inference. The chunk's own ``run_id`` (threaded
+    container→orchestrator in phase A) wins over the closure-tracked
+    ``active_run_id``, which goes stale on warm-container follow-ups.
 
-    Exceptions are swallowed so a transient DB hiccup never crashes
-    the forwarding loop — the run row stays ``running`` and a future
-    GET ``/api/v1/runs/{id}`` will report the (now-incorrect) state
-    until the operator notices. The lifecycle helper's guard makes
-    the UPDATE idempotent in case the NATS chunk redelivers and we
-    run here twice.
+    Field whitelisting matches the progress/approval posture: only
+    ``code`` / ``message`` / ``details`` reach the browser, with the
+    same defaults the #128 stopgap used.
     """
-    usage_dict: dict[str, Any] | None = (
-        usage if isinstance(usage, dict) else None
-    )
-    try:
-        async with tenant_conn(tenant_id) as conn:
-            return await terminate_run_via_ws_completed(
-                run_id=run_id, usage=usage_dict, conn=conn
-            )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "ws_stream: terminator UPDATE failed (run stays 'running'); "
-            "investigate orchestrator side",
-            run_id=run_id,
-            exc_info=True,
-        )
-        return None
-
-
-async def _get_run_snapshot(run_id: str, tenant_id: str) -> dict[str, Any] | None:
-    """Best-effort read of the authoritative run row (status + error).
-
-    Only consulted on the cold path — a ``done`` frame whose
-    completed-write lost to an earlier terminal writer. ``None`` on
-    any failure; the caller then falls back to the legacy frame.
-    """
-    try:
-        async with tenant_conn(tenant_id) as conn:
-            return await get_run(run_id=run_id, tenant_id=tenant_id, conn=conn)
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "ws_stream: run snapshot lookup failed",
-            run_id=run_id,
-            exc_info=True,
-        )
-        return None
-
-
-async def _done_frame(
-    run_id: str, tenant_id: str, transitioned: bool | None
-) -> dict[str, Any]:
-    """Pick the terminal WS frame for a ``done`` stream chunk.
-
-    ``transitioned`` is the completed-terminator's outcome. ``True``
-    (this call moved the row to ``completed``) and ``None`` (DB
-    hiccup — keep legacy best-effort behavior) emit
-    ``event.run.completed``. ``False`` means the ``WHERE
-    status='running'`` guard did not match: another terminal writer
-    beat this ``done`` — typically the orchestrator marking
-    AGENT_ERROR after partial output already streamed (e.g. a
-    provider content-filter kill mid-generation). The frame must then
-    reflect the AUTHORITATIVE row, not the stream's optimism: a
-    failed run whose stream ends with ``completed`` shows the user a
-    truncated answer under a green check, and only the (rarely
-    consulted) ``GET /api/v1/runs/{id}`` disagrees.
-
-    Only ``failed`` / ``awaiting_reauth`` divert to an error frame —
-    a redelivered ``done`` on an already-completed/stopped/cancelled
-    row must NOT morph into a phantom error, and a lookup failure
-    falls back to the legacy completed frame.
-    """
-    if transitioned is False:
-        snapshot = await _get_run_snapshot(run_id, tenant_id)
-        status = (snapshot or {}).get("status")
-        if status in ("failed", "awaiting_reauth"):
-            err = (snapshot or {}).get("error")
-            err = err if isinstance(err, dict) else {}
-            return {
-                "type": "event.run.error",
-                "run_id": run_id,
-                "code": str(err.get("code") or "AGENT_ERROR"),
-                "message": str(err.get("message") or "run failed"),
-                "details": err,
-            }
-    return {"type": "event.run.completed", "run_id": run_id}
-
-
-async def _terminate_run_errored(
-    *, run_id: str, tenant_id: str, error: dict[str, Any]
-) -> None:
-    """Symmetric helper for INV-6 path 2 (ws_error)."""
-    try:
-        async with tenant_conn(tenant_id) as conn:
-            await terminate_run_via_ws_error(
-                run_id=run_id, error=error, conn=conn
-            )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "ws_stream: error terminator UPDATE failed",
-            run_id=run_id,
-            exc_info=True,
-        )
+    inner = json.loads(content or "{}")
+    if not isinstance(inner, dict):
+        inner = {}
+    rid = inner.get("run_id")
+    run_id = rid if isinstance(rid, str) and rid else active_run_id
+    if kind == "run_completed":
+        return {"type": "event.run.completed", "run_id": run_id}
+    err = inner.get("error")
+    err = err if isinstance(err, dict) else {}
+    return {
+        "type": "event.run.error",
+        "run_id": run_id,
+        "code": str(err.get("code") or "AGENT_ERROR"),
+        "message": str(err.get("message") or "run failed"),
+        "details": err,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -563,20 +480,22 @@ async def stream(
     async def _forward_stream() -> None:
         """Fan NATS stream chunks to ``event.run.*`` frames.
 
-        The legacy ``web.stream.*`` carrier is reused here so this
-        endpoint can interoperate with the existing orchestrator
-        emitter — replacing the emitter would be another session.
+        Single-writer refactor (phase B): this loop is a PURE
+        projection — it never touches the runs table. The orchestrator
+        owns every terminal write (INV-6 paths 1/2) and publishes
+        explicit ``run_completed`` / ``run_error`` chunks AFTER the
+        write, so the frames forwarded here can't contradict
+        ``GET /api/v1/runs/{id}``. A ``done`` chunk means "one
+        assistant reply (one bubble) is complete" and nothing more —
+        it projects to ``event.run.output_done``, never to a terminal
+        frame. Disconnect-mid-turn is therefore harmless to the DB:
+        the orchestrator's writer doesn't live in this handler.
+
         ``run_id`` is stamped from the closure's ``active_run_id``;
         when ``None``, the frame is dropped because no client
-        side-effect could meaningfully consume it.
-
-        INV-6 happy-path UPDATE: on ``done`` / ``safety_blocked`` the
-        terminator fires here so ``runs.{status, completed_at}`` lands
-        in the DB. Disconnect-mid-turn still leaves the row at
-        ``running`` (the ``finally`` in :func:`stream` cancels this
-        task — the WS handler does not survive a closed socket). A
-        durable orchestrator-side terminator for that case is on the
-        backlog (see 01c smoke Findings — design §11 INV-6 path 1).
+        side-effect could meaningfully consume it. Terminal chunks
+        carry their own (phase-A-attributed) run_id which wins over
+        the closure — see ``_run_terminal_frame_or_none``.
         """
         async for msg in stream_sub.messages:
             try:
@@ -596,32 +515,21 @@ async def stream(
                         },
                     )
                 elif kind == "done":
-                    # INV-6 path 1: write the terminal status FIRST so
-                    # the UPDATE survives even if the client closes
-                    # the WS the moment it sees ``event.run.completed``
-                    # (the disconnect cancels ``_forward_stream`` —
-                    # without ordering this before ``_send_event``, a
-                    # fast-close races the cancellation against the
-                    # DB write and the row stays at ``running``). We
-                    # also wrap in ``asyncio.shield`` so cancellation
-                    # mid-UPDATE doesn't strand the row. Lifecycle
-                    # helper is idempotent on the ``WHERE
-                    # status='running'`` guard, so re-delivery is safe.
-                    transitioned = await asyncio.shield(
-                        _terminate_run_completed(
-                            run_id=run_id,
-                            tenant_id=payload.tenant_id,
-                            usage=data.get("usage"),
-                        )
-                    )
-                    # Frame reflects the AUTHORITATIVE row, not the
-                    # stream's optimism — see ``_done_frame``.
+                    # Bubble terminator: the current assistant reply is
+                    # complete. In a batched turn (queued follow-ups)
+                    # several of these arrive before the single
+                    # run-terminal chunk; the SPA closes the streaming
+                    # bubble but keeps the run state untouched.
                     await _send_event(
                         ws,
-                        await _done_frame(
-                            run_id, payload.tenant_id, transitioned
-                        ),
+                        {"type": "event.run.output_done", "run_id": run_id},
                     )
+                elif kind in ("run_completed", "run_error"):
+                    frame = _run_terminal_frame_or_none(
+                        kind, run_id, data.get("content", "")
+                    )
+                    if frame is not None:
+                        await _send_event(ws, frame)
                 elif kind == "status":
                     # Per-turn progress indicator (running / tool_use /
                     # queued / container_starting). Legacy ``/ws/chat``
@@ -648,20 +556,12 @@ async def stream(
                         if progress is not None:
                             await _send_event(ws, progress)
                 elif kind == "safety_blocked":
+                    # Frame-only: the orchestrator already terminal-wrote
+                    # SAFETY_BLOCKED before publishing this chunk (its
+                    # write-only safety site) — projecting is all that's
+                    # left. The SPA renders the dedicated safety bubble
+                    # from code=SAFETY_BLOCKED.
                     inner = json.loads(data.get("content", "{}"))
-                    # Same ordering rationale as ``done`` above.
-                    await asyncio.shield(
-                        _terminate_run_errored(
-                            run_id=run_id,
-                            tenant_id=payload.tenant_id,
-                            error={
-                                "code": "SAFETY_BLOCKED",
-                                "message": inner.get("reason") or "blocked",
-                                "stage": inner.get("stage"),
-                                "rule_id": inner.get("rule_id"),
-                            },
-                        )
-                    )
                     await _send_event(
                         ws,
                         {

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -59,6 +59,7 @@ from rolemesh.db import (
 from rolemesh.ipc.web_protocol import WebInboundMessage
 from rolemesh.runs import (
     create_run,
+    get_run,
     terminate_run_via_ws_completed,
     terminate_run_via_ws_error,
 )
@@ -359,23 +360,30 @@ def _build_approval_frame_or_none(
 
 async def _terminate_run_completed(
     *, run_id: str, tenant_id: str, usage: Any | None
-) -> None:
+) -> bool | None:
     """Fire INV-6 path 1 (ws_completed) inside a tenant-scoped txn.
 
-    Wrapped in :class:`contextlib.suppress` so a transient DB
-    hiccup never crashes the forwarding loop — the run row stays
-    ``running`` and a future GET ``/api/v1/runs/{id}`` will report
-    the (now-incorrect) state until the operator notices. The
-    lifecycle helper's ``WHERE status='running'`` guard makes the
-    UPDATE idempotent in case the NATS chunk redelivers and we run
-    here twice.
+    Returns the lifecycle helper's outcome: ``True`` when THIS call
+    moved the row to ``completed``, ``False`` when the row was already
+    terminal (the ``WHERE status='running'`` guard did not match —
+    e.g. the orchestrator marked it ``failed`` after partial output
+    streamed), ``None`` on a DB error. The caller uses ``False`` to
+    reflect the authoritative state in the frame it sends instead of
+    blindly certifying success.
+
+    Exceptions are swallowed so a transient DB hiccup never crashes
+    the forwarding loop — the run row stays ``running`` and a future
+    GET ``/api/v1/runs/{id}`` will report the (now-incorrect) state
+    until the operator notices. The lifecycle helper's guard makes
+    the UPDATE idempotent in case the NATS chunk redelivers and we
+    run here twice.
     """
     usage_dict: dict[str, Any] | None = (
         usage if isinstance(usage, dict) else None
     )
     try:
         async with tenant_conn(tenant_id) as conn:
-            await terminate_run_via_ws_completed(
+            return await terminate_run_via_ws_completed(
                 run_id=run_id, usage=usage_dict, conn=conn
             )
     except Exception:  # noqa: BLE001
@@ -385,6 +393,65 @@ async def _terminate_run_completed(
             run_id=run_id,
             exc_info=True,
         )
+        return None
+
+
+async def _get_run_snapshot(run_id: str, tenant_id: str) -> dict[str, Any] | None:
+    """Best-effort read of the authoritative run row (status + error).
+
+    Only consulted on the cold path — a ``done`` frame whose
+    completed-write lost to an earlier terminal writer. ``None`` on
+    any failure; the caller then falls back to the legacy frame.
+    """
+    try:
+        async with tenant_conn(tenant_id) as conn:
+            return await get_run(run_id=run_id, tenant_id=tenant_id, conn=conn)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ws_stream: run snapshot lookup failed",
+            run_id=run_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _done_frame(
+    run_id: str, tenant_id: str, transitioned: bool | None
+) -> dict[str, Any]:
+    """Pick the terminal WS frame for a ``done`` stream chunk.
+
+    ``transitioned`` is the completed-terminator's outcome. ``True``
+    (this call moved the row to ``completed``) and ``None`` (DB
+    hiccup — keep legacy best-effort behavior) emit
+    ``event.run.completed``. ``False`` means the ``WHERE
+    status='running'`` guard did not match: another terminal writer
+    beat this ``done`` — typically the orchestrator marking
+    AGENT_ERROR after partial output already streamed (e.g. a
+    provider content-filter kill mid-generation). The frame must then
+    reflect the AUTHORITATIVE row, not the stream's optimism: a
+    failed run whose stream ends with ``completed`` shows the user a
+    truncated answer under a green check, and only the (rarely
+    consulted) ``GET /api/v1/runs/{id}`` disagrees.
+
+    Only ``failed`` / ``awaiting_reauth`` divert to an error frame —
+    a redelivered ``done`` on an already-completed/stopped/cancelled
+    row must NOT morph into a phantom error, and a lookup failure
+    falls back to the legacy completed frame.
+    """
+    if transitioned is False:
+        snapshot = await _get_run_snapshot(run_id, tenant_id)
+        status = (snapshot or {}).get("status")
+        if status in ("failed", "awaiting_reauth"):
+            err = (snapshot or {}).get("error")
+            err = err if isinstance(err, dict) else {}
+            return {
+                "type": "event.run.error",
+                "run_id": run_id,
+                "code": str(err.get("code") or "AGENT_ERROR"),
+                "message": str(err.get("message") or "run failed"),
+                "details": err,
+            }
+    return {"type": "event.run.completed", "run_id": run_id}
 
 
 async def _terminate_run_errored(
@@ -540,19 +607,20 @@ async def stream(
                     # mid-UPDATE doesn't strand the row. Lifecycle
                     # helper is idempotent on the ``WHERE
                     # status='running'`` guard, so re-delivery is safe.
-                    await asyncio.shield(
+                    transitioned = await asyncio.shield(
                         _terminate_run_completed(
                             run_id=run_id,
                             tenant_id=payload.tenant_id,
                             usage=data.get("usage"),
                         )
                     )
+                    # Frame reflects the AUTHORITATIVE row, not the
+                    # stream's optimism — see ``_done_frame``.
                     await _send_event(
                         ws,
-                        {
-                            "type": "event.run.completed",
-                            "run_id": run_id,
-                        },
+                        await _done_frame(
+                            run_id, payload.tenant_id, transitioned
+                        ),
                     )
                 elif kind == "status":
                     # Per-turn progress indicator (running / tool_use /

--- a/tests/container/test_scheduler.py
+++ b/tests/container/test_scheduler.py
@@ -92,6 +92,62 @@ async def test_interrupt_current_turn_active_no_transport() -> None:
     assert state.job_id == "job-abc"
 
 
+class _CapturingJs:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append((subject, data))
+
+
+class _CapturingTransport:
+    def __init__(self) -> None:
+        self.js = _CapturingJs()
+
+
+async def test_send_message_includes_run_id_in_payload() -> None:
+    """Run attribution (single-writer refactor, phase A): the input payload
+    carries the run the piped message answers so the container can echo it
+    on output events."""
+    import json
+
+    queue = GroupQueue()
+    transport = _CapturingTransport()
+    queue._transport = transport  # type: ignore[assignment]
+    state = queue._get_group("group1")
+    state.active = True
+    state.job_id = "job-abc"
+    state.processing = True  # mid-turn: skips warm-resume admission
+
+    assert queue.send_message("group1", "hello", run_id="run-1") is True
+    await asyncio.sleep(0)  # let the background publish run
+
+    subject, data = transport.js.published[0]
+    assert subject == "agent.job-abc.input"
+    assert json.loads(data) == {"type": "message", "text": "hello", "run_id": "run-1"}
+    await queue.shutdown()
+
+
+async def test_send_message_without_run_id_keeps_legacy_payload() -> None:
+    """No attribution → byte-identical payload shape to before the change."""
+    import json
+
+    queue = GroupQueue()
+    transport = _CapturingTransport()
+    queue._transport = transport  # type: ignore[assignment]
+    state = queue._get_group("group1")
+    state.active = True
+    state.job_id = "job-abc"
+    state.processing = True
+
+    assert queue.send_message("group1", "hello") is True
+    await asyncio.sleep(0)
+
+    _subject, data = transport.js.published[0]
+    assert json.loads(data) == {"type": "message", "text": "hello"}
+    await queue.shutdown()
+
+
 async def test_enqueue_message_while_active() -> None:
     queue = GroupQueue()
     call_count = 0

--- a/tests/ipc/test_protocol.py
+++ b/tests/ipc/test_protocol.py
@@ -54,6 +54,31 @@ def test_agent_init_data_optional_fields() -> None:
     assert restored.system_prompt is None
     assert restored.role_config is None
     assert restored.user_id == ""
+    assert restored.run_id is None
+
+
+def test_agent_init_data_run_id_roundtrip() -> None:
+    """Run attribution seed (single-writer refactor, phase A) survives the
+    KV wire, and its absence — an orchestrator predating the field —
+    deserializes to None rather than erroring."""
+    perms = AgentPermissions().to_dict()
+    init = AgentInitData(
+        prompt="Test",
+        group_folder="group",
+        chat_jid="jid",
+        permissions=perms,
+        run_id="run-abc",
+    )
+    restored = AgentInitData.deserialize(init.serialize())
+    assert restored.run_id == "run-abc"
+
+    # Payload from an older orchestrator: no run_id key at all.
+    import json
+
+    raw = json.loads(init.serialize())
+    del raw["run_id"]
+    legacy = AgentInitData.deserialize(json.dumps(raw).encode())
+    assert legacy.run_id is None
 
 
 def test_agent_init_data_frozen() -> None:

--- a/tests/orchestration/test_run_attribution_orchestrator.py
+++ b/tests/orchestration/test_run_attribution_orchestrator.py
@@ -1,0 +1,347 @@
+"""Orchestrator side of run attribution (single-writer refactor, phase A).
+
+``_process_conversation_messages`` used to terminal-write whatever run its
+closure captured at turn start (``active_run_id``) — correct for the cold
+start, stale for follow-ups piped into a warm container. The container now
+echoes the run of the prompt it actually served on each output event
+(``AgentOutput.run_id``), and the terminal-write sites prefer that echo:
+``result.run_id or active_run_id``.
+
+The contract under test:
+
+* The initial prompt's run is threaded into ``AgentInput.run_id`` so the
+  container can seed its attribution.
+* An echoed run_id wins over the closure at every terminal-write site
+  (success, retryable error, non-retryable error).
+* No echo (older container) → the closure fallback keeps today's
+  behavior byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rolemesh.core.orchestrator_state import (
+    ConversationState,
+    CoworkerState,
+    OrchestratorState,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+    from rolemesh.agent import AgentOutput
+    from rolemesh.core.types import Conversation
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pg_url: str) -> Path:
+    data_dir = tmp_path / "data"
+    groups_dir = tmp_path / "groups"
+    monkeypatch.setattr("rolemesh.core.config.DATA_DIR", data_dir)
+    monkeypatch.setattr("rolemesh.core.config.GROUPS_DIR", groups_dir)
+    monkeypatch.setattr("rolemesh.core.config.STORE_DIR", tmp_path / "store")
+    monkeypatch.setattr("rolemesh.core.config.TIMEZONE", "UTC")
+    monkeypatch.setattr("rolemesh.core.group_folder.DATA_DIR", data_dir)
+    monkeypatch.setattr("rolemesh.core.group_folder.GROUPS_DIR", groups_dir)
+
+    from rolemesh.db import _init_test_database
+
+    await _init_test_database(pg_url)
+
+    yield tmp_path
+
+    from rolemesh.db import close_database
+
+    await close_database()
+
+
+# ---------------------------------------------------------------------------
+# Harness (same shape as test_non_retryable_agent_errors, kept self-contained)
+# ---------------------------------------------------------------------------
+
+
+class EchoExecutor:
+    """Executor that emits one AgentOutput built by the test, and records
+    the AgentInput it was given (to assert run_id threading)."""
+
+    def __init__(self, output: AgentOutput) -> None:
+        self._output = output
+        self.inputs: list[object] = []
+
+    @property
+    def name(self) -> str:
+        return "mock"
+
+    async def execute(
+        self,
+        inp: object,
+        on_process: Callable[..., None],
+        on_output: Callable[..., Awaitable[None]] | None = None,
+    ) -> object:
+        self.inputs.append(inp)
+        on_process("mock-container", f"job-{uuid.uuid4().hex[:6]}")
+        if on_output:
+            await on_output(self._output)
+        return self._output
+
+
+@dataclass
+class MockGateway:
+    _channel_type: str = "telegram"
+    sent: list[tuple[str, str, str]] = field(default_factory=list)
+
+    @property
+    def channel_type(self) -> str:
+        return self._channel_type
+
+    async def send_message(self, binding_id: str, chat_id: str, text: str) -> None:
+        self.sent.append((binding_id, chat_id, text))
+
+    async def set_typing(self, binding_id: str, chat_id: str, is_typing: bool) -> None:
+        pass
+
+
+async def _seed_scenario(
+    executor: object, gateway: MockGateway, *, bind_run: bool
+) -> tuple[str, Conversation, str | None]:
+    """Tenant + coworker + telegram conversation + one unanswered message.
+
+    ``bind_run=True`` creates a real ``runs`` row (messages.run_id has an
+    FK) and binds the message to it — that id becomes the closure's
+    ``active_run_id``. Returns it as the third element (None otherwise)."""
+    import rolemesh.main as m
+    from rolemesh.db import (
+        create_channel_binding,
+        create_conversation,
+        create_coworker,
+        create_tenant,
+        store_message,
+        tenant_conn,
+    )
+    from rolemesh.runs.lifecycle import create_run
+
+    t = await create_tenant(name="T", slug=f"attr-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="Bot", folder=f"f-{uuid.uuid4().hex[:8]}"
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id,
+        tenant_id=t.id,
+        channel_type="telegram",
+        credentials={"bot_token": "tok"},
+    )
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id="chat-1",
+    )
+    run_id: str | None = None
+    if bind_run:
+        async with tenant_conn(t.id) as conn:
+            run_id = await create_run(
+                tenant_id=t.id, conversation_id=conv.id, conn=conn
+            )
+    await store_message(
+        tenant_id=t.id,
+        conversation_id=conv.id,
+        msg_id=f"msg-{uuid.uuid4().hex[:8]}",
+        sender="user-1",
+        sender_name="Alice",
+        content="hello",
+        timestamp="2024-06-01T12:00:01+00:00",
+        run_id=run_id,
+    )
+
+    cw_state = CoworkerState.from_coworker(cw)
+    cw_state.channel_bindings[binding.channel_type] = binding
+    cw_state.conversations[conv.id] = ConversationState(conversation=conv)
+    state = OrchestratorState()
+    state.coworkers[cw.id] = cw_state
+
+    m._state = state
+    m._executor = executor  # type: ignore[assignment]
+    m._executors = {"claude": executor, "pi": executor}  # type: ignore[assignment]
+    m._gateways = {"telegram": gateway}  # type: ignore[assignment]
+    m._queue = m.GroupQueue()
+    m._queue.set_process_messages_fn(m._process_conversation_messages)
+    m._transport = None
+    return cw.id, conv, run_id
+
+
+def _capture_terminations(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    import rolemesh.main as m
+
+    calls: list[dict[str, object]] = []
+
+    async def _fake_terminate(
+        run_id: str | None,
+        tenant_id: str,
+        *,
+        success: bool,
+        usage: dict[str, object] | None = None,
+        error: dict[str, object] | None = None,
+    ) -> None:
+        calls.append(
+            {"run_id": run_id, "success": success, "error": error}
+        )
+
+    monkeypatch.setattr(m, "_terminate_run_safe", _fake_terminate)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# run_id threading into the container
+# ---------------------------------------------------------------------------
+
+
+async def test_active_run_id_threaded_into_agent_input(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(status="success", result="hi", is_final=True)
+    )
+    _cw_id, conv, closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert len(executor.inputs) == 1
+    assert executor.inputs[0].run_id == closure_run, (
+        "the closure's active_run_id must seed the container's attribution"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Echo wins over the closure at every terminal-write site
+# ---------------------------------------------------------------------------
+
+
+async def test_success_prefers_echoed_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The warm-follow-up case in miniature: the container answers a NEWER
+    run than the one the closure captured — the echo must win, or the new
+    run's row is stranded while the old row double-terminates as a no-op."""
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(
+            status="success", result="hi", is_final=True, run_id="run-echo"
+        )
+    )
+    _cw_id, conv, closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert closure_run is not None
+    assert [c["run_id"] for c in calls if c["success"]] == ["run-echo"]
+
+
+async def test_retryable_error_prefers_echoed_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(
+            status="error", result=None, error="boom", run_id="run-echo"
+        )
+    )
+    _cw_id, conv, _closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    await m._process_conversation_messages(conv.id)
+    failures = [c for c in calls if not c["success"]]
+    assert [c["run_id"] for c in failures] == ["run-echo"]
+
+
+async def test_non_retryable_error_prefers_echoed_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(
+            status="error",
+            result=None,
+            error="bad config",
+            retryable=False,
+            run_id="run-echo",
+        )
+    )
+    _cw_id, conv, _closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    failures = [c for c in calls if not c["success"]]
+    assert [c["run_id"] for c in failures] == ["run-echo"]
+    assert failures[0]["error"] == {"code": "CONFIG_ERROR", "message": "bad config"}
+
+
+# ---------------------------------------------------------------------------
+# Fallback: no echo → closure behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+async def test_no_echo_falls_back_to_closure_run_id(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Events from an older container carry no run_id — the pre-refactor
+    closure attribution must keep working unchanged."""
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(status="success", result="hi", is_final=True)
+    )
+    _cw_id, conv, closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=True
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert closure_run is not None
+    assert [c["run_id"] for c in calls if c["success"]] == [closure_run]
+
+
+async def test_no_echo_no_closure_terminates_nothing(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IM turns have no run at all: the terminal write must stay a no-op
+    (run_id=None reaches _terminate_run_safe, whose guard returns early —
+    here we just assert None is what's passed)."""
+    import rolemesh.main as m
+    from rolemesh.agent import AgentOutput
+
+    calls = _capture_terminations(monkeypatch)
+    executor = EchoExecutor(
+        AgentOutput(status="success", result="hi", is_final=True)
+    )
+    _cw_id, conv, _closure_run = await _seed_scenario(
+        executor, MockGateway(), bind_run=False
+    )
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert [c["run_id"] for c in calls if c["success"]] == [None]

--- a/tests/orchestration/test_run_terminal_single_writer.py
+++ b/tests/orchestration/test_run_terminal_single_writer.py
@@ -1,0 +1,388 @@
+"""Orchestrator-side run termination + explicit terminal chunks (phase B).
+
+The single-writer refactor makes ``rolemesh.main`` the ONLY terminal
+writer for INV-6 paths 1/2 and moves the "frame mirrors the
+authoritative row" logic (born as the #128 WS stopgap) to the writer
+itself: ``_terminate_and_emit_run_terminal`` writes the row first, then
+publishes a ``run_completed`` / ``run_error`` stream chunk that the WS
+projects verbatim. The frame therefore can never contradict
+``GET /api/v1/runs/{id}``.
+
+The contract under test:
+
+* ``_terminate_run_safe`` reports the lifecycle outcome (True moved the
+  row, False lost to an earlier terminal writer, None nothing to do).
+* ``_run_terminal_error_or_none`` mirrors the row when the write lost —
+  failed/awaiting_reauth report the recorded error; a redelivered write
+  on a completed/cancelled row does NOT fabricate a phantom error.
+* ``_terminate_and_emit_run_terminal`` publishes the chunk that matches
+  the row — including the field-trace case: a run failed mid-batch by a
+  content-filter kill must end the stream with ``run_error`` even
+  though the batch-final marker tried to certify success.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pg_url: str) -> Path:
+    monkeypatch.setattr("rolemesh.core.config.DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr("rolemesh.core.config.GROUPS_DIR", tmp_path / "groups")
+    monkeypatch.setattr("rolemesh.core.config.STORE_DIR", tmp_path / "store")
+
+    from rolemesh.db import _init_test_database
+
+    await _init_test_database(pg_url)
+
+    yield tmp_path
+
+    from rolemesh.db import close_database
+
+    await close_database()
+
+
+async def _seed_run() -> tuple[str, str, str, str]:
+    """Tenant + web-bound coworker + conversation + running run.
+
+    Returns ``(tenant_id, binding_id, chat_id, run_id)`` — enough to
+    both drive the terminal helpers and assert on the stream subject
+    the gateway publishes to.
+    """
+    from rolemesh.db import (
+        create_channel_binding,
+        create_conversation,
+        create_coworker,
+        create_tenant,
+        tenant_conn,
+    )
+    from rolemesh.runs import create_run
+
+    t = await create_tenant(
+        name=f"T-{uuid.uuid4().hex[:6]}", slug=f"sw-{uuid.uuid4().hex[:6]}"
+    )
+    cw = await create_coworker(
+        tenant_id=t.id,
+        name=f"cw-{uuid.uuid4().hex[:6]}",
+        folder=f"folder-{uuid.uuid4().hex[:6]}",
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id, tenant_id=t.id, channel_type="web"
+    )
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id="chat-sw",
+    )
+    async with tenant_conn(t.id) as conn:
+        run_id = await create_run(
+            tenant_id=t.id, conversation_id=conv.id, conn=conn
+        )
+    return t.id, binding.id, "chat-sw", run_id
+
+
+async def _read_run(tenant_id: str, run_id: str) -> dict[str, Any]:
+    from rolemesh.db import tenant_conn
+
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT status, completed_at, error FROM runs WHERE id = $1::uuid",
+            run_id,
+        )
+    assert row is not None
+    return dict(row)
+
+
+class _CapturingJs:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append((subject, json.loads(data)))
+
+
+class _CapturingTransport:
+    def __init__(self) -> None:
+        self.js = _CapturingJs()
+
+
+def _make_gateway() -> tuple[Any, _CapturingJs]:
+    from rolemesh.channels.web_nats_gateway import WebNatsGateway
+
+    async def _noop(*args: Any) -> None:
+        pass
+
+    transport = _CapturingTransport()
+    gw = WebNatsGateway(on_message=_noop, transport=transport)  # type: ignore[arg-type]
+    return gw, transport.js
+
+
+class _Binding:
+    def __init__(self, binding_id: str) -> None:
+        self.id = binding_id
+
+
+def _stream_chunks(js: _CapturingJs, binding_id: str, chat_id: str) -> list[dict[str, Any]]:
+    subject = f"web.stream.{binding_id}.{chat_id}"
+    return [payload for subj, payload in js.published if subj == subject]
+
+
+# ---------------------------------------------------------------------------
+# _terminate_run_safe outcome reporting
+# ---------------------------------------------------------------------------
+
+
+async def test_terminate_reports_transition_and_loss(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    first = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert first is True
+    row = await _read_run(tenant_id, run_id)
+    assert row["status"] == "completed"
+    assert row["completed_at"] is not None
+
+    # Redelivered/duplicate write loses on the WHERE status='running' guard.
+    second = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert second is False
+
+
+async def test_terminate_none_run_id_is_noop(env: Path) -> None:
+    import rolemesh.main as m
+
+    assert await m._terminate_run_safe(None, str(uuid.uuid4()), success=True) is None
+
+
+async def test_terminate_error_records_structured_error(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    outcome = await m._terminate_run_safe(
+        run_id,
+        tenant_id,
+        success=False,
+        error={
+            "code": "SAFETY_BLOCKED",
+            "message": "policy violation",
+            "stage": "input_prompt",
+            "rule_id": "rule-42",
+        },
+    )
+    assert outcome is True
+    row = await _read_run(tenant_id, run_id)
+    assert row["status"] == "failed"
+    err = row["error"]
+    if isinstance(err, str):
+        err = json.loads(err)
+    assert err["code"] == "SAFETY_BLOCKED"
+    assert err["rule_id"] == "rule-42"
+
+
+# ---------------------------------------------------------------------------
+# _run_terminal_error_or_none — the relocated #128 frame selection
+# ---------------------------------------------------------------------------
+
+
+async def test_frame_selection_write_won_keeps_intent(env: Path) -> None:
+    import rolemesh.main as m
+
+    assert (
+        await m._run_terminal_error_or_none(
+            str(uuid.uuid4()),
+            str(uuid.uuid4()),
+            transitioned=True,
+            intent_error=None,
+        )
+        is None
+    ), "no row lookup on the happy path — intent is the truth"
+
+
+async def test_frame_selection_lost_to_failure_mirrors_row(env: Path) -> None:
+    """The field-trace case: a completed write that lost to an earlier
+    AGENT_ERROR must report the row's recorded error, not success."""
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    await m._terminate_run_safe(
+        run_id,
+        tenant_id,
+        success=False,
+        error={
+            "code": "AGENT_ERROR",
+            "message": "Output blocked by content filtering policy",
+        },
+    )
+    transitioned = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert transitioned is False
+
+    err = await m._run_terminal_error_or_none(
+        run_id, tenant_id, transitioned=transitioned, intent_error=None
+    )
+    assert err is not None
+    assert err["code"] == "AGENT_ERROR"
+    assert "content filtering" in str(err["message"])
+
+
+async def test_frame_selection_redelivery_on_completed_stays_completed(
+    env: Path,
+) -> None:
+    """A duplicate completed write on an already-completed row must NOT
+    fabricate a phantom error."""
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    assert await m._terminate_run_safe(run_id, tenant_id, success=True) is True
+    redelivered = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert redelivered is False
+    assert (
+        await m._run_terminal_error_or_none(
+            run_id, tenant_id, transitioned=redelivered, intent_error=None
+        )
+        is None
+    )
+
+
+async def test_frame_selection_snapshot_miss_falls_back_to_intent(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, _run_id = await _seed_run()
+    intent = {"code": "CONFIG_ERROR", "message": "bad tool name"}
+    err = await m._run_terminal_error_or_none(
+        str(uuid.uuid4()), tenant_id, transitioned=False, intent_error=intent
+    )
+    assert err == intent
+
+
+# ---------------------------------------------------------------------------
+# _terminate_and_emit_run_terminal — write first, then the mirroring chunk
+# ---------------------------------------------------------------------------
+
+
+async def test_success_emits_run_completed_chunk(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+    gw, js = _make_gateway()
+
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=True,
+    )
+
+    assert (await _read_run(tenant_id, run_id))["status"] == "completed"
+    chunks = _stream_chunks(js, binding_id, chat_id)
+    assert len(chunks) == 1
+    assert chunks[0]["type"] == "run_completed"
+    assert json.loads(chunks[0]["content"]) == {"run_id": run_id}
+
+
+async def test_success_after_failure_emits_run_error_chunk(env: Path) -> None:
+    """The end-to-end trace case at the single writer: the run already
+    failed (content-filter kill mid-batch); the batch-final marker's
+    completed write loses and the emitted chunk mirrors the failure."""
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+    await m._terminate_run_safe(
+        run_id,
+        tenant_id,
+        success=False,
+        error={
+            "code": "AGENT_ERROR",
+            "message": "Output blocked by content filtering policy",
+        },
+    )
+    gw, js = _make_gateway()
+
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=True,
+    )
+
+    assert (await _read_run(tenant_id, run_id))["status"] == "failed"
+    chunks = _stream_chunks(js, binding_id, chat_id)
+    assert len(chunks) == 1
+    assert chunks[0]["type"] == "run_error"
+    inner = json.loads(chunks[0]["content"])
+    assert inner["run_id"] == run_id
+    assert inner["error"]["code"] == "AGENT_ERROR"
+
+
+async def test_error_write_emits_run_error_chunk(env: Path) -> None:
+    """The non-retryable-config-error site: container dead, no batch
+    marker coming — the site itself both writes and notifies."""
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+    gw, js = _make_gateway()
+
+    error = {"code": "CONFIG_ERROR", "message": "tool name too long"}
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=False,
+        error=error,
+    )
+
+    assert (await _read_run(tenant_id, run_id))["status"] == "failed"
+    chunks = _stream_chunks(js, binding_id, chat_id)
+    assert len(chunks) == 1
+    assert chunks[0]["type"] == "run_error"
+    assert json.loads(chunks[0]["content"])["error"] == error
+
+
+async def test_no_run_id_publishes_nothing(env: Path) -> None:
+    import rolemesh.main as m
+
+    _tenant_id, binding_id, chat_id, _run_id = await _seed_run()
+    gw, js = _make_gateway()
+
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=None,
+        tenant_id=_tenant_id,
+        success=True,
+    )
+    assert _stream_chunks(js, binding_id, chat_id) == []
+
+
+async def test_non_web_gateway_writes_db_but_skips_chunk(env: Path) -> None:
+    """IM channels terminal-write the run (a Telegram turn can carry a
+    run in the future) but have no stream to notify."""
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+
+    await m._terminate_and_emit_run_terminal(
+        object(),  # not a WebNatsGateway
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=True,
+    )
+    assert (await _read_run(tenant_id, run_id))["status"] == "completed"

--- a/tests/test_agent_runner/test_nats_bridge.py
+++ b/tests/test_agent_runner/test_nats_bridge.py
@@ -245,18 +245,25 @@ class TestChannel3FollowUpInput:
         _nc, js = nats_conn
         job_id = _unique_job_id()
 
-        # Publish 3 pending messages
+        # Publish 3 pending messages; one carries run attribution.
         for i in range(3):
+            payload: dict[str, str] = {"type": "message", "text": f"pending-{i}"}
+            if i == 1:
+                payload["run_id"] = "run-1"
             await js.publish(
                 f"agent.{job_id}.input",
-                json.dumps({"type": "message", "text": f"pending-{i}"}).encode(),
+                json.dumps(payload).encode(),
             )
         await asyncio.sleep(0.1)
 
         sub = await js.subscribe(f"agent.{job_id}.input")
         messages = await drain_nats_input(sub)
         await sub.unsubscribe()
-        assert messages == ["pending-0", "pending-1", "pending-2"]
+        assert messages == [
+            ("pending-0", None),
+            ("pending-1", "run-1"),
+            ("pending-2", None),
+        ]
 
     async def test_drain_empty_returns_empty(self, nats_conn: tuple) -> None:
         _nc, js = nats_conn
@@ -528,6 +535,59 @@ class TestBridgeFullCycle:
             assert "run backup" in backend.prompts[0]
         finally:
             bridge_mod._create_backend = original_create
+
+    async def test_run_id_echoed_on_results(self, nats_conn: tuple) -> None:
+        """Attribution end-to-end: the initial prompt's run (from
+        AgentInitData) is echoed on its result and on the batch-final
+        marker; a between-query follow-up carrying a different run_id gets
+        ITS run echoed — the exact case the orchestrator's stale closure
+        used to misattribute."""
+        nc, js = nats_conn
+        job_id = _unique_job_id()
+        init = _make_init(job_id, prompt="first question", run_id="run-cold")
+
+        backend = FakeBackend()
+        backend.prompt_delay = 0.05
+
+        sub = await js.subscribe(f"agent.{job_id}.results")
+
+        import agent_runner.main as bridge_mod
+        original_create = bridge_mod._create_backend
+
+        bridge_mod._create_backend = lambda _: backend
+        try:
+            loop_task = asyncio.create_task(run_query_loop(init, nc, js, job_id))
+
+            # Wait for first query to finish, then send a follow-up bound
+            # to a different run (warm-container continuation).
+            await asyncio.sleep(0.3)
+            await js.publish(
+                f"agent.{job_id}.input",
+                json.dumps(
+                    {"type": "message", "text": "second question", "run_id": "run-warm"}
+                ).encode(),
+            )
+            await asyncio.sleep(0.3)
+
+            await nc.request(f"agent.{job_id}.shutdown", b"", timeout=2)
+            await asyncio.wait_for(loop_task, timeout=5)
+
+            results: list[dict] = []
+            with contextlib.suppress(Exception):
+                while True:
+                    msg = await asyncio.wait_for(sub.next_msg(timeout=1), timeout=2)
+                    await msg.ack()
+                    results.append(json.loads(msg.data))
+
+            successes = [r for r in results if r.get("status") == "success"]
+            # First query: per-prompt result + batch-final marker → run-cold.
+            # Second query: same pair → run-warm.
+            assert [r.get("runId") for r in successes] == [
+                "run-cold", "run-cold", "run-warm", "run-warm",
+            ]
+        finally:
+            bridge_mod._create_backend = original_create
+            await sub.unsubscribe()
 
     async def test_second_prompt_after_follow_up_message(self, nats_conn: tuple) -> None:
         """After first query ends, a new NATS input message triggers a second prompt."""

--- a/tests/test_agent_runner/test_run_attribution.py
+++ b/tests/test_agent_runner/test_run_attribution.py
@@ -1,0 +1,163 @@
+"""Run attribution in the agent runner (single-writer refactor, phase A).
+
+The orchestrator's terminal-write closure (``active_run_id``) goes stale
+when follow-ups are piped into a warm container: the closure was captured
+at cold start and never learns about the newer runs. The fix is to make
+the container itself track which ``runs`` row each prompt answers — seeded
+from ``AgentInitData.run_id``, updated from the ``run_id`` on follow-up
+input payloads — and echo it on every output event.
+
+Bug-bait focus:
+
+* FIFO discipline: batch replies must attribute one queue entry per
+  ResultEvent, in arrival order — off-by-one here terminal-writes the
+  WRONG run, which the WHERE status='running' guard then makes permanent.
+* Non-consuming reads: progress/error/stop events describe the prompt
+  still being served; consuming on them would shift the whole batch.
+* Wire shape stays legacy-compatible: ``runId`` appears in the JSON only
+  when there is something to attribute, mirroring isFinal/retryable.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from agent_runner.main import ContainerOutput, _RunAttribution, drain_nats_input
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# _RunAttribution semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_single_prompt_consume_then_fallback_to_last() -> None:
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    assert a.current() == "run-1"
+    assert a.current() == "run-1", "current() must not consume"
+    assert a.consume() == "run-1"
+    # Queue drained: the batch-final marker (and any straggler event)
+    # still attributes to the last prompt served.
+    assert a.current() == "run-1"
+    assert a.consume() == "run-1"
+
+
+async def test_fifo_across_batched_prompts() -> None:
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    a.enqueue("run-2")
+    a.enqueue("run-3")
+    assert a.current() == "run-1"
+    assert a.consume() == "run-1"
+    assert a.current() == "run-2", "after consuming, events belong to the next prompt"
+    assert a.consume() == "run-2"
+    assert a.consume() == "run-3"
+    assert a.current() == "run-3"
+
+
+async def test_none_entries_flow_through() -> None:
+    """A prompt with no run (scheduled task, legacy orchestrator) must
+    yield None — not resurrect a stale earlier id."""
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    a.enqueue(None)
+    assert a.consume() == "run-1"
+    assert a.current() is None
+    assert a.consume() is None
+    assert a.current() is None, "last must track the None, not keep run-1"
+
+
+async def test_empty_attribution_yields_none() -> None:
+    a = _RunAttribution()
+    assert a.current() is None
+    assert a.consume() is None
+
+
+async def test_error_mid_batch_attributes_to_prompt_being_served() -> None:
+    """An error while serving prompt 1 of a batch must attribute to run-1
+    (non-consuming) — the queued run-2 stays untouched for the retry path."""
+    a = _RunAttribution()
+    a.enqueue("run-1")
+    a.enqueue("run-2")
+    assert a.current() == "run-1", "error event attributes to the in-flight prompt"
+    assert a.current() == "run-1", "and does not advance the queue"
+
+
+# ---------------------------------------------------------------------------
+# Input drain: (text, run_id) pairs
+# ---------------------------------------------------------------------------
+
+
+class _FakeMsg:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.data = json.dumps(payload).encode()
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+
+class _FakeSub:
+    def __init__(self, msgs: list[_FakeMsg]) -> None:
+        self._msgs = list(msgs)
+
+    async def next_msg(self, timeout: float = 0.1) -> _FakeMsg:
+        if not self._msgs:
+            raise TimeoutError
+        return self._msgs.pop(0)
+
+
+async def test_drain_returns_text_and_run_id_pairs() -> None:
+    sub = _FakeSub(
+        [
+            _FakeMsg({"type": "message", "text": "a", "run_id": "run-1"}),
+            _FakeMsg({"type": "message", "text": "b"}),
+            _FakeMsg({"type": "message", "text": "c", "run_id": "run-3"}),
+        ]
+    )
+    assert await drain_nats_input(sub) == [
+        ("a", "run-1"),
+        ("b", None),
+        ("c", "run-3"),
+    ]
+
+
+async def test_drain_junk_run_id_becomes_none() -> None:
+    """A non-string or empty run_id must not leak into attribution."""
+    sub = _FakeSub(
+        [
+            _FakeMsg({"type": "message", "text": "a", "run_id": 42}),
+            _FakeMsg({"type": "message", "text": "b", "run_id": ""}),
+        ]
+    )
+    assert await drain_nats_input(sub) == [("a", None), ("b", None)]
+
+
+async def test_drain_skips_non_message_payloads() -> None:
+    sub = _FakeSub(
+        [
+            _FakeMsg({"type": "ping"}),
+            _FakeMsg({"type": "message", "text": "real", "run_id": "run-1"}),
+        ]
+    )
+    assert await drain_nats_input(sub) == [("real", "run-1")]
+
+
+# ---------------------------------------------------------------------------
+# Wire shape
+# ---------------------------------------------------------------------------
+
+
+async def test_run_id_absent_from_wire_when_none() -> None:
+    """No attribution → serialize exactly as before this change."""
+    d = ContainerOutput(status="success", result="ok").to_dict()
+    assert "runId" not in d
+
+
+async def test_run_id_emitted_when_set() -> None:
+    d = ContainerOutput(status="success", result="ok", run_id="run-1").to_dict()
+    assert d["runId"] == "run-1"

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -556,6 +556,9 @@ def test_backends_endpoint_advertises_cache_control_header_in_yaml() -> None:
 _EXPECTED_SERVER_EVENTS: dict[str, str] = {
     "event.run.started": "WsServerEventRunStarted",
     "event.run.token": "WsServerEventRunToken",
+    # Bubble terminator (single-writer refactor phase B): one reply
+    # finished; NOT a run-terminal event.
+    "event.run.output_done": "WsServerEventRunOutputDone",
     "event.run.completed": "WsServerEventRunCompleted",
     "event.run.error": "WsServerEventRunError",
     "event.run.progress": "WsServerEventRunProgress",
@@ -663,6 +666,7 @@ def test_ws_server_event_pydantic_round_trips_each_member() -> None:
     from webui.schemas_v1 import (
         WsServerEventRunCompleted,
         WsServerEventRunError,
+        WsServerEventRunOutputDone,
         WsServerEventRunStarted,
         WsServerEventRunToken,
     )
@@ -670,6 +674,7 @@ def test_ws_server_event_pydantic_round_trips_each_member() -> None:
     union = Annotated[
         WsServerEventRunStarted
         | WsServerEventRunToken
+        | WsServerEventRunOutputDone
         | WsServerEventRunCompleted
         | WsServerEventRunError,
         PField(discriminator="type"),
@@ -681,6 +686,9 @@ def test_ws_server_event_pydantic_round_trips_each_member() -> None:
         ),
         WsServerEventRunToken(
             type="event.run.token", run_id="r", delta="hi",
+        ),
+        WsServerEventRunOutputDone(
+            type="event.run.output_done", run_id="r",
         ),
         WsServerEventRunCompleted(
             type="event.run.completed", run_id="r",

--- a/tests/webui/test_ws_terminators_inv6.py
+++ b/tests/webui/test_ws_terminators_inv6.py
@@ -247,3 +247,107 @@ async def test_helpers_swallow_db_errors_to_keep_forwarder_alive() -> None:
         tenant_id=tenant_id,
         error={"code": "X"},
     )
+
+
+# ---------------------------------------------------------------------------
+# fix/ws-completed-frame-on-failed-run — the ``done`` frame must reflect
+# the AUTHORITATIVE run row, not the stream's optimism.
+#
+# Field trace that motivated this: a provider content-filter killed the
+# stream mid-generation AFTER partial output reached the browser; the
+# orchestrator marked the run failed (AGENT_ERROR), but a ``done`` chunk
+# still arrived and the WS blindly emitted ``event.run.completed`` — a
+# truncated answer under a green check, contradicted only by
+# ``GET /api/v1/runs/{id}``. The completed-terminator's idempotent guard
+# already refused the second write; the frame just never consulted it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_helper_returns_true_on_transition() -> None:
+    tenant_id, run_id = await _seed_run()
+    transitioned = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert transitioned is True
+
+
+@pytest.mark.asyncio
+async def test_completed_helper_returns_false_when_already_failed() -> None:
+    """The lost-race signal the frame selection rides on."""
+    tenant_id, run_id = await _seed_run()
+    await _terminate_run_errored(
+        run_id=run_id,
+        tenant_id=tenant_id,
+        error={"code": "AGENT_ERROR", "message": "content filter"},
+    )
+    transitioned = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert transitioned is False
+    row = await _read_run(tenant_id, run_id)
+    assert row["status"] == "failed", "authoritative status must survive"
+
+
+@pytest.mark.asyncio
+async def test_done_frame_reports_error_when_row_already_failed() -> None:
+    """The observed bug: failed row + done chunk → error frame, not completed."""
+    from webui.v1.ws_stream import _done_frame
+
+    tenant_id, run_id = await _seed_run()
+    await _terminate_run_errored(
+        run_id=run_id,
+        tenant_id=tenant_id,
+        error={
+            "code": "AGENT_ERROR",
+            "message": "Output blocked by content filtering policy",
+        },
+    )
+    transitioned = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    frame = await _done_frame(run_id, tenant_id, transitioned)
+
+    assert frame["type"] == "event.run.error"
+    assert frame["run_id"] == run_id
+    assert frame["code"] == "AGENT_ERROR"
+    assert "content filtering" in frame["message"]
+
+
+@pytest.mark.asyncio
+async def test_done_frame_redelivery_on_completed_row_stays_completed() -> None:
+    """NATS redelivery of ``done`` on an already-completed row must NOT
+    morph into a phantom error — the idempotent-redelivery contract."""
+    from webui.v1.ws_stream import _done_frame
+
+    tenant_id, run_id = await _seed_run()
+    first = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert first is True
+    redelivered = await _terminate_run_completed(
+        run_id=run_id, tenant_id=tenant_id, usage=None
+    )
+    assert redelivered is False
+    frame = await _done_frame(run_id, tenant_id, redelivered)
+    assert frame["type"] == "event.run.completed"
+
+
+@pytest.mark.asyncio
+async def test_done_frame_happy_path_skips_row_lookup() -> None:
+    """transitioned=True → completed frame with no extra DB read."""
+    from webui.v1.ws_stream import _done_frame
+
+    frame = await _done_frame(str(uuid.uuid4()), str(uuid.uuid4()), True)
+    assert frame["type"] == "event.run.completed"
+
+
+@pytest.mark.asyncio
+async def test_done_frame_lookup_miss_falls_back_to_completed() -> None:
+    """transitioned=False but the row can't be read (unknown id) → keep
+    the legacy completed frame rather than fabricating an error."""
+    from webui.v1.ws_stream import _done_frame
+
+    tenant_id, _run_id = await _seed_run()
+    frame = await _done_frame(str(uuid.uuid4()), tenant_id, False)
+    assert frame["type"] == "event.run.completed"

--- a/tests/webui/test_ws_terminators_inv6.py
+++ b/tests/webui/test_ws_terminators_inv6.py
@@ -1,353 +1,123 @@
-"""INV-6 happy-path UPDATE wiring (smoke-discovered gap).
+"""INV-6 single-writer pin: the WS handler must never write the runs table.
 
-Live smoke after 01c found that ``terminate_run_via_ws_completed``
-was *defined* in ``rolemesh.runs.terminators`` but **never called**
-from production code. Result: every Phase-1 chat run stayed at
-``status='running'`` even after the orchestrator emitted ``done``.
+History: 01c smoke found ``terminate_run_via_ws_completed`` defined but
+never called, so runs stayed at ``running``; the first fix put the
+terminal writer INTO ``webui.v1.ws_stream`` (this file's original
+subject). That created dual writers — orchestrator + WS — racing on the
+``WHERE status='running'`` guard, and the ``done`` stream chunk was
+forced to carry two meanings at once (bubble finished vs run finished).
+Field trace: a content-filter kill mid-generation left the row
+``failed`` while the WS still framed ``event.run.completed`` (#128
+stopgap patched the frame; the single-writer refactor removed the race).
 
-Fix lives in ``webui.v1.ws_stream``: ``_terminate_run_completed`` /
-``_terminate_run_errored`` helpers run the lifecycle UPDATE inside
-a tenant-scoped txn, called from ``_forward_stream`` whenever a
-``web.stream.*`` chunk of type ``done`` / ``safety_blocked`` is
-seen.
+Now the orchestrator is the ONLY terminal writer (INV-6 paths 1/2 live
+in ``rolemesh.main._terminate_run_safe``; DB-backed coverage in
+``tests/orchestration/test_run_terminal_single_writer.py``). The WS
+handler is a pure projection:
 
-These tests pin the helper round-trip against a real test DB
-(see ``test_db`` fixture in ``conftest``). They are deliberately
-NOT exercised through ``TestClient.websocket_connect`` — that
-path runs the handler in a threadpool and crosses asyncio event
-loops with the asyncpg pool (same issue ``test_ws_v1_handshake``
-sidesteps by stubbing ``get_conversation``). The helper-level
-tests cover the lifecycle gap the smoke caught; the end-to-end
-wiring of the helpers into ``_forward_stream`` is verified by
-live smoke.
+* ``done``            → ``event.run.output_done``  (bubble terminator)
+* ``run_completed``   → ``event.run.completed``    (run terminal)
+* ``run_error``       → ``event.run.error``        (run terminal)
+* ``safety_blocked``  → ``event.run.error``        (frame only)
 
-Anti-mirror: assertions read the ``runs`` table directly and
-check ``status`` + ``error`` JSONB values, not which Python
-function name was on the call stack.
+These tests pin (a) the projection function's wire contract and (b) a
+source-level guard that ws_stream cannot regrow a runs-table writer.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
-import uuid
 
-import pytest
-
-from rolemesh.db import (
-    create_channel_binding,
-    create_conversation,
-    create_coworker,
-    create_tenant,
-    tenant_conn,
-)
-from rolemesh.runs import create_run
-from webui.v1.ws_stream import _terminate_run_completed, _terminate_run_errored
-
-pytestmark = pytest.mark.usefixtures("test_db")
-
-
-async def _seed_run() -> tuple[str, str]:
-    """Spin up a tenant + coworker + conversation + run row.
-
-    Returns ``(tenant_id, run_id)`` — caller passes these into the
-    helper under test. A coworker is needed because the
-    ``channel_bindings.coworker_id`` FK is enforced; the binding
-    itself isn't used by the lifecycle helpers but the conversation
-    row points at it.
-
-    Note: deliberately does NOT touch the ``WS_TICKET_SECRET`` env
-    var — the helpers under test don't use ws_ticket at all, and
-    setting it would leak across to ``test_v1_auth_endpoints`` which
-    asserts on the production secret.
-    """
-    t = await create_tenant(
-        name=f"T-{uuid.uuid4().hex[:6]}",
-        slug=f"inv6-{uuid.uuid4().hex[:6]}",
-    )
-    cw = await create_coworker(
-        tenant_id=t.id,
-        name=f"cw-{uuid.uuid4().hex[:6]}",
-        folder=f"folder-{uuid.uuid4().hex[:6]}",
-        agent_backend="claude",
-    )
-    binding = await create_channel_binding(
-        coworker_id=cw.id,
-        tenant_id=t.id,
-        channel_type="web",
-    )
-    conv = await create_conversation(
-        tenant_id=t.id,
-        coworker_id=cw.id,
-        channel_binding_id=binding.id,
-        channel_chat_id="chat-inv6",
-        name=None,
-    )
-    async with tenant_conn(t.id) as conn:
-        run_id = await create_run(
-            tenant_id=t.id, conversation_id=conv.id, conn=conn
-        )
-    return t.id, run_id
-
-
-async def _read_run(tenant_id: str, run_id: str) -> dict:
-    async with tenant_conn(tenant_id) as conn:
-        row = await conn.fetchrow(
-            "SELECT status, completed_at, usage, error FROM runs "
-            "WHERE id = $1::uuid",
-            run_id,
-        )
-    assert row is not None, "seeded run row vanished"
-    return dict(row)
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_flips_status_and_records_usage() -> None:
-    """``_terminate_run_completed`` writes status='completed' + usage JSONB.
-
-    Smoke gap reproducer: before the fix, this UPDATE never ran and
-    every Phase-1 happy-path run stayed at ``status='running'``.
-    The terminator's usage column accepts any JSON payload from the
-    orchestrator; we assert that a non-dict input is dropped (the
-    helper only persists actual dicts) — that's the boundary we
-    care about given the WS chunk shape is loose.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id,
-        tenant_id=tenant_id,
-        usage={"tokens_in": 12, "tokens_out": 8, "total_cost_usd": 0.0001},
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "completed"
-    assert row["completed_at"] is not None, (
-        "completed_at must be stamped — used by GET /runs/{id} clients"
-    )
-    usage = row["usage"]
-    if isinstance(usage, str):
-        usage = json.loads(usage)
-    assert usage == {"tokens_in": 12, "tokens_out": 8, "total_cost_usd": 0.0001}
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_with_no_usage_still_writes_terminal() -> None:
-    """No usage payload on the chunk -> status='completed' + usage NULL.
-
-    Many ``done`` chunks won't carry usage today (the orchestrator
-    only attaches it when the backend reports it); the helper must
-    not strand the run row over a missing optional.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "completed"
-    assert row["usage"] is None
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_drops_non_dict_usage_silently() -> None:
-    """Hostile / accidentally non-JSON usage is coerced to NULL.
-
-    The orchestrator emits chunks with arbitrary content. A bad
-    payload should not crash the helper *and* should not poison the
-    DB with a non-dict ``usage`` value — the row stays
-    ``completed`` with ``usage=NULL``, which is the design's open
-    schema fallback.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage="not-a-dict",
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "completed"
-    assert row["usage"] is None
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_idempotent_against_redelivery() -> None:
-    """Two calls in a row must not double-flip / regress the row.
-
-    NATS chunk redelivery on consumer reconnect can cause the
-    forwarder to see the same ``done`` chunk twice. The lifecycle
-    helper's ``WHERE status='running'`` guard is the idempotency
-    seat — the second call no-ops and leaves the original
-    ``completed_at`` intact.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage={"x": 1}
-    )
-    first = await _read_run(tenant_id, run_id)
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage={"x": 999}
-    )
-    second = await _read_run(tenant_id, run_id)
-    assert second["status"] == "completed"
-    assert second["completed_at"] == first["completed_at"], (
-        "redelivery must not overwrite completed_at"
-    )
-    # Usage on the original row stays — second UPDATE was a no-op.
-    usage_first = first["usage"]
-    if isinstance(usage_first, str):
-        usage_first = json.loads(usage_first)
-    usage_second = second["usage"]
-    if isinstance(usage_second, str):
-        usage_second = json.loads(usage_second)
-    assert usage_first == usage_second
-
-
-@pytest.mark.asyncio
-async def test_errored_helper_records_safety_block_metadata() -> None:
-    """``_terminate_run_errored`` lands status='failed' + structured error.
-
-    Safety-block chunks carry the rule_id / stage that fired; the
-    helper must persist them so a future ``GET /runs/{id}`` can
-    surface "blocked by rule X at stage Y" without re-querying the
-    safety_decisions table.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_errored(
-        run_id=run_id,
-        tenant_id=tenant_id,
-        error={
-            "code": "SAFETY_BLOCKED",
-            "message": "policy violation",
-            "stage": "input_prompt",
-            "rule_id": "rule-42",
-        },
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "failed"
-    err = row["error"]
-    if isinstance(err, str):
-        err = json.loads(err)
-    assert err["code"] == "SAFETY_BLOCKED"
-    assert err["stage"] == "input_prompt"
-    assert err["rule_id"] == "rule-42"
-
-
-@pytest.mark.asyncio
-async def test_helpers_swallow_db_errors_to_keep_forwarder_alive() -> None:
-    """Smoke contract: a missing run_id must NOT bring down ``_forward_stream``.
-
-    The helper wraps its DB work in ``except Exception`` because the
-    forwarder loop is the only consumer of NATS ``web.stream.*``
-    chunks; a single bad chunk killing it would strand every other
-    run on the same WS. We assert that calling with a non-existent
-    run_id is a silent no-op (logged but not raised).
-    """
-    tenant_id, _ = await _seed_run()
-    # Should not raise.
-    await _terminate_run_completed(
-        run_id=str(uuid.uuid4()), tenant_id=tenant_id, usage=None
-    )
-    await _terminate_run_errored(
-        run_id=str(uuid.uuid4()),
-        tenant_id=tenant_id,
-        error={"code": "X"},
-    )
-
+from webui.v1 import ws_stream
+from webui.v1.ws_stream import _run_terminal_frame_or_none
 
 # ---------------------------------------------------------------------------
-# fix/ws-completed-frame-on-failed-run — the ``done`` frame must reflect
-# the AUTHORITATIVE run row, not the stream's optimism.
-#
-# Field trace that motivated this: a provider content-filter killed the
-# stream mid-generation AFTER partial output reached the browser; the
-# orchestrator marked the run failed (AGENT_ERROR), but a ``done`` chunk
-# still arrived and the WS blindly emitted ``event.run.completed`` — a
-# truncated answer under a green check, contradicted only by
-# ``GET /api/v1/runs/{id}``. The completed-terminator's idempotent guard
-# already refused the second write; the frame just never consulted it.
+# Single-writer guard
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_completed_helper_returns_true_on_transition() -> None:
-    tenant_id, run_id = await _seed_run()
-    transitioned = await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
+def test_ws_stream_has_no_runs_table_writer() -> None:
+    """Source-level pin: the WS module must not import or call any runs
+    terminator. If someone re-adds a ``terminate_run_via_*`` call here,
+    the dual-writer race (two writers deciding one row, frames emitted
+    from the loser's perspective) comes back — fail loudly.
+
+    ``create_run`` (request.run mints the row) is the ONE allowed runs
+    write; everything terminal belongs to the orchestrator.
+    """
+    src = inspect.getsource(ws_stream)
+    assert "terminate_run_via" not in src, (
+        "ws_stream must stay a pure projection — terminal writes live in "
+        "rolemesh.main (single-writer refactor phase B)"
     )
-    assert transitioned is True
+    assert "update_run_terminal" not in src
 
 
-@pytest.mark.asyncio
-async def test_completed_helper_returns_false_when_already_failed() -> None:
-    """The lost-race signal the frame selection rides on."""
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_errored(
-        run_id=run_id,
-        tenant_id=tenant_id,
-        error={"code": "AGENT_ERROR", "message": "content filter"},
+# ---------------------------------------------------------------------------
+# Projection: run_completed / run_error chunks → frames
+# ---------------------------------------------------------------------------
+
+
+def test_run_completed_chunk_projects_completed_frame() -> None:
+    frame = _run_terminal_frame_or_none(
+        "run_completed", "run-closure", json.dumps({"run_id": "run-echo"})
     )
-    transitioned = await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
+    assert frame == {"type": "event.run.completed", "run_id": "run-echo"}
+
+
+def test_terminal_chunk_run_id_wins_over_closure() -> None:
+    """The chunk's run_id is phase-A-attributed (container echo) and
+    authoritative; the closure's active_run_id goes stale on
+    warm-container follow-ups and is only the fallback."""
+    frame = _run_terminal_frame_or_none(
+        "run_error",
+        "run-closure",
+        json.dumps({"run_id": "run-echo", "error": {"code": "X", "message": "m"}}),
     )
-    assert transitioned is False
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "failed", "authoritative status must survive"
+    assert frame is not None
+    assert frame["run_id"] == "run-echo"
 
 
-@pytest.mark.asyncio
-async def test_done_frame_reports_error_when_row_already_failed() -> None:
-    """The observed bug: failed row + done chunk → error frame, not completed."""
-    from webui.v1.ws_stream import _done_frame
+def test_terminal_chunk_without_run_id_falls_back_to_closure() -> None:
+    frame = _run_terminal_frame_or_none("run_completed", "run-closure", "{}")
+    assert frame == {"type": "event.run.completed", "run_id": "run-closure"}
 
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_errored(
-        run_id=run_id,
-        tenant_id=tenant_id,
-        error={
-            "code": "AGENT_ERROR",
-            "message": "Output blocked by content filtering policy",
-        },
+
+def test_run_error_chunk_projects_error_frame_with_details() -> None:
+    error = {
+        "code": "SAFETY_BLOCKED",
+        "message": "policy violation",
+        "stage": "input_prompt",
+        "rule_id": "rule-42",
+    }
+    frame = _run_terminal_frame_or_none(
+        "run_error", "run-1", json.dumps({"run_id": "run-1", "error": error})
     )
-    transitioned = await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
+    assert frame == {
+        "type": "event.run.error",
+        "run_id": "run-1",
+        "code": "SAFETY_BLOCKED",
+        "message": "policy violation",
+        "details": error,
+    }
+
+
+def test_run_error_chunk_with_junk_error_uses_defaults() -> None:
+    """A malformed error payload must not crash the forwarder or leak
+    raw junk — same defaults the #128 stopgap frame used."""
+    frame = _run_terminal_frame_or_none(
+        "run_error", "run-1", json.dumps({"run_id": "run-1", "error": "not-a-dict"})
     )
-    frame = await _done_frame(run_id, tenant_id, transitioned)
-
-    assert frame["type"] == "event.run.error"
-    assert frame["run_id"] == run_id
-    assert frame["code"] == "AGENT_ERROR"
-    assert "content filtering" in frame["message"]
-
-
-@pytest.mark.asyncio
-async def test_done_frame_redelivery_on_completed_row_stays_completed() -> None:
-    """NATS redelivery of ``done`` on an already-completed row must NOT
-    morph into a phantom error — the idempotent-redelivery contract."""
-    from webui.v1.ws_stream import _done_frame
-
-    tenant_id, run_id = await _seed_run()
-    first = await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
-    )
-    assert first is True
-    redelivered = await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
-    )
-    assert redelivered is False
-    frame = await _done_frame(run_id, tenant_id, redelivered)
-    assert frame["type"] == "event.run.completed"
+    assert frame == {
+        "type": "event.run.error",
+        "run_id": "run-1",
+        "code": "AGENT_ERROR",
+        "message": "run failed",
+        "details": {},
+    }
 
 
-@pytest.mark.asyncio
-async def test_done_frame_happy_path_skips_row_lookup() -> None:
-    """transitioned=True → completed frame with no extra DB read."""
-    from webui.v1.ws_stream import _done_frame
-
-    frame = await _done_frame(str(uuid.uuid4()), str(uuid.uuid4()), True)
-    assert frame["type"] == "event.run.completed"
-
-
-@pytest.mark.asyncio
-async def test_done_frame_lookup_miss_falls_back_to_completed() -> None:
-    """transitioned=False but the row can't be read (unknown id) → keep
-    the legacy completed frame rather than fabricating an error."""
-    from webui.v1.ws_stream import _done_frame
-
-    tenant_id, _run_id = await _seed_run()
-    frame = await _done_frame(str(uuid.uuid4()), tenant_id, False)
-    assert frame["type"] == "event.run.completed"
+def test_terminal_chunk_with_non_dict_content_still_frames() -> None:
+    frame = _run_terminal_frame_or_none("run_completed", "run-1", json.dumps([1, 2]))
+    assert frame == {"type": "event.run.completed", "run_id": "run-1"}

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2689,6 +2689,7 @@ export interface components {
              */
             delta: string;
         };
+        /** @description Sent only when the run actually reached `completed` (or the terminal write could not be confirmed). When the underlying run was already terminal `failed`/`awaiting_reauth` — e.g. the orchestrator recorded an agent error after partial output streamed — the stream ends with `event.run.error` carrying the run's recorded error instead, matching what `GET /api/v1/runs/{id}` reports. */
         WsServerEventRunCompleted: {
             /**
              * @description discriminator enum property added by openapi-typescript

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2689,7 +2689,17 @@ export interface components {
              */
             delta: string;
         };
-        /** @description Sent only when the run actually reached `completed` (or the terminal write could not be confirmed). When the underlying run was already terminal `failed`/`awaiting_reauth` — e.g. the orchestrator recorded an agent error after partial output streamed — the stream ends with `event.run.error` carrying the run's recorded error instead, matching what `GET /api/v1/runs/{id}` reports. */
+        /** @description One assistant reply (one chat bubble) is complete. In a batched turn — the user queued follow-ups while the agent was busy — several of these arrive before the single run-terminal event, one per reply, so the client can close each bubble separately. Says nothing about the run's terminal state: the run may still be serving queued messages. Run-level state changes ride `event.run.completed` / `event.run.error` exclusively. */
+        WsServerEventRunOutputDone: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "event.run.output_done";
+            /** Format: uuid */
+            run_id: string;
+        };
+        /** @description The run reached its terminal state `completed`. Emitted exactly once per run, projected from the orchestrator's explicit run-terminal marker which is published AFTER the terminal DB write (single-writer refactor) — so this event can never contradict `GET /api/v1/runs/{id}`. When the underlying run was already terminal `failed`/`awaiting_reauth` — e.g. the orchestrator recorded an agent error after partial output streamed — the stream ends with `event.run.error` carrying the run's recorded error instead. */
         WsServerEventRunCompleted: {
             /**
              * @description discriminator enum property added by openapi-typescript
@@ -2930,7 +2940,7 @@ export interface components {
             final_status: string;
             duration_ms?: number | null;
         };
-        WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"] | components["schemas"]["WsServerEventRunProgress"] | components["schemas"]["WsServerEventMessageAppended"] | components["schemas"]["WsServerEventApprovalRequested"] | components["schemas"]["WsServerEventApprovalResolved"] | components["schemas"]["WsServerEventDelegationStarted"] | components["schemas"]["WsServerEventDelegationProgress"] | components["schemas"]["WsServerEventDelegationToolUse"] | components["schemas"]["WsServerEventDelegationCompleted"];
+        WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunOutputDone"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"] | components["schemas"]["WsServerEventRunProgress"] | components["schemas"]["WsServerEventMessageAppended"] | components["schemas"]["WsServerEventApprovalRequested"] | components["schemas"]["WsServerEventApprovalResolved"] | components["schemas"]["WsServerEventDelegationStarted"] | components["schemas"]["WsServerEventDelegationProgress"] | components["schemas"]["WsServerEventDelegationToolUse"] | components["schemas"]["WsServerEventDelegationCompleted"];
         WsClientFrameRequestRun: {
             /**
              * @description discriminator enum property added by openapi-typescript

--- a/web/src/components/chat-panel.test.ts
+++ b/web/src/components/chat-panel.test.ts
@@ -223,6 +223,45 @@ describe('ChatPanel — side-channel events (PR #38)', () => {
     }
   });
 
+  it('event.run.output_done closes the streaming bubble without ending the run', () => {
+    // Single-writer refactor: `done` chunks became per-bubble
+    // event.run.output_done. In a batched turn (queued follow-ups)
+    // several arrive before the one true run-terminal frame — the
+    // bubble must close (so the next reply spawns a fresh one) while
+    // Stop stays available and the run state stays 'running'.
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.runState = 'running';
+    i.runTerminal = false;
+    i.activeRunId = 'run-1';
+    i.messages = [
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer', streaming: true },
+    ];
+
+    i.handleV1Event({ type: 'event.run.output_done', run_id: 'run-1' });
+
+    expect(i.messages[1].streaming).toBeFalsy();
+    expect(i.runState).toBe('running');
+    expect(i.runTerminal).toBe(false);
+
+    // Next reply's token spawns a NEW bubble instead of appending to
+    // the closed one — the exact behavior the split exists to keep.
+    i.handleV1Event({ type: 'event.run.token', run_id: 'run-1', delta: 'second' });
+    expect(i.messages).toHaveLength(3);
+    expect(i.messages[2]).toMatchObject({
+      role: 'assistant',
+      content: 'second',
+      streaming: true,
+    });
+
+    // Only the run-terminal frame flips the run state.
+    i.handleV1Event({ type: 'event.run.completed', run_id: 'run-1' });
+    expect(i.runState).toBe('idle');
+    expect(i.runTerminal).toBe(true);
+    expect(i.messages[2].streaming).toBeFalsy();
+  });
+
   it('event.run.progress from a stale run is ignored', () => {
     // JetStream redelivery on reconnect can replay an old progress
     // frame after the user has moved on to a new turn. Without the

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -449,7 +449,23 @@ export class ChatPanel extends LitElement {
         }
         break;
       }
+      case 'event.run.output_done': {
+        // Bubble terminator (single-writer refactor): one assistant
+        // reply is complete. In a batched turn several of these arrive
+        // before the single run-terminal event — close the streaming
+        // bubble so the next reply's tokens spawn a fresh one, but do
+        // NOT touch run state; the run may still be serving queued
+        // follow-ups. Run-level transitions ride event.run.completed /
+        // event.run.error exclusively.
+        this.finalizeStreamingBubble();
+        break;
+      }
       case 'event.run.completed': {
+        // Run terminal: emitted exactly once per run, after the
+        // orchestrator's terminal DB write — so this can never
+        // contradict GET /runs/{id}. finalizeStreamingBubble() stays
+        // as a belt-and-braces close for the last bubble (no-op when
+        // output_done already closed it).
         this.finalizeStreamingBubble();
         this.runState = 'idle';
         this.runTerminal = true;

--- a/web/src/ws/v1_client.ts
+++ b/web/src/ws/v1_client.ts
@@ -58,6 +58,8 @@ export type RunStartedEvent =
   components['schemas']['WsServerEventRunStarted'];
 export type RunTokenEvent =
   components['schemas']['WsServerEventRunToken'];
+export type RunOutputDoneEvent =
+  components['schemas']['WsServerEventRunOutputDone'];
 export type RunCompletedEvent =
   components['schemas']['WsServerEventRunCompleted'];
 export type RunErrorEvent =


### PR DESCRIPTION
## Background

INV-6 paths 1/2 had **two writers** racing on the runs table: the orchestrator's `_on_output` terminal sites and the WS handler, which *inferred* run-terminal state from the `done` stream chunk. The `done` chunk was forced to carry two meanings at once — "one reply (bubble) finished" **and** "the run finished" — which is how a run failed by a content-filter kill could still close its stream with `event.run.completed` (the production trace behind stopgap #128).

This is **phase B of the single-writer refactor** (sequence: stopgap #128 → run_id threading #129 → this). Dual writes are gone; the WS handler is now a pure frame projection.

## Semantic split on the wire (`web.stream.*`)

| chunk | meaning | WS projection |
|---|---|---|
| `done` | one assistant reply (bubble) complete — several per batched turn | **new** `event.run.output_done` (bubble close only) |
| `run_completed` *(new)* | run reached `completed`; published **after** the terminal DB write, exactly once per run | `event.run.completed` |
| `run_error` *(new)* | run terminal failure, mirroring the runs row | `event.run.error` |
| `safety_blocked` | unchanged | `event.run.error` (frame-only; write moved orchestrator-side, now write-first) |

Terminal chunks carry their own run_id (phase-A container attribution), which wins over the WS closure's stale `active_run_id`.

## Orchestrator = the single writer

- `_terminate_run_safe` now returns the lifecycle outcome (`True` moved the row / `False` lost to an earlier terminal writer / `None` nothing to write).
- `_run_terminal_error_or_none` relocates #128's frame-selection to the writer, where the race is decided: a completed write that **lost** to an earlier failure mirrors the row's recorded error into the frame; a redelivered write on an already-completed/cancelled row does **not** fabricate a phantom error; a snapshot miss keeps the write's intent.
- `_terminate_and_emit_run_terminal` = write first, then emit the mirroring chunk. Wired at:
  - **batch-final success** (also covers stop and cancel: their markers lose to / follow the authoritative row and emit the mirroring frame), and
  - **non-retryable config error** (container dead, no marker coming — the site emits itself).
  - **Retryable-error** and **safety** sites stay write-only: retries must not flash per-attempt terminal errors (frame arrives from the retry's marker, mirroring the row), and the safety chunk is already the user-facing frame.

## WS handler: pure projection

`_terminate_run_completed`, `_terminate_run_errored`, `_get_run_snapshot`, and the #128 `_done_frame` reconciliation layer are deleted, along with the runs-terminator imports. A source-level test pins that `terminate_run_via*` can never regrow in `ws_stream` — the dual-writer race would come back with it.

## Contract + SPA

- `WsServerEventRunOutputDone` added to `contracts/openapi.yaml` (oneOf + discriminator mapping), `schemas_v1.py`, and regenerated `types.ts` (`openapi:check` green); `RunCompleted` description now states the exactly-once, post-write guarantee.
- `chat-panel.ts`: `event.run.output_done` finalizes the streaming bubble only (next reply's tokens spawn a fresh bubble); `event.run.completed`/`error` keep exclusive ownership of run state. Old SPAs keep working against the new backend — they ignore `output_done` and still receive the terminal frames.

## Tests

- `tests/orchestration/test_run_terminal_single_writer.py` (new, DB-backed): outcome reporting, frame selection incl. the field-trace case (completed write losing to a content-filter failure → `run_error` chunk mirroring the row), write-then-emit through a real `WebNatsGateway` over a capturing transport, no-run and non-web no-op paths.
- `tests/webui/test_ws_terminators_inv6.py` rewritten: projection wire contract (chunk run_id wins over closure, defaults on junk payloads) + the no-writer source guard.
- `tests/test_openapi_contract.py`: `output_done` added to the pinned discriminator set and the Pydantic round-trip.
- `chat-panel.test.ts`: batched-turn split — `output_done` closes the bubble while the run stays running, next token spawns a new bubble, only `completed` flips run state.

Verification: backend suites (`tests/webui tests/orchestration tests/channels tests/container tests/test_agent_runner` + runs/ipc/contract) **1650+81 passed, 13 failed** — the same 13 webui safety tests that fail on origin/main in this environment (spacy model download blocked by proxy, verified previously by stash-and-rerun). SPA: `tsc` clean, **661/661 vitest passed**, `openapi:check` green.

Depends on #129 (phase A) — merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_