### PR TITLE
feat(k8s): hybrid gateway ClusterIP — static pin or runtime discovery

### DIFF
--- a/deploy/charts/rolemesh/templates/NOTES.txt
+++ b/deploy/charts/rolemesh/templates/NOTES.txt
@@ -29,9 +29,16 @@ RoleMesh has been installed as release {{ .Release.Name }} in namespace {{ .Rele
 
 2. EGRESS_GATEWAY_DNS_IP / Service ClusterIP contract.
 {{- if not .Values.egressGateway.clusterIP }}
-   *** egressGateway.clusterIP is UNSET. The install template should have
-   *** failed — if you see this, something is wrong. Set it to a free
-   *** address inside the cluster Service CIDR.
+   egressGateway.clusterIP is UNSET -> DYNAMIC mode: K8s allocated the
+   gateway ClusterIP and the orchestrator discovers it at runtime
+   (re-reading before every agent spawn). Intended for ephemeral
+   multi-instance deployments. Notes:
+     * the connectivity-probe helm test is SKIPPED in this mode (it
+       needs the IP at template time) — only the deny-probe runs;
+     * deleting/recreating the gateway Service changes the IP: new
+       spawns converge, agents spawned before it keep a dead resolver
+       until respawned (the orchestrator logs an ERROR);
+     * production should pin a static clusterIP instead.
 {{- else }}
    The gateway Service holds the static ClusterIP {{ .Values.egressGateway.clusterIP }}.
    The orchestrator's verify_infrastructure asserts this equals

--- a/deploy/charts/rolemesh/templates/egress-gateway.yaml
+++ b/deploy/charts/rolemesh/templates/egress-gateway.yaml
@@ -5,9 +5,11 @@ HARD CONTRACT with verify_infrastructure:
   * Service NAME == EGRESS_GATEWAY_CONTAINER_NAME (default "egress-gateway").
     NOT release-scoped — agents reach it by this service name and the
     orchestrator reads the Service by this exact name. Keep it literal.
-  * Service has a STATIC clusterIP == EGRESS_GATEWAY_DNS_IP
-    (.Values.egressGateway.clusterIP). verify compares the two and refuses
-    to start on drift.
+  * clusterIP set (static mode, production-recommended): Service holds
+    that exact ClusterIP == EGRESS_GATEWAY_DNS_IP; verify compares the
+    two and refuses to start on drift. clusterIP unset (dynamic mode):
+    K8s allocates; verify degrades to "exists + holds an IP" and the
+    orchestrator discovers the address at runtime.
   * healthz lives at clusterIP:3001 (CREDENTIAL_PROXY_PORT).
 The pod carries app.kubernetes.io/component: egress-gateway so the
 gateway-policy NetworkPolicy selects it (and the agent/orchestrator
@@ -27,9 +29,14 @@ metadata:
     app.kubernetes.io/component: egress-gateway
 spec:
   type: ClusterIP
-  # Static ClusterIP == EGRESS_GATEWAY_DNS_IP. Must be inside the cluster
-  # Service CIDR and free. See values.yaml egressGateway.clusterIP.
-  clusterIP: {{ required "egressGateway.clusterIP is REQUIRED (= EGRESS_GATEWAY_DNS_IP, a free address in the cluster Service CIDR). See values.yaml." .Values.egressGateway.clusterIP | quote }}
+  # Static ClusterIP == EGRESS_GATEWAY_DNS_IP (recommended for
+  # production: survives Service recreation, strict startup verify).
+  # UNSET = dynamic mode: K8s allocates the ClusterIP and the
+  # orchestrator discovers it at runtime — for e.g. many ephemeral
+  # instances on one cluster. See values.yaml egressGateway.clusterIP.
+  {{- with .Values.egressGateway.clusterIP }}
+  clusterIP: {{ . | quote }}
+  {{- end }}
   selector:
     app.kubernetes.io/component: egress-gateway
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
+++ b/deploy/charts/rolemesh/templates/orchestrator-deployment.yaml
@@ -134,8 +134,12 @@ spec:
               value: {{ if .Values.postgres.enabled }}{{ include "rolemesh.databaseUrl" . | quote }}{{ else }}{{ .Values.postgres.externalAdminUrl | default .Values.postgres.externalUrl | quote }}{{ end }}
             # EGRESS_GATEWAY_DNS_IP == the gateway Service ClusterIP; agents
             # get it pinned as their resolver and verify asserts the match.
+            # ALWAYS rendered, possibly as "": present-but-empty tells the
+            # K8s runtime "discover the dynamic ClusterIP"; omitting the env
+            # would fall back to the config default (a docker bridge IP) and
+            # silently masquerade as static mode.
             - name: EGRESS_GATEWAY_DNS_IP
-              value: {{ required "egressGateway.clusterIP is required" .Values.egressGateway.clusterIP | quote }}
+              value: {{ .Values.egressGateway.clusterIP | quote }}
             - name: EGRESS_TOKEN_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/charts/rolemesh/templates/tests/connectivity-probe.yaml
+++ b/deploy/charts/rolemesh/templates/tests/connectivity-probe.yaml
@@ -24,8 +24,13 @@ is portable to kind and RKE2 alike. Any failure exits non-zero -> helm test
 fails. Host-search-domain pollution (an exfil-class regression) is
 environment-specific and is locked by the dns_internal unit tests instead.
 */ -}}
+{{- /* Dynamic-gateway mode (clusterIP unset): the probe's dnsConfig
+needs the gateway IP at TEMPLATE time, which does not exist until K8s
+allocates it — the probe cannot render and is skipped (NOTES points
+this out). The deny-probe (no dnsConfig) still runs. */ -}}
+{{- if .Values.egressGateway.clusterIP }}
 {{- $clusterDomain := .Values.clusterDomain | default "cluster.local" -}}
-{{- $gwIP := required "egressGateway.clusterIP is REQUIRED for the connectivity probe (= EGRESS_GATEWAY_DNS_IP)." .Values.egressGateway.clusterIP -}}
+{{- $gwIP := .Values.egressGateway.clusterIP -}}
 {{- $nats := include "rolemesh.natsServiceName" . -}}
 apiVersion: v1
 kind: Pod
@@ -134,3 +139,4 @@ spec:
               sys.exit(1)
           print("PASS: internal names resolve + reachable (NATS, gateway); "
                 "external blocked")
+{{- end }}

--- a/deploy/charts/rolemesh/values-production.yaml
+++ b/deploy/charts/rolemesh/values-production.yaml
@@ -46,10 +46,12 @@ egressGateway:
   image:
     repository: "registry.example.com/CHANGEME/rolemesh-egress-gateway"
     tag: "0.1.0"
-  # REQUIRED — free address inside THIS cluster's Service CIDR, unique
-  # per RoleMesh instance on the cluster (ClusterIPs are cluster-global,
-  # not namespace-scoped). See values.yaml and docs/23 §1.1 for how to
-  # pick and pre-verify one.
+  # Production: a free address inside THIS cluster's Service CIDR,
+  # unique per RoleMesh instance on the cluster (ClusterIPs are
+  # cluster-global, not namespace-scoped). See values.yaml and docs/23
+  # §1.1 for how to pick and pre-verify one. (Ephemeral/feature-branch
+  # instances may instead leave this "" for dynamic discovery — see
+  # values.yaml for the trade-offs; production should pin.)
   clusterIP: "CHANGEME-e.g.-10.43.0.53"
 agent:
   image:

--- a/deploy/charts/rolemesh/values.yaml
+++ b/deploy/charts/rolemesh/values.yaml
@@ -125,7 +125,19 @@ egressGateway:
   # collisions with dynamic allocation unlikely. Pre-verify a candidate
   # with a server-side dry run: docs/23 §1.1.
   # ----------------------------------------------------------------------
-  clusterIP: ""  # REQUIRED — e.g. "10.96.0.53"
+  #
+  # UNSET (dynamic mode): K8s allocates the ClusterIP and the
+  # orchestrator DISCOVERS it at runtime (re-reading before every agent
+  # spawn). Use for ephemeral multi-instance deployments (feature
+  # branches / per-PR namespaces) where per-instance static allocation
+  # is impractical — instances never collide because nothing is pinned.
+  # Trade-offs vs static: startup verify degrades from strict equality
+  # to existence, the connectivity-probe helm test is skipped (it needs
+  # the IP at template time), and a Service recreation mid-run changes
+  # the IP — new spawns converge, agents spawned before it keep a dead
+  # resolver until respawned (loud ERROR in the orchestrator log).
+  # Production should pin.
+  clusterIP: ""  # static IP (production), or leave "" for dynamic mode
   # K8s listens for DNS on 1053 (PSA restricted forbids NET_BIND_SERVICE,
   # so the privileged port 53 is unreachable inside the pod). The Service
   # maps the well-known 53 -> 1053. Do not change without changing both.

--- a/docs/23-rke2-production-deploy.md
+++ b/docs/23-rke2-production-deploy.md
@@ -199,10 +199,12 @@ helm upgrade --install rolemesh deploy/charts/rolemesh \
   -f my-production-values.yaml      # your overrides on top of values.yaml
 ```
 
-Minimum required overrides: `egressGateway.clusterIP`, real `secrets.*`,
-external `postgres`, a real `storage.storageClass` — start from the
-skeleton `deploy/charts/rolemesh/values-production.yaml` (copy per
-environment, fill every CHANGEME).
+Minimum required overrides: `egressGateway.clusterIP` (static pin —
+recommended for production; ephemeral instances may leave it unset for
+runtime discovery, see values.yaml), real `secrets.*`, external
+`postgres`, a real `storage.storageClass` — start from the skeleton
+`deploy/charts/rolemesh/values-production.yaml` (copy per environment,
+fill every CHANGEME).
 
 ### 5.1 Verify enforcement (deny probe)
 

--- a/src/rolemesh/container/gateway_address.py
+++ b/src/rolemesh/container/gateway_address.py
@@ -1,0 +1,57 @@
+"""Runtime-resolved egress gateway address (docs/21 §4.2).
+
+Agents get the gateway pinned as their DNS resolver (``resolv.conf``
+accepts only IPs), so every spawn needs the gateway's address. Where it
+comes from depends on the deployment mode:
+
+* **docker** — always the static ``EGRESS_GATEWAY_DNS_IP`` config value
+  (the fixed bridge address); this module is a pass-through.
+* **k8s, static ClusterIP** (``egressGateway.clusterIP`` set — the
+  recommended production mode): same pass-through; verify_infrastructure
+  strictly asserts the Service matches the configured value.
+* **k8s, dynamic ClusterIP** (``egressGateway.clusterIP`` empty — e.g.
+  many ephemeral instances on one cluster, where per-instance static
+  allocation is impractical): the chart renders
+  ``EGRESS_GATEWAY_DNS_IP=""`` and the K8s runtime DISCOVERS the
+  Service's allocated ClusterIP at startup, seeding the override here;
+  it re-reads before every spawn and updates on drift (Service
+  recreation) with a loud error.
+
+This module exists because ``EGRESS_GATEWAY_DNS_IP`` is imported by
+value at module load across the codebase — a runtime-discovered address
+needs one explicit, mutable home instead of a rebindable global. The
+override is process-local state owned by the K8s runtime; nothing else
+may set it.
+"""
+
+from __future__ import annotations
+
+from rolemesh.core.config import EGRESS_GATEWAY_DNS_IP
+
+_override: str | None = None
+
+
+def get_gateway_dns_ip() -> str:
+    """The address agents should use for the gateway right now.
+
+    The discovered override wins when set; otherwise the static config
+    value (which is authoritative in docker mode and k8s static mode).
+    """
+    return _override if _override is not None else EGRESS_GATEWAY_DNS_IP
+
+
+def set_gateway_dns_ip(ip: str) -> None:
+    """Record the runtime-discovered gateway address (K8s dynamic mode).
+
+    Called by the K8s runtime only: once at verify time, and again from
+    the spawn path whenever a pre-spawn re-read observes a changed
+    ClusterIP.
+    """
+    global _override
+    _override = ip
+
+
+def reset_gateway_dns_ip() -> None:
+    """Drop the override (tests; process restart does this naturally)."""
+    global _override
+    _override = None

--- a/src/rolemesh/container/k8s_runtime.py
+++ b/src/rolemesh/container/k8s_runtime.py
@@ -14,6 +14,7 @@ install hint when the extra is missing.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import os
 import re
 import time
@@ -25,6 +26,10 @@ from rolemesh.container.docker_runtime import (
     _check_tcp_reachable,
     _normalize_image_ref,
     _parse_memory,
+)
+from rolemesh.container.gateway_address import (
+    get_gateway_dns_ip,
+    set_gateway_dns_ip,
 )
 from rolemesh.core.logger import get_logger
 
@@ -224,6 +229,19 @@ def _security_context(spec: ContainerSpec) -> dict[str, Any]:
         if gid_str:
             ctx["runAsGroup"] = int(gid_str)
     return ctx
+
+
+def _spec_with_dns(spec: ContainerSpec, dns: list[str]) -> ContainerSpec:
+    """Return ``spec`` with its DNS servers replaced (no-op if equal).
+
+    Dynamic-gateway support: the spec's ``dns`` was computed from the
+    address known at spec-build time; the K8s runtime substitutes the
+    freshly re-read ClusterIP just before the manifest is generated so
+    the pod's immutable resolv.conf carries the newest address.
+    """
+    if list(spec.dns) == dns:
+        return spec
+    return dataclasses.replace(spec, dns=dns)
 
 
 def spec_to_pod_manifest(
@@ -698,6 +716,8 @@ class K8sRuntime:
         core = self._ensure_core()
         from rolemesh.core.config import (
             DATA_DIR,
+            EGRESS_GATEWAY_CONTAINER_NAME,
+            EGRESS_GATEWAY_DNS_IP,
             ROLEMESH_K8S_AGENT_PIN_NODE,
             ROLEMESH_K8S_DATA_PVC,
             ROLEMESH_K8S_IMAGE_PULL_POLICY,
@@ -705,6 +725,41 @@ class K8sRuntime:
             ROLEMESH_K8S_NAMESPACE,
             ROLEMESH_K8S_RUNTIME_CLASS,
         )
+
+        # Dynamic gateway mode (EGRESS_GATEWAY_DNS_IP empty): the pod's
+        # resolv.conf is immutable after creation, so re-read the
+        # gateway Service's ClusterIP at the last moment before the
+        # manifest is built. A drift (Service recreated -> new IP) is
+        # loud: agents spawned before it keep a dead resolver until
+        # respawned, but every pod from HERE on gets the fresh address.
+        # A failed re-read falls back to the last known address rather
+        # than blocking the spawn — verify established it once.
+        if not EGRESS_GATEWAY_DNS_IP and spec.dns:
+            try:
+                fresh = await self._read_gateway_cluster_ip(
+                    ROLEMESH_K8S_NAMESPACE,
+                    service_name=EGRESS_GATEWAY_CONTAINER_NAME,
+                )
+            except Exception as exc:  # noqa: BLE001 — degrade, don't block
+                logger.warning(
+                    "Pre-spawn gateway ClusterIP re-read failed — using last known address",
+                    pod=spec.name,
+                    error=str(exc),
+                )
+            else:
+                if fresh:
+                    current = get_gateway_dns_ip()
+                    if fresh != current:
+                        logger.error(
+                            "Gateway ClusterIP CHANGED (Service recreated?) — "
+                            "agents spawned before this point hold a dead "
+                            "resolver until respawned; new spawns use the "
+                            "fresh address",
+                            old=current,
+                            new=fresh,
+                        )
+                        set_gateway_dns_ip(fresh)
+                    spec = _spec_with_dns(spec, [fresh])
 
         manifest = spec_to_pod_manifest(
             spec,
@@ -848,7 +903,12 @@ class K8sRuntime:
           (b) the data PVC is Bound;
           (c) the gateway Service exists and its ClusterIP equals
               ``EGRESS_GATEWAY_DNS_IP`` (the value agents get pinned as
-              their resolver);
+              their resolver). With EGRESS_GATEWAY_DNS_IP empty (K8s
+              dynamic mode — the chart left egressGateway.clusterIP
+              unset), this degrades to "Service exists and holds an
+              IP": the allocated ClusterIP is DISCOVERED here and
+              seeded into ``container.gateway_address`` for the spawn
+              path; there is no configured value to compare against.
           (d) the gateway answers healthz through that Service IP;
           (e) NATS is TCP-reachable at ``NATS_URL``;
           (f) RBAC self-check: pods create/delete/get/list/watch and
@@ -885,13 +945,41 @@ class K8sRuntime:
         # The gateway Service shares its name with the docker-side
         # container (default "egress-gateway") — one config knob, both
         # backends.
-        await self._check_gateway_service(
-            namespace,
-            service_name=EGRESS_GATEWAY_CONTAINER_NAME,
-            expected_cluster_ip=EGRESS_GATEWAY_DNS_IP,
-        )
+        if EGRESS_GATEWAY_DNS_IP:
+            # Static mode: the configured value is the contract — strict
+            # equality, fail-closed on drift (the recommended production
+            # mode; a statically pinned Service survives recreation with
+            # the same IP, so running agents' resolv.conf stays valid).
+            await self._check_gateway_service(
+                namespace,
+                service_name=EGRESS_GATEWAY_CONTAINER_NAME,
+                expected_cluster_ip=EGRESS_GATEWAY_DNS_IP,
+            )
+            gateway_ip = EGRESS_GATEWAY_DNS_IP
+        else:
+            # Dynamic mode: no configured value exists — discover the
+            # allocated ClusterIP and seed the runtime provider. The
+            # spawn path re-reads before every pod creation (see run()),
+            # so a Service recreation mid-run only strands agents
+            # spawned BEFORE it — loudly, not silently.
+            gateway_ip = await self._read_gateway_cluster_ip(
+                namespace, service_name=EGRESS_GATEWAY_CONTAINER_NAME
+            )
+            if not gateway_ip:
+                msg = (
+                    f"Egress gateway Service "
+                    f"{EGRESS_GATEWAY_CONTAINER_NAME!r} exists but holds "
+                    f"no ClusterIP (headless?). Agents need an IP to pin "
+                    f"as their resolver. {_HELM_HINT}"
+                )
+                raise RuntimeError(msg)
+            set_gateway_dns_ip(gateway_ip)
+            logger.info(
+                "Gateway ClusterIP discovered (dynamic mode)",
+                gateway_cluster_ip=gateway_ip,
+            )
 
-        healthz_url = f"http://{EGRESS_GATEWAY_DNS_IP}:{CREDENTIAL_PROXY_PORT}/healthz"
+        healthz_url = f"http://{gateway_ip}:{CREDENTIAL_PROXY_PORT}/healthz"
         await _retry_within_budget(
             lambda: _check_http_healthz(healthz_url, hint=_HELM_HINT),
             what="egress gateway /healthz",
@@ -909,7 +997,7 @@ class K8sRuntime:
             network_policies=REQUIRED_AGENT_NETWORK_POLICIES
             + REQUIRED_COMPONENT_NETWORK_POLICIES,
             data_pvc=ROLEMESH_K8S_DATA_PVC,
-            gateway_cluster_ip=EGRESS_GATEWAY_DNS_IP,
+            gateway_cluster_ip=gateway_ip,
         )
 
     @staticmethod
@@ -1003,9 +1091,15 @@ class K8sRuntime:
             )
             raise RuntimeError(msg)
 
-    async def _check_gateway_service(
-        self, namespace: str, *, service_name: str, expected_cluster_ip: str
-    ) -> None:
+    async def _read_gateway_cluster_ip(
+        self, namespace: str, *, service_name: str
+    ) -> str:
+        """Read the gateway Service's ClusterIP (RBAC: services get).
+
+        Shared by the static-mode verify (compare against the configured
+        value) and the dynamic-mode paths (discover at verify, re-read
+        before each spawn). 404 raises with chart guidance.
+        """
         from kubernetes_asyncio.client.exceptions import ApiException
 
         try:
@@ -1018,7 +1112,14 @@ class K8sRuntime:
                 )
                 raise RuntimeError(msg) from exc
             raise
-        actual_ip = str(getattr(getattr(service, "spec", None), "cluster_ip", "") or "")
+        return str(getattr(getattr(service, "spec", None), "cluster_ip", "") or "")
+
+    async def _check_gateway_service(
+        self, namespace: str, *, service_name: str, expected_cluster_ip: str
+    ) -> None:
+        actual_ip = await self._read_gateway_cluster_ip(
+            namespace, service_name=service_name
+        )
         if actual_ip != expected_cluster_ip:
             msg = (
                 f"Egress gateway Service ClusterIP mismatch: configured "

--- a/src/rolemesh/container/runner.py
+++ b/src/rolemesh/container/runner.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from rolemesh.auth.permissions import AgentPermissions
 from rolemesh.container.docker_runtime import _parse_memory
+from rolemesh.container.gateway_address import get_gateway_dns_ip
 from rolemesh.container.runtime import (
     ContainerSpec,
     VolumeMount,
@@ -31,7 +32,6 @@ from rolemesh.core.config import (
     CREDENTIAL_PROXY_PORT,
     DATA_DIR,
     EGRESS_GATEWAY_CONTAINER_NAME,
-    EGRESS_GATEWAY_DNS_IP,
     EGRESS_GATEWAY_FORWARD_PORT,
     NATS_URL,
     TIMEZONE,
@@ -330,10 +330,11 @@ def compute_egress_routing(egress_token: str | None) -> EgressRouting:
     (compose / Helm declare it; the URL is passed through verbatim);
     LLM/MCP calls go to the gateway container by service name;
     HTTP(S)_PROXY points every client at the forward proxy; DNS is
-    pinned to the gateway's resolver — a static address declared by
-    the deployment layer (``EGRESS_GATEWAY_DNS_IP``, verified against
-    the running gateway at startup by ``verify_infrastructure``); only
-    the metadata blackhole rides in extra_hosts.
+    pinned to the gateway's resolver — an address the deployment layer
+    declares statically or, on K8s with a dynamically allocated gateway
+    ClusterIP, discovers at runtime (``container.gateway_address``:
+    verify_infrastructure seeds it, the K8s runtime refreshes it before
+    each spawn); only the metadata blackhole rides in extra_hosts.
 
     The signed token rides in two places (spike-verified): the
     forward-proxy userinfo (clients emit Proxy-Authorization
@@ -363,7 +364,7 @@ def compute_egress_routing(egress_token: str | None) -> EgressRouting:
         # ``or None`` keeps an empty bridge name mapping to the
         # default bridge instead of an empty NetworkMode string.
         network_name=CONTAINER_NETWORK_NAME or None,
-        dns_servers=[EGRESS_GATEWAY_DNS_IP],
+        dns_servers=[get_gateway_dns_ip()],
         extra_hosts=extra_hosts,
         mcp_proxy_host=EGRESS_GATEWAY_CONTAINER_NAME,
     )

--- a/src/rolemesh/core/config.py
+++ b/src/rolemesh/core/config.py
@@ -217,12 +217,21 @@ EGRESS_GATEWAY_CONTAINER_NAME: str = os.environ.get(
 EGRESS_GATEWAY_IMAGE: str = os.environ.get(
     "EGRESS_GATEWAY_IMAGE", "rolemesh-egress-gateway:latest"
 )
-# Static address of the egress gateway on the agent bridge. The
-# deployment layer declares it (compose ipam fixed IP today; K8s
-# Service ClusterIP later) and the orchestrator only VERIFIES it at
-# startup (ContainerRuntime.verify_infrastructure) — replacing the old
-# runtime discovery via docker-inspect after gateway launch. The
-# default matches the compose subnet in deploy/compose/compose.yaml
+# Address of the egress gateway on the agent network. The deployment
+# layer declares it (compose ipam fixed IP; K8s Service static
+# ClusterIP) and the orchestrator VERIFIES it at startup
+# (ContainerRuntime.verify_infrastructure).
+#
+# K8s dynamic mode: the chart always renders this env — a present-but-
+# EMPTY value means "egressGateway.clusterIP was left unset, discover
+# the dynamically allocated ClusterIP at runtime" (K8sRuntime seeds
+# container.gateway_address at verify and re-reads before each spawn).
+# The empty string never occurs on docker: compose either sets the env
+# or leaves it absent, and an absent env falls back to the fixed
+# bridge default below — which is also why the K8s chart must render
+# the env EXPLICITLY empty rather than omit it (an omitted env would
+# silently look like the docker default).
+# The default matches the compose subnet in deploy/compose/compose.yaml
 # (agent-net 172.28.100.0/24); override the env var if you override
 # the subnet. Consumers: runner (pins it as each agent's DNS resolver)
 # and docker_runtime (verifies the gateway actually holds this IP).

--- a/tests/container/test_gateway_address.py
+++ b/tests/container/test_gateway_address.py
@@ -1,0 +1,51 @@
+"""Gateway address provider (container.gateway_address).
+
+The provider is the single mutable home for the agent-facing gateway
+address: static config value by default (docker mode, K8s static
+ClusterIP mode), overridden by the K8s runtime's discovery in dynamic
+mode. These tests lock the fallback/override/reset semantics the spawn
+path (compute_egress_routing) depends on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rolemesh.container import gateway_address
+from rolemesh.core.config import EGRESS_GATEWAY_DNS_IP
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    gateway_address.reset_gateway_dns_ip()
+    yield
+    gateway_address.reset_gateway_dns_ip()
+
+
+def test_defaults_to_static_config_value() -> None:
+    # docker mode and K8s static mode never call set(): the provider is
+    # a pass-through to the config constant.
+    assert gateway_address.get_gateway_dns_ip() == EGRESS_GATEWAY_DNS_IP
+
+
+def test_discovered_override_wins() -> None:
+    gateway_address.set_gateway_dns_ip("10.96.7.42")
+    assert gateway_address.get_gateway_dns_ip() == "10.96.7.42"
+
+
+def test_reset_restores_config_fallback() -> None:
+    gateway_address.set_gateway_dns_ip("10.96.7.42")
+    gateway_address.reset_gateway_dns_ip()
+    assert gateway_address.get_gateway_dns_ip() == EGRESS_GATEWAY_DNS_IP
+
+
+def test_spawn_path_reads_the_provider() -> None:
+    # The value agents get as their resolver must follow the provider —
+    # runner imports the getter (call-time read), so an override set by
+    # the K8s runtime reaches every subsequently built spec.
+    from rolemesh.container.runner import compute_egress_routing
+
+    gateway_address.set_gateway_dns_ip("10.96.7.42")
+    assert compute_egress_routing(None).dns_servers == ["10.96.7.42"]
+    gateway_address.reset_gateway_dns_ip()
+    assert compute_egress_routing(None).dns_servers == [EGRESS_GATEWAY_DNS_IP]

--- a/tests/container/test_k8s_runtime.py
+++ b/tests/container/test_k8s_runtime.py
@@ -1311,3 +1311,67 @@ def test_no_pin_node_means_no_node_selector() -> None:
         "nodeSelector"
         not in _manifest(ContainerSpec(name="a", image="img"), pin_node="")["spec"]
     )
+
+
+# ===========================================================================
+# Dynamic gateway ClusterIP (docs/21 §4.2, hybrid mode).
+# With EGRESS_GATEWAY_DNS_IP empty, the runtime discovers the Service's
+# allocated ClusterIP and substitutes the freshest value into the spec's
+# DNS just before the manifest is built (resolv.conf is immutable after
+# pod creation).
+# ===========================================================================
+
+
+def test_spec_with_dns_replaces_differing_servers() -> None:
+    from rolemesh.container.k8s_runtime import _spec_with_dns
+
+    spec = ContainerSpec(name="a", image="img", dns=["10.96.0.53"])
+    fresh = _spec_with_dns(spec, ["10.96.9.9"])
+    assert fresh.dns == ["10.96.9.9"]
+    assert fresh is not spec
+    assert spec.dns == ["10.96.0.53"]  # frozen original untouched
+
+
+def test_spec_with_dns_is_noop_when_equal() -> None:
+    from rolemesh.container.k8s_runtime import _spec_with_dns
+
+    spec = ContainerSpec(name="a", image="img", dns=["10.96.0.53"])
+    assert _spec_with_dns(spec, ["10.96.0.53"]) is spec
+
+
+class _FakeCoreServices:
+    """Stub of the CoreV1 client surface _read_gateway_cluster_ip uses."""
+
+    def __init__(self, cluster_ip: str | None) -> None:
+        self._cluster_ip = cluster_ip
+        self.calls: list[tuple[str, str]] = []
+
+    async def read_namespaced_service(self, name: str, namespace: str) -> Any:
+        self.calls.append((name, namespace))
+
+        class _Spec:
+            cluster_ip = self._cluster_ip
+
+        class _Svc:
+            spec = _Spec()
+
+        return _Svc()
+
+
+@pytest.mark.asyncio
+async def test_read_gateway_cluster_ip_returns_service_ip() -> None:
+    rt = K8sRuntime()
+    rt._core = _FakeCoreServices("10.96.7.42")
+    ip = await rt._read_gateway_cluster_ip(_NS, service_name="egress-gateway")
+    assert ip == "10.96.7.42"
+    assert rt._core.calls == [("egress-gateway", _NS)]
+
+
+@pytest.mark.asyncio
+async def test_read_gateway_cluster_ip_empty_when_headless() -> None:
+    # A headless/None ClusterIP must surface as "" so callers can
+    # fail-close (verify) or keep the last known address (spawn path)
+    # instead of pinning agents to the string "None".
+    rt = K8sRuntime()
+    rt._core = _FakeCoreServices(None)
+    assert await rt._read_gateway_cluster_ip(_NS, service_name="egress-gateway") == ""

--- a/tests/container/test_runner.py
+++ b/tests/container/test_runner.py
@@ -228,14 +228,19 @@ class TestBuildContainerSpec:
         ContainerSpec.dns so agent containers actually use the
         authoritative resolver. Pre-fix the field didn't exist and
         Docker fell back to 127.0.0.11 — the DNS exfil protection was
-        dead code."""
-        from rolemesh.container import runner
+        dead code. (The address now flows through the
+        container.gateway_address provider so the K8s dynamic mode can
+        override it at runtime — the test pins it there.)"""
+        from rolemesh.container import gateway_address
 
-        with (
-            patch.object(runner, "EGRESS_GATEWAY_DNS_IP", "172.22.0.2"),
-            patch("rolemesh.container.runner.detect_auth_mode", return_value="api-key"),
-        ):
-            spec = build_container_spec([], "c", "j")
+        gateway_address.set_gateway_dns_ip("172.22.0.2")
+        try:
+            with patch(
+                "rolemesh.container.runner.detect_auth_mode", return_value="api-key"
+            ):
+                spec = build_container_spec([], "c", "j")
+        finally:
+            gateway_address.reset_gateway_dns_ip()
         assert spec.dns == ["172.22.0.2"], (
             f"agent spec must pin gateway IP as DNS; got {spec.dns!r}"
         )
@@ -524,15 +529,18 @@ class TestComputeEgressRouting:
     """Single source of truth for the spawn-path network topology."""
 
     def test_routing_with_token(self) -> None:
-        from rolemesh.container import runner
+        from rolemesh.container import gateway_address, runner
 
         # Pin the bridge name against developer-.env pollution (see
-        # test_custom_network_name_applied_from_config).
-        with (
-            patch.object(runner, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"),
-            patch.object(runner, "EGRESS_GATEWAY_DNS_IP", "172.20.0.2"),
-        ):
-            r = compute_egress_routing("TOK")
+        # test_custom_network_name_applied_from_config). The gateway
+        # address is pinned via its provider (the runner reads it at
+        # call time so the K8s dynamic mode can override at runtime).
+        gateway_address.set_gateway_dns_ip("172.20.0.2")
+        try:
+            with patch.object(runner, "CONTAINER_NETWORK_NAME", "rolemesh-agent-net"):
+                r = compute_egress_routing("TOK")
+        finally:
+            gateway_address.reset_gateway_dns_ip()
 
         assert r.proxy_base == "http://egress-gateway:3001"
         assert r.provider_prefix == "/proxy/TOK"


### PR DESCRIPTION
## Problem

`egressGateway.clusterIP` was **required**, and ClusterIPs are cluster-global: every RoleMesh instance on a cluster needs its own free Service-CIDR address. Ephemeral multi-instance deployments (feature branches / per-PR namespaces) collide on allocation — the second install fails at apply with `provided IP is already allocated`.

## Fix: the value becomes optional — two modes

| | **SET** (static — production-recommended) | **UNSET** (dynamic — ephemeral instances) |
|---|---|---|
| Service | pins the configured ClusterIP | K8s allocates |
| verify | strict `actual == configured`, fail-closed on drift (**unchanged**) | degraded: Service exists + holds an IP; the address is **discovered** and seeded |
| agent DNS | configured value | discovered at verify, **re-read before every spawn**, freshest value substituted into the pod spec at the last moment (resolv.conf is immutable after creation) |
| Service recreation | same IP comes back — running agents unaffected | new IP: ERROR logged, new spawns converge, agents spawned before it hold a dead resolver until respawned |
| collisions | one address per instance (allocation ledger) | none — nothing is pinned |

## Design notes

- **`container/gateway_address.py`** — the one mutable home for the runtime-resolved address (`EGRESS_GATEWAY_DNS_IP` is imported by value at module load across the codebase); `compute_egress_routing` reads it at call time. Docker mode and k8s static mode are pure pass-throughs.
- **Mode signal**: the chart **always renders** `EGRESS_GATEWAY_DNS_IP`, possibly as `""` — an omitted env would fall back to the config default (a docker bridge IP) and silently masquerade as static mode.
- **Pre-spawn re-read failure** degrades to the last known address with a warning rather than blocking the spawn (verify established it once); the drift path is loud, never silent.
- **connectivity-probe** needs the IP at template time → skipped in dynamic mode (NOTES explains); **deny-probe still runs**. Docker runtime untouched.

## Verification

- **Static mode functionally identical to main**: rendered-manifest diff is template comments only; all functional fields byte-identical. helm lint clean.
- **Dynamic render**: Service carries no `clusterIP` field; env renders explicitly `value: ""`; connectivity-probe absent (deny-probe present).
- New unit tests: provider fallback/override/reset + spawn-path pickup; `_spec_with_dns` substitution (frozen-spec replace / no-op); Service ClusterIP read incl. headless→`""` (fail-closed in verify, keep-last-known in spawn path).
- Suites: container/agent/egress/orchestration **1011 passed** vs main baseline 1003 (+8 = exactly the new tests), same 103 pre-existing docker-daemon-dependent errors; ruff clean.
- Live acceptance (needs a real multi-node/kind cluster): two namespaces installed with `clusterIP` unset — both reach `Infrastructure verified`, agents resolve DNS, no collision; drift drill (delete/recreate the gateway Service) shows the ERROR and new spawns converging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi

---
_Generated by [Claude Code](https://claude.ai/code/session_018wMVNajw9zZeXLc5RSKWKi)_