### PR TITLE
feat(egress): auto-allow registered MCP server origins on the reverse path

### DIFF
--- a/docs/7-external-mcp-architecture-cn.md
+++ b/docs/7-external-mcp-architecture-cn.md
@@ -232,6 +232,7 @@ MCP 注册表存在于两个必须保持一致的位置：orchestrator 在宿主
 | Token 过期 | TokenVault 对 IdP 自动刷新；永久失败时强制重新登录 |
 | MCP 服务器校验 | MCP 服务器通过 OIDC discovery 校验 token——RoleMesh 是穿透方，不是签发方 |
 | 代理范围 | MCP 路由只转发到**已注册**的服务器名——未知名称返回 404 |
+| 出口白名单 | 已注册 MCP 的 origin 在反向代理路径上自动放行（审计记录 `EGRESS.MCP_REGISTRY_ALLOWED`）——通过管理 API 注册服务器本身即出口授权，无需再手写 `egress.domain_rule`。同一域名走 agent 可控的 forward/DNS 路径时仍默认拒绝 |
 
 ### 被攻陷的容器能做什么
 

--- a/docs/7-external-mcp-architecture.md
+++ b/docs/7-external-mcp-architecture.md
@@ -232,6 +232,7 @@ Editing `coworkers.tools` through the admin REST API is therefore a hot operatio
 | Token expiry | TokenVault auto-refreshes against the IdP; permanent failure forces re-login |
 | MCP server validation | MCP server validates the token via OIDC discovery — RoleMesh is a passthrough, not an issuer |
 | Proxy scope | The MCP route only forwards to **registered** server names — unknown names return 404 |
+| Egress allowlist | Registered MCP origins are allowed automatically on the reverse path (`EGRESS.MCP_REGISTRY_ALLOWED` in the audit trail) — registering the server through the admin API *is* the egress approval, no hand-written `egress.domain_rule` needed. The same host stays default-denied on the agent-controlled forward/DNS paths |
 
 ### What a compromised container can do
 

--- a/src/rolemesh/egress/gateway.py
+++ b/src/rolemesh/egress/gateway.py
@@ -85,6 +85,7 @@ from .remote_credentials import RemoteCredentialResolver
 from .remote_token_vault import RemoteTokenVault
 from .reverse_proxy import (
     is_known_provider_host,
+    is_registered_mcp_origin,
     known_provider_endpoints,
     set_token_vault,
     start_credential_proxy,
@@ -448,13 +449,18 @@ async def main() -> None:
 
         # Platform-managed provider allow layer: known LLM-provider hosts
         # are always permitted egress so a tenant's BYOK credential works
-        # without hand-configuring an egress allowlist. Per-tenant rules in
-        # the policy cache still govern MCP and any custom egress.
+        # without hand-configuring an egress allowlist. Registered MCP
+        # server origins get the same reverse-only treatment via
+        # ``mcp_allow`` — adding an MCP server through the admin API is
+        # itself the egress approval, no hand-written egress.domain_rule
+        # needed. Per-tenant rules in the policy cache still govern any
+        # custom egress.
         safety = EgressSafetyCaller(
             cache=cache,
             checks=check_map,
             audit_publisher=audit,
             platform_allow=is_known_provider_host,
+            mcp_allow=is_registered_mcp_origin,
         )
         logger.info(
             "gateway: platform provider allowlist active",

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -204,9 +204,10 @@ def _bedrock_upstream(cred: dict[str, Any]) -> str:
 # Known LLM-provider upstreams the platform always allows egress to, so a
 # tenant's BYOK credential works without anyone hand-configuring an
 # ``egress.domain_rule``. The gateway consumes ``is_known_provider_host``
-# as its platform-allow layer (see ``EgressSafetyCaller.decide``); the
-# per-tenant ``safety_rules`` allowlist is left for everything else (MCP,
-# tenant-custom egress).
+# as its platform-allow layer (see ``EgressSafetyCaller.decide``);
+# registered MCP origins get the same treatment via
+# ``is_registered_mcp_origin`` below. The per-tenant ``safety_rules``
+# allowlist is left for tenant-custom egress.
 #
 # Hosts are derived from the SAME routing source the reverse proxy dials —
 # ``_provider_upstream`` / ``_anthropic_upstream`` — so deployment
@@ -299,6 +300,34 @@ def unregister_mcp_server(name: str) -> bool:
 
 def get_mcp_registry() -> dict[str, tuple[str, dict[str, str], str]]:
     return dict(_mcp_registry)
+
+
+def registered_mcp_origins() -> set[tuple[str, int]]:
+    """``(host, port)`` endpoints of every registered MCP server origin.
+
+    Recomputed from ``_mcp_registry`` on every call — same pattern as
+    :func:`known_provider_endpoints` — so the set follows registry
+    hot-reload (``egress.mcp.changed`` / snapshot reconcile) with no
+    cache of its own to invalidate. An unseeded registry is empty, so
+    this yields nothing during the gateway's degraded-startup window.
+    """
+    out: set[tuple[str, int]] = set()
+    for url, _headers, _auth_mode in _mcp_registry.values():
+        hp = _upstream_host_port(url)
+        if hp is not None:
+            out.add(hp)
+    return out
+
+
+def is_registered_mcp_origin(host: str, port: int) -> bool:
+    """True when ``host:port`` is the origin of a registered MCP server.
+
+    Used by the egress gateway as a registry-managed allow layer on the
+    REVERSE path only (see ``EgressSafetyCaller.decide``): the MCP proxy
+    derives its upstream from the registry entry, so an origin an admin
+    registered is by construction an authorised destination.
+    """
+    return (host.lower().rstrip("."), port) in registered_mcp_origins()
 
 
 def _collapse_trailing_slash(path: str) -> str:
@@ -720,7 +749,9 @@ __all__ = [
     "AuthMode",
     "detect_auth_mode",
     "get_mcp_registry",
+    "is_registered_mcp_origin",
     "register_mcp_server",
+    "registered_mcp_origins",
     "set_token_vault",
     "start_credential_proxy",
     "unregister_mcp_server",

--- a/src/rolemesh/egress/safety_call.py
+++ b/src/rolemesh/egress/safety_call.py
@@ -108,6 +108,7 @@ class EgressSafetyCaller:
         checks: dict[str, CheckFunc],
         audit_publisher: AuditPublisher,
         platform_allow: Callable[[str, int], bool] | None = None,
+        mcp_allow: Callable[[str, int], bool] | None = None,
     ) -> None:
         self._cache = cache
         self._checks = checks
@@ -117,6 +118,12 @@ class EgressSafetyCaller:
         # without a per-tenant egress allowlist. ``None`` disables it (the
         # gateway always wires it; unit tests opt in).
         self._platform_allow = platform_allow
+        # Registry-managed allow layer: a host/port predicate for origins
+        # of admin-registered MCP servers, so a configured MCP server works
+        # without a hand-written egress.domain_rule. Same reverse-mode-only
+        # scoping and safety argument as ``platform_allow``. ``None``
+        # disables it.
+        self._mcp_allow = mcp_allow
         self._audit_tasks: set[asyncio.Task[None]] = set()
 
     async def decide(
@@ -168,6 +175,42 @@ class EgressSafetyCaller:
                         "severity": "info",
                         "message": (
                             f"platform-managed provider host "
+                            f"{request.host}:{request.port}"
+                        ),
+                        "metadata": {"host": request.host, "port": request.port},
+                    }
+                ],
+            )
+            self._publish_audit(identity=identity, request=request, decision=decision)
+            return decision
+
+        # Registry-managed MCP allow — reverse proxy ONLY, for the same
+        # reason as the provider layer above: on the /mcp-proxy route the
+        # upstream host is looked up from the registered server entry
+        # (server-derived), never taken from the agent, so an origin an
+        # admin registered via ``mcp.configure`` is already an authorised
+        # destination. Registering the server IS the approval; requiring a
+        # second, hand-written egress.domain_rule for the same origin was
+        # the papercut this layer removes. Forward/DNS requests to the very
+        # same host stay on the default-deny path below. Also ahead of the
+        # ``seeded`` gate: the MCP registry has its own snapshot lifecycle
+        # (an unseeded registry is empty, so this predicate cannot match
+        # during that window), and MCP egress must not additionally wait
+        # for the tenant-rule snapshot.
+        if (
+            request.mode == "reverse"
+            and self._mcp_allow is not None
+            and self._mcp_allow(request.host, request.port)
+        ):
+            decision = EgressDecision(
+                action="allow",
+                reason="Registered MCP server origin",
+                findings=[
+                    {
+                        "code": "EGRESS.MCP_REGISTRY_ALLOWED",
+                        "severity": "info",
+                        "message": (
+                            f"registered MCP server origin "
                             f"{request.host}:{request.port}"
                         ),
                         "metadata": {"host": request.host, "port": request.port},

--- a/tests/egress/test_mcp_origin_allow.py
+++ b/tests/egress/test_mcp_origin_allow.py
@@ -1,0 +1,278 @@
+"""Registry-managed MCP origin allow layer (feat/egress-allow-registered-mcp-origins).
+
+Adding an MCP server through the admin API must be sufficient for the
+gateway to permit egress to its origin on the REVERSE (credential proxy)
+path — no hand-written ``egress.domain_rule`` required. The properties
+under test:
+
+  - a registered origin is allowed on the reverse path, with its own
+    audit finding code;
+  - the SAME host:port stays default-denied on the forward and DNS
+    paths (those hosts are agent-controlled);
+  - the allow set follows the registry live: URL edits drop the old
+    origin immediately, deletes drop the origin entirely;
+  - the layer does not depend on the tenant-rule snapshot (an MCP call
+    works during the rules-degraded window).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from rolemesh.egress import reverse_proxy
+from rolemesh.egress.policy_cache import PolicyCache
+from rolemesh.egress.reverse_proxy import (
+    is_registered_mcp_origin,
+    register_mcp_server,
+    registered_mcp_origins,
+    unregister_mcp_server,
+)
+from rolemesh.egress.safety_call import (
+    AuditPublisher,
+    EgressRequest,
+    EgressSafetyCaller,
+)
+from rolemesh.egress.token_identity import Identity
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    """Snapshot + restore the module-global MCP registry around each test."""
+    saved = reverse_proxy.get_mcp_registry()
+    for name in list(saved):
+        unregister_mcp_server(name)
+    yield
+    for name in list(reverse_proxy.get_mcp_registry()):
+        unregister_mcp_server(name)
+    for name, (url, headers, auth_mode) in saved.items():
+        register_mcp_server(name, url, headers, auth_mode)
+
+
+@dataclass
+class _FakeNats:
+    published: list[tuple[str, dict[str, Any]]]
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        import json
+
+        self.published.append((subject, json.loads(data)))
+
+
+def _identity() -> Identity:
+    return Identity(
+        tenant_id="tenant-a",
+        coworker_id="coworker-x",
+        user_id="user-1",
+        conversation_id="conv-1",
+        job_id="job-1",
+        container_name="rolemesh-foo-1",
+    )
+
+
+async def _make_caller(*, nc: _FakeNats, seeded: bool = True) -> EgressSafetyCaller:
+    """Caller with zero tenant rules, wired the way the gateway wires it."""
+    cache = PolicyCache()
+    if seeded:
+        await cache.seed([])
+    return EgressSafetyCaller(
+        cache=cache,
+        checks={},
+        audit_publisher=AuditPublisher(nats_client=nc),  # type: ignore[arg-type]
+        mcp_allow=is_registered_mcp_origin,
+    )
+
+
+async def _drain_audit(nc: _FakeNats) -> None:
+    for _ in range(50):
+        await asyncio.sleep(0.02)
+        if nc.published:
+            return
+
+
+# ---------------------------------------------------------------------------
+# Origin derivation
+# ---------------------------------------------------------------------------
+
+
+async def test_registered_origins_default_ports() -> None:
+    """Scheme-default ports match the ports the proxy actually dials."""
+    register_mcp_server("a", "https://mcp.example.com")
+    register_mcp_server("b", "http://intranet.local")
+    register_mcp_server("c", "http://host.docker.internal:9100")
+    assert registered_mcp_origins() == {
+        ("mcp.example.com", 443),
+        ("intranet.local", 80),
+        ("host.docker.internal", 9100),
+    }
+
+
+async def test_predicate_normalises_host() -> None:
+    """Case and trailing-dot differences must not defeat the match."""
+    register_mcp_server("a", "https://mcp.example.com")
+    assert is_registered_mcp_origin("MCP.Example.COM.", 443)
+    assert not is_registered_mcp_origin("mcp.example.com", 8443)
+    assert not is_registered_mcp_origin("evil-mcp.example.com", 443)
+
+
+# ---------------------------------------------------------------------------
+# Decision layer: reverse allowed, forward/DNS unaffected
+# ---------------------------------------------------------------------------
+
+
+async def test_registered_origin_allowed_on_reverse() -> None:
+    """The user-facing fix: adding an MCP server is enough for its calls
+    to pass the egress gate — no separate egress.domain_rule needed."""
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "allow"
+    assert decision.reason == "Registered MCP server origin"
+    assert decision.findings[0]["code"] == "EGRESS.MCP_REGISTRY_ALLOWED"
+
+
+async def test_unregistered_origin_still_blocked_on_reverse() -> None:
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "block"
+    assert "No egress allowlist rule matched" in decision.reason
+
+
+async def test_mcp_allow_does_not_apply_to_forward_proxy() -> None:
+    """Security boundary: the forward CONNECT target is agent-controlled,
+    so a registered MCP host must NOT be reachable that way — only via
+    the /mcp-proxy route whose upstream is server-derived."""
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(
+            host="mcp.example.com", port=9100, mode="forward", method="CONNECT"
+        ),
+    )
+    assert decision.action == "block"
+
+
+async def test_mcp_allow_does_not_apply_to_dns() -> None:
+    """Same boundary for the DNS plane: the queried name is agent-controlled."""
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(
+            host="mcp.example.com", port=9100, mode="dns", qtype="A"
+        ),
+    )
+    assert decision.action == "block"
+
+
+# ---------------------------------------------------------------------------
+# Hot-reload semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_url_edit_drops_old_origin_and_allows_new() -> None:
+    """Editing a server's URL (same registry semantics as the
+    egress.mcp.changed hot-reload) must revoke the old origin at once."""
+    register_mcp_server("jira", "http://old.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+
+    register_mcp_server("jira", "http://new.example.com:9200")
+
+    old = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="old.example.com", port=9100, mode="reverse"),
+    )
+    new = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="new.example.com", port=9200, mode="reverse"),
+    )
+    assert old.action == "block"
+    assert new.action == "allow"
+
+
+async def test_delete_revokes_origin() -> None:
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    unregister_mcp_server("jira")
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "block"
+
+
+async def test_shared_origin_survives_deleting_one_server() -> None:
+    """Two servers on one origin: deleting one must not revoke the other."""
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("wiki", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    unregister_mcp_server("jira")
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Degraded startup + audit
+# ---------------------------------------------------------------------------
+
+
+async def test_mcp_allow_works_during_rules_degraded_window() -> None:
+    """MCP egress depends on the MCP registry snapshot, not the tenant-rule
+    snapshot — a registered origin is allowed even before rules seed."""
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc, seeded=False)
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "allow"
+
+
+async def test_empty_registry_blocks_during_degraded_window() -> None:
+    """Fail-closed before the MCP snapshot lands: nothing registered →
+    the predicate cannot match and the rules gate still denies."""
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc, seeded=False)
+    decision = await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "block"
+
+
+async def test_mcp_allow_decision_is_audited() -> None:
+    register_mcp_server("jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    await caller.decide(
+        identity=_identity(),
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    await _drain_audit(nc)
+    assert nc.published, "MCP-allow decision was not audited"
+    _, payload = nc.published[-1]
+    assert payload["verdict_action"] == "allow"
+    assert payload["findings"][0]["code"] == "EGRESS.MCP_REGISTRY_ALLOWED"


### PR DESCRIPTION
## Problem

Adding an MCP server through the admin API registered its **route** with the egress gateway (via the existing `egress.mcp.changed` hot-reload), but not its **egress permission**: the `/mcp-proxy` safety gate still default-denied the upstream host unless an admin also hand-wrote an `egress.domain_rule` for the same host:port. Every new — or URL-edited — MCP server answered `403 No egress allowlist rule matched` until that second, redundant approval step was performed.

## Fix

Give the MCP registry the same treatment as the LLM-provider platform allowlist (`is_known_provider_host`):

- **`reverse_proxy.py`** — new `registered_mcp_origins()` / `is_registered_mcp_origin(host, port)`: the set of registered MCP origins, recomputed from the live registry on every call (same pattern as `known_provider_endpoints()`), so `egress.mcp.changed` hot-reloads — create / URL edit / delete — take effect immediately with no second data store to sync.
- **`safety_call.py`** — new `mcp_allow` layer in `EgressSafetyCaller.decide`, scoped to **reverse mode only**: on the `/mcp-proxy` route the upstream host is looked up from the registered entry (server-derived), never taken from the agent, so registering the server through `mcp.configure` *is* the egress approval. Placed ahead of the tenant-rule `seeded` gate — MCP egress depends on the MCP registry snapshot, not the tenant-rule snapshot. Every allow writes an audit row with its own finding code `EGRESS.MCP_REGISTRY_ALLOWED`.
- **`gateway.py`** — wires `mcp_allow=is_registered_mcp_origin`.

### Security boundary unchanged

The same host:port stays default-denied on the agent-controlled paths: forward-CONNECT and DNS requests to a registered MCP host still require a tenant `egress.domain_rule`. An unseeded registry is empty, so the degraded-startup window remains fail-closed.

## Tests

12 new tests in `tests/egress/test_mcp_origin_allow.py` covering: registered origin allowed on reverse / blocked on forward and DNS; URL edit revokes the old origin immediately; delete revokes; two servers sharing an origin survive deleting one; rules-degraded window (allowed with registry seeded, blocked without); allow decisions audited; host normalisation and scheme-default ports.

Regression: full `tests/egress/` + `tests/attack_sim/test_I_egress_gateway.py` — 218 passed (15 pre-existing errors are testcontainers/Docker-unavailable in the sandbox, unrelated). `ruff` clean; the 3 `mypy` warnings on these files pre-exist on `main`.

## Known follow-ups (out of scope, discussed during review)

- The MCP registry is keyed by name only (no tenant dimension) — a pre-existing isolation gap in routing that deserves its own issue; the allow predicate here inherits it but does not meaningfully widen it (routing already permits cross-tenant calls with credential injection).
- `handle_mcp_proxy` follows redirects after the safety gate checks the pre-redirect origin; cross-origin redirects deserve a same-origin restriction.

Supersedes #131 (closed at the author's request to renumber; identical branch and content, rebased onto current `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3cb6LnBi5pN9mHbeoeLmC

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3cb6LnBi5pN9mHbeoeLmC)_