### PR TITLE
refactor(runs): single terminal writer + frame semantic split (direct, minimal)

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -4274,8 +4274,33 @@ components:
             event. Always a (possibly empty) string — never a chunk
             schema or structured content.
 
+    WsServerEventRunOutputDone:
+      type: object
+      description: >-
+        One assistant reply (one chat bubble) is complete. In a batched
+        turn — the user queued follow-ups while the agent was busy —
+        several of these arrive before the single run-terminal event, one
+        per reply, so the client can close each bubble separately. Says
+        nothing about the run's terminal state: the run may still be
+        serving queued messages. Run-level state changes ride
+        `event.run.completed` / `event.run.error` exclusively.
+      required: [type, run_id]
+      properties:
+        type: { type: string, enum: [event.run.output_done] }
+        run_id: { type: string, format: uuid }
+
     WsServerEventRunCompleted:
       type: object
+      description: >-
+        The run reached its terminal state `completed`. Emitted exactly
+        once per run, projected from the orchestrator's explicit
+        run-terminal marker which is published AFTER the terminal DB
+        write (single-writer refactor) — so this event can never
+        contradict `GET /api/v1/runs/{id}`. When the underlying run was
+        already terminal `failed`/`awaiting_reauth` — e.g. the
+        orchestrator recorded an agent error after partial output
+        streamed — the stream ends with `event.run.error` carrying the
+        run's recorded error instead.
       required: [type, run_id]
       properties:
         type: { type: string, enum: [event.run.completed] }
@@ -4535,6 +4560,7 @@ components:
       oneOf:
         - $ref: '#/components/schemas/WsServerEventRunStarted'
         - $ref: '#/components/schemas/WsServerEventRunToken'
+        - $ref: '#/components/schemas/WsServerEventRunOutputDone'
         - $ref: '#/components/schemas/WsServerEventRunCompleted'
         - $ref: '#/components/schemas/WsServerEventRunError'
         - $ref: '#/components/schemas/WsServerEventRunProgress'
@@ -4550,6 +4576,7 @@ components:
         mapping:
           event.run.started: '#/components/schemas/WsServerEventRunStarted'
           event.run.token: '#/components/schemas/WsServerEventRunToken'
+          event.run.output_done: '#/components/schemas/WsServerEventRunOutputDone'
           event.run.completed: '#/components/schemas/WsServerEventRunCompleted'
           event.run.error: '#/components/schemas/WsServerEventRunError'
           event.run.progress: '#/components/schemas/WsServerEventRunProgress'

--- a/src/rolemesh/channels/web_nats_gateway.py
+++ b/src/rolemesh/channels/web_nats_gateway.py
@@ -187,6 +187,47 @@ class WebNatsGateway:
             chunk.to_bytes(),
         )
 
+    async def send_run_completed(
+        self, binding_id: str, chat_id: str, *, run_id: str
+    ) -> None:
+        """Publish the run-terminal success marker (single-writer contract).
+
+        Emitted by the orchestrator exactly once per run, AFTER the
+        terminal DB write, so the WS projection (``event.run.completed``)
+        can never contradict ``GET /api/v1/runs/{id}``. Rides the same
+        ``web.stream.*`` subject as text/done so it stays ordered after
+        the tokens it certifies.
+        """
+        chunk = WebStreamChunk(
+            type="run_completed", content=json.dumps({"run_id": run_id})
+        )
+        await self._transport.js.publish(
+            f"web.stream.{binding_id}.{chat_id}",
+            chunk.to_bytes(),
+        )
+
+    async def send_run_error(
+        self,
+        binding_id: str,
+        chat_id: str,
+        *,
+        run_id: str,
+        error: dict[str, object],
+    ) -> None:
+        """Publish the run-terminal failure marker (single-writer contract).
+
+        ``error`` mirrors the runs row's error JSONB ({code, message, ...}).
+        Same ordering and once-per-run contract as ``send_run_completed``.
+        """
+        chunk = WebStreamChunk(
+            type="run_error",
+            content=json.dumps({"run_id": run_id, "error": error}),
+        )
+        await self._transport.js.publish(
+            f"web.stream.{binding_id}.{chat_id}",
+            chunk.to_bytes(),
+        )
+
     async def send_safety_block(
         self,
         binding_id: str,

--- a/src/rolemesh/core/orchestrator_state.py
+++ b/src/rolemesh/core/orchestrator_state.py
@@ -27,6 +27,21 @@ class ConversationState:
     conversation: Conversation
     session_id: str | None = None
     last_agent_timestamp: str = ""
+    # The ``runs`` row the conversation's in-flight turn answers ("last
+    # message's run" convention — web sends stamp a run_id on the inbound
+    # message; IM channels leave it None). Lives HERE, not in a local
+    # variable of ``_process_conversation_messages``, because a warm
+    # container outlives that call: follow-ups piped via
+    # ``send_message`` join the in-flight batch, and the ``_on_output``
+    # closure captured at cold start must attribute their terminal
+    # events to the NEW run. The warm-pipe path updates this field; the
+    # closure reads it live. (Known small window: a message piped at
+    # the exact moment the previous batch's final marker is being
+    # processed can attribute that marker to the new run. Accepted —
+    # the alternative is threading run ids through the container
+    # protocol, which is not warranted while the product allows one
+    # active web run per conversation.)
+    active_run_id: str | None = None
 
 
 @dataclass

--- a/src/rolemesh/ipc/web_protocol.py
+++ b/src/rolemesh/ipc/web_protocol.py
@@ -48,13 +48,26 @@ class WebStreamChunk:
     """Streaming chunk from Orchestrator to FastAPI (web.stream.{binding_id}.{chat_id}).
 
     type="text"           — content carries a text fragment
-    type="done"           — end-of-stream marker (content ignored)
+    type="done"           — end-of-OUTPUT marker: one assistant reply
+                            (one chat bubble) is complete (content
+                            ignored). Emitted once per reply in a
+                            batched turn — it says nothing about the
+                            run's terminal state.
     type="status"         — content carries a JSON-encoded progress payload
     type="safety_blocked" — content carries a JSON-encoded safety block
                             payload with keys {reason, stage, rule_id?}
+    type="run_completed"  — run-terminal marker (single-writer
+                            contract): the orchestrator terminal-wrote the
+                            run and it ended ``completed``. content is
+                            JSON ``{run_id}``. Emitted exactly once per
+                            run, after the terminal DB write, so the
+                            frame can never contradict ``GET /runs/{id}``.
+    type="run_error"      — run-terminal marker, failure side. content is
+                            JSON ``{run_id, error: {code, message, ...}}``
+                            mirroring the authoritative runs row.
     """
 
-    type: str  # "text" | "done" | "status" | "safety_blocked"
+    type: str  # "text" | "done" | "status" | "safety_blocked" | "run_completed" | "run_error"
     content: str = ""
 
     def to_bytes(self) -> bytes:

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -1008,16 +1008,16 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
 
     prompt = format_messages(missed_messages, TIMEZONE)
 
-    # INV-6 path 1/2 (server-side): the run this turn answers. Web sends carry a
-    # run_id on the inbound message; the most recent one is the active run (same
-    # single-active-run model as ws_stream). Writing the terminal status here, at
-    # is_final/error, means a browser that disconnected mid-turn no longer
-    # strands the row at 'running'. Idempotent with the WS-side writer via the
-    # lifecycle helper's WHERE status='running' guard. (Limitation: follow-ups
-    # piped into a warm container via send_message are not threaded here, so
-    # their runs still rely on the WS path / reaper — the dominant
-    # disconnect-mid-cold-start case is covered.)
-    active_run_id = next((m.run_id for m in reversed(missed_messages) if m.run_id), None)
+    # INV-6 paths 1/2 (server-side): the run this turn answers. Web sends carry
+    # a run_id on the inbound message; the most recent one is the active run
+    # (same single-active-run model as ws_stream). Stored on conv_state — NOT a
+    # local — because a warm container outlives this call: follow-ups piped via
+    # send_message update the field so the _on_output closure below attributes
+    # their terminal events to the right run instead of the one captured at
+    # cold start. See ConversationState.active_run_id for the full rationale.
+    conv_state.active_run_id = next(
+        (m.run_id for m in reversed(missed_messages) if m.run_id), None
+    )
 
     previous_cursor = conv_state.last_agent_timestamp
     conv_state.last_agent_timestamp = missed_messages[-1].timestamp
@@ -1102,7 +1102,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.is_final:
                 _queue.notify_idle(conversation_id)
                 await _terminate_run_safe(
-                    active_run_id,
+                    conv_state.active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={
@@ -1202,7 +1202,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 _queue.notify_idle(conversation_id)
                 usage_dict = result.metadata.get("usage") if result.metadata else None
                 await _terminate_run_safe(
-                    active_run_id,
+                    conv_state.active_run_id,
                     conv.tenant_id,
                     success=True,
                     usage=usage_dict if isinstance(usage_dict, dict) else None,
@@ -1224,7 +1224,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.retryable:
                 had_error = True
                 await _terminate_run_safe(
-                    active_run_id,
+                    conv_state.active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={"code": "AGENT_ERROR", "message": result.error or "agent run failed"},
@@ -1236,7 +1236,7 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 # once with a user-visible explanation.
                 non_retryable_error = result.error or "agent configuration error"
                 await _terminate_run_safe(
-                    active_run_id,
+                    conv_state.active_run_id,
                     conv.tenant_id,
                     success=False,
                     error={"code": "CONFIG_ERROR", "message": non_retryable_error},
@@ -1757,6 +1757,17 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                     )
                     if all_pending:
                         formatted = format_messages(all_pending, TIMEZONE)
+                        # Re-point the conversation's active run BEFORE the
+                        # pipe: these messages join the warm container's
+                        # in-flight batch, and the _on_output closure from
+                        # cold start reads conv_state.active_run_id live —
+                        # without this update it would terminal-write the
+                        # PREVIOUS turn's run when this batch settles. Same
+                        # "last message's run" convention as turn start.
+                        conv_state.active_run_id = next(
+                            (m.run_id for m in reversed(all_pending) if m.run_id),
+                            None,
+                        )
                         if _queue.send_message(conv_id, formatted):
                             logger.debug("Piped messages to active container", conv_id=conv_id)
                             conv_state.last_agent_timestamp = all_pending[-1].timestamp

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -99,6 +99,7 @@ from rolemesh.db import (
     store_message as db_store_message,
 )
 from rolemesh.runs import (
+    get_run,
     terminate_run_via_ws_completed,
     terminate_run_via_ws_error,
 )
@@ -964,25 +965,134 @@ async def _terminate_run_safe(
     success: bool,
     usage: dict[str, object] | None = None,
     error: dict[str, object] | None = None,
-) -> None:
-    """Write a run's terminal status server-side (INV-6 path 1/2), suppressing
+) -> bool | None:
+    """Write a run's terminal status server-side (INV-6 paths 1/2), suppressing
     errors so a DB hiccup never crashes the processing loop. No-op when there is
-    no run_id (IM channels, or a turn with no associated run)."""
+    no run_id (IM channels, or a turn with no associated run).
+
+    Single-writer contract: this is now the ONLY writer for
+    paths 1/2 — the WS handler no longer touches the runs table.
+
+    Returns the lifecycle helper's outcome: ``True`` when THIS call moved
+    the row to terminal, ``False`` when the ``WHERE status='running'``
+    guard did not match (an earlier terminal writer won — e.g. the run
+    failed mid-batch and the batch-final marker's completed write lost),
+    ``None`` when there was nothing to write or the write errored. The
+    caller uses ``False`` to mirror the authoritative row in the frame it
+    emits instead of blindly certifying its own intent.
+    """
     if not run_id:
-        return
+        return None
     try:
         async with tenant_conn(tenant_id) as conn:
             if success:
-                await terminate_run_via_ws_completed(run_id=run_id, usage=usage, conn=conn)
-            else:
-                await terminate_run_via_ws_error(
-                    run_id=run_id,
-                    error=error or {"code": "AGENT_ERROR", "message": "agent run failed"},
-                    conn=conn,
+                return await terminate_run_via_ws_completed(
+                    run_id=run_id, usage=usage, conn=conn
                 )
+            return await terminate_run_via_ws_error(
+                run_id=run_id,
+                error=error or {"code": "AGENT_ERROR", "message": "agent run failed"},
+                conn=conn,
+            )
     except Exception:  # noqa: BLE001 — terminal write must never crash the loop
         logger.warning(
             "orchestrator-side run terminator failed (run stays 'running')",
+            run_id=run_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _run_terminal_error_or_none(
+    run_id: str,
+    tenant_id: str,
+    *,
+    transitioned: bool | None,
+    intent_error: dict[str, object] | None,
+) -> dict[str, object] | None:
+    """Pick what the run-terminal frame must report: ``None`` for
+    completed, an error dict for a failure.
+
+    ``transitioned`` is `_terminate_run_safe`'s outcome for the write this
+    frame certifies; ``intent_error`` is what that write TRIED to record
+    (``None`` for a completed write). When the write won (``True``) or
+    could not be confirmed (``None`` — DB hiccup, keep legacy best-effort
+    optimism), the intent is the truth. When it LOST (``False``), an
+    earlier terminal writer owns the row — e.g. the run failed on a
+    content-filter kill mid-batch and this is the batch-final marker's
+    completed write — so read the row and mirror it: ``failed`` /
+    ``awaiting_reauth`` report the row's recorded error, every other
+    terminal state (a redelivered write on an already-completed or
+    cancelled row) reports completed rather than fabricating a phantom
+    error. A snapshot miss falls back to the intent.
+
+    Living at the single writer — where the race is decided — is what
+    lets the WS stay a pure projection that never infers terminal state
+    from stream chunks at all.
+    """
+    if transitioned is not False:
+        return intent_error
+    snapshot: dict[str, object] | None = None
+    try:
+        async with tenant_conn(tenant_id) as conn:
+            snapshot = await get_run(run_id=run_id, tenant_id=tenant_id, conn=conn)
+    except Exception:  # noqa: BLE001 — frame selection must never crash the loop
+        logger.warning(
+            "run snapshot lookup failed; terminal frame keeps write intent",
+            run_id=run_id,
+            exc_info=True,
+        )
+    if snapshot is None:
+        return intent_error
+    status = snapshot.get("status")
+    if status in ("failed", "awaiting_reauth"):
+        err = snapshot.get("error")
+        return err if isinstance(err, dict) else {}
+    return None
+
+
+async def _terminate_and_emit_run_terminal(
+    gw: object,
+    binding: object,
+    chat_id: str,
+    *,
+    run_id: str | None,
+    tenant_id: str,
+    success: bool,
+    usage: dict[str, object] | None = None,
+    error: dict[str, object] | None = None,
+) -> None:
+    """Terminal-write a run AND publish the explicit run-terminal chunk
+    (single-writer contract).
+
+    Ordering is load-bearing: the DB write happens first, then the frame
+    mirrors the authoritative outcome — so a browser can never see
+    ``event.run.completed`` while ``GET /runs/{id}`` says ``failed``
+    (the field trace that motivated this refactor). Non-web channels and
+    turns with no run write the DB only; there is no stream to notify.
+    """
+    transitioned = await _terminate_run_safe(
+        run_id, tenant_id, success=success, usage=usage, error=error
+    )
+    if not run_id or binding is None or not isinstance(gw, WebNatsGateway):
+        return
+    intent_error = None if success else (
+        error or {"code": "AGENT_ERROR", "message": "agent run failed"}
+    )
+    frame_error = await _run_terminal_error_or_none(
+        run_id, tenant_id, transitioned=transitioned, intent_error=intent_error
+    )
+    try:
+        if frame_error is None:
+            await gw.send_run_completed(binding.id, chat_id, run_id=run_id)  # type: ignore[attr-defined]
+        else:
+            await gw.send_run_error(
+                binding.id, chat_id, run_id=run_id, error=frame_error  # type: ignore[attr-defined]
+            )
+    except (OSError, RuntimeError):
+        logger.warning(
+            "run-terminal chunk publish failed (DB already terminal; "
+            "client reconciles via GET /runs/{id})",
             run_id=run_id,
             exc_info=True,
         )
@@ -1086,6 +1196,25 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 rule_id=rule_id,
                 chars=len(reason),
             )
+            # Write-only site, and write-FIRST: the single-writer rule is
+            # "frames follow the DB" — the terminal row must exist before
+            # any frame that implies it. The safety chunk below is the
+            # user-facing frame, and the batch-final marker that follows a
+            # safety block mirrors this row into the run-terminal frame
+            # (its completed write loses to this one, so the marker emits
+            # run_error SAFETY_BLOCKED).
+            if result.is_final:
+                await _terminate_run_safe(
+                    conv_state.active_run_id,
+                    conv.tenant_id,
+                    success=False,
+                    error={
+                        "code": "SAFETY_BLOCKED",
+                        "message": reason,
+                        "stage": stage,
+                        "rule_id": rule_id if isinstance(rule_id, str) else None,
+                    },
+                )
             if binding and isinstance(gw, WebNatsGateway):
                 with contextlib.suppress(OSError, RuntimeError, TypeError, ValueError):
                     await gw.send_safety_block(
@@ -1101,17 +1230,6 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             _reset_idle_timer()
             if result.is_final:
                 _queue.notify_idle(conversation_id)
-                await _terminate_run_safe(
-                    conv_state.active_run_id,
-                    conv.tenant_id,
-                    success=False,
-                    error={
-                        "code": "SAFETY_BLOCKED",
-                        "message": reason,
-                        "stage": stage,
-                        "rule_id": rule_id if isinstance(rule_id, str) else None,
-                    },
-                )
             return
         if result.result:
             raw = result.result
@@ -1201,9 +1319,18 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
             if result.is_final:
                 _queue.notify_idle(conversation_id)
                 usage_dict = result.metadata.get("usage") if result.metadata else None
-                await _terminate_run_safe(
-                    conv_state.active_run_id,
-                    conv.tenant_id,
+                # Single-writer contract: terminal write + explicit
+                # run-terminal chunk in one ordered step. When the
+                # completed write loses to an earlier failure (e.g. a
+                # content-filter kill mid-batch already marked the run
+                # failed), the emitted chunk mirrors the row — the SPA
+                # sees event.run.error, matching GET /runs/{id}.
+                await _terminate_and_emit_run_terminal(
+                    gw,
+                    binding,
+                    conv.channel_chat_id,
+                    run_id=conv_state.active_run_id,
+                    tenant_id=conv.tenant_id,
                     success=True,
                     usage=usage_dict if isinstance(usage_dict, dict) else None,
                 )
@@ -1223,6 +1350,14 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
         if result.status == "error":
             if result.retryable:
                 had_error = True
+                # Write-only site — deliberately NO run-terminal frame.
+                # The retry ladder may still produce an answer on a fresh
+                # container; pushing event.run.error now would flash a
+                # terminal error at the user per attempt. The row is
+                # already failed (first-write-wins), so whichever later
+                # write certifies the turn (the retry's batch-final
+                # marker) loses the race and mirrors THIS row into the
+                # frame — the stream still ends truthfully.
                 await _terminate_run_safe(
                     conv_state.active_run_id,
                     conv.tenant_id,
@@ -1233,11 +1368,16 @@ async def _process_conversation_messages(conversation_id: str) -> bool:
                 # Deterministic configuration error, classified at the source
                 # (pi.ai.types.NonRetryableConfigError). Respawning cannot fix
                 # it — record it and let the post-run branch drop the message
-                # once with a user-visible explanation.
+                # once with a user-visible explanation. Unlike the retryable
+                # branch, the container is done and no batch-final marker is
+                # coming, so this site emits the run-terminal frame itself.
                 non_retryable_error = result.error or "agent configuration error"
-                await _terminate_run_safe(
-                    conv_state.active_run_id,
-                    conv.tenant_id,
+                await _terminate_and_emit_run_terminal(
+                    gw,
+                    binding,
+                    conv.channel_chat_id,
+                    run_id=conv_state.active_run_id,
+                    tenant_id=conv.tenant_id,
                     success=False,
                     error={"code": "CONFIG_ERROR", "message": non_retryable_error},
                 )

--- a/src/rolemesh/runs/terminators.py
+++ b/src/rolemesh/runs/terminators.py
@@ -22,12 +22,17 @@ guarantee — comment out the ``update_run_terminal`` call inside
 one wrapper, watch pytest turn red — is what makes this list
 load-bearing rather than informational.
 
-Wire-up status (2026-05-20, post 01b):
+Wire-up status (2026-07-16, single-writer contract):
 
-* Paths 1, 2 (WS completed / error) — orchestrator NATS handler
-  + 01b WS forwarding path (see :mod:`webui.v1.ws_stream`). The
-  webui forwards stream events; the orchestrator-side terminal
-  writer calls one of these wrappers.
+* Paths 1, 2 (turn completed / error) — the orchestrator's
+  ``_on_output`` terminal sites are the ONLY callers
+  (``rolemesh.main._terminate_run_safe``). The WS handler
+  (:mod:`webui.v1.ws_stream`) is a pure frame projection and never
+  writes the runs table; the orchestrator publishes explicit
+  ``run_completed`` / ``run_error`` stream chunks AFTER the write
+  so the browser frame mirrors the row. (The ``via_ws`` names are
+  historical — kept because they name the *path semantics* in the
+  design's seven-path table, not the caller.)
 * Path 3 (HTTP cancel) — :mod:`webui.v1.runs` publishes
   ``web.run.cancel.{run_id}``; the orchestrator-side subscriber
   calls :func:`terminate_run_via_user_cancel`.

--- a/src/webui/schemas_v1.py
+++ b/src/webui/schemas_v1.py
@@ -1091,6 +1091,19 @@ class WsServerEventRunToken(BaseModel):
     delta: str
 
 
+class WsServerEventRunOutputDone(BaseModel):
+    """One assistant reply (bubble) finished — NOT a run-terminal event.
+
+    Several arrive per run when follow-ups were batched; the run-level
+    terminal is exclusively event.run.completed / event.run.error
+    (single-writer contract).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["event.run.output_done"]
+    run_id: str
+
+
 class WsServerEventRunCompleted(BaseModel):
     model_config = ConfigDict(extra="forbid")
     type: Literal["event.run.completed"]
@@ -1247,6 +1260,7 @@ class WsServerEventDelegationCompleted(BaseModel):
 WsServerEventModel = (
     WsServerEventRunStarted
     | WsServerEventRunToken
+    | WsServerEventRunOutputDone
     | WsServerEventRunCompleted
     | WsServerEventRunError
     | WsServerEventRunProgress

--- a/src/webui/v1/ws_stream.py
+++ b/src/webui/v1/ws_stream.py
@@ -57,11 +57,7 @@ from rolemesh.db import (
     tenant_conn,
 )
 from rolemesh.ipc.web_protocol import WebInboundMessage
-from rolemesh.runs import (
-    create_run,
-    terminate_run_via_ws_completed,
-    terminate_run_via_ws_error,
-)
+from rolemesh.runs import create_run
 from webui.v1.idempotency import cache as idempotency_cache
 from webui.v1.run_events import publish_run_cancel
 
@@ -357,51 +353,41 @@ def _build_approval_frame_or_none(
     return None
 
 
-async def _terminate_run_completed(
-    *, run_id: str, tenant_id: str, usage: Any | None
-) -> None:
-    """Fire INV-6 path 1 (ws_completed) inside a tenant-scoped txn.
+def _run_terminal_frame_or_none(
+    kind: str, active_run_id: str, content: str
+) -> dict[str, Any] | None:
+    """Project an explicit run-terminal chunk (``run_completed`` /
+    ``run_error``) to its ``event.run.*`` frame.
 
-    Wrapped in :class:`contextlib.suppress` so a transient DB
-    hiccup never crashes the forwarding loop — the run row stays
-    ``running`` and a future GET ``/api/v1/runs/{id}`` will report
-    the (now-incorrect) state until the operator notices. The
-    lifecycle helper's ``WHERE status='running'`` guard makes the
-    UPDATE idempotent in case the NATS chunk redelivers and we run
-    here twice.
+    Single-writer contract: the orchestrator terminal-writes
+    the runs row and THEN publishes one of these chunks mirroring the
+    authoritative outcome, so this projection is a dumb pipe — no DB
+    read, no write, no inference. The chunk's own ``run_id`` — stamped
+    by the orchestrator from its live per-conversation attribution
+    (ConversationState.active_run_id) — wins over the closure-tracked
+    ``active_run_id`` here, which goes stale on warm-container
+    follow-ups.
+
+    Field whitelisting matches the progress/approval posture: only
+    ``code`` / ``message`` / ``details`` reach the browser, with
+    conservative defaults for malformed payloads.
     """
-    usage_dict: dict[str, Any] | None = (
-        usage if isinstance(usage, dict) else None
-    )
-    try:
-        async with tenant_conn(tenant_id) as conn:
-            await terminate_run_via_ws_completed(
-                run_id=run_id, usage=usage_dict, conn=conn
-            )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "ws_stream: terminator UPDATE failed (run stays 'running'); "
-            "investigate orchestrator side",
-            run_id=run_id,
-            exc_info=True,
-        )
-
-
-async def _terminate_run_errored(
-    *, run_id: str, tenant_id: str, error: dict[str, Any]
-) -> None:
-    """Symmetric helper for INV-6 path 2 (ws_error)."""
-    try:
-        async with tenant_conn(tenant_id) as conn:
-            await terminate_run_via_ws_error(
-                run_id=run_id, error=error, conn=conn
-            )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "ws_stream: error terminator UPDATE failed",
-            run_id=run_id,
-            exc_info=True,
-        )
+    inner = json.loads(content or "{}")
+    if not isinstance(inner, dict):
+        inner = {}
+    rid = inner.get("run_id")
+    run_id = rid if isinstance(rid, str) and rid else active_run_id
+    if kind == "run_completed":
+        return {"type": "event.run.completed", "run_id": run_id}
+    err = inner.get("error")
+    err = err if isinstance(err, dict) else {}
+    return {
+        "type": "event.run.error",
+        "run_id": run_id,
+        "code": str(err.get("code") or "AGENT_ERROR"),
+        "message": str(err.get("message") or "run failed"),
+        "details": err,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -496,20 +482,22 @@ async def stream(
     async def _forward_stream() -> None:
         """Fan NATS stream chunks to ``event.run.*`` frames.
 
-        The legacy ``web.stream.*`` carrier is reused here so this
-        endpoint can interoperate with the existing orchestrator
-        emitter — replacing the emitter would be another session.
+        Single-writer contract: this loop is a PURE
+        projection — it never touches the runs table. The orchestrator
+        owns every terminal write (INV-6 paths 1/2) and publishes
+        explicit ``run_completed`` / ``run_error`` chunks AFTER the
+        write, so the frames forwarded here can't contradict
+        ``GET /api/v1/runs/{id}``. A ``done`` chunk means "one
+        assistant reply (one bubble) is complete" and nothing more —
+        it projects to ``event.run.output_done``, never to a terminal
+        frame. Disconnect-mid-turn is therefore harmless to the DB:
+        the orchestrator's writer doesn't live in this handler.
+
         ``run_id`` is stamped from the closure's ``active_run_id``;
         when ``None``, the frame is dropped because no client
-        side-effect could meaningfully consume it.
-
-        INV-6 happy-path UPDATE: on ``done`` / ``safety_blocked`` the
-        terminator fires here so ``runs.{status, completed_at}`` lands
-        in the DB. Disconnect-mid-turn still leaves the row at
-        ``running`` (the ``finally`` in :func:`stream` cancels this
-        task — the WS handler does not survive a closed socket). A
-        durable orchestrator-side terminator for that case is on the
-        backlog (see 01c smoke Findings — design §11 INV-6 path 1).
+        side-effect could meaningfully consume it. Terminal chunks
+        carry their own (orchestrator-stamped) run_id which wins over
+        the closure — see ``_run_terminal_frame_or_none``.
         """
         async for msg in stream_sub.messages:
             try:
@@ -529,31 +517,21 @@ async def stream(
                         },
                     )
                 elif kind == "done":
-                    # INV-6 path 1: write the terminal status FIRST so
-                    # the UPDATE survives even if the client closes
-                    # the WS the moment it sees ``event.run.completed``
-                    # (the disconnect cancels ``_forward_stream`` —
-                    # without ordering this before ``_send_event``, a
-                    # fast-close races the cancellation against the
-                    # DB write and the row stays at ``running``). We
-                    # also wrap in ``asyncio.shield`` so cancellation
-                    # mid-UPDATE doesn't strand the row. Lifecycle
-                    # helper is idempotent on the ``WHERE
-                    # status='running'`` guard, so re-delivery is safe.
-                    await asyncio.shield(
-                        _terminate_run_completed(
-                            run_id=run_id,
-                            tenant_id=payload.tenant_id,
-                            usage=data.get("usage"),
-                        )
-                    )
+                    # Bubble terminator: the current assistant reply is
+                    # complete. In a batched turn (queued follow-ups)
+                    # several of these arrive before the single
+                    # run-terminal chunk; the SPA closes the streaming
+                    # bubble but keeps the run state untouched.
                     await _send_event(
                         ws,
-                        {
-                            "type": "event.run.completed",
-                            "run_id": run_id,
-                        },
+                        {"type": "event.run.output_done", "run_id": run_id},
                     )
+                elif kind in ("run_completed", "run_error"):
+                    frame = _run_terminal_frame_or_none(
+                        kind, run_id, data.get("content", "")
+                    )
+                    if frame is not None:
+                        await _send_event(ws, frame)
                 elif kind == "status":
                     # Per-turn progress indicator (running / tool_use /
                     # queued / container_starting). Legacy ``/ws/chat``
@@ -580,20 +558,12 @@ async def stream(
                         if progress is not None:
                             await _send_event(ws, progress)
                 elif kind == "safety_blocked":
+                    # Frame-only: the orchestrator already terminal-wrote
+                    # SAFETY_BLOCKED before publishing this chunk (its
+                    # write-only safety site) — projecting is all that's
+                    # left. The SPA renders the dedicated safety bubble
+                    # from code=SAFETY_BLOCKED.
                     inner = json.loads(data.get("content", "{}"))
-                    # Same ordering rationale as ``done`` above.
-                    await asyncio.shield(
-                        _terminate_run_errored(
-                            run_id=run_id,
-                            tenant_id=payload.tenant_id,
-                            error={
-                                "code": "SAFETY_BLOCKED",
-                                "message": inner.get("reason") or "blocked",
-                                "stage": inner.get("stage"),
-                                "rule_id": inner.get("rule_id"),
-                            },
-                        )
-                    )
                     await _send_event(
                         ws,
                         {

--- a/tests/orchestration/test_active_run_attribution.py
+++ b/tests/orchestration/test_active_run_attribution.py
@@ -1,0 +1,247 @@
+"""Live run attribution for terminal writes (single-writer groundwork).
+
+``_process_conversation_messages`` used to keep the run it terminal-writes
+in a LOCAL variable captured at turn start. Correct for the cold start —
+wrong for a warm container: follow-ups piped via ``send_message`` join the
+in-flight batch, but the ``_on_output`` closure still held the old run, so
+the batch's terminal events were attributed to a run that already ended.
+
+The fix moves the value to ``ConversationState.active_run_id``: the
+warm-pipe path re-points it and the closure reads it live. These tests pin
+exactly that seam — the closure must observe a mid-flight re-point, not
+its captured snapshot.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rolemesh.core.orchestrator_state import (
+    ConversationState,
+    CoworkerState,
+    OrchestratorState,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+    from rolemesh.core.types import Conversation
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pg_url: str) -> Path:
+    monkeypatch.setattr("rolemesh.core.config.DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr("rolemesh.core.config.GROUPS_DIR", tmp_path / "groups")
+    monkeypatch.setattr("rolemesh.core.config.STORE_DIR", tmp_path / "store")
+
+    from rolemesh.db import _init_test_database
+
+    await _init_test_database(pg_url)
+
+    yield tmp_path
+
+    from rolemesh.db import close_database
+
+    await close_database()
+
+
+class RepointingExecutor:
+    """Executor that re-points conv_state.active_run_id mid-flight (the
+    warm-pipe effect) before emitting its final output.
+
+    ``repoint_to=None`` leaves the field alone — the plain cold-start
+    case.
+    """
+
+    def __init__(self, conv_state: ConversationState | None = None,
+                 repoint_to: str | None = None) -> None:
+        self._conv_state = conv_state
+        self._repoint_to = repoint_to
+
+    @property
+    def name(self) -> str:
+        return "mock"
+
+    async def execute(
+        self,
+        inp: object,
+        on_process: Callable[..., None],
+        on_output: Callable[..., Awaitable[None]] | None = None,
+    ) -> object:
+        from rolemesh.agent import AgentOutput
+
+        on_process("mock-container", f"job-{uuid.uuid4().hex[:6]}")
+        if self._conv_state is not None and self._repoint_to is not None:
+            # Simulates the warm-pipe path updating the field while the
+            # container is mid-batch — the closure must see this.
+            self._conv_state.active_run_id = self._repoint_to
+        output = AgentOutput(status="success", result="hi", is_final=True)
+        if on_output:
+            await on_output(output)
+        return output
+
+
+@dataclass
+class MockGateway:
+    _channel_type: str = "telegram"
+    sent: list[tuple[str, str, str]] = field(default_factory=list)
+
+    @property
+    def channel_type(self) -> str:
+        return self._channel_type
+
+    async def send_message(self, binding_id: str, chat_id: str, text: str) -> None:
+        self.sent.append((binding_id, chat_id, text))
+
+    async def set_typing(self, binding_id: str, chat_id: str, is_typing: bool) -> None:
+        pass
+
+
+async def _seed_scenario(
+    gateway: MockGateway, *, bind_run: bool
+) -> tuple[ConversationState, Conversation, str | None]:
+    """Tenant + coworker + telegram conversation + one unanswered message,
+    optionally bound to a real ``runs`` row (messages.run_id has an FK)."""
+    import rolemesh.main as m
+    from rolemesh.db import (
+        create_channel_binding,
+        create_conversation,
+        create_coworker,
+        create_tenant,
+        store_message,
+        tenant_conn,
+    )
+    from rolemesh.runs import create_run
+
+    t = await create_tenant(name="T", slug=f"attr-{uuid.uuid4().hex[:8]}")
+    cw = await create_coworker(
+        tenant_id=t.id, name="Bot", folder=f"f-{uuid.uuid4().hex[:8]}"
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id,
+        tenant_id=t.id,
+        channel_type="telegram",
+        credentials={"bot_token": "tok"},
+    )
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id="chat-1",
+    )
+    run_id: str | None = None
+    if bind_run:
+        async with tenant_conn(t.id) as conn:
+            run_id = await create_run(
+                tenant_id=t.id, conversation_id=conv.id, conn=conn
+            )
+    await store_message(
+        tenant_id=t.id,
+        conversation_id=conv.id,
+        msg_id=f"msg-{uuid.uuid4().hex[:8]}",
+        sender="user-1",
+        sender_name="Alice",
+        content="hello",
+        timestamp="2024-06-01T12:00:01+00:00",
+        run_id=run_id,
+    )
+
+    cw_state = CoworkerState.from_coworker(cw)
+    cw_state.channel_bindings[binding.channel_type] = binding
+    conv_state = ConversationState(conversation=conv)
+    cw_state.conversations[conv.id] = conv_state
+    state = OrchestratorState()
+    state.coworkers[cw.id] = cw_state
+
+    m._state = state
+    m._gateways = {"telegram": gateway}  # type: ignore[assignment]
+    m._queue = m.GroupQueue()
+    m._queue.set_process_messages_fn(m._process_conversation_messages)
+    m._transport = None
+    return conv_state, conv, run_id
+
+
+def _capture_terminations(monkeypatch: pytest.MonkeyPatch) -> list[str | None]:
+    import rolemesh.main as m
+
+    seen: list[str | None] = []
+
+    async def _fake_terminate(
+        run_id: str | None,
+        tenant_id: str,
+        *,
+        success: bool,
+        usage: dict[str, object] | None = None,
+        error: dict[str, object] | None = None,
+    ) -> None:
+        seen.append(run_id)
+
+    monkeypatch.setattr(m, "_terminate_run_safe", _fake_terminate)
+    return seen
+
+
+def _install_executor(executor: object) -> None:
+    import rolemesh.main as m
+
+    m._executor = executor  # type: ignore[assignment]
+    m._executors = {"claude": executor, "pi": executor}  # type: ignore[assignment]
+
+
+async def test_turn_start_points_conv_state_at_message_run(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import rolemesh.main as m
+
+    seen = _capture_terminations(monkeypatch)
+    gateway = MockGateway()
+    conv_state, conv, run_id = await _seed_scenario(gateway, bind_run=True)
+    _install_executor(RepointingExecutor())
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert run_id is not None
+    assert conv_state.active_run_id == run_id
+    assert seen == [run_id]
+
+
+async def test_closure_reads_repointed_run_not_its_snapshot(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The warm-pipe case in miniature: the field is re-pointed while the
+    executor is mid-batch; the terminal write must land on the NEW run.
+    A closure that snapshotted the value at turn start fails this."""
+    import rolemesh.main as m
+
+    seen = _capture_terminations(monkeypatch)
+    gateway = MockGateway()
+    conv_state, conv, _old_run = await _seed_scenario(gateway, bind_run=True)
+    _install_executor(RepointingExecutor(conv_state, repoint_to="run-warm"))
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert seen == ["run-warm"]
+
+
+async def test_no_run_turn_passes_none(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IM turns have no run — the terminal write must receive None (its
+    guard no-ops), not a stale id from a previous turn."""
+    import rolemesh.main as m
+
+    seen = _capture_terminations(monkeypatch)
+    gateway = MockGateway()
+    conv_state, conv, _none = await _seed_scenario(gateway, bind_run=False)
+    conv_state.active_run_id = "stale-from-previous-turn"
+    _install_executor(RepointingExecutor())
+
+    assert await m._process_conversation_messages(conv.id) is True
+    assert conv_state.active_run_id is None, (
+        "turn start must overwrite, not inherit, the previous turn's run"
+    )
+    assert seen == [None]

--- a/tests/orchestration/test_run_terminal_single_writer.py
+++ b/tests/orchestration/test_run_terminal_single_writer.py
@@ -1,0 +1,388 @@
+"""Orchestrator-side run termination + explicit terminal chunks.
+
+The single-writer refactor makes ``rolemesh.main`` the ONLY terminal
+writer for INV-6 paths 1/2 and puts the "frame mirrors the
+authoritative row" logic at the writer itself:
+``_terminate_and_emit_run_terminal`` writes the row first, then
+publishes a ``run_completed`` / ``run_error`` stream chunk that the WS
+projects verbatim. The frame therefore can never contradict
+``GET /api/v1/runs/{id}``.
+
+The contract under test:
+
+* ``_terminate_run_safe`` reports the lifecycle outcome (True moved the
+  row, False lost to an earlier terminal writer, None nothing to do).
+* ``_run_terminal_error_or_none`` mirrors the row when the write lost —
+  failed/awaiting_reauth report the recorded error; a redelivered write
+  on a completed/cancelled row does NOT fabricate a phantom error.
+* ``_terminate_and_emit_run_terminal`` publishes the chunk that matches
+  the row — including the field-trace case: a run failed mid-batch by a
+  content-filter kill must end the stream with ``run_error`` even
+  though the batch-final marker tried to certify success.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pg_url: str) -> Path:
+    monkeypatch.setattr("rolemesh.core.config.DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr("rolemesh.core.config.GROUPS_DIR", tmp_path / "groups")
+    monkeypatch.setattr("rolemesh.core.config.STORE_DIR", tmp_path / "store")
+
+    from rolemesh.db import _init_test_database
+
+    await _init_test_database(pg_url)
+
+    yield tmp_path
+
+    from rolemesh.db import close_database
+
+    await close_database()
+
+
+async def _seed_run() -> tuple[str, str, str, str]:
+    """Tenant + web-bound coworker + conversation + running run.
+
+    Returns ``(tenant_id, binding_id, chat_id, run_id)`` — enough to
+    both drive the terminal helpers and assert on the stream subject
+    the gateway publishes to.
+    """
+    from rolemesh.db import (
+        create_channel_binding,
+        create_conversation,
+        create_coworker,
+        create_tenant,
+        tenant_conn,
+    )
+    from rolemesh.runs import create_run
+
+    t = await create_tenant(
+        name=f"T-{uuid.uuid4().hex[:6]}", slug=f"sw-{uuid.uuid4().hex[:6]}"
+    )
+    cw = await create_coworker(
+        tenant_id=t.id,
+        name=f"cw-{uuid.uuid4().hex[:6]}",
+        folder=f"folder-{uuid.uuid4().hex[:6]}",
+    )
+    binding = await create_channel_binding(
+        coworker_id=cw.id, tenant_id=t.id, channel_type="web"
+    )
+    conv = await create_conversation(
+        tenant_id=t.id,
+        coworker_id=cw.id,
+        channel_binding_id=binding.id,
+        channel_chat_id="chat-sw",
+    )
+    async with tenant_conn(t.id) as conn:
+        run_id = await create_run(
+            tenant_id=t.id, conversation_id=conv.id, conn=conn
+        )
+    return t.id, binding.id, "chat-sw", run_id
+
+
+async def _read_run(tenant_id: str, run_id: str) -> dict[str, Any]:
+    from rolemesh.db import tenant_conn
+
+    async with tenant_conn(tenant_id) as conn:
+        row = await conn.fetchrow(
+            "SELECT status, completed_at, error FROM runs WHERE id = $1::uuid",
+            run_id,
+        )
+    assert row is not None
+    return dict(row)
+
+
+class _CapturingJs:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any]]] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append((subject, json.loads(data)))
+
+
+class _CapturingTransport:
+    def __init__(self) -> None:
+        self.js = _CapturingJs()
+
+
+def _make_gateway() -> tuple[Any, _CapturingJs]:
+    from rolemesh.channels.web_nats_gateway import WebNatsGateway
+
+    async def _noop(*args: Any) -> None:
+        pass
+
+    transport = _CapturingTransport()
+    gw = WebNatsGateway(on_message=_noop, transport=transport)  # type: ignore[arg-type]
+    return gw, transport.js
+
+
+class _Binding:
+    def __init__(self, binding_id: str) -> None:
+        self.id = binding_id
+
+
+def _stream_chunks(js: _CapturingJs, binding_id: str, chat_id: str) -> list[dict[str, Any]]:
+    subject = f"web.stream.{binding_id}.{chat_id}"
+    return [payload for subj, payload in js.published if subj == subject]
+
+
+# ---------------------------------------------------------------------------
+# _terminate_run_safe outcome reporting
+# ---------------------------------------------------------------------------
+
+
+async def test_terminate_reports_transition_and_loss(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    first = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert first is True
+    row = await _read_run(tenant_id, run_id)
+    assert row["status"] == "completed"
+    assert row["completed_at"] is not None
+
+    # Redelivered/duplicate write loses on the WHERE status='running' guard.
+    second = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert second is False
+
+
+async def test_terminate_none_run_id_is_noop(env: Path) -> None:
+    import rolemesh.main as m
+
+    assert await m._terminate_run_safe(None, str(uuid.uuid4()), success=True) is None
+
+
+async def test_terminate_error_records_structured_error(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    outcome = await m._terminate_run_safe(
+        run_id,
+        tenant_id,
+        success=False,
+        error={
+            "code": "SAFETY_BLOCKED",
+            "message": "policy violation",
+            "stage": "input_prompt",
+            "rule_id": "rule-42",
+        },
+    )
+    assert outcome is True
+    row = await _read_run(tenant_id, run_id)
+    assert row["status"] == "failed"
+    err = row["error"]
+    if isinstance(err, str):
+        err = json.loads(err)
+    assert err["code"] == "SAFETY_BLOCKED"
+    assert err["rule_id"] == "rule-42"
+
+
+# ---------------------------------------------------------------------------
+# _run_terminal_error_or_none — frame selection mirrors the authoritative row
+# ---------------------------------------------------------------------------
+
+
+async def test_frame_selection_write_won_keeps_intent(env: Path) -> None:
+    import rolemesh.main as m
+
+    assert (
+        await m._run_terminal_error_or_none(
+            str(uuid.uuid4()),
+            str(uuid.uuid4()),
+            transitioned=True,
+            intent_error=None,
+        )
+        is None
+    ), "no row lookup on the happy path — intent is the truth"
+
+
+async def test_frame_selection_lost_to_failure_mirrors_row(env: Path) -> None:
+    """The field-trace case: a completed write that lost to an earlier
+    AGENT_ERROR must report the row's recorded error, not success."""
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    await m._terminate_run_safe(
+        run_id,
+        tenant_id,
+        success=False,
+        error={
+            "code": "AGENT_ERROR",
+            "message": "Output blocked by content filtering policy",
+        },
+    )
+    transitioned = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert transitioned is False
+
+    err = await m._run_terminal_error_or_none(
+        run_id, tenant_id, transitioned=transitioned, intent_error=None
+    )
+    assert err is not None
+    assert err["code"] == "AGENT_ERROR"
+    assert "content filtering" in str(err["message"])
+
+
+async def test_frame_selection_redelivery_on_completed_stays_completed(
+    env: Path,
+) -> None:
+    """A duplicate completed write on an already-completed row must NOT
+    fabricate a phantom error."""
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, run_id = await _seed_run()
+    assert await m._terminate_run_safe(run_id, tenant_id, success=True) is True
+    redelivered = await m._terminate_run_safe(run_id, tenant_id, success=True)
+    assert redelivered is False
+    assert (
+        await m._run_terminal_error_or_none(
+            run_id, tenant_id, transitioned=redelivered, intent_error=None
+        )
+        is None
+    )
+
+
+async def test_frame_selection_snapshot_miss_falls_back_to_intent(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, _b, _c, _run_id = await _seed_run()
+    intent = {"code": "CONFIG_ERROR", "message": "bad tool name"}
+    err = await m._run_terminal_error_or_none(
+        str(uuid.uuid4()), tenant_id, transitioned=False, intent_error=intent
+    )
+    assert err == intent
+
+
+# ---------------------------------------------------------------------------
+# _terminate_and_emit_run_terminal — write first, then the mirroring chunk
+# ---------------------------------------------------------------------------
+
+
+async def test_success_emits_run_completed_chunk(env: Path) -> None:
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+    gw, js = _make_gateway()
+
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=True,
+    )
+
+    assert (await _read_run(tenant_id, run_id))["status"] == "completed"
+    chunks = _stream_chunks(js, binding_id, chat_id)
+    assert len(chunks) == 1
+    assert chunks[0]["type"] == "run_completed"
+    assert json.loads(chunks[0]["content"]) == {"run_id": run_id}
+
+
+async def test_success_after_failure_emits_run_error_chunk(env: Path) -> None:
+    """The end-to-end trace case at the single writer: the run already
+    failed (content-filter kill mid-batch); the batch-final marker's
+    completed write loses and the emitted chunk mirrors the failure."""
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+    await m._terminate_run_safe(
+        run_id,
+        tenant_id,
+        success=False,
+        error={
+            "code": "AGENT_ERROR",
+            "message": "Output blocked by content filtering policy",
+        },
+    )
+    gw, js = _make_gateway()
+
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=True,
+    )
+
+    assert (await _read_run(tenant_id, run_id))["status"] == "failed"
+    chunks = _stream_chunks(js, binding_id, chat_id)
+    assert len(chunks) == 1
+    assert chunks[0]["type"] == "run_error"
+    inner = json.loads(chunks[0]["content"])
+    assert inner["run_id"] == run_id
+    assert inner["error"]["code"] == "AGENT_ERROR"
+
+
+async def test_error_write_emits_run_error_chunk(env: Path) -> None:
+    """The non-retryable-config-error site: container dead, no batch
+    marker coming — the site itself both writes and notifies."""
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+    gw, js = _make_gateway()
+
+    error = {"code": "CONFIG_ERROR", "message": "tool name too long"}
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=False,
+        error=error,
+    )
+
+    assert (await _read_run(tenant_id, run_id))["status"] == "failed"
+    chunks = _stream_chunks(js, binding_id, chat_id)
+    assert len(chunks) == 1
+    assert chunks[0]["type"] == "run_error"
+    assert json.loads(chunks[0]["content"])["error"] == error
+
+
+async def test_no_run_id_publishes_nothing(env: Path) -> None:
+    import rolemesh.main as m
+
+    _tenant_id, binding_id, chat_id, _run_id = await _seed_run()
+    gw, js = _make_gateway()
+
+    await m._terminate_and_emit_run_terminal(
+        gw,
+        _Binding(binding_id),
+        chat_id,
+        run_id=None,
+        tenant_id=_tenant_id,
+        success=True,
+    )
+    assert _stream_chunks(js, binding_id, chat_id) == []
+
+
+async def test_non_web_gateway_writes_db_but_skips_chunk(env: Path) -> None:
+    """IM channels terminal-write the run (a Telegram turn can carry a
+    run in the future) but have no stream to notify."""
+    import rolemesh.main as m
+
+    tenant_id, binding_id, chat_id, run_id = await _seed_run()
+
+    await m._terminate_and_emit_run_terminal(
+        object(),  # not a WebNatsGateway
+        _Binding(binding_id),
+        chat_id,
+        run_id=run_id,
+        tenant_id=tenant_id,
+        success=True,
+    )
+    assert (await _read_run(tenant_id, run_id))["status"] == "completed"

--- a/tests/test_openapi_contract.py
+++ b/tests/test_openapi_contract.py
@@ -556,6 +556,9 @@ def test_backends_endpoint_advertises_cache_control_header_in_yaml() -> None:
 _EXPECTED_SERVER_EVENTS: dict[str, str] = {
     "event.run.started": "WsServerEventRunStarted",
     "event.run.token": "WsServerEventRunToken",
+    # Bubble terminator (single-writer contract): one reply
+    # finished; NOT a run-terminal event.
+    "event.run.output_done": "WsServerEventRunOutputDone",
     "event.run.completed": "WsServerEventRunCompleted",
     "event.run.error": "WsServerEventRunError",
     "event.run.progress": "WsServerEventRunProgress",
@@ -663,6 +666,7 @@ def test_ws_server_event_pydantic_round_trips_each_member() -> None:
     from webui.schemas_v1 import (
         WsServerEventRunCompleted,
         WsServerEventRunError,
+        WsServerEventRunOutputDone,
         WsServerEventRunStarted,
         WsServerEventRunToken,
     )
@@ -670,6 +674,7 @@ def test_ws_server_event_pydantic_round_trips_each_member() -> None:
     union = Annotated[
         WsServerEventRunStarted
         | WsServerEventRunToken
+        | WsServerEventRunOutputDone
         | WsServerEventRunCompleted
         | WsServerEventRunError,
         PField(discriminator="type"),
@@ -681,6 +686,9 @@ def test_ws_server_event_pydantic_round_trips_each_member() -> None:
         ),
         WsServerEventRunToken(
             type="event.run.token", run_id="r", delta="hi",
+        ),
+        WsServerEventRunOutputDone(
+            type="event.run.output_done", run_id="r",
         ),
         WsServerEventRunCompleted(
             type="event.run.completed", run_id="r",

--- a/tests/webui/test_ws_terminators_inv6.py
+++ b/tests/webui/test_ws_terminators_inv6.py
@@ -1,249 +1,124 @@
-"""INV-6 happy-path UPDATE wiring (smoke-discovered gap).
+"""INV-6 single-writer pin: the WS handler must never write the runs table.
 
-Live smoke after 01c found that ``terminate_run_via_ws_completed``
-was *defined* in ``rolemesh.runs.terminators`` but **never called**
-from production code. Result: every Phase-1 chat run stayed at
-``status='running'`` even after the orchestrator emitted ``done``.
+History: 01c smoke found ``terminate_run_via_ws_completed`` defined but
+never called, so runs stayed at ``running``; the first fix put the
+terminal writer INTO ``webui.v1.ws_stream`` (this file's original
+subject). That created dual writers — orchestrator + WS — racing on the
+``WHERE status='running'`` guard, and the ``done`` stream chunk was
+forced to carry two meanings at once (bubble finished vs run finished).
+Field trace: a content-filter kill mid-generation left the row
+``failed`` while the WS still framed ``event.run.completed`` — the
+single-writer refactor removed that race at its root.
 
-Fix lives in ``webui.v1.ws_stream``: ``_terminate_run_completed`` /
-``_terminate_run_errored`` helpers run the lifecycle UPDATE inside
-a tenant-scoped txn, called from ``_forward_stream`` whenever a
-``web.stream.*`` chunk of type ``done`` / ``safety_blocked`` is
-seen.
+Now the orchestrator is the ONLY terminal writer (INV-6 paths 1/2 live
+in ``rolemesh.main._terminate_run_safe``; DB-backed coverage in
+``tests/orchestration/test_run_terminal_single_writer.py``). The WS
+handler is a pure projection:
 
-These tests pin the helper round-trip against a real test DB
-(see ``test_db`` fixture in ``conftest``). They are deliberately
-NOT exercised through ``TestClient.websocket_connect`` — that
-path runs the handler in a threadpool and crosses asyncio event
-loops with the asyncpg pool (same issue ``test_ws_v1_handshake``
-sidesteps by stubbing ``get_conversation``). The helper-level
-tests cover the lifecycle gap the smoke caught; the end-to-end
-wiring of the helpers into ``_forward_stream`` is verified by
-live smoke.
+* ``done``            → ``event.run.output_done``  (bubble terminator)
+* ``run_completed``   → ``event.run.completed``    (run terminal)
+* ``run_error``       → ``event.run.error``        (run terminal)
+* ``safety_blocked``  → ``event.run.error``        (frame only)
 
-Anti-mirror: assertions read the ``runs`` table directly and
-check ``status`` + ``error`` JSONB values, not which Python
-function name was on the call stack.
+These tests pin (a) the projection function's wire contract and (b) a
+source-level guard that ws_stream cannot regrow a runs-table writer.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
-import uuid
 
-import pytest
+from webui.v1 import ws_stream
+from webui.v1.ws_stream import _run_terminal_frame_or_none
 
-from rolemesh.db import (
-    create_channel_binding,
-    create_conversation,
-    create_coworker,
-    create_tenant,
-    tenant_conn,
-)
-from rolemesh.runs import create_run
-from webui.v1.ws_stream import _terminate_run_completed, _terminate_run_errored
-
-pytestmark = pytest.mark.usefixtures("test_db")
+# ---------------------------------------------------------------------------
+# Single-writer guard
+# ---------------------------------------------------------------------------
 
 
-async def _seed_run() -> tuple[str, str]:
-    """Spin up a tenant + coworker + conversation + run row.
+def test_ws_stream_has_no_runs_table_writer() -> None:
+    """Source-level pin: the WS module must not import or call any runs
+    terminator. If someone re-adds a ``terminate_run_via_*`` call here,
+    the dual-writer race (two writers deciding one row, frames emitted
+    from the loser's perspective) comes back — fail loudly.
 
-    Returns ``(tenant_id, run_id)`` — caller passes these into the
-    helper under test. A coworker is needed because the
-    ``channel_bindings.coworker_id`` FK is enforced; the binding
-    itself isn't used by the lifecycle helpers but the conversation
-    row points at it.
-
-    Note: deliberately does NOT touch the ``WS_TICKET_SECRET`` env
-    var — the helpers under test don't use ws_ticket at all, and
-    setting it would leak across to ``test_v1_auth_endpoints`` which
-    asserts on the production secret.
+    ``create_run`` (request.run mints the row) is the ONE allowed runs
+    write; everything terminal belongs to the orchestrator.
     """
-    t = await create_tenant(
-        name=f"T-{uuid.uuid4().hex[:6]}",
-        slug=f"inv6-{uuid.uuid4().hex[:6]}",
+    src = inspect.getsource(ws_stream)
+    assert "terminate_run_via" not in src, (
+        "ws_stream must stay a pure projection — terminal writes live in "
+        "rolemesh.main (single-writer contract)"
     )
-    cw = await create_coworker(
-        tenant_id=t.id,
-        name=f"cw-{uuid.uuid4().hex[:6]}",
-        folder=f"folder-{uuid.uuid4().hex[:6]}",
-        agent_backend="claude",
+    assert "update_run_terminal" not in src
+
+
+# ---------------------------------------------------------------------------
+# Projection: run_completed / run_error chunks → frames
+# ---------------------------------------------------------------------------
+
+
+def test_run_completed_chunk_projects_completed_frame() -> None:
+    frame = _run_terminal_frame_or_none(
+        "run_completed", "run-closure", json.dumps({"run_id": "run-echo"})
     )
-    binding = await create_channel_binding(
-        coworker_id=cw.id,
-        tenant_id=t.id,
-        channel_type="web",
+    assert frame == {"type": "event.run.completed", "run_id": "run-echo"}
+
+
+def test_terminal_chunk_run_id_wins_over_closure() -> None:
+    """The chunk's run_id is orchestrator-stamped from its live
+    per-conversation attribution and authoritative; the closure's
+    active_run_id goes stale on warm-container follow-ups and is only
+    the fallback."""
+    frame = _run_terminal_frame_or_none(
+        "run_error",
+        "run-closure",
+        json.dumps({"run_id": "run-echo", "error": {"code": "X", "message": "m"}}),
     )
-    conv = await create_conversation(
-        tenant_id=t.id,
-        coworker_id=cw.id,
-        channel_binding_id=binding.id,
-        channel_chat_id="chat-inv6",
-        name=None,
+    assert frame is not None
+    assert frame["run_id"] == "run-echo"
+
+
+def test_terminal_chunk_without_run_id_falls_back_to_closure() -> None:
+    frame = _run_terminal_frame_or_none("run_completed", "run-closure", "{}")
+    assert frame == {"type": "event.run.completed", "run_id": "run-closure"}
+
+
+def test_run_error_chunk_projects_error_frame_with_details() -> None:
+    error = {
+        "code": "SAFETY_BLOCKED",
+        "message": "policy violation",
+        "stage": "input_prompt",
+        "rule_id": "rule-42",
+    }
+    frame = _run_terminal_frame_or_none(
+        "run_error", "run-1", json.dumps({"run_id": "run-1", "error": error})
     )
-    async with tenant_conn(t.id) as conn:
-        run_id = await create_run(
-            tenant_id=t.id, conversation_id=conv.id, conn=conn
-        )
-    return t.id, run_id
+    assert frame == {
+        "type": "event.run.error",
+        "run_id": "run-1",
+        "code": "SAFETY_BLOCKED",
+        "message": "policy violation",
+        "details": error,
+    }
 
 
-async def _read_run(tenant_id: str, run_id: str) -> dict:
-    async with tenant_conn(tenant_id) as conn:
-        row = await conn.fetchrow(
-            "SELECT status, completed_at, usage, error FROM runs "
-            "WHERE id = $1::uuid",
-            run_id,
-        )
-    assert row is not None, "seeded run row vanished"
-    return dict(row)
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_flips_status_and_records_usage() -> None:
-    """``_terminate_run_completed`` writes status='completed' + usage JSONB.
-
-    Smoke gap reproducer: before the fix, this UPDATE never ran and
-    every Phase-1 happy-path run stayed at ``status='running'``.
-    The terminator's usage column accepts any JSON payload from the
-    orchestrator; we assert that a non-dict input is dropped (the
-    helper only persists actual dicts) — that's the boundary we
-    care about given the WS chunk shape is loose.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id,
-        tenant_id=tenant_id,
-        usage={"tokens_in": 12, "tokens_out": 8, "total_cost_usd": 0.0001},
+def test_run_error_chunk_with_junk_error_uses_defaults() -> None:
+    """A malformed error payload must not crash the forwarder or leak
+    raw junk — conservative defaults instead."""
+    frame = _run_terminal_frame_or_none(
+        "run_error", "run-1", json.dumps({"run_id": "run-1", "error": "not-a-dict"})
     )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "completed"
-    assert row["completed_at"] is not None, (
-        "completed_at must be stamped — used by GET /runs/{id} clients"
-    )
-    usage = row["usage"]
-    if isinstance(usage, str):
-        usage = json.loads(usage)
-    assert usage == {"tokens_in": 12, "tokens_out": 8, "total_cost_usd": 0.0001}
+    assert frame == {
+        "type": "event.run.error",
+        "run_id": "run-1",
+        "code": "AGENT_ERROR",
+        "message": "run failed",
+        "details": {},
+    }
 
 
-@pytest.mark.asyncio
-async def test_completed_helper_with_no_usage_still_writes_terminal() -> None:
-    """No usage payload on the chunk -> status='completed' + usage NULL.
-
-    Many ``done`` chunks won't carry usage today (the orchestrator
-    only attaches it when the backend reports it); the helper must
-    not strand the run row over a missing optional.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage=None
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "completed"
-    assert row["usage"] is None
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_drops_non_dict_usage_silently() -> None:
-    """Hostile / accidentally non-JSON usage is coerced to NULL.
-
-    The orchestrator emits chunks with arbitrary content. A bad
-    payload should not crash the helper *and* should not poison the
-    DB with a non-dict ``usage`` value — the row stays
-    ``completed`` with ``usage=NULL``, which is the design's open
-    schema fallback.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage="not-a-dict",
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "completed"
-    assert row["usage"] is None
-
-
-@pytest.mark.asyncio
-async def test_completed_helper_idempotent_against_redelivery() -> None:
-    """Two calls in a row must not double-flip / regress the row.
-
-    NATS chunk redelivery on consumer reconnect can cause the
-    forwarder to see the same ``done`` chunk twice. The lifecycle
-    helper's ``WHERE status='running'`` guard is the idempotency
-    seat — the second call no-ops and leaves the original
-    ``completed_at`` intact.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage={"x": 1}
-    )
-    first = await _read_run(tenant_id, run_id)
-    await _terminate_run_completed(
-        run_id=run_id, tenant_id=tenant_id, usage={"x": 999}
-    )
-    second = await _read_run(tenant_id, run_id)
-    assert second["status"] == "completed"
-    assert second["completed_at"] == first["completed_at"], (
-        "redelivery must not overwrite completed_at"
-    )
-    # Usage on the original row stays — second UPDATE was a no-op.
-    usage_first = first["usage"]
-    if isinstance(usage_first, str):
-        usage_first = json.loads(usage_first)
-    usage_second = second["usage"]
-    if isinstance(usage_second, str):
-        usage_second = json.loads(usage_second)
-    assert usage_first == usage_second
-
-
-@pytest.mark.asyncio
-async def test_errored_helper_records_safety_block_metadata() -> None:
-    """``_terminate_run_errored`` lands status='failed' + structured error.
-
-    Safety-block chunks carry the rule_id / stage that fired; the
-    helper must persist them so a future ``GET /runs/{id}`` can
-    surface "blocked by rule X at stage Y" without re-querying the
-    safety_decisions table.
-    """
-    tenant_id, run_id = await _seed_run()
-    await _terminate_run_errored(
-        run_id=run_id,
-        tenant_id=tenant_id,
-        error={
-            "code": "SAFETY_BLOCKED",
-            "message": "policy violation",
-            "stage": "input_prompt",
-            "rule_id": "rule-42",
-        },
-    )
-    row = await _read_run(tenant_id, run_id)
-    assert row["status"] == "failed"
-    err = row["error"]
-    if isinstance(err, str):
-        err = json.loads(err)
-    assert err["code"] == "SAFETY_BLOCKED"
-    assert err["stage"] == "input_prompt"
-    assert err["rule_id"] == "rule-42"
-
-
-@pytest.mark.asyncio
-async def test_helpers_swallow_db_errors_to_keep_forwarder_alive() -> None:
-    """Smoke contract: a missing run_id must NOT bring down ``_forward_stream``.
-
-    The helper wraps its DB work in ``except Exception`` because the
-    forwarder loop is the only consumer of NATS ``web.stream.*``
-    chunks; a single bad chunk killing it would strand every other
-    run on the same WS. We assert that calling with a non-existent
-    run_id is a silent no-op (logged but not raised).
-    """
-    tenant_id, _ = await _seed_run()
-    # Should not raise.
-    await _terminate_run_completed(
-        run_id=str(uuid.uuid4()), tenant_id=tenant_id, usage=None
-    )
-    await _terminate_run_errored(
-        run_id=str(uuid.uuid4()),
-        tenant_id=tenant_id,
-        error={"code": "X"},
-    )
+def test_terminal_chunk_with_non_dict_content_still_frames() -> None:
+    frame = _run_terminal_frame_or_none("run_completed", "run-1", json.dumps([1, 2]))
+    assert frame == {"type": "event.run.completed", "run_id": "run-1"}

--- a/web/src/api/generated/types.ts
+++ b/web/src/api/generated/types.ts
@@ -2689,6 +2689,17 @@ export interface components {
              */
             delta: string;
         };
+        /** @description One assistant reply (one chat bubble) is complete. In a batched turn — the user queued follow-ups while the agent was busy — several of these arrive before the single run-terminal event, one per reply, so the client can close each bubble separately. Says nothing about the run's terminal state: the run may still be serving queued messages. Run-level state changes ride `event.run.completed` / `event.run.error` exclusively. */
+        WsServerEventRunOutputDone: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "event.run.output_done";
+            /** Format: uuid */
+            run_id: string;
+        };
+        /** @description The run reached its terminal state `completed`. Emitted exactly once per run, projected from the orchestrator's explicit run-terminal marker which is published AFTER the terminal DB write (single-writer refactor) — so this event can never contradict `GET /api/v1/runs/{id}`. When the underlying run was already terminal `failed`/`awaiting_reauth` — e.g. the orchestrator recorded an agent error after partial output streamed — the stream ends with `event.run.error` carrying the run's recorded error instead. */
         WsServerEventRunCompleted: {
             /**
              * @description discriminator enum property added by openapi-typescript
@@ -2929,7 +2940,7 @@ export interface components {
             final_status: string;
             duration_ms?: number | null;
         };
-        WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"] | components["schemas"]["WsServerEventRunProgress"] | components["schemas"]["WsServerEventMessageAppended"] | components["schemas"]["WsServerEventApprovalRequested"] | components["schemas"]["WsServerEventApprovalResolved"] | components["schemas"]["WsServerEventDelegationStarted"] | components["schemas"]["WsServerEventDelegationProgress"] | components["schemas"]["WsServerEventDelegationToolUse"] | components["schemas"]["WsServerEventDelegationCompleted"];
+        WsServerEvent: components["schemas"]["WsServerEventRunStarted"] | components["schemas"]["WsServerEventRunToken"] | components["schemas"]["WsServerEventRunOutputDone"] | components["schemas"]["WsServerEventRunCompleted"] | components["schemas"]["WsServerEventRunError"] | components["schemas"]["WsServerEventRunProgress"] | components["schemas"]["WsServerEventMessageAppended"] | components["schemas"]["WsServerEventApprovalRequested"] | components["schemas"]["WsServerEventApprovalResolved"] | components["schemas"]["WsServerEventDelegationStarted"] | components["schemas"]["WsServerEventDelegationProgress"] | components["schemas"]["WsServerEventDelegationToolUse"] | components["schemas"]["WsServerEventDelegationCompleted"];
         WsClientFrameRequestRun: {
             /**
              * @description discriminator enum property added by openapi-typescript

--- a/web/src/components/chat-panel.test.ts
+++ b/web/src/components/chat-panel.test.ts
@@ -223,6 +223,45 @@ describe('ChatPanel — side-channel events (PR #38)', () => {
     }
   });
 
+  it('event.run.output_done closes the streaming bubble without ending the run', () => {
+    // Single-writer refactor: `done` chunks became per-bubble
+    // event.run.output_done. In a batched turn (queued follow-ups)
+    // several arrive before the one true run-terminal frame — the
+    // bubble must close (so the next reply spawns a fresh one) while
+    // Stop stays available and the run state stays 'running'.
+    const { i: base } = makePanel();
+    const i = base as unknown as InternalsWithEvents;
+    i.runState = 'running';
+    i.runTerminal = false;
+    i.activeRunId = 'run-1';
+    i.messages = [
+      { role: 'user', content: 'first question' },
+      { role: 'assistant', content: 'first answer', streaming: true },
+    ];
+
+    i.handleV1Event({ type: 'event.run.output_done', run_id: 'run-1' });
+
+    expect(i.messages[1].streaming).toBeFalsy();
+    expect(i.runState).toBe('running');
+    expect(i.runTerminal).toBe(false);
+
+    // Next reply's token spawns a NEW bubble instead of appending to
+    // the closed one — the exact behavior the split exists to keep.
+    i.handleV1Event({ type: 'event.run.token', run_id: 'run-1', delta: 'second' });
+    expect(i.messages).toHaveLength(3);
+    expect(i.messages[2]).toMatchObject({
+      role: 'assistant',
+      content: 'second',
+      streaming: true,
+    });
+
+    // Only the run-terminal frame flips the run state.
+    i.handleV1Event({ type: 'event.run.completed', run_id: 'run-1' });
+    expect(i.runState).toBe('idle');
+    expect(i.runTerminal).toBe(true);
+    expect(i.messages[2].streaming).toBeFalsy();
+  });
+
   it('event.run.progress from a stale run is ignored', () => {
     // JetStream redelivery on reconnect can replay an old progress
     // frame after the user has moved on to a new turn. Without the

--- a/web/src/components/chat-panel.ts
+++ b/web/src/components/chat-panel.ts
@@ -449,7 +449,23 @@ export class ChatPanel extends LitElement {
         }
         break;
       }
+      case 'event.run.output_done': {
+        // Bubble terminator (single-writer refactor): one assistant
+        // reply is complete. In a batched turn several of these arrive
+        // before the single run-terminal event — close the streaming
+        // bubble so the next reply's tokens spawn a fresh one, but do
+        // NOT touch run state; the run may still be serving queued
+        // follow-ups. Run-level transitions ride event.run.completed /
+        // event.run.error exclusively.
+        this.finalizeStreamingBubble();
+        break;
+      }
       case 'event.run.completed': {
+        // Run terminal: emitted exactly once per run, after the
+        // orchestrator's terminal DB write — so this can never
+        // contradict GET /runs/{id}. finalizeStreamingBubble() stays
+        // as a belt-and-braces close for the last bubble (no-op when
+        // output_done already closed it).
         this.finalizeStreamingBubble();
         this.runState = 'idle';
         this.runTerminal = true;

--- a/web/src/ws/v1_client.ts
+++ b/web/src/ws/v1_client.ts
@@ -58,6 +58,8 @@ export type RunStartedEvent =
   components['schemas']['WsServerEventRunStarted'];
 export type RunTokenEvent =
   components['schemas']['WsServerEventRunToken'];
+export type RunOutputDoneEvent =
+  components['schemas']['WsServerEventRunOutputDone'];
 export type RunCompletedEvent =
   components['schemas']['WsServerEventRunCompleted'];
 export type RunErrorEvent =


### PR DESCRIPTION
## Background

INV-6 paths 1/2 had **two writers** racing on the runs table: the orchestrator's `_on_output` terminal sites and the WS handler, which *inferred* run-terminal state from the `done` stream chunk. The `done` chunk carried two meanings at once — "one reply (bubble) finished" **and** "the run finished" — which is how a run failed by a content-filter kill mid-generation could still close its stream with `event.run.completed`: a truncated answer under a green check, contradicted only by `GET /runs/{id}`.

This is the **direct, minimal implementation** on a clean base (`17a0072`): no stopgap layer, no container-side attribution protocol — the earlier incremental path (#128/#129/#130) is superseded and removed from main. **+1193 / −371** over 24→16 files; the container and IPC protocol layers are untouched.

## Commits

**1. `fix(runs)`: live run attribution (`ConversationState.active_run_id`)**
The run a terminal write lands on was a local variable captured at cold start — stale for follow-ups piped into a warm container via `send_message`. It is now a field on `ConversationState`: the warm-pipe path re-points it, the `_on_output` closure reads it live. A known millisecond-scale window (a message piped exactly as the previous batch-final marker is processed) is documented and accepted — closing it would require threading run ids through the container protocol, not warranted while the product allows one active web run per conversation.

**2. `refactor(runs)`: single terminal writer + explicit run-terminal frames**

Semantic split on the wire (`web.stream.*`):

| chunk | meaning | WS projection |
|---|---|---|
| `done` | one reply (bubble) complete — several per batched turn | **new** `event.run.output_done` |
| `run_completed` *(new)* | run ended `completed`; published **after** the terminal DB write, exactly once per run | `event.run.completed` |
| `run_error` *(new)* | run terminal failure, mirroring the runs row | `event.run.error` |
| `safety_blocked` | unchanged | `event.run.error` (frame-only; write moved orchestrator-side, write-first) |

Orchestrator is the single writer: `_terminate_run_safe` reports the lifecycle outcome; `_run_terminal_error_or_none` selects the frame where the race is decided (a completed write that lost to an earlier failure mirrors the row's recorded error; a redelivered write on a completed/cancelled row does not fabricate a phantom error); `_terminate_and_emit_run_terminal` wires write-then-emit at the batch-final success site and the non-retryable-config-error site. Retryable-error and safety sites stay write-only (retries must not flash per-attempt errors; the safety chunk is already the user-facing frame).

The WS handler is a pure projection — its terminal writers and runs-table imports are gone; a source-level test pins that no writer can regrow there.

Contract: `WsServerEventRunOutputDone` in openapi.yaml + schemas_v1 + regenerated types.ts; `RunCompleted` description now states the exactly-once, post-write guarantee.

**3. `feat(web)`: SPA handler split**
`event.run.output_done` closes the streaming bubble only (next reply's tokens spawn a fresh bubble); `event.run.completed`/`error` keep exclusive ownership of run state.

## Tests

- `tests/orchestration/test_active_run_attribution.py` (new): closure must observe a mid-flight re-point, not its turn-start snapshot; no-run turns pass None.
- `tests/orchestration/test_run_terminal_single_writer.py` (new, DB-backed): outcome reporting, frame selection incl. the field-trace case, write-then-emit through a real `WebNatsGateway`, no-run/non-web no-ops.
- `tests/webui/test_ws_terminators_inv6.py` rewritten: projection wire contract + no-writer source guard.
- Contract pin + Pydantic round-trip extended with `output_done`; `chat-panel.test.ts` covers the batched-turn bubble/run split.

Verification: backend suites **1662 passed** (13 failures = the known env-only webui safety set, spacy model download blocked by proxy — identical on the pre-refactor baseline); SPA `tsc` clean, **661/661 vitest**, `openapi:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD

---
_Generated by [Claude Code](https://claude.ai/code/session_011b3BFcdUpKgp6adgD5JfSD)_