### PR TITLE
fix(egress): key the MCP registry on (tenant_id, name) — tenant isolation

### DIFF
--- a/docs/7-external-mcp-architecture-cn.md
+++ b/docs/7-external-mcp-architecture-cn.md
@@ -231,7 +231,7 @@ MCP 注册表存在于两个必须保持一致的位置：orchestrator 在宿主
 | 容器访问 | 容器只知道 proxy URL——没有 token，也没有上游主机 |
 | Token 过期 | TokenVault 对 IdP 自动刷新；永久失败时强制重新登录 |
 | MCP 服务器校验 | MCP 服务器通过 OIDC discovery 校验 token——RoleMesh 是穿透方，不是签发方 |
-| 代理范围 | MCP 路由只转发到**已注册**的服务器名——未知名称返回 404 |
+| 代理范围 | MCP 路由只转发到**调用方租户注册**的服务器名——注册表按 `(tenant_id, name)` 索引，租户取自已验证的出口令牌，因此其他租户的服务器（不论是否同名）与不存在的名称一样返回 404 |
 | 出口白名单 | 已注册 MCP 的 origin 在反向代理路径上自动放行（审计记录 `EGRESS.MCP_REGISTRY_ALLOWED`）——通过管理 API 注册服务器本身即出口授权，无需再手写 `egress.domain_rule`。同一域名走 agent 可控的 forward/DNS 路径时仍默认拒绝 |
 
 ### 被攻陷的容器能做什么

--- a/docs/7-external-mcp-architecture.md
+++ b/docs/7-external-mcp-architecture.md
@@ -231,7 +231,7 @@ Editing `coworkers.tools` through the admin REST API is therefore a hot operatio
 | Container access | Container only knows the proxy URL — no token, no upstream host |
 | Token expiry | TokenVault auto-refreshes against the IdP; permanent failure forces re-login |
 | MCP server validation | MCP server validates the token via OIDC discovery — RoleMesh is a passthrough, not an issuer |
-| Proxy scope | The MCP route only forwards to **registered** server names — unknown names return 404 |
+| Proxy scope | The MCP route only forwards to server names **the caller's tenant registered** — the registry keys on `(tenant_id, name)` and the tenant comes from the verified egress token, so another tenant's server (same name or not) is indistinguishable from a nonexistent one (404) |
 | Egress allowlist | Registered MCP origins are allowed automatically on the reverse path (`EGRESS.MCP_REGISTRY_ALLOWED` in the audit trail) — registering the server through the admin API *is* the egress approval, no hand-written `egress.domain_rule` needed. The same host stays default-denied on the agent-controlled forward/DNS paths |
 
 ### What a compromised container can do

--- a/src/rolemesh/egress/mcp_cache.py
+++ b/src/rolemesh/egress/mcp_cache.py
@@ -63,12 +63,20 @@ class McpEntry:
     orchestrator computes it as ``urlparse(tool.url).scheme + ://
     + .netloc`` before publishing — same shape ``register_mcp_server``
     has stored historically.
+
+    ``tenant_id`` scopes the entry: MCP servers are tenant resources
+    (``UNIQUE (tenant_id, name)`` in the DB) and the registry keys on
+    ``(tenant_id, name)``. An empty tenant_id (a pre-tenancy publisher
+    during a rolling upgrade) still registers but can never match a
+    verified identity's tenant, so it is unreachable — fail-closed
+    per request rather than a parse error.
     """
 
     name: str
     url: str
     headers: dict[str, str]
     auth_mode: str
+    tenant_id: str = ""
 
 
 def entry_to_dict(entry: McpEntry) -> dict[str, Any]:
@@ -78,18 +86,28 @@ def entry_to_dict(entry: McpEntry) -> dict[str, Any]:
         "url": entry.url,
         "headers": dict(entry.headers),
         "auth_mode": entry.auth_mode,
+        "tenant_id": entry.tenant_id,
     }
 
 
 def entry_from_dict(d: dict[str, Any]) -> McpEntry:
     """Parse one wire entry. Raises on missing required keys; the
     snapshot/event handlers catch + log so a single malformed entry
-    can't poison the rest."""
+    can't poison the rest. A missing ``tenant_id`` (old wire format)
+    parses as "" — see the McpEntry docstring for why that is safe."""
+    tenant_id = str(d.get("tenant_id") or "")
+    if not tenant_id:
+        logger.warning(
+            "mcp_cache: entry without tenant_id — registered but "
+            "unreachable until the publisher is upgraded",
+            name=str(d.get("name") or ""),
+        )
     return McpEntry(
         name=str(d["name"]),
         url=str(d["url"]),
         headers={str(k): str(v) for k, v in (d.get("headers") or {}).items()},
         auth_mode=str(d.get("auth_mode") or "user"),
+        tenant_id=tenant_id,
     )
 
 
@@ -154,12 +172,12 @@ def apply_snapshot_to_registry(entries: list[McpEntry]) -> None:
         unregister_mcp_server,
     )
 
-    new_names = {e.name for e in entries}
-    for stale in set(get_mcp_registry()) - new_names:
-        unregister_mcp_server(stale)
+    new_keys = {(e.tenant_id, e.name) for e in entries}
+    for stale_tenant, stale_name in set(get_mcp_registry()) - new_keys:
+        unregister_mcp_server(stale_tenant, stale_name)
     for entry in entries:
         register_mcp_server(
-            entry.name, entry.url, entry.headers, entry.auth_mode
+            entry.tenant_id, entry.name, entry.url, entry.headers, entry.auth_mode
         )
 
 
@@ -168,13 +186,17 @@ def apply_change_event(event: dict[str, Any]) -> None:
 
     Event shape:
         {"action": "created" | "updated" | "deleted",
+         "tenant_id": "<tenant>",
          "name": "<name>",
          "url": "<origin>",
          "headers": {...},
          "auth_mode": "user" | "service" | "both"}
 
-    For ``deleted``, only ``name`` is required; other fields are
-    ignored if present.
+    For ``deleted``, only ``tenant_id`` + ``name`` are required; other
+    fields are ignored if present. A delete without tenant_id (old wire
+    format) targets the "" tenant slot, matching where the same old
+    publisher's creates landed — old and new publishers cannot delete
+    each other's entries.
     """
     from rolemesh.egress.reverse_proxy import (
         register_mcp_server,
@@ -190,7 +212,7 @@ def apply_change_event(event: dict[str, Any]) -> None:
         return
 
     if action == "deleted":
-        unregister_mcp_server(name)
+        unregister_mcp_server(str(event.get("tenant_id") or ""), name)
         return
 
     if action not in ("created", "updated"):
@@ -206,7 +228,9 @@ def apply_change_event(event: dict[str, Any]) -> None:
             name=name,
         )
         return
-    register_mcp_server(entry.name, entry.url, entry.headers, entry.auth_mode)
+    register_mcp_server(
+        entry.tenant_id, entry.name, entry.url, entry.headers, entry.auth_mode
+    )
 
 
 async def subscribe_mcp_changes(

--- a/src/rolemesh/egress/orch_glue.py
+++ b/src/rolemesh/egress/orch_glue.py
@@ -64,21 +64,30 @@ async def publish_mcp_registry_changed(
     action: str,
     entry: McpEntry | None = None,
     name: str | None = None,
+    tenant_id: str | None = None,
 ) -> None:
     """Push a single MCP registry delta to the gateway.
 
     For ``created`` / ``updated``: pass ``entry`` with the full payload.
-    For ``deleted``: pass ``name`` (the only field the consumer needs).
+    For ``deleted``: pass ``tenant_id`` + ``name`` — the registry keys
+    on the pair, so a delete without the tenant could only ever target
+    the unreachable "" slot (and would leave the real entry alive).
 
     Best-effort publish: a failure here means the gateway misses one
     delta, but its next snapshot fetch on restart still recovers full
     state.
     """
     if action == "deleted":
-        if not name:
-            logger.warning("mcp_registry publish: deleted without name")
+        if not name or not tenant_id:
+            logger.warning(
+                "mcp_registry publish: deleted without tenant_id+name"
+            )
             return
-        payload: dict[str, Any] = {"action": "deleted", "name": name}
+        payload: dict[str, Any] = {
+            "action": "deleted",
+            "tenant_id": tenant_id,
+            "name": name,
+        }
     else:
         if entry is None:
             logger.warning(
@@ -204,13 +213,14 @@ async def fetch_all_mcp_servers() -> list[McpEntry]:
     from rolemesh.egress.reverse_proxy import get_mcp_registry
 
     out: list[McpEntry] = []
-    for name, (url, headers, auth_mode) in get_mcp_registry().items():
+    for (tenant_id, name), (url, headers, auth_mode) in get_mcp_registry().items():
         out.append(
             McpEntry(
                 name=name,
                 url=url,
                 headers=dict(headers),
                 auth_mode=auth_mode,
+                tenant_id=tenant_id,
             )
         )
     return out

--- a/src/rolemesh/egress/reverse_proxy.py
+++ b/src/rolemesh/egress/reverse_proxy.py
@@ -269,41 +269,55 @@ def is_known_provider_host(host: str, port: int) -> bool:
 # MCP server registry
 # ---------------------------------------------------------------------------
 
-_mcp_registry: dict[str, tuple[str, dict[str, str], str]] = {}
+# Keyed by ``(tenant_id, name)``. MCP servers are tenant resources
+# (``UNIQUE (tenant_id, name)`` in the DB); a name-only key let two
+# tenants' same-named servers overwrite each other AND let any tenant
+# reach — with the owner's injected service credentials — a server
+# another tenant registered. The composite key makes both impossible
+# structurally: ``handle_mcp_proxy`` looks up with the VERIFIED token
+# identity's tenant, so a foreign entry is simply not found (404).
+_mcp_registry: dict[tuple[str, str], tuple[str, dict[str, str], str]] = {}
 
 
 def register_mcp_server(
+    tenant_id: str,
     name: str,
     url: str,
     headers: dict[str, str] | None = None,
     auth_mode: str = "user",
 ) -> None:
-    """Register an MCP server for proxy forwarding."""
-    _mcp_registry[name] = (url, headers or {}, auth_mode)
-    logger.info("MCP server registered", name=name, url=url, auth_mode=auth_mode)
+    """Register an MCP server for proxy forwarding, scoped to *tenant_id*."""
+    _mcp_registry[(tenant_id, name)] = (url, headers or {}, auth_mode)
+    logger.info(
+        "MCP server registered",
+        tenant_id=tenant_id,
+        name=name,
+        url=url,
+        auth_mode=auth_mode,
+    )
 
 
-def unregister_mcp_server(name: str) -> bool:
-    """Remove an MCP server from the registry. Returns True if it was present.
+def unregister_mcp_server(tenant_id: str, name: str) -> bool:
+    """Remove one tenant's MCP server. Returns True if it was present.
 
     Used by the gateway-side hot-reload subscriber when the orchestrator
     publishes ``egress.mcp.changed action=deleted``. Idempotent: a
     redundant delete (e.g. the same broadcast arriving twice) returns
     False rather than raising.
     """
-    removed = _mcp_registry.pop(name, None)
+    removed = _mcp_registry.pop((tenant_id, name), None)
     if removed is None:
         return False
-    logger.info("MCP server unregistered", name=name)
+    logger.info("MCP server unregistered", tenant_id=tenant_id, name=name)
     return True
 
 
-def get_mcp_registry() -> dict[str, tuple[str, dict[str, str], str]]:
+def get_mcp_registry() -> dict[tuple[str, str], tuple[str, dict[str, str], str]]:
     return dict(_mcp_registry)
 
 
-def registered_mcp_origins() -> set[tuple[str, int]]:
-    """``(host, port)`` endpoints of every registered MCP server origin.
+def registered_mcp_origins(tenant_id: str) -> set[tuple[str, int]]:
+    """``(host, port)`` endpoints of *tenant_id*'s registered MCP origins.
 
     Recomputed from ``_mcp_registry`` on every call — same pattern as
     :func:`known_provider_endpoints` — so the set follows registry
@@ -312,22 +326,26 @@ def registered_mcp_origins() -> set[tuple[str, int]]:
     this yields nothing during the gateway's degraded-startup window.
     """
     out: set[tuple[str, int]] = set()
-    for url, _headers, _auth_mode in _mcp_registry.values():
+    for (entry_tenant, _name), (url, _headers, _auth_mode) in _mcp_registry.items():
+        if entry_tenant != tenant_id:
+            continue
         hp = _upstream_host_port(url)
         if hp is not None:
             out.add(hp)
     return out
 
 
-def is_registered_mcp_origin(host: str, port: int) -> bool:
-    """True when ``host:port`` is the origin of a registered MCP server.
+def is_registered_mcp_origin(tenant_id: str, host: str, port: int) -> bool:
+    """True when ``host:port`` is the origin of an MCP server *tenant_id*
+    registered.
 
     Used by the egress gateway as a registry-managed allow layer on the
     REVERSE path only (see ``EgressSafetyCaller.decide``): the MCP proxy
     derives its upstream from the registry entry, so an origin an admin
-    registered is by construction an authorised destination.
+    registered is by construction an authorised destination — for the
+    registering tenant's coworkers, not anyone else's.
     """
-    return (host.lower().rstrip("."), port) in registered_mcp_origins()
+    return (host.lower().rstrip("."), port) in registered_mcp_origins(tenant_id)
 
 
 def _collapse_trailing_slash(path: str) -> str:
@@ -614,6 +632,15 @@ async def start_credential_proxy(
         rest = request.match_info.get("path_info", "")
         identity, server_name, upstream_path = _resolve(request, first_seg, rest)
 
+        # Identity must resolve BEFORE the registry lookup: the registry
+        # is keyed by (tenant_id, name) and the tenant comes from the
+        # verified token — same 401 the provider route returns, and what
+        # this route's docstring always promised. (Previously an
+        # identity-less request only failed later at the safety gate,
+        # or not at all on host-side deployments without one.)
+        if identity is None:
+            return web.Response(status=401, text="UNKNOWN_SOURCE")
+
         # Collapse a redundant trailing slash (``/mcp/`` → ``/mcp``) so the
         # FastMCP/Starlette 307 redirect never fires in the common case;
         # _stream_upstream still follows any other redirect with the
@@ -622,7 +649,11 @@ async def start_credential_proxy(
         if request.query_string:
             remaining_path += "?" + request.query_string
 
-        entry = _mcp_registry.get(server_name)
+        # Tenant-scoped lookup: another tenant's server — same name or
+        # not — is indistinguishable from a nonexistent one (404), so the
+        # response also can't be used to probe what other tenants have
+        # configured.
+        entry = _mcp_registry.get((identity.tenant_id, server_name))
         if not entry:
             return web.Response(status=404, text=f"MCP server not found: {server_name}")
 

--- a/src/rolemesh/egress/safety_call.py
+++ b/src/rolemesh/egress/safety_call.py
@@ -108,7 +108,7 @@ class EgressSafetyCaller:
         checks: dict[str, CheckFunc],
         audit_publisher: AuditPublisher,
         platform_allow: Callable[[str, int], bool] | None = None,
-        mcp_allow: Callable[[str, int], bool] | None = None,
+        mcp_allow: Callable[[str, str, int], bool] | None = None,
     ) -> None:
         self._cache = cache
         self._checks = checks
@@ -118,10 +118,12 @@ class EgressSafetyCaller:
         # without a per-tenant egress allowlist. ``None`` disables it (the
         # gateway always wires it; unit tests opt in).
         self._platform_allow = platform_allow
-        # Registry-managed allow layer: a host/port predicate for origins
-        # of admin-registered MCP servers, so a configured MCP server works
-        # without a hand-written egress.domain_rule. Same reverse-mode-only
-        # scoping and safety argument as ``platform_allow``. ``None``
+        # Registry-managed allow layer: a (tenant_id, host, port) predicate
+        # for origins of admin-registered MCP servers, so a configured MCP
+        # server works without a hand-written egress.domain_rule. Same
+        # reverse-mode-only scoping and safety argument as
+        # ``platform_allow``, but tenant-scoped: one tenant registering an
+        # origin must not grant egress to it for anyone else. ``None``
         # disables it.
         self._mcp_allow = mcp_allow
         self._audit_tasks: set[asyncio.Task[None]] = set()
@@ -200,7 +202,7 @@ class EgressSafetyCaller:
         if (
             request.mode == "reverse"
             and self._mcp_allow is not None
-            and self._mcp_allow(request.host, request.port)
+            and self._mcp_allow(identity.tenant_id, request.host, request.port)
         ):
             decision = EgressDecision(
                 action="allow",

--- a/src/rolemesh/main.py
+++ b/src/rolemesh/main.py
@@ -606,12 +606,19 @@ async def _load_state() -> None:
 
         _state.coworkers[cw.id] = cw_state
 
-    # Register MCP servers with the credential proxy.
+    # Register MCP servers with the credential proxy, scoped to the
+    # owning coworker's tenant — the registry keys on (tenant_id, name).
     for cw_state in _state.coworkers.values():
         for tool_cfg in cw_state.mcp_configs:
             parsed = urlparse(tool_cfg.url)
             origin = f"{parsed.scheme}://{parsed.netloc}"
-            register_mcp_server(tool_cfg.name, origin, tool_cfg.headers, tool_cfg.auth_mode)
+            register_mcp_server(
+                cw_state.config.tenant_id,
+                tool_cfg.name,
+                origin,
+                tool_cfg.headers,
+                tool_cfg.auth_mode,
+            )
 
     logger.info(
         "State loaded",

--- a/src/webui/v1/mcp_events.py
+++ b/src/webui/v1/mcp_events.py
@@ -64,6 +64,7 @@ def _build_entry(row: MCPServerRow):
         url=origin,
         headers={str(k): str(v) for k, v in (row.extra_headers or {}).items()},
         auth_mode=row.auth_mode,
+        tenant_id=row.tenant_id,
     )
 
 
@@ -102,18 +103,21 @@ async def publish_mcp_server_changed(*, action: str, row: MCPServerRow) -> None:
         )
 
 
-async def publish_mcp_server_deleted(*, name: str) -> None:
-    """Publish ``egress.mcp.changed action=deleted`` for ``name``."""
+async def publish_mcp_server_deleted(*, name: str, tenant_id: str) -> None:
+    """Publish ``egress.mcp.changed action=deleted`` for ``(tenant_id, name)``."""
     nc = _get_publisher()
     if nc is None:
         return
     from rolemesh.egress.orch_glue import publish_mcp_registry_changed
 
     try:
-        await publish_mcp_registry_changed(nc, action="deleted", name=name)
+        await publish_mcp_registry_changed(
+            nc, action="deleted", name=name, tenant_id=tenant_id,
+        )
     except Exception:  # noqa: BLE001
         logger.warning(
             "Failed to publish egress.mcp.changed (deleted)",
             name=name,
+            tenant_id=tenant_id,
             exc_info=True,
         )

--- a/src/webui/v1/mcp_servers.py
+++ b/src/webui/v1/mcp_servers.py
@@ -214,5 +214,7 @@ async def delete_endpoint(
             status_code=404,
             details={"mcp_server_id": mcp_id},
         )
-    await mcp_events.publish_mcp_server_deleted(name=row.name)
+    await mcp_events.publish_mcp_server_deleted(
+        name=row.name, tenant_id=row.tenant_id,
+    )
     return Response(status_code=204)

--- a/tests/attack_sim/test_E_identity_isolation.py
+++ b/tests/attack_sim/test_E_identity_isolation.py
@@ -23,6 +23,13 @@ That dead-code gap is exactly why a deterministic white-box pin is needed.
                 forged header has no effect (control — pins the path that
                 is already correct, and shows the pattern the MCP path
                 must follow).
+  E8 (MCP)      a tenant-a token must not reach an MCP server tenant-b
+                registered — by name or at all. Before the registry was
+                keyed on (tenant_id, name) this succeeded WITH tenant-b's
+                injected service credentials (cross-tenant credential use).
+  E9 (MCP)      two tenants' same-named servers route independently — the
+                name-only registry let the later registration overwrite
+                the earlier one, silently cross-wiring tenants.
 """
 
 from __future__ import annotations
@@ -175,7 +182,9 @@ async def test_E7_mcp_forged_user_id_header_does_not_select_another_users_token(
     await echo.start()
     vault = _StubVault({"userA": "token-A", "userB": "token-B"})
     rp.set_token_vault(vault)
-    register_mcp_server("acme", f"http://127.0.0.1:{echo.port}", auth_mode="user")
+    register_mcp_server(
+        "tenant-a", "acme", f"http://127.0.0.1:{echo.port}", auth_mode="user"
+    )
     runner, port = await _start_proxy(_NullResolver())
     try:
         token = _token(user_id="userA", tenant_id="tenant-a")
@@ -242,3 +251,101 @@ async def test_E7_provider_credential_selection_ignores_forged_user_id_header(
     finally:
         await runner.cleanup()
         await echo.stop()
+
+
+# ---------------------------------------------------------------------------
+# E8 — MCP path: another tenant's server must be unreachable (404), with
+# no upstream contact and no injected credentials
+# ---------------------------------------------------------------------------
+
+
+async def test_E8_mcp_cross_tenant_server_name_is_unreachable() -> None:
+    """Attacker: a tenant-a container guesses the name of an MCP server
+    tenant-b registered ("victim") and calls it through the proxy. Before
+    the registry keyed on (tenant_id, name) this request was FORWARDED —
+    with tenant-b's admin-configured service Authorization injected, i.e.
+    cross-tenant use of another tenant's credential. Defense: the lookup
+    key includes the verified token's tenant, so the name simply does not
+    exist for tenant-a — 404, upstream never contacted."""
+    echo = _Echo()
+    await echo.start()
+    register_mcp_server(
+        "tenant-b",
+        "victim",
+        f"http://127.0.0.1:{echo.port}",
+        headers={"Authorization": "Bearer tenant-b-service-key"},
+        auth_mode="service",
+    )
+    runner, port = await _start_proxy(_NullResolver())
+    try:
+        token = _token(user_id="userA", tenant_id="tenant-a")
+        url = f"http://127.0.0.1:{port}/mcp-proxy/{token}/victim/mcp"
+        async with (
+            aiohttp.ClientSession() as session,
+            session.post(url, data=b"{}") as resp,
+        ):
+            assert resp.status == 404, (
+                f"cross-tenant MCP access returned {resp.status}; another "
+                "tenant's server must be indistinguishable from a nonexistent one"
+            )
+        assert echo.received == [], (
+            "tenant-b's upstream was contacted on a tenant-a request — "
+            "cross-tenant forwarding (with tenant-b's service key injected)"
+        )
+    finally:
+        await runner.cleanup()
+        await echo.stop()
+
+
+# ---------------------------------------------------------------------------
+# E9 — MCP path: same-named servers in two tenants route independently
+# ---------------------------------------------------------------------------
+
+
+async def test_E9_mcp_same_name_across_tenants_routes_to_own_upstream() -> None:
+    """Two tenants register the same server name ("jira"). The name-only
+    registry let the later registration silently overwrite the earlier one,
+    cross-wiring tenant-a's traffic (and injected headers) to tenant-b's
+    upstream. With the composite key each tenant's calls reach exactly the
+    upstream that tenant configured."""
+    echo_a, echo_b = _Echo(), _Echo()
+    await echo_a.start()
+    await echo_b.start()
+    register_mcp_server(
+        "tenant-a",
+        "jira",
+        f"http://127.0.0.1:{echo_a.port}",
+        headers={"Authorization": "Bearer key-a"},
+        auth_mode="service",
+    )
+    register_mcp_server(
+        "tenant-b",
+        "jira",
+        f"http://127.0.0.1:{echo_b.port}",
+        headers={"Authorization": "Bearer key-b"},
+        auth_mode="service",
+    )
+    runner, port = await _start_proxy(_NullResolver())
+    try:
+        for tenant, echo, other_echo, key in (
+            ("tenant-a", echo_a, echo_b, "Bearer key-a"),
+            ("tenant-b", echo_b, echo_a, "Bearer key-b"),
+        ):
+            other_before = len(other_echo.received)
+            token = _token(user_id="userX", tenant_id=tenant)
+            url = f"http://127.0.0.1:{port}/mcp-proxy/{token}/jira/mcp"
+            async with (
+                aiohttp.ClientSession() as session,
+                session.post(url, data=b"{}") as resp,
+            ):
+                assert resp.status == 200
+            assert echo.last_headers().get("authorization") == key, (
+                f"{tenant}'s request must carry {tenant}'s own service key"
+            )
+            assert len(other_echo.received) == other_before, (
+                f"{tenant}'s request leaked to the other tenant's upstream"
+            )
+    finally:
+        await runner.cleanup()
+        await echo_a.stop()
+        await echo_b.stop()

--- a/tests/egress/test_gateway_mcp_sync.py
+++ b/tests/egress/test_gateway_mcp_sync.py
@@ -61,8 +61,14 @@ class _Sub:
         return None
 
 
-def _entry(name: str, url: str) -> dict[str, Any]:
-    return {"name": name, "url": url, "headers": {}, "auth_mode": "user"}
+def _entry(name: str, url: str, tenant: str = "t1") -> dict[str, Any]:
+    return {
+        "name": name,
+        "url": url,
+        "headers": {},
+        "auth_mode": "user",
+        "tenant_id": tenant,
+    }
 
 
 class _ScriptedMcpNats:
@@ -140,7 +146,7 @@ async def test_cold_start_race_converges_when_responder_appears(
         # loop must land the snapshot on the next attempt.
         await _wait_for(lambda: state.seeded)
         assert nc.request_count == 4, "3 failures + 1 success"
-        assert set(reverse_proxy.get_mcp_registry()) == {"github"}
+        assert set(reverse_proxy.get_mcp_registry()) == {("t1", "github")}
 
 
 async def test_seed_success_with_empty_snapshot_still_counts_as_seeded() -> None:
@@ -179,12 +185,15 @@ async def test_reconcile_heals_registry_drift(
         await _wait_for(lambda: state.seeded)
 
         # Drift: one entry vanished, one points at the wrong origin.
-        reverse_proxy.unregister_mcp_server("github")
-        reverse_proxy.register_mcp_server("jira", "https://wrong", {}, "user")
+        reverse_proxy.unregister_mcp_server("t1", "github")
+        reverse_proxy.register_mcp_server("t1", "jira", "https://wrong", {}, "user")
 
         def _healed() -> bool:
             reg = reverse_proxy.get_mcp_registry()
-            return set(reg) == {"github", "jira"} and reg["jira"][0] == "https://jira.internal"
+            return (
+                set(reg) == {("t1", "github"), ("t1", "jira")}
+                and reg[("t1", "jira")][0] == "https://jira.internal"
+            )
 
         await _wait_for(_healed)
 
@@ -203,9 +212,9 @@ async def test_reconcile_failure_keeps_task_alive_until_next_interval(
         await _wait_for(lambda: state.seeded)
 
         nc.fail_next = 1  # one orchestrator hiccup
-        reverse_proxy.unregister_mcp_server("github")  # drift during the hiccup
+        reverse_proxy.unregister_mcp_server("t1", "github")  # drift during the hiccup
 
-        await _wait_for(lambda: "github" in reverse_proxy.get_mcp_registry())
+        await _wait_for(lambda: ("t1", "github") in reverse_proxy.get_mcp_registry())
         assert state.seeded
 
 
@@ -297,7 +306,7 @@ async def test_healthz_combines_both_seed_flags_and_stays_200() -> None:
             "mcp_entries": 0,
         }
 
-        reverse_proxy.register_mcp_server("github", "https://api.github.com", {}, "user")
+        reverse_proxy.register_mcp_server("t1", "github", "https://api.github.com", {}, "user")
         assert await _body() == {
             "status": "ok",
             "rules_seeded": True,
@@ -338,7 +347,7 @@ async def test_apply_failure_is_retried_not_fatal(
         state = await gateway._start_mcp_sync(nc, stack)  # type: ignore[arg-type]
         await _wait_for(lambda: state.seeded)
         assert calls["n"] == 2, "failed apply + successful retry"
-        assert set(reverse_proxy.get_mcp_registry()) == {"github"}
+        assert set(reverse_proxy.get_mcp_registry()) == {("t1", "github")}
 
 
 async def test_sync_task_death_emits_error_log(

--- a/tests/egress/test_mcp_cache.py
+++ b/tests/egress/test_mcp_cache.py
@@ -5,6 +5,10 @@ These pin the wire-format contract and the dispatch logic from
 ``reverse_proxy._mcp_registry`` it controls. Each case clears the
 registry first so leftover state from another test can't paper over a
 regression.
+
+The registry (and the wire format) is tenant-scoped: entries key on
+``(tenant_id, name)``. Old-format payloads without ``tenant_id`` parse
+into the "" tenant slot, which no verified identity can match.
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ def test_entry_roundtrip_preserves_all_fields() -> None:
         url="https://api.github.com",
         headers={"X-Custom": "value"},
         auth_mode="user",
+        tenant_id="t1",
     )
     assert entry_from_dict(entry_to_dict(entry)) == entry
 
@@ -48,9 +53,18 @@ def test_entry_from_dict_defaults_auth_mode_to_user() -> None:
     # crafting a snapshot manually. Explicit default protects the
     # downstream RBAC check.
     entry = entry_from_dict(
-        {"name": "x", "url": "https://x", "headers": {}}
+        {"name": "x", "url": "https://x", "headers": {}, "tenant_id": "t1"}
     )
     assert entry.auth_mode == "user"
+
+
+def test_entry_from_dict_missing_tenant_parses_as_unreachable_sentinel() -> None:
+    # Old wire format (pre-tenancy publisher during a rolling upgrade):
+    # parse must not raise, but the entry lands in the "" tenant slot —
+    # no verified identity carries an empty tenant, so it can never be
+    # served. Fail-closed per request, not a parse error.
+    entry = entry_from_dict({"name": "x", "url": "https://x"})
+    assert entry.tenant_id == ""
 
 
 def test_entry_from_dict_normalises_header_keys_and_values_to_str() -> None:
@@ -63,6 +77,7 @@ def test_entry_from_dict_normalises_header_keys_and_values_to_str() -> None:
             "url": "https://x",
             "headers": {"X-Int": 42, "X-Bool": True},
             "auth_mode": "service",
+            "tenant_id": "t1",
         }
     )
     assert entry.headers == {"X-Int": "42", "X-Bool": "True"}
@@ -76,14 +91,16 @@ def test_entry_from_dict_normalises_header_keys_and_values_to_str() -> None:
 def test_apply_snapshot_seeds_empty_registry() -> None:
     apply_snapshot_to_registry(
         [
-            McpEntry("github", "https://api.github.com", {}, "user"),
-            McpEntry("internal", "http://localhost:9100", {"X-Tenant": "t1"}, "service"),
+            McpEntry("github", "https://api.github.com", {}, "user", "t1"),
+            McpEntry(
+                "internal", "http://localhost:9100", {"X-Tenant": "t1"}, "service", "t1"
+            ),
         ]
     )
     reg = reverse_proxy.get_mcp_registry()
-    assert set(reg) == {"github", "internal"}
-    assert reg["github"][0] == "https://api.github.com"
-    assert reg["internal"][2] == "service"
+    assert set(reg) == {("t1", "github"), ("t1", "internal")}
+    assert reg[("t1", "github")][0] == "https://api.github.com"
+    assert reg[("t1", "internal")][2] == "service"
 
 
 def test_apply_snapshot_drops_stale_names() -> None:
@@ -92,21 +109,35 @@ def test_apply_snapshot_drops_stale_names() -> None:
     Failure mode of the alternative (merge) is "deleted server still
     routable on the gateway after the orchestrator forgot it" —
     a privilege-escalation-grade bug."""
-    reverse_proxy.register_mcp_server("stale", "https://stale", {}, "user")
-    reverse_proxy.register_mcp_server("kept", "https://kept", {}, "user")
+    reverse_proxy.register_mcp_server("t1", "stale", "https://stale", {}, "user")
+    reverse_proxy.register_mcp_server("t1", "kept", "https://kept", {}, "user")
 
     apply_snapshot_to_registry(
-        [McpEntry("kept", "https://kept", {}, "user")]
+        [McpEntry("kept", "https://kept", {}, "user", "t1")]
     )
-    assert set(reverse_proxy.get_mcp_registry()) == {"kept"}
+    assert set(reverse_proxy.get_mcp_registry()) == {("t1", "kept")}
 
 
 def test_apply_snapshot_overwrites_existing_entry() -> None:
-    # Same name, different URL — the snapshot wins. Catches the
-    # regression where a half-merge leaves the original URL.
-    reverse_proxy.register_mcp_server("x", "https://old", {}, "user")
-    apply_snapshot_to_registry([McpEntry("x", "https://new", {}, "user")])
-    assert reverse_proxy.get_mcp_registry()["x"][0] == "https://new"
+    # Same (tenant, name), different URL — the snapshot wins. Catches
+    # the regression where a half-merge leaves the original URL.
+    reverse_proxy.register_mcp_server("t1", "x", "https://old", {}, "user")
+    apply_snapshot_to_registry([McpEntry("x", "https://new", {}, "user", "t1")])
+    assert reverse_proxy.get_mcp_registry()[("t1", "x")][0] == "https://new"
+
+
+def test_apply_snapshot_keeps_same_name_across_tenants_distinct() -> None:
+    # The bug the composite key fixes: two tenants' same-named servers
+    # must coexist, not overwrite each other last-writer-wins.
+    apply_snapshot_to_registry(
+        [
+            McpEntry("jira", "https://a.example.com", {}, "user", "tenant-a"),
+            McpEntry("jira", "https://b.example.com", {}, "user", "tenant-b"),
+        ]
+    )
+    reg = reverse_proxy.get_mcp_registry()
+    assert reg[("tenant-a", "jira")][0] == "https://a.example.com"
+    assert reg[("tenant-b", "jira")][0] == "https://b.example.com"
 
 
 # ---------------------------------------------------------------------------
@@ -122,13 +153,14 @@ def test_change_event_created_inserts() -> None:
             "url": "https://api.github.com",
             "headers": {},
             "auth_mode": "user",
+            "tenant_id": "t1",
         }
     )
-    assert "github" in reverse_proxy.get_mcp_registry()
+    assert ("t1", "github") in reverse_proxy.get_mcp_registry()
 
 
 def test_change_event_updated_overwrites() -> None:
-    reverse_proxy.register_mcp_server("x", "https://old", {}, "user")
+    reverse_proxy.register_mcp_server("t1", "x", "https://old", {}, "user")
     apply_change_event(
         {
             "action": "updated",
@@ -136,29 +168,55 @@ def test_change_event_updated_overwrites() -> None:
             "url": "https://new",
             "headers": {},
             "auth_mode": "service",
+            "tenant_id": "t1",
         }
     )
-    url, _, mode = reverse_proxy.get_mcp_registry()["x"]
+    url, _, mode = reverse_proxy.get_mcp_registry()[("t1", "x")]
     assert url == "https://new"
     assert mode == "service"
 
 
-def test_change_event_deleted_only_needs_name() -> None:
-    reverse_proxy.register_mcp_server("x", "https://x", {}, "user")
+def test_change_event_deleted_needs_tenant_and_name() -> None:
+    reverse_proxy.register_mcp_server("t1", "x", "https://x", {}, "user")
+    apply_change_event({"action": "deleted", "name": "x", "tenant_id": "t1"})
+    assert ("t1", "x") not in reverse_proxy.get_mcp_registry()
+
+
+def test_change_event_deleted_without_tenant_cannot_hit_real_entry() -> None:
+    # Old-format delete (no tenant_id) targets the "" slot — it must
+    # NOT delete some tenant's same-named entry, or a stale publisher
+    # could knock out live routing (or a crafted event could target
+    # another tenant's server by name alone).
+    reverse_proxy.register_mcp_server("t1", "x", "https://x", {}, "user")
     apply_change_event({"action": "deleted", "name": "x"})
-    assert "x" not in reverse_proxy.get_mcp_registry()
+    assert ("t1", "x") in reverse_proxy.get_mcp_registry()
+
+
+def test_change_event_deleted_scoped_to_its_tenant() -> None:
+    reverse_proxy.register_mcp_server("tenant-a", "jira", "https://a", {}, "user")
+    reverse_proxy.register_mcp_server("tenant-b", "jira", "https://b", {}, "user")
+    apply_change_event({"action": "deleted", "name": "jira", "tenant_id": "tenant-a"})
+    reg = reverse_proxy.get_mcp_registry()
+    assert ("tenant-a", "jira") not in reg
+    assert ("tenant-b", "jira") in reg
 
 
 def test_change_event_deleted_unknown_name_is_idempotent() -> None:
     # An at-most-once-loss broadcast may re-deliver the same delete
     # twice. Apply must not raise on the second arrival.
-    apply_change_event({"action": "deleted", "name": "ghost"})
+    apply_change_event({"action": "deleted", "name": "ghost", "tenant_id": "t1"})
     assert reverse_proxy.get_mcp_registry() == {}  # still empty, no exception
 
 
 def test_change_event_unknown_action_is_dropped() -> None:
     apply_change_event(
-        {"action": "renamed", "name": "x", "url": "https://x", "auth_mode": "user"}
+        {
+            "action": "renamed",
+            "name": "x",
+            "url": "https://x",
+            "auth_mode": "user",
+            "tenant_id": "t1",
+        }
     )
     assert reverse_proxy.get_mcp_registry() == {}
 
@@ -167,7 +225,7 @@ def test_change_event_missing_name_is_dropped() -> None:
     # Required field. Missing => skip + log; never raise (handler is
     # behind a NATS callback and an exception there crashes the
     # subscriber loop).
-    apply_change_event({"action": "created", "url": "https://x"})
+    apply_change_event({"action": "created", "url": "https://x", "tenant_id": "t1"})
     assert reverse_proxy.get_mcp_registry() == {}
 
 
@@ -175,5 +233,5 @@ def test_change_event_malformed_url_is_dropped_not_raised() -> None:
     # Missing required field on a created event. The reverse_proxy is
     # protected against half-populated entries because we'd try to
     # forward to ``None``.
-    apply_change_event({"action": "created", "name": "x"})
+    apply_change_event({"action": "created", "name": "x", "tenant_id": "t1"})
     assert reverse_proxy.get_mcp_registry() == {}

--- a/tests/egress/test_mcp_glue.py
+++ b/tests/egress/test_mcp_glue.py
@@ -93,6 +93,7 @@ async def test_publish_created_carries_full_entry(nc: FakeNats) -> None:
         url="https://api.github.com",
         headers={"X-T": "v"},
         auth_mode="user",
+        tenant_id="t1",
     )
     await publish_mcp_registry_changed(nc, action="created", entry=entry)
     assert len(nc.published) == 1
@@ -105,17 +106,28 @@ async def test_publish_created_carries_full_entry(nc: FakeNats) -> None:
         "url": "https://api.github.com",
         "headers": {"X-T": "v"},
         "auth_mode": "user",
+        "tenant_id": "t1",
     }
 
 
 @pytest.mark.asyncio
-async def test_publish_deleted_only_carries_name(nc: FakeNats) -> None:
+async def test_publish_deleted_carries_tenant_and_name(nc: FakeNats) -> None:
     # Deleted events are intentionally minimal — the consumer just
-    # needs to know which name to drop, the rest of the row was
-    # already removed.
-    await publish_mcp_registry_changed(nc, action="deleted", name="github")
+    # needs the (tenant_id, name) registry key to drop; the rest of
+    # the row was already removed.
+    await publish_mcp_registry_changed(
+        nc, action="deleted", name="github", tenant_id="t1"
+    )
     payload = json.loads(nc.published[0][1])
-    assert payload == {"action": "deleted", "name": "github"}
+    assert payload == {"action": "deleted", "name": "github", "tenant_id": "t1"}
+
+
+@pytest.mark.asyncio
+async def test_publish_deleted_without_tenant_is_no_op(nc: FakeNats) -> None:
+    # A tenant-less delete could only ever target the unreachable ""
+    # slot while leaving the real entry alive — refuse to publish it.
+    await publish_mcp_registry_changed(nc, action="deleted", name="github")
+    assert nc.published == []
 
 
 @pytest.mark.asyncio
@@ -128,7 +140,9 @@ async def test_publish_created_without_entry_is_no_op(nc: FakeNats) -> None:
 
 @pytest.mark.asyncio
 async def test_publish_deleted_without_name_is_no_op(nc: FakeNats) -> None:
-    await publish_mcp_registry_changed(nc, action="deleted", name=None)
+    await publish_mcp_registry_changed(
+        nc, action="deleted", name=None, tenant_id="t1"
+    )
     assert nc.published == []
 
 
@@ -159,7 +173,7 @@ async def test_fetch_all_mcp_servers_reads_registry() -> None:
     # registry-pass-through. The loopback-rewrite contract has its
     # own dedicated test class below (Bug 5 regression).
     reverse_proxy.register_mcp_server(
-        "internal", "https://api.example.com", {"X-Tenant": "t1"}, "service"
+        "t1", "internal", "https://api.example.com", {"X-Tenant": "t1"}, "service"
     )
     entries = await fetch_all_mcp_servers()
     assert len(entries) == 1
@@ -168,6 +182,7 @@ async def test_fetch_all_mcp_servers_reads_registry() -> None:
         url="https://api.example.com",
         headers={"X-Tenant": "t1"},
         auth_mode="service",
+        tenant_id="t1",
     )
 
 
@@ -183,7 +198,7 @@ async def test_fetch_all_mcp_servers_returns_empty_when_unregistered() -> None:
 
 @pytest.mark.asyncio
 async def test_responder_returns_current_registry(nc: FakeNats) -> None:
-    reverse_proxy.register_mcp_server("x", "https://x", {}, "user")
+    reverse_proxy.register_mcp_server("t1", "x", "https://x", {}, "user")
 
     async def _rules_fetcher() -> list[dict[str, Any]]:
         return []
@@ -198,7 +213,13 @@ async def test_responder_returns_current_registry(nc: FakeNats) -> None:
     payload = json.loads(msg.replies[0])
     assert payload == {
         "entries": [
-            {"name": "x", "url": "https://x", "headers": {}, "auth_mode": "user"}
+            {
+                "name": "x",
+                "url": "https://x",
+                "headers": {},
+                "auth_mode": "user",
+                "tenant_id": "t1",
+            }
         ]
     }
 
@@ -253,7 +274,7 @@ class TestSnapshotUrlPassthrough:
     @pytest.mark.asyncio
     async def test_fetch_all_passes_service_name_url_verbatim(self) -> None:
         reverse_proxy.register_mcp_server(
-            "example-mcp", "https://example-mcp:8509", {}, "user"
+            "t1", "example-mcp", "https://example-mcp:8509", {}, "user"
         )
         entries = await fetch_all_mcp_servers()
         assert len(entries) == 1
@@ -267,7 +288,7 @@ class TestSnapshotUrlPassthrough:
         # (and are simply wrong config the operator must fix — never
         # silently "repaired").
         reverse_proxy.register_mcp_server(
-            "local-mcp", "http://127.0.0.1:9100", {}, "service"
+            "t1", "local-mcp", "http://127.0.0.1:9100", {}, "service"
         )
         entries = await fetch_all_mcp_servers()
         assert entries[0].url == "http://127.0.0.1:9100"
@@ -275,7 +296,7 @@ class TestSnapshotUrlPassthrough:
     @pytest.mark.asyncio
     async def test_fetch_all_leaves_external_host_unchanged(self) -> None:
         reverse_proxy.register_mcp_server(
-            "github", "https://api.github.com", {}, "user"
+            "t1", "github", "https://api.github.com", {}, "user"
         )
         entries = await fetch_all_mcp_servers()
         assert entries[0].url == "https://api.github.com"

--- a/tests/egress/test_mcp_origin_allow.py
+++ b/tests/egress/test_mcp_origin_allow.py
@@ -45,13 +45,13 @@ pytestmark = pytest.mark.asyncio
 def _isolated_registry():
     """Snapshot + restore the module-global MCP registry around each test."""
     saved = reverse_proxy.get_mcp_registry()
-    for name in list(saved):
-        unregister_mcp_server(name)
+    for tenant_id, name in list(saved):
+        unregister_mcp_server(tenant_id, name)
     yield
-    for name in list(reverse_proxy.get_mcp_registry()):
-        unregister_mcp_server(name)
-    for name, (url, headers, auth_mode) in saved.items():
-        register_mcp_server(name, url, headers, auth_mode)
+    for tenant_id, name in list(reverse_proxy.get_mcp_registry()):
+        unregister_mcp_server(tenant_id, name)
+    for (tenant_id, name), (url, headers, auth_mode) in saved.items():
+        register_mcp_server(tenant_id, name, url, headers, auth_mode)
 
 
 @dataclass
@@ -102,10 +102,10 @@ async def _drain_audit(nc: _FakeNats) -> None:
 
 async def test_registered_origins_default_ports() -> None:
     """Scheme-default ports match the ports the proxy actually dials."""
-    register_mcp_server("a", "https://mcp.example.com")
-    register_mcp_server("b", "http://intranet.local")
-    register_mcp_server("c", "http://host.docker.internal:9100")
-    assert registered_mcp_origins() == {
+    register_mcp_server("tenant-a", "a", "https://mcp.example.com")
+    register_mcp_server("tenant-a", "b", "http://intranet.local")
+    register_mcp_server("tenant-a", "c", "http://host.docker.internal:9100")
+    assert registered_mcp_origins("tenant-a") == {
         ("mcp.example.com", 443),
         ("intranet.local", 80),
         ("host.docker.internal", 9100),
@@ -114,10 +114,10 @@ async def test_registered_origins_default_ports() -> None:
 
 async def test_predicate_normalises_host() -> None:
     """Case and trailing-dot differences must not defeat the match."""
-    register_mcp_server("a", "https://mcp.example.com")
-    assert is_registered_mcp_origin("MCP.Example.COM.", 443)
-    assert not is_registered_mcp_origin("mcp.example.com", 8443)
-    assert not is_registered_mcp_origin("evil-mcp.example.com", 443)
+    register_mcp_server("tenant-a", "a", "https://mcp.example.com")
+    assert is_registered_mcp_origin("tenant-a", "MCP.Example.COM.", 443)
+    assert not is_registered_mcp_origin("tenant-a", "mcp.example.com", 8443)
+    assert not is_registered_mcp_origin("tenant-a", "evil-mcp.example.com", 443)
 
 
 # ---------------------------------------------------------------------------
@@ -128,7 +128,7 @@ async def test_predicate_normalises_host() -> None:
 async def test_registered_origin_allowed_on_reverse() -> None:
     """The user-facing fix: adding an MCP server is enough for its calls
     to pass the egress gate — no separate egress.domain_rule needed."""
-    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
     decision = await caller.decide(
@@ -151,11 +151,25 @@ async def test_unregistered_origin_still_blocked_on_reverse() -> None:
     assert "No egress allowlist rule matched" in decision.reason
 
 
+async def test_other_tenants_origin_not_allowed() -> None:
+    """Tenant isolation: an origin tenant-b registered must NOT grant
+    egress to tenant-a's coworkers — the allow layer is keyed on the
+    verified identity's tenant, same as the routing lookup."""
+    register_mcp_server("tenant-b", "jira", "http://mcp.example.com:9100")
+    nc = _FakeNats(published=[])
+    caller = await _make_caller(nc=nc)
+    decision = await caller.decide(
+        identity=_identity(),  # tenant-a
+        request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
+    )
+    assert decision.action == "block"
+
+
 async def test_mcp_allow_does_not_apply_to_forward_proxy() -> None:
     """Security boundary: the forward CONNECT target is agent-controlled,
     so a registered MCP host must NOT be reachable that way — only via
     the /mcp-proxy route whose upstream is server-derived."""
-    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
     decision = await caller.decide(
@@ -169,7 +183,7 @@ async def test_mcp_allow_does_not_apply_to_forward_proxy() -> None:
 
 async def test_mcp_allow_does_not_apply_to_dns() -> None:
     """Same boundary for the DNS plane: the queried name is agent-controlled."""
-    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
     decision = await caller.decide(
@@ -189,11 +203,11 @@ async def test_mcp_allow_does_not_apply_to_dns() -> None:
 async def test_url_edit_drops_old_origin_and_allows_new() -> None:
     """Editing a server's URL (same registry semantics as the
     egress.mcp.changed hot-reload) must revoke the old origin at once."""
-    register_mcp_server("jira", "http://old.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://old.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
 
-    register_mcp_server("jira", "http://new.example.com:9200")
+    register_mcp_server("tenant-a", "jira", "http://new.example.com:9200")
 
     old = await caller.decide(
         identity=_identity(),
@@ -208,10 +222,10 @@ async def test_url_edit_drops_old_origin_and_allows_new() -> None:
 
 
 async def test_delete_revokes_origin() -> None:
-    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
-    unregister_mcp_server("jira")
+    unregister_mcp_server("tenant-a", "jira")
     decision = await caller.decide(
         identity=_identity(),
         request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
@@ -221,11 +235,11 @@ async def test_delete_revokes_origin() -> None:
 
 async def test_shared_origin_survives_deleting_one_server() -> None:
     """Two servers on one origin: deleting one must not revoke the other."""
-    register_mcp_server("jira", "http://mcp.example.com:9100")
-    register_mcp_server("wiki", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "wiki", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
-    unregister_mcp_server("jira")
+    unregister_mcp_server("tenant-a", "jira")
     decision = await caller.decide(
         identity=_identity(),
         request=EgressRequest(host="mcp.example.com", port=9100, mode="reverse"),
@@ -241,7 +255,7 @@ async def test_shared_origin_survives_deleting_one_server() -> None:
 async def test_mcp_allow_works_during_rules_degraded_window() -> None:
     """MCP egress depends on the MCP registry snapshot, not the tenant-rule
     snapshot — a registered origin is allowed even before rules seed."""
-    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc, seeded=False)
     decision = await caller.decide(
@@ -264,7 +278,7 @@ async def test_empty_registry_blocks_during_degraded_window() -> None:
 
 
 async def test_mcp_allow_decision_is_audited() -> None:
-    register_mcp_server("jira", "http://mcp.example.com:9100")
+    register_mcp_server("tenant-a", "jira", "http://mcp.example.com:9100")
     nc = _FakeNats(published=[])
     caller = await _make_caller(nc=nc)
     await caller.decide(

--- a/tests/egress/test_mcp_view_convergence.py
+++ b/tests/egress/test_mcp_view_convergence.py
@@ -53,6 +53,7 @@ CHANGE_EVENT = {
     "url": NEW_URL,
     "headers": {"X-Key": "v2"},
     "auth_mode": "service",
+    "tenant_id": "t1",
 }
 
 
@@ -64,7 +65,7 @@ def _isolate_registry() -> None:
 
 
 def _apply_to_registry() -> None:
-    register_mcp_server("X", OLD_URL, {"X-Key": "v1"}, "user")
+    register_mcp_server("t1", "X", OLD_URL, {"X-Key": "v1"}, "user")
     apply_change_event(CHANGE_EVENT)
 
 
@@ -76,7 +77,7 @@ def _apply_to_registry() -> None:
 async def test_view_converges_after_mcp_server_update(view: str) -> None:
     if view in ("gateway-registry", "orch-registry-mirror"):
         _apply_to_registry()
-        url, headers, auth_mode = get_mcp_registry()["X"]
+        url, headers, auth_mode = get_mcp_registry()[("t1", "X")]
         assert url == NEW_URL
         assert headers == {"X-Key": "v2"}
         assert auth_mode == "service"

--- a/tests/egress/test_reverse_proxy_mcp_redirect.py
+++ b/tests/egress/test_reverse_proxy_mcp_redirect.py
@@ -99,6 +99,7 @@ async def _proxy(authority: TokenAuthority) -> web.AppRunner:
 
 def _register(origin: str) -> None:
     register_mcp_server(
+        "t1",
         "srv",
         origin,
         headers={
@@ -141,7 +142,7 @@ async def test_redirect_preserves_injected_headers(
         assert headers.get("X-Actor-Id") == _ACTOR_ID
         assert headers.get("X-Actor-Role") == _ACTOR_ROLE
     finally:
-        unregister_mcp_server("srv")
+        unregister_mcp_server("t1", "srv")
         await client.close()
         await runner.cleanup()
         await upstream.close()
@@ -171,7 +172,7 @@ async def test_trailing_slash_collapsed_no_redirect() -> None:
         assert headers.get("Authorization") == _SERVICE_TOKEN
         assert headers.get("X-Actor-Id") == _ACTOR_ID
     finally:
-        unregister_mcp_server("srv")
+        unregister_mcp_server("t1", "srv")
         await client.close()
         await runner.cleanup()
         await upstream.close()
@@ -187,4 +188,4 @@ async def test_collapse_trailing_slash_unit() -> None:
     assert _collapse_trailing_slash("/") == "/"
     assert _collapse_trailing_slash("") == ""
     # Registry stays clean across the test module.
-    assert "srv" not in get_mcp_registry()
+    assert ("t1", "srv") not in get_mcp_registry()

--- a/tests/webui/test_v1_mcp_servers.py
+++ b/tests/webui/test_v1_mcp_servers.py
@@ -306,10 +306,10 @@ async def test_patch_publishes_updated_event(monkeypatch) -> None:
 
 async def test_delete_publishes_deleted_event(monkeypatch) -> None:
     user = await _make_user()
-    deleted: list[str] = []
+    deleted: list[tuple[str, str]] = []
 
-    async def _capture(*, name: str) -> None:
-        deleted.append(name)
+    async def _capture(*, name: str, tenant_id: str) -> None:
+        deleted.append((name, tenant_id))
 
     monkeypatch.setattr(
         "webui.v1.mcp_servers.mcp_events.publish_mcp_server_deleted",
@@ -327,16 +327,18 @@ async def test_delete_publishes_deleted_event(monkeypatch) -> None:
             headers={"Authorization": "Bearer x"},
         )
     assert resp.status_code == 204
-    assert deleted == ["to-delete"]
+    # The event carries the registry key: (name, OWNING tenant) — the
+    # gateway needs both to drop the right (tenant_id, name) entry.
+    assert deleted == [("to-delete", user.tenant_id)]
 
 
 async def test_delete_409_does_not_emit_event(monkeypatch) -> None:
     """409 path must not announce an absent change to the gateway."""
     user = await _make_user()
-    deleted: list[str] = []
+    deleted: list[tuple[str, str]] = []
 
-    async def _capture(*, name: str) -> None:
-        deleted.append(name)
+    async def _capture(*, name: str, tenant_id: str) -> None:
+        deleted.append((name, tenant_id))
 
     monkeypatch.setattr(
         "webui.v1.mcp_servers.mcp_events.publish_mcp_server_deleted",


### PR DESCRIPTION
## Problem

The runtime MCP registry — the in-memory mirrors of the tenant-scoped `mcp_servers` table held by both the orchestrator and the egress gateway — was keyed **by name alone**, even though the DB table is `UNIQUE (tenant_id, name)`. Two pre-existing cross-tenant holes followed:

1. **Same-named servers overwrote each other.** Tenant A and tenant B both registering a server called `jira` collapsed to one registry entry (last registration wins), silently cross-wiring one tenant's MCP traffic — with its injected headers — to the other tenant's upstream.
2. **No ownership check on forward.** `handle_mcp_proxy` looked up by name only, so any tenant could reach another tenant's server by guessing its name — and the proxy injected the **owner's** admin-configured service credentials into the caller's request (cross-tenant credential use).

Neither was introduced by the egress-allow work (#133); the allow layer inherited hole #1's blast radius, which this PR also closes.

## Fix

Carry `tenant_id` through the whole sync path and make it part of the registry key, so isolation is **structural** rather than a check that can be forgotten:

- **`McpEntry`** (wire format) gains `tenant_id`. An old-format payload without it parses into the `""` slot that no verified identity can match — registered but unreachable, so a rolling upgrade fails closed instead of crashing.
- **`_mcp_registry`** keys on `(tenant_id, name)`; `register` / `unregister` / lookup take the tenant. Delete events now carry `tenant_id` too — a name-only delete could never target the right entry (and a tenant-less delete is refused rather than hitting the `""` slot).
- **`handle_mcp_proxy`** now requires a verified identity (401 `UNKNOWN_SOURCE`, same as the provider route and what its docstring always promised) and looks up with the token's tenant. A foreign entry is indistinguishable from a nonexistent one (404), so the response can't probe another tenant's config either.
- The **registry-managed egress allow layer** (#133) is tenant-scoped the same way: `registered_mcp_origins(tenant_id)` / `is_registered_mcp_origin(tenant_id, host, port)`, so registering an origin grants egress to the **registering tenant's** coworkers only.

Four producers (webui create/patch/delete events, orchestrator startup registration, snapshot responder, snapshot apply) thread the tenant through.

## Tests

New attack-sim pins in `test_E_identity_isolation.py`:
- **E8** — a tenant-a token calling a server tenant-b registered gets 404, the upstream is never contacted, and no credential is injected.
- **E9** — two tenants' same-named servers route independently, each carrying its own service key.

Plus unit coverage: same name across tenants stays distinct; delete scoped to its tenant; tenant-less/old-format delete cannot hit a real entry; old-format entry parses unreachable; allow predicate tenant isolation. The 9 existing registry-touching test files are mechanically updated to the tenant-scoped API.

Regression: `tests/egress/ tests/attack_sim/ tests/orchestration/ tests/safety/` — 755 passed, 0 failed. The 107 errored tests are testcontainers/Docker-unavailable in the sandbox and are identical in count and identity on unmodified `main`. `ruff` clean; `mypy` output matches `main` (no new errors).

Note: E8/E9 encode attacks that forwarded successfully before this change, but cannot be run verbatim against the pre-fix code because the fix changes the registration API signature itself — they were validated by scenario analysis, called out in the commit message.

## Follow-up (discussed, not in this PR)

`handle_mcp_proxy` follows redirects after the safety gate checks only the pre-redirect origin — a cross-origin 3xx from a compromised MCP server bypasses the egress allowlist. Deserves a same-origin restriction; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3cb6LnBi5pN9mHbeoeLmC